### PR TITLE
fix(editor): mask unquoted template fragments so the JSON editor stops flagging valid bodies

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -14,6 +14,7 @@ import { setupAutoComplete, showRootHints } from 'utils/codemirror/autocomplete'
 import { setupAiAutocomplete } from 'utils/codemirror/aiGhostText';
 import { buildAutocompleteContext } from 'utils/ai';
 import StyledWrapper from './StyledWrapper';
+import { maskJsonTemplateVariables } from './mask-json-variables';
 import * as jsonlint from '@prantlf/jsonlint';
 import { JSHINT } from 'jshint';
 import stripJsonComments from 'strip-json-comments';
@@ -179,7 +180,7 @@ class CodeEditor extends React.Component {
       }
       const jsonlint = window.jsonlint.parser || window.jsonlint;
       try {
-        jsonlint.parse(stripJsonComments(text.replace(/(?<!"[^":{]*){{[^}]*}}(?![^"},]*")/g, '1')));
+        jsonlint.parse(stripJsonComments(maskJsonTemplateVariables(text)));
       } catch (error) {
         const { message, location } = error;
         const line = location?.start?.line;

--- a/packages/bruno-app/src/components/CodeEditor/mask-json-variables.js
+++ b/packages/bruno-app/src/components/CodeEditor/mask-json-variables.js
@@ -1,0 +1,64 @@
+// Masks Bruno template variables ({{name}}) in a JSON body so the editor's lint
+// pass can syntax-check it *before* the request send path interpolates the real
+// values. A variable may splice either a single JSON value or a whole fragment
+// (several array elements / object members), so the mask must be position-aware:
+//
+//   - Value position  (nearest non-whitespace char before it is `:`, or the
+//     placeholder is the whole body) — the variable stands for one value, so it
+//     is replaced by `1`.
+//   - Element position (anything else: between `[`, `{`, `,`, `]`, `}`) — the
+//     variable may splice several elements, so it is marked for removal and the
+//     commas its removal dislodges are cleaned up at that spot only.
+//   - Inside a quoted JSON string — left untouched (its value may legitimately
+//     contain quotes/braces). The lookbehind/lookahead guard skips a placeholder
+//     that sits inside a quoted string; the lookahead also stops at `{` so a
+//     standalone fragment followed by the next object is not mistaken for a
+//     quoted value.
+//
+// Pure: no window, CodeMirror, or React — directly unit-testable with jsonlint.
+
+const UNQUOTED_PLACEHOLDER = /(?<!"[^":{]*){{[^}]*}}(?![^"},{]*")/g;
+const WHITESPACE = /\s/;
+
+// Marks where an element-position placeholder was removed, so the comma clean-up
+// below stays scoped to the removal site and never rewrites real commas the user
+// typed elsewhere or inside a string literal. A private-use char never occurs in
+// real JSON and is never produced by the masking regex above.
+const REMOVED_ELEMENT = '\uE000';
+
+function nearestNonWhitespaceBefore(text, end) {
+  for (let j = end - 1; j >= 0; j -= 1) {
+    if (!WHITESPACE.test(text[j])) {
+      return text[j];
+    }
+  }
+  return '';
+}
+
+export function maskJsonTemplateVariables(text) {
+  const masked = text.replace(UNQUOTED_PLACEHOLDER, (_match, offset) => {
+    const previous = nearestNonWhitespaceBefore(text, offset);
+    return previous === ':' || previous === '' ? '1' : REMOVED_ELEMENT;
+  });
+
+  // Nothing to clean up unless at least one element-position placeholder was removed.
+  if (!masked.includes(REMOVED_ELEMENT)) {
+    return masked;
+  }
+
+  // A bare removal can leave `, REMOVED ,` (middle element), `[{ REMOVED ,`
+  // (first element, now a leading comma), or `, REMOVED ]}` (last element, now a
+  // trailing comma). Looped so runs of adjacent removals fully reduce; a leftover
+  // marker with no adjacent comma (an only-element fragment) is dropped last.
+  let out = masked;
+  let previous;
+  do {
+    previous = out;
+    out = out
+      .replace(/,\s*\uE000\s*,/g, ',')
+      .replace(/([\[\{])\s*\uE000\s*,/g, '$1')
+      .replace(/,\s*\uE000\s*(?=[\]\}])/g, '');
+  } while (out !== previous);
+
+  return out.replace(/\uE000/g, '');
+}

--- a/packages/bruno-app/src/components/CodeEditor/mask-json-variables.spec.js
+++ b/packages/bruno-app/src/components/CodeEditor/mask-json-variables.spec.js
@@ -1,0 +1,100 @@
+import * as jsonlintNamespace from '@prantlf/jsonlint';
+import { maskJsonTemplateVariables } from './mask-json-variables';
+
+// Parses through the same jsonlint the lint site uses. Comment stripping lives
+// in the lint site (out of scope for the masker); these fixtures have none, so
+// parsing the masked text directly is equivalent to the full lint pipeline.
+// jsonlint v16 has no `.parser` property, so the `||` falls back to the namespace.
+const jsonlint = jsonlintNamespace.parser || jsonlintNamespace;
+const lintParse = (text) => jsonlint.parse(text);
+
+// The pre-fix inline mask, kept to document the baseline behaviour: it leaks an
+// unquoted standalone fragment through unmasked, so jsonlint reports a false
+// "Unexpected token". Not exported by the helper.
+const LEGACY_INLINE_MASK = /(?<!"[^":{]*){{[^}]*}}(?![^"},]*")/g;
+
+describe('CodeEditor / maskJsonTemplateVariables', () => {
+  describe('issue #8859 — unquoted fragment splicing into an array', () => {
+    const body = ['[', '  { "abc": 1 },', '  {{DEDUPLICATION}}', '  { "ccc": 3 }', ']'].join('\n');
+
+    it('the legacy inline mask still leaves the standalone fragment unmasked', () => {
+      // The legacy regex does not mask the standalone placeholder (its lookahead
+      // crosses into the next object), so jsonlint chokes on `{{DEDUPLICATION}}`.
+      const legacyMasked = body.replace(LEGACY_INLINE_MASK, '1');
+      expect(legacyMasked).toContain('{{DEDUPLICATION}}');
+      expect(() => lintParse(legacyMasked)).toThrow();
+    });
+
+    it('the helper masks the fragment so the body lints clean', () => {
+      const masked = maskJsonTemplateVariables(body);
+      // Both real objects survive; the standalone fragment is gone and the comma
+      // structure between the two objects is preserved.
+      expect(masked).toContain('{ "abc": 1 }');
+      expect(masked).toContain('{ "ccc": 3 }');
+      expect(masked).not.toContain('{{DEDUPLICATION}}');
+      expect(() => lintParse(masked)).not.toThrow();
+    });
+  });
+
+  it('masks a value-position placeholder as a JSON value', () => {
+    expect(maskJsonTemplateVariables('{"k": {{OBJ}}}')).toBe('{"k": 1}');
+  });
+
+  it('does not normalize when only value-position placeholders are present', () => {
+    // Exercises the early return: no element removal -> no comma clean-up, and a
+    // real trailing comma elsewhere is left intact for jsonlint to report.
+    expect(maskJsonTemplateVariables('{"a": {{X}}, "b": {{Y}}}')).toBe('{"a": 1, "b": 1}');
+  });
+
+  it('treats a placeholder that is the whole body as a value', () => {
+    // No structural char before it -> a single templated value, not a fragment.
+    expect(maskJsonTemplateVariables('{{BODY}}')).toBe('1');
+    expect(() => lintParse(maskJsonTemplateVariables('{{BODY}}'))).not.toThrow();
+  });
+
+  it('leaves a placeholder inside a quoted string untouched', () => {
+    const masked = maskJsonTemplateVariables('{"msg": "hello {{name}}"}');
+    expect(masked).toContain('{{name}}');
+    expect(() => lintParse(masked)).not.toThrow();
+  });
+
+  it('does not rewrite commas that live inside a string literal', () => {
+    // The `,,` is string content in a different part of the body; the element
+    // removal in "list" must not collapse it (clean-up is scoped to the removal).
+    const masked = maskJsonTemplateVariables('{"msg": "a,,b", "list": [{{X}}]}');
+    expect(masked).toContain('"a,,b"');
+    expect(() => lintParse(masked)).not.toThrow();
+  });
+
+  it('still reports a genuine syntax error that is independent of the placeholder', () => {
+    // "bad" has no value (independent of {{X}}); the masker must not repair it.
+    expect(() => lintParse(maskJsonTemplateVariables('{\n  "ok": {{X}},\n  "bad":\n}'))).toThrow();
+  });
+
+  it('still reports a real comma error that is unrelated to a removed fragment', () => {
+    // The trailing comma in [1,] is a genuine user mistake in a different part of
+    // the body than the removed [{{X}}]; comma clean-up is scoped to the removal
+    // site, so this error survives masking.
+    const body = '{"good": [1,], "list": [{{X}}]}';
+    expect(() => lintParse(maskJsonTemplateVariables(body))).toThrow();
+  });
+
+  it.each([
+    ['first element', '[{{A}}, { "c": 1 }]', '[ { "c": 1 }]'],
+    ['last element (trailing comma normalised)', '[ { "c": 1 }, {{Z}}]', '[ { "c": 1 }]'],
+    ['only element', '[{{X}}]', '[]']
+  ])('masks an element-position placeholder cleanly: %s', (_name, body, expected) => {
+    expect(maskJsonTemplateVariables(body)).toBe(expected);
+    expect(() => lintParse(maskJsonTemplateVariables(body))).not.toThrow();
+  });
+
+  it('collapses a run of interior element fragments and keeps the neighbours', () => {
+    // Drives the do-while loop for 3+ passes and isolates the `, REMOVED ,` rule.
+    expect(maskJsonTemplateVariables('[1, {{A}}, {{B}}, {{C}}, 2]')).toBe('[1, 2]');
+  });
+
+  it('masks an object-member fragment', () => {
+    // A placeholder splicing several object members (not just array elements).
+    expect(() => lintParse(maskJsonTemplateVariables('{ "a": 1, {{MEMBERS}}, "b": 2 }'))).not.toThrow();
+  });
+});


### PR DESCRIPTION
### Description

The JSON body editor's lint pass reports a false **"Unexpected token"** parse error for a request body that Bruno itself sends successfully: an **unquoted** `{{variable}}` used to splice a JSON fragment into an array/object (e.g. several array elements passed in one variable).

### Problem

When a `{{variable}}` placeholder sits as a **standalone array element** (between `,` / `[` / `]`), the editor's JSON linter flags the body as invalid even though the interpolated request is perfectly valid JSON. The variable typically carries its own separators (its value ends in `,`), so the *sent* request is correct — only the editor's lint diagnostic is wrong.

Closes #8859.

The lint helper (`CodeEditor/index.js`) masked every unquoted placeholder with a literal `1` via an inline regex. That regex had two compounding flaws for this case:

1. Its negative lookahead `(?![^"},]*")` did **not** exclude `{`, so for a placeholder followed by `\n  {` (the next object) it ate the `{`, reached the next object's `"`, and wrongly concluded the placeholder was inside a quoted string — leaving it **un-masked**, so `jsonlint` choked on `{{variable}}` directly.
2. Even after fixing (1), masking a standalone element with `1` yields `1 {` with **no comma** between it and the next element — still a parse error. A single static per-placeholder mask cannot satisfy both the value-position case (`"k": {{OBJ}}`, which needs `1`) and the element-position case (which must vanish).

### Fix

Extract the masking into a small position-aware pure helper, `maskJsonTemplateVariables(text)`, and tighten the in-string guard:

- **Value position** (nearest non-whitespace char before the placeholder is `:`, or the placeholder is the whole body) → replaced with `1` (unchanged behaviour, correct for `"k": {{OBJ}}`).
- **Element position** (standalone between `[`/`{`/`,`/`]`/`}`) → marked for removal, then the commas its removal dislodges are cleaned up **at that spot only** (collapse `,,`, drop a leading `,` after `[`/`{`, drop a trailing `,` before `]`/`}`), looped until stable. Scoping the clean-up to the removal site means a genuine comma mistake elsewhere in the body is still reported.
- **Inside a quoted JSON string** → left untouched (its value may legitimately contain quotes/braces); the lookbehind/lookahead guard is preserved, with the lookahead tightened to also stop at `{` so a standalone fragment followed by the next object is no longer mistaken for a quoted value.

The helper is pure (no `window`/CodeMirror/React) and unit-tested directly against `@prantlf/jsonlint`. The call site keeps `stripJsonComments` exactly where it was: `jsonlint.parse(stripJsonComments(maskJsonTemplateVariables(text)))`. Real syntax errors (e.g. a missing value, or a stray comma away from a placeholder) are still reported — the masker masks template variables, it does not repair JSON.

### Screenshots

No UI change — editor lint diagnostic only. A body such as

```json
[
  { "abc": 1 },
  {{DEDUPLICATION}}
  { "ccc": 3 }
]
```

no longer shows a false "Unexpected token" error in the editor (it was already being sent correctly).

| Before | After |
| --- | --- |
| False "Unexpected token" lint error on a valid unquoted `{{fragment}}` | Lints clean |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON linting for requests containing template variables.
  * Fixed validation of template variables used as values, array elements, and object fragments.
  * Preserved template variables inside quoted strings while maintaining accurate syntax-error reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->