### PR TITLE
fix(grpc): preserve explicit default port in generated grpcurl target

### DIFF
--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -133,10 +133,22 @@ const getParsedGrpcUrlObject = (url) => {
     return { host: normalizeWindowsNamedPipe(url), path: '', protocol: 'pipe', isLocalTransport: true };
   }
 
-  const urlObj = new URL(addProtocolIfMissing(url.toLowerCase()));
+  const protocolUrl = addProtocolIfMissing(url.toLowerCase());
+  const urlObj = new URL(protocolUrl);
+
+  // WHATWG URL parsing elides default ports (http:80, https:443) for special schemes,
+  // so urlObj.host drops a port the user typed explicitly. Recover it from the
+  // protocol-added authority so callers (e.g. grpcurl) receive a full host:port.
+  let host = urlObj.host;
+  if (!urlObj.port) {
+    const portMatch = protocolUrl.match(/^[a-z][a-z0-9+\-.]*:\/\/[^/?#]*:(\d+)(?=[/?#]|$)/);
+    if (portMatch) {
+      host = `${urlObj.hostname}:${portMatch[1]}`;
+    }
+  }
 
   return {
-    host: urlObj.host,
+    host,
     protocol: urlObj.protocol.replace(':', ''),
     path: removeTrailingSlash(urlObj.pathname),
     isLocalTransport: false

--- a/packages/bruno-requests/src/grpc/grpc-client.spec.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.spec.js
@@ -715,4 +715,58 @@ describe('GrpcClient', () => {
       expect(capturedHost).toBe('myserver:50051');
     });
   });
+
+  describe('generateGrpcurlCommand port preservation', () => {
+    const buildCommand = (url) =>
+      grpcClient.generateGrpcurlCommand({
+        request: {
+          url,
+          method: '/pkg.svc/M',
+          methodType: 'unary',
+          body: { grpc: [] },
+          headers: {},
+          protoPath: ''
+        },
+        collectionPath: ''
+      });
+
+    test('should preserve an explicit default http port (:80) in the target', () => {
+      const cmd = buildCommand('http://x.mydomain.com:80');
+      expect(cmd).toContain('x.mydomain.com:80');
+    });
+
+    test('should preserve an explicit default https port (:443) in the target', () => {
+      const cmd = buildCommand('https://x.mydomain.com:443');
+      expect(cmd).toContain('x.mydomain.com:443');
+    });
+
+    test('should not append a port when none was specified', () => {
+      const cmd = buildCommand('http://x.mydomain.com');
+      expect(cmd).toContain('x.mydomain.com');
+      expect(cmd).not.toMatch(/x\.mydomain\.com:\d+/);
+    });
+
+    test('should not scrape a bogus port from an IPv6 host without an explicit port (http)', () => {
+      const cmd = buildCommand('http://[::1]');
+      expect(cmd).toContain('[::1]');
+      expect(cmd).not.toMatch(/\[::1\]:\d+/);
+    });
+
+    test('should not scrape a bogus port from an IPv6 host without an explicit port (grpcs)', () => {
+      const cmd = buildCommand('grpcs://[2001:db8::1]');
+      expect(cmd).toContain('[2001:db8::1]');
+      expect(cmd).not.toMatch(/\[2001:db8::1\]:\d+/);
+    });
+
+    test('should preserve an explicit port on an IPv6 host', () => {
+      const cmd = buildCommand('https://[2001:db8::1]:443');
+      expect(cmd).toContain('[2001:db8::1]:443');
+    });
+
+    test('should not scrape a port from userinfo when no host port is present', () => {
+      const cmd = buildCommand('http://user:80@host');
+      expect(cmd).toContain('host');
+      expect(cmd).not.toMatch(/host:\d+/);
+    });
+  });
 });


### PR DESCRIPTION
### Description

`grpcurl` commands generated from a plaintext gRPC endpoint that carries an explicit default port
(e.g. `x.mydomain.com:80`) were emitted with a **portless** target, so `grpcurl` could not connect.

### Problem

`getParsedGrpcUrlObject` returned `urlObj.host`, and the WHATWG `URL` parser **elides default ports**
for special schemes (`http`→`80`, `https`→`443`). The `grpc:generate-grpcurl` IPC handler rewrites
schemeless endpoints to `http://…` before generating the command, so a typed `x.mydomain.com:80`
became `http://x.mydomain.com:80`, the port was elided to `x.mydomain.com`, and `grpcurl` got no port.

Fixes #8543

### Fix

In `getParsedGrpcUrlObject`, when `urlObj.port` is empty, recover the explicitly-typed port from the
protocol-added URL (regex over the authority, before any path/query/hash) and rebuild `host` as
`hostname:port`. Non-default ports (already preserved) and portless URLs are unchanged. Because
`grpc://`/`grpcs://` are non-special schemes, this only affects the `http`/`https` targets the grpcurl
handler synthesizes; the TLS branch keys off the raw URL, not the returned host.

- Added a regression test asserting `x.mydomain.com:80` and `x.mydomain.com:443` are preserved in the
  generated `grpcurl` target, plus a guard that no port is appended when none was typed.
- All 37 `grpc-client.spec.js` tests pass; lint clean on changed lines.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (#8543)
- [x] **I've run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly specified default ports in gRPC connection URLs.
  * Improved handling of IPv6 hosts and credentials in gRPC command generation.
  * Omitted ports when they were not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->