### PR TITLE
feat(app): Ctrl+Tab / Ctrl+Shift+Tab tab navigation

### DIFF
--- a/packages/bruno-app/src/providers/Hotkeys/index.js
+++ b/packages/bruno-app/src/providers/Hotkeys/index.js
@@ -107,33 +107,39 @@ export const HotkeysProvider = (props) => {
 
   // Switch to the previous tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToPreviousTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const prevIndex = (currentIndex - 1 + collectionTabs.length) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[prevIndex].uid }));
       return false;
-    });
+    };
+    bindAction('switchToPreviousTab', handler);
+    bindAction('switchToPreviousTabAlt', handler);
 
     return () => {
       unbindAction('switchToPreviousTab');
+      unbindAction('switchToPreviousTabAlt');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
 
   // Switch to the next tab (active-collection-tabs-only)
   useEffect(() => {
-    bindAction('switchToNextTab', (e) => {
+    const handler = (e) => {
       const collectionTabs = getCollectionTabs();
       if (collectionTabs.length === 0) return false;
       const currentIndex = collectionTabs.findIndex((t) => t.uid === activeTabUid);
       const nextIndex = (currentIndex + 1) % collectionTabs.length;
       dispatch(focusTab({ uid: collectionTabs[nextIndex].uid }));
       return false;
-    });
+    };
+    bindAction('switchToNextTab', handler);
+    bindAction('switchToNextTabAlt', handler);
 
     return () => {
       unbindAction('switchToNextTab');
+      unbindAction('switchToNextTabAlt');
     };
   }, [activeTabUid, tabs, dispatch, userKeyBindings, keybindingsEnabled]);
 

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -20,7 +20,9 @@ export const KEY_BINDING_SECTIONS = [
       switchToTab5: { mac: 'command+bind+5', windows: 'ctrl+bind+5', name: 'Switch to Tab at Position', readOnly: true, hidden: true },
       switchToTab6: { mac: 'command+bind+6', windows: 'ctrl+bind+6', name: 'Switch to Tab at Position', readOnly: true, hidden: true },
       switchToTab7: { mac: 'command+bind+7', windows: 'ctrl+bind+7', name: 'Switch to Tab at Position', readOnly: true, hidden: true },
-      switchToTab8: { mac: 'command+bind+8', windows: 'ctrl+bind+8', name: 'Switch to Tab at Position', readOnly: true, hidden: true }
+      switchToTab8: { mac: 'command+bind+8', windows: 'ctrl+bind+8', name: 'Switch to Tab at Position', readOnly: true, hidden: true },
+      switchToNextTabAlt: { mac: 'ctrl+bind+tab', windows: 'ctrl+bind+tab', name: 'Switch to Next Tab', readOnly: true, hidden: true },
+      switchToPreviousTabAlt: { mac: 'ctrl+bind+shift+bind+tab', windows: 'ctrl+bind+shift+bind+tab', name: 'Switch to Previous Tab', readOnly: true, hidden: true }
     }
   },
   {


### PR DESCRIPTION
## Summary
- Adds Ctrl+Tab and Ctrl+Shift+Tab as alternate keybindings for switching between tabs (cycles within the active collection)
- Follows the existing hidden keybinding pattern (like switchToTab1-8)
- No UI changes — these are hidden alternate bindings alongside the existing Shift+Ctrl+] / Shift+Ctrl+[ shortcuts

## Changes
- `packages/bruno-app/src/providers/Hotkeys/keyMappings.js` — added `switchToNextTabAlt` and `switchToPreviousTabAlt` hidden entries
- `packages/bruno-app/src/providers/Hotkeys/index.js` — bound the alt actions to the same handlers as the primary tab-switch bindings

## Test plan
- Open multiple requests in tabs
- Press Ctrl+Tab to cycle forward through tabs
- Press Ctrl+Shift+Tab to cycle backward
- Verify existing Shift+Ctrl+] and Shift+Ctrl+[ still work
- Verify wrapping behavior (last tab → first tab and vice versa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alternate keyboard shortcuts for switching to the next and previous tabs.
  * On macOS and Windows, use `Ctrl+Tab` for the next tab and `Ctrl+Shift+Tab` for the previous tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->