### PR TITLE
feat(app): quick-save response without file picker dialog

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseDownload/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseDownload/index.js
@@ -17,16 +17,17 @@ const ResponseDownload = forwardRef(({ item, children }, ref) => {
     isDisabled
   }), [isDisabled]);
 
-  const saveResponseToFile = () => {
+  const saveResponseToFile = (e) => {
     if (isDisabled) {
       return;
     }
+    const quickSave = !e?.shiftKey;
     return new Promise((resolve, reject) => {
       ipcRenderer
-        .invoke('renderer:save-response-to-file', response, item?.requestSent?.url, item.pathname)
+        .invoke('renderer:save-response-to-file', response, item?.requestSent?.url, item.pathname, quickSave)
         .then((result) => {
           if (result && result.success) {
-            toast.success('Response downloaded to file');
+            toast.success(quickSave ? `Response saved to ${result.filePath}` : 'Response downloaded to file');
           }
           resolve();
         })
@@ -42,7 +43,7 @@ const ResponseDownload = forwardRef(({ item, children }, ref) => {
       ref={elementRef}
       aria-disabled={isDisabled}
       onClick={saveResponseToFile}
-      title={!children ? 'Save response to file' : null}
+      title={!children ? 'Save response (Shift+Click for Save As...)' : null}
       className={classnames({
         'opacity-50 cursor-not-allowed': isDisabled && !children
       })}

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -820,7 +820,7 @@ class CollectionWatcher {
 
     // Always ignore node_modules and .git, regardless of user config
     // This prevents infinite loops with symlinked directories (e.g., npm workspaces)
-    const defaultIgnores = ['node_modules', '.git'];
+    const defaultIgnores = ['node_modules', '.git', 'responses'];
 
     const watcher = chokidar.watch(watchPath, {
       ignoreInitial,

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1,6 +1,7 @@
 const https = require('https');
 const axios = require('axios');
 const path = require('path');
+const fs = require('fs');
 const { applyOAuth1ToRequest } = require('@usebruno/requests');
 const { buildScriptedEntry } = require('@usebruno/requests').scripting;
 const qs = require('qs');
@@ -2172,7 +2173,7 @@ const registerNetworkIpc = (mainWindow) => {
   );
 
   // save response to file
-  ipcMain.handle('renderer:save-response-to-file', async (event, response, url, pathname) => {
+  ipcMain.handle('renderer:save-response-to-file', async (event, response, url, pathname, quickSave) => {
     try {
       const getHeaderValue = (headerName) => {
         const headersArray = typeof response.headers === 'object' ? Object.entries(response.headers) : [];
@@ -2220,6 +2221,22 @@ const registerNetworkIpc = (mainWindow) => {
 
       const dirPath = path.dirname(pathname);
       const fileName = determineFileName();
+
+      if (quickSave) {
+        const responsesDir = path.join(dirPath, 'responses');
+        fs.mkdirSync(responsesDir, { recursive: true });
+        const timestampedFileName = `${Date.now()}_${fileName}`;
+        const filePath = path.join(responsesDir, timestampedFileName);
+        const encoding = getEncodingFormat();
+        const data = Buffer.from(response.dataBuffer, 'base64');
+        if (encoding === 'utf-8') {
+          await writeFile(filePath, data);
+        } else {
+          await writeFile(filePath, data, true);
+        }
+        return { success: true, filePath };
+      }
+
       const filePath = await chooseFileToSave(mainWindow, path.join(dirPath, fileName));
       if (filePath) {
         const encoding = getEncodingFormat();

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -2224,9 +2224,14 @@ const registerNetworkIpc = (mainWindow) => {
 
       if (quickSave) {
         const responsesDir = path.join(dirPath, 'responses');
-        fs.mkdirSync(responsesDir, { recursive: true });
-        const timestampedFileName = `${Date.now()}_${fileName}`;
-        const filePath = path.join(responsesDir, timestampedFileName);
+        await fs.promises.mkdir(responsesDir, { recursive: true });
+        const safeFileName = path.basename(fileName.replace(/\\/g, '/')) || 'response.txt';
+        const timestampedFileName = `${Date.now()}_${safeFileName}`;
+        const responsesRoot = path.resolve(responsesDir);
+        const filePath = path.resolve(responsesRoot, timestampedFileName);
+        if (!filePath.startsWith(responsesRoot)) {
+          throw new Error('Invalid response filename');
+        }
         const encoding = getEncodingFormat();
         const data = Buffer.from(response.dataBuffer, 'base64');
         if (encoding === 'utf-8') {


### PR DESCRIPTION
## Summary
- Click the save button to instantly save the response to a `responses/` directory next to the request file (no dialog)
- Shift+Click opens the traditional Save As dialog for custom location
- Saved files are timestamped for uniqueness (e.g. `1723456789000_response.json`)
- The `responses/` directory is added to the collection watcher ignore list

## Changes
- `packages/bruno-app/src/components/ResponsePane/ResponseDownload/index.js` — detect Shift key, pass `quickSave` flag to IPC
- `packages/bruno-electron/src/ipc/network/index.js` — handle `quickSave` param: create `responses/` dir and write directly
- `packages/bruno-electron/src/app/collection-watcher.js` — ignore `responses` directory

## Test plan
- Send a request and click the save/download button → file saved to `responses/` folder without dialog
- Verify toast shows the saved file path
- Shift+Click the save button → traditional file picker dialog appears
- Verify the collection watcher doesn't trigger on saved response files
- Verify the dropdown menu "Save Response" still works (defaults to quick-save)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Shift+Click quick saving for responses.
  * Quick saves automatically store timestamped files in a responses folder without opening a dialog.
  * Save confirmations now distinguish quick saves from regular downloads.
* **Bug Fixes**
  * Collection monitoring now ignores response directories, preventing unnecessary processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->