### PR TITLE
feat(app): delete sidebar item with Delete key

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -140,6 +140,11 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     return false;
   }, { enabled: isKeyboardFocused, deps: [isKeyboardFocused] });
 
+  useKeybinding('deleteItem', () => {
+    setDeleteItemModalOpen(true);
+    return false;
+  }, { enabled: isKeyboardFocused, deps: [isKeyboardFocused] });
+
   useKeybinding('newRequest', () => {
     if (!isFolder) return false;
     setNewRequestModalOpen(true);

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -31,6 +31,7 @@ export const KEY_BINDING_SECTIONS = [
       pasteItem: { mac: 'command+bind+v', windows: 'ctrl+bind+v', name: 'Paste Item' }, // D
       cloneItem: { mac: 'command+bind+d', windows: 'ctrl+bind+d', name: 'Clone Item' }, // D
       renameItem: { mac: 'command+bind+r', windows: 'ctrl+bind+r', name: 'Rename Item' }, // D
+      deleteItem: { mac: 'backspace', windows: 'del', name: 'Delete Item' },
       collapseSidebar: { mac: 'command+bind+\\', windows: 'ctrl+bind+\\', name: 'Collapse Sidebar' } // D
     }
   },

--- a/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/bruno-app/src/providers/Hotkeys/keyMappings.js
@@ -106,6 +106,7 @@ export const formatSingleKeyForDisplay = (key, os) => {
     enter: os === 'mac' ? '↩' : 'Enter',
     backspace: os === 'mac' ? '⌫' : 'Backspace',
     tab: os === 'mac' ? '⇥' : 'Tab',
+    del: os === 'mac' ? '⌦' : 'Delete',
     delete: os === 'mac' ? '⌦' : 'Delete',
     esc: os === 'mac' ? '⎋' : 'Esc',
     space: os === 'mac' ? '␣' : 'Space',


### PR DESCRIPTION
## Summary
- Press Delete (Windows) or Backspace (Mac) to delete the focused sidebar item
- Opens the existing delete confirmation modal (same as right-click → Delete)
- Only triggers when the sidebar item has keyboard focus (won't interfere with text inputs)

## Changes
- `packages/bruno-app/src/providers/Hotkeys/keyMappings.js` — added `deleteItem` binding in the Sidebar section
- `packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js` — added `useKeybinding('deleteItem', ...)` following the existing pattern

## Test plan
- Click a request/folder in the sidebar to focus it
- Press Delete key → confirmation modal appears
- Confirm deletion works for both requests and folders
- Verify Delete key does NOT trigger when typing in rename field or search box
- Verify right-click → Delete still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for deleting focused sidebar collection items.
  * Press Backspace on macOS or Delete on Windows to open the deletion confirmation modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->