### PR TITLE
fix(app): show inherit for folders without auth config

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/AuthMode/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/AuthMode/index.js
@@ -10,7 +10,9 @@ import StyledWrapper from './StyledWrapper';
 
 const AuthMode = ({ collection, folder }) => {
   const dispatch = useDispatch();
-  const authMode = folder.draft ? get(folder, 'draft.request.auth.mode') : get(folder, 'root.request.auth.mode');
+  const authMode = folder.draft
+    ? get(folder, 'draft.request.auth.mode', 'inherit')
+    : get(folder, 'root.request.auth.mode', 'inherit');
 
   const onModeChange = useCallback((value) => {
     dispatch(

--- a/packages/bruno-app/src/components/FolderSettings/AuthMode/index.spec.js
+++ b/packages/bruno-app/src/components/FolderSettings/AuthMode/index.spec.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { ThemeProvider } from 'styled-components';
+import themes from 'themes/index';
+import AuthMode from './index';
+
+const renderAuthMode = (folder) => {
+  const store = configureStore({
+    reducer: (state = {}) => state
+  });
+
+  return render(
+    <Provider store={store}>
+      <ThemeProvider theme={themes.dark}>
+        <AuthMode collection={{ uid: 'collection-1' }} folder={folder} />
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+describe('FolderSettings AuthMode', () => {
+  it('shows Inherit when the folder has no auth configuration', () => {
+    renderAuthMode({
+      uid: 'folder-1',
+      type: 'folder'
+    });
+
+    expect(screen.getByTestId('auth-mode-label')).toHaveTextContent('Inherit');
+  });
+
+  it('shows No Auth when the folder explicitly disables auth', () => {
+    renderAuthMode({
+      uid: 'folder-1',
+      type: 'folder',
+      root: {
+        request: {
+          auth: {
+            mode: 'none'
+          }
+        }
+      }
+    });
+
+    expect(screen.getByTestId('auth-mode-label')).toHaveTextContent('No Auth');
+  });
+});


### PR DESCRIPTION
### Description

Fixes #8905.

Folders from older collections may not have a `folder.bru` file. Such folders already inherit authentication from their parent at runtime, but the folder Auth selector currently displays `No Auth`.

### Problem

When `folder.bru` is missing, `folder.root.request.auth.mode` is undefined. The auth mode humanizer treats an undefined value as `No Auth`, even though request execution skips that folder and continues inheriting authentication from its parent.

This makes the UI inconsistent with the authentication behavior.

### Fix

Use `inherit` as the folder Auth selector's fallback mode when no saved or draft auth mode exists.

The fallback is scoped to the folder selector so shared request auth formatting and runtime inheritance behavior remain unchanged.

Added component tests covering both a missing folder auth configuration and an explicit `No Auth` configuration.

### Testing

- `npm test --workspace=packages/bruno-app -- --runTestsByPath src/components/FolderSettings/AuthMode/index.spec.js`
- `npm run lint -- packages/bruno-app/src/components/FolderSettings/AuthMode/index.js packages/bruno-app/src/components/FolderSettings/AuthMode/index.spec.js`
- `npm run build:web`

### Screenshots

Not provided yet. The visible label behavior is covered by the component regression test.

| Before | After |
| --- | --- |
| Folder without `folder.bru` displays `No Auth` | Folder without `folder.bru` displays `Inherit` |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder authentication settings now correctly default to **Inherit** when no authentication mode is configured.
  * Folders explicitly configured with **No Auth** continue to display that setting.

* **Tests**
  * Added coverage for inherited and explicitly disabled authentication modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->