### PR TITLE
fix(converters): preserve enabled state for Env variables, collection variables  for export, import

### DIFF
--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -971,6 +971,7 @@ const EnvironmentVariablesTable = ({
                       type="checkbox"
                       className="mousetrap"
                       name={`${actualIndex}.enabled`}
+                      data-testid="env-var-enabled-checkbox"
                       checked={variable.enabled}
                       onChange={formik.handleChange}
                     />

--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
@@ -139,7 +139,7 @@ const EnvironmentListContent = ({
               <IconPlus size={16} strokeWidth={1.5} />
               Create
             </button>
-            <button onClick={onImportClick} id="import-env">
+            <button onClick={onImportClick} id="import-env" data-testid="empty-state-import-env-btn">
               <IconDownload size={16} strokeWidth={1.5} />
               Import
             </button>

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
@@ -625,6 +625,7 @@ const EnvironmentList = ({
                   <div
                     key={env.uid}
                     id={env.uid}
+                    data-testid="collection-env-list-item"
                     className={classnames('environment-item', {
                       active: activeView === 'environment' && selectedEnvironment?.uid === env.uid,
                       renaming: renamingEnvUid === env.uid,

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/index.js
@@ -631,6 +631,7 @@ const EnvironmentList = ({
                   <div
                     key={env.uid}
                     id={env.uid}
+                    data-testid="workspace-env-list-item"
                     className={classnames('environment-item', {
                       active: activeView === 'environment' && selectedEnvironment?.uid === env.uid,
                       renaming: renamingEnvUid === env.uid,

--- a/packages/bruno-converters/src/postman/bruno-to-postman.js
+++ b/packages/bruno-converters/src/postman/bruno-to-postman.js
@@ -191,16 +191,18 @@ export const brunoToPostman = (collection, { preserveScripts = false } = {}) => 
     findOccurrences(collection, collectionVars);
 
     // Add request and response vars
-    let reqVars = (collection.root?.request?.vars?.req || []).map((v) => ({
+    const reqVars = (collection.root?.request?.vars?.req || []).map((v) => ({
       key: v.name,
       value: v.value,
-      type: 'default'
+      type: 'default',
+      ...(v.enabled === false ? { disabled: true } : {})
     }));
 
-    let resVars = (collection.root?.request?.vars?.res || []).map((v) => ({
+    const resVars = (collection.root?.request?.vars?.res || []).map((v) => ({
       key: v.name,
       value: v.value,
-      type: 'default'
+      type: 'default',
+      ...(v.enabled === false ? { disabled: true } : {})
     }));
 
     // Merge and deduplicate final result

--- a/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
+++ b/packages/bruno-converters/src/postman/postman-env-to-bruno-env.js
@@ -14,7 +14,7 @@ const importPostmanEnvironmentVariables = (brunoEnvironment, values = []) => {
       uid: uuid(),
       name: (i.key ?? '').replace(invalidVariableCharacterRegex, '_'),
       value: i.value ?? '',
-      enabled: i.enabled,
+      enabled: i.enabled ?? true,
       type: 'text',
       secret: isSecret(i.type)
     };

--- a/packages/bruno-converters/src/postman/postman-to-bruno.js
+++ b/packages/bruno-converters/src/postman/postman-to-bruno.js
@@ -238,7 +238,7 @@ const importCollectionLevelVariables = (variables, requestObject) => {
     uid: uuid(),
     name: (v.key ?? '').replace(invalidVariableCharacterRegex, '_'),
     value: v.value == null ? '' : typeof v.value === 'string' ? v.value : JSON.stringify(v.value),
-    enabled: true
+    enabled: !v.disabled
   }));
 
   requestObject.vars.req = vars;

--- a/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
+++ b/packages/bruno-converters/tests/postman/bruno-to-postman.spec.js
@@ -405,6 +405,39 @@ describe('brunoToPostman null checks and fallbacks', () => {
   });
 });
 
+describe('brunoToPostman collection variables', () => {
+  it('should emit disabled: true for disabled collection variables and omit it for enabled ones', () => {
+    const collection = {
+      items: [],
+      root: {
+        request: {
+          vars: {
+            req: [
+              { name: 'enabledVar', value: 'value1', enabled: true },
+              { name: 'disabledVar', value: 'value2', enabled: false },
+              { name: 'defaultVar', value: 'value3' }
+            ],
+            res: [
+              { name: 'resEnabled', value: 'r1', enabled: true },
+              { name: 'resDisabled', value: 'r2', enabled: false }
+            ]
+          }
+        }
+      }
+    };
+
+    const result = brunoToPostman(collection);
+
+    expect(result.variable).toEqual([
+      { key: 'enabledVar', value: 'value1', type: 'default' },
+      { key: 'disabledVar', value: 'value2', type: 'default', disabled: true },
+      { key: 'defaultVar', value: 'value3', type: 'default' },
+      { key: 'resEnabled', value: 'r1', type: 'default' },
+      { key: 'resDisabled', value: 'r2', type: 'default', disabled: true }
+    ]);
+  });
+});
+
 describe('brunoToPostman auth export', () => {
   const makeRequestWithAuth = (auth) => ({
     items: [

--- a/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-env-to-bruno-env.spec.js
@@ -112,6 +112,52 @@ describe('postmanToBrunoEnvironment Function', () => {
     expect(brunoEnvironment).toEqual(expectedEnvironment);
   });
 
+  it('should default enabled to true when Postman omits or nulls it', async () => {
+    const postmanEnvironment = {
+      id: 'some-id',
+      name: 'My Environment',
+      values: [
+        {
+          key: 'noEnabled',
+          value: 'value1',
+          type: 'default'
+        },
+        {
+          key: 'nullEnabled',
+          value: 'value2',
+          enabled: null,
+          type: 'default'
+        }
+      ]
+    };
+
+    const brunoEnvironment = await postmanToBrunoEnvironment(postmanEnvironment);
+
+    const expectedEnvironment = {
+      name: 'My Environment',
+      variables: [
+        {
+          name: 'noEnabled',
+          value: 'value1',
+          enabled: true,
+          secret: false,
+          type: 'text',
+          uid: 'mockeduuidvalue123456'
+        },
+        {
+          name: 'nullEnabled',
+          value: 'value2',
+          enabled: true,
+          secret: false,
+          type: 'text',
+          uid: 'mockeduuidvalue123456'
+        }
+      ]
+    };
+
+    expect(brunoEnvironment).toEqual(expectedEnvironment);
+  });
+
   it.skip('should throw Error when JSON parsing fails', async () => {
     const invalidBrunoEnvironment = {
       id: 'some-id',

--- a/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
+++ b/packages/bruno-converters/tests/postman/postman-to-bruno/postman-to-bruno.spec.js
@@ -290,6 +290,45 @@ describe('postman-collection', () => {
     expect(brunoCollection.root.request.vars.req).toEqual([]);
   });
 
+  it('should preserve the disabled state of collection variables', async () => {
+    const collectionWithDisabledVar = {
+      info: {
+        _postman_id: 'c1d0e5a6-2b3c-4d5e-6f7a-8b9c0d1e2f3a',
+        name: 'collection with disabled var',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+      },
+      variable: [
+        { key: 'enabledVar', value: 'value1' },
+        { key: 'disabledVar', value: 'value2', disabled: true },
+        { key: 'explicitlyEnabledVar', value: 'value3', disabled: false }
+      ],
+      item: []
+    };
+
+    const { collection: brunoCollection } = await postmanToBruno(collectionWithDisabledVar);
+
+    expect(brunoCollection.root.request.vars.req).toEqual([
+      {
+        uid: 'mockeduuidvalue123456',
+        name: 'enabledVar',
+        value: 'value1',
+        enabled: true
+      },
+      {
+        uid: 'mockeduuidvalue123456',
+        name: 'disabledVar',
+        value: 'value2',
+        enabled: false
+      },
+      {
+        uid: 'mockeduuidvalue123456',
+        name: 'explicitlyEnabledVar',
+        value: 'value3',
+        enabled: true
+      }
+    ]);
+  });
+
   it('should correctly import protocolProfileBehavior settings from Postman requests', async () => {
     const collectionWithSettings = {
       info: {

--- a/tests/environments/import-environment/fixtures/postman-env-mixed-enabled.json
+++ b/tests/environments/import-environment/fixtures/postman-env-mixed-enabled.json
@@ -1,0 +1,32 @@
+{
+  "id": "mixed-enabled-env-id",
+  "name": "Mixed Enabled Env",
+  "values": [
+    {
+      "key": "enabledVar",
+      "value": "value1",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "disabledVar",
+      "value": "value2",
+      "enabled": false,
+      "type": "text"
+    },
+    {
+      "key": "defaultEnabledVar",
+      "value": "value3",
+      "type": "text"
+    },
+    {
+      "key": "nullEnabledVar",
+      "value": "value4",
+      "enabled": null,
+      "type": "text"
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2024-01-01T00:00:00.000Z",
+  "_postman_exported_using": "Postman/10.0.0"
+}

--- a/tests/environments/import-environment/postman-enabled-state.spec.ts
+++ b/tests/environments/import-environment/postman-enabled-state.spec.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  importEnvironment
+} from '../../utils/page';
+
+const envFile = path.join(__dirname, 'fixtures', 'postman-env-mixed-enabled.json');
+
+test.describe('Postman env import preserves enabled/disabled state', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  for (const scope of ['collection', 'global'] as const) {
+    test(`${scope} env import: honors enabled=false and defaults missing enabled to true`, async ({
+      page,
+      createTmpDir
+    }) => {
+      const locators = buildCommonLocators(page);
+      const tmpDir = await createTmpDir(`${scope}-env-enabled-state`);
+
+      await createCollection(page, `${scope}-env-enabled-state`, tmpDir);
+      await importEnvironment(page, envFile, scope);
+
+      await test.step('Imported env appears in the settings sidebar', async () => {
+        await expect(locators.environment.sidebarListItem(scope, 'Mixed Enabled Env')).toBeVisible();
+      });
+
+      await test.step('Enabled, default-enabled, and null-enabled rows are checked; disabled row is unchecked', async () => {
+        await expect(locators.environment.varRowEnabledCheckbox('enabledVar')).toBeChecked();
+        await expect(locators.environment.varRowEnabledCheckbox('defaultEnabledVar')).toBeChecked();
+        await expect(locators.environment.varRowEnabledCheckbox('nullEnabledVar')).toBeChecked();
+        await expect(locators.environment.varRowEnabledCheckbox('disabledVar')).not.toBeChecked();
+      });
+    });
+  }
+});

--- a/tests/import/postman/fixtures/postman-collection-vars-mixed-disabled.json
+++ b/tests/import/postman/fixtures/postman-collection-vars-mixed-disabled.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "_postman_id": "vars-mixed-disabled-id",
+    "name": "Vars Mixed Disabled Collection",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Sample",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "https://example.com",
+          "protocol": "https",
+          "host": ["example", "com"]
+        }
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "enabledVar",
+      "value": "value1",
+      "type": "string"
+    },
+    {
+      "key": "disabledVar",
+      "value": "value2",
+      "type": "string",
+      "disabled": true
+    },
+    {
+      "key": "explicitlyEnabledVar",
+      "value": "value3",
+      "type": "string",
+      "disabled": false
+    }
+  ]
+}

--- a/tests/import/postman/import-collection-vars-disabled-state.spec.ts
+++ b/tests/import/postman/import-collection-vars-disabled-state.spec.ts
@@ -1,0 +1,35 @@
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import { buildCommonLocators, closeAllCollections, importCollection } from '../../utils/page';
+
+const collectionFile = path.join(__dirname, 'fixtures', 'postman-collection-vars-mixed-disabled.json');
+
+test.describe('Postman collection variable import preserves disabled state', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('collection variables: honors disabled=true and defaults missing/false disabled to enabled', async ({
+    page,
+    createTmpDir
+  }) => {
+    const locators = buildCommonLocators(page);
+    const tmpDir = await createTmpDir('postman-vars-mixed-disabled');
+
+    await importCollection(page, collectionFile, tmpDir, {
+      expectedCollectionName: 'Vars Mixed Disabled Collection'
+    });
+
+    await test.step('Open the Vars tab in collection settings', async () => {
+      await locators.paneTabs.collectionSettingsTab('vars').click();
+      await expect(locators.table('collection-vars-req').allRows().first()).toBeVisible();
+    });
+
+    await test.step('Enabled and explicitly-enabled rows are checked; disabled row is unchecked', async () => {
+      const varsTable = locators.table('collection-vars-req');
+      await expect(varsTable.rowCheckboxByName('enabledVar')).toBeChecked();
+      await expect(varsTable.rowCheckboxByName('explicitlyEnabledVar')).toBeChecked();
+      await expect(varsTable.rowCheckboxByName('disabledVar')).not.toBeChecked();
+    });
+  });
+});

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -718,6 +718,36 @@ const openEnvironmentConfigTab = async (page: Page, type: EnvironmentType = 'col
 };
 
 /**
+ * Import a Postman-format environment file into the given scope.
+ * @param page - The page object
+ * @param filePath - Path to the .postman_environment.json file
+ * @param type - Target scope ('collection' | 'global')
+ */
+const importEnvironment = async (
+  page: Page,
+  filePath: string,
+  type: EnvironmentType = 'collection'
+) => {
+  await test.step(`Import ${type} environment from "${filePath}"`, async () => {
+    const locators = buildCommonLocators(page);
+
+    await openEnvironmentSelector(page, type);
+    await locators.environment.importEmptyStateButton().click();
+    await expect(locators.environment.importModal(type)).toBeVisible();
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await locators.environment.importFileTrigger(type).click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(filePath);
+
+    const settingsTab = type === 'global'
+      ? locators.environment.globalEnvTab()
+      : locators.environment.collectionEnvTab();
+    await expect(settingsTab).toBeVisible();
+  });
+};
+
+/**
  * Create a new environment
  * @param page - The page object
  * @param environmentName - The name of the environment
@@ -2622,6 +2652,7 @@ export {
   createFolder,
   openEnvironmentSelector,
   openEnvironmentConfigTab,
+  importEnvironment,
   createEnvironment,
   addEnvironmentVariable,
   addEnvironmentVariables,

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -88,7 +88,18 @@ export const buildEnvironmentLocators = (page: Page) => ({
     closeWithoutSave: () => page.getByTestId('env-unsaved-close-without-save'),
     cancel: () => page.getByTestId('env-unsaved-cancel'),
     saveAndClose: () => page.getByTestId('env-unsaved-save-and-close')
-  }
+  },
+  importEmptyStateButton: () => page.getByTestId('empty-state-import-env-btn'),
+  importModal: (scope: 'collection' | 'global') =>
+    page.getByTestId(scope === 'global' ? 'import-global-environment-modal' : 'import-environment-modal'),
+  importFileTrigger: (scope: 'collection' | 'global') =>
+    page.getByTestId(scope === 'global' ? 'import-global-environment' : 'import-environment'),
+  sidebarListItem: (scope: 'collection' | 'global', name: string) =>
+    page
+      .getByTestId(scope === 'global' ? 'workspace-env-list-item' : 'collection-env-list-item')
+      .filter({ hasText: name }),
+  varRowEnabledCheckbox: (name: string) =>
+    page.getByTestId(`env-var-row-${name}`).getByTestId('env-var-enabled-checkbox')
 });
 
 /**

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -299,6 +299,8 @@ export const buildCommonLocators = (page: Page) => ({
         return row.getByTestId(`column-${columnKey}`);
       },
       rowCheckbox: (rowIndex: number) => getBodyRow(rowIndex).getByTestId('column-checkbox'),
+      rowCheckboxByName: (name: string) =>
+        container().locator(`tbody tr[data-row-name="${name}"]`).getByTestId('column-checkbox'),
       rowDeleteButton: (rowIndex: number) => getBodyRow(rowIndex).getByTestId('column-delete'),
       allRows: () => container().locator('tbody tr')
     };


### PR DESCRIPTION
Followup https://github.com/usebruno/bruno/pull/8681

### Description

- Postman ENV import to Bruno Global, Collection Env, now defaults to `true` when enabled key is undefined
- Updated the brunoToPostman and postmanToBruno functions to correctly handle the enabled state of collection variables. Disabled variables are now emitted with `disabled: true`, while enabled ones omit the field. Added tests to ensure the correct behaviour for both conversion directions.

### Problem

Enabled state is dropped when exporting, importing collection variables, postman treats absence of enabled key as true, but absence of enabled key cause failures while importing to bruno

### Fix

Honor enabled state which exporting and importing collection variables, Env variables enabled key default to true when it is missing in json exported from postman

| Before | After |
  | --- | --- |
  | <video src="https://github.com/user-attachments/assets/6883c8ad-c608-4041-b7e7-5991657b1797" width="400"></video> | <video src="https://github.com/user-attachments/assets/ad61ac19-08c0-4c02-9701-c671abb2b8bf" width="400"></video> |


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
