### PR TITLE
fix: support escaping colon in URL path params

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -1421,7 +1421,11 @@ export const extractVariableInfo = (str, variables) => {
     }
     variableValue = interpolate(get(variables, variableName), variables);
   } else if (str.startsWith('/:')) {
-    variableName = str.replace('/:', '').trim();
+    const rawName = str.replace('/:', '').trim();
+    // A `\:` marks the end of the param name; anything after is a literal
+    // suffix, not part of the variable (see parsePathParams in utils/url).
+    const escapeIdx = rawName.indexOf('\\:');
+    variableName = escapeIdx === -1 ? rawName : rawName.slice(0, escapeIdx);
     // Don't return empty variable names
     if (!variableName) {
       return { variableName: undefined, variableValue: undefined };

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -255,6 +255,24 @@ describe('extractVariableInfo', () => {
         variableValue: undefined
       });
     });
+
+    it('should only use the part before an escaped colon as the variable name', () => {
+      const result = extractVariableInfo('/:id\\:reactivate', mockVariables);
+
+      expect(result).toEqual({
+        variableName: 'id',
+        variableValue: 'user-123'
+      });
+    });
+
+    it('should return undefined for an escaped colon with no param name before it', () => {
+      const result = extractVariableInfo('/:\\:reactivate', mockVariables);
+
+      expect(result).toEqual({
+        variableName: undefined,
+        variableValue: undefined
+      });
+    });
   });
 
   describe('direct variable format', () => {

--- a/packages/bruno-app/src/utils/common/codemirror.js
+++ b/packages/bruno-app/src/utils/common/codemirror.js
@@ -58,6 +58,11 @@ export const defineCodeMirrorBrunoVariablesMode = (_variables, mode, highlightPa
           let ch;
           let word = '';
           while ((ch = stream.next()) != null) {
+            // `\:` marks the end of the param name; everything after is a literal, unhighlighted suffix
+            if (ch === '\\' && stream.peek() === ':') {
+              stream.backUp(1);
+              break;
+            }
             if (ch === '/' || ch === '?' || ch === '&' || ch === '=') {
               stream.backUp(1);
               const found = pathFoundInVariables(word, pathParams);

--- a/packages/bruno-app/src/utils/common/codemirror.spec.js
+++ b/packages/bruno-app/src/utils/common/codemirror.spec.js
@@ -1,0 +1,57 @@
+import CodeMirror from 'codemirror';
+import 'codemirror/addon/mode/overlay';
+import { defineCodeMirrorBrunoVariablesMode } from './codemirror';
+
+// Tokenizes `line` with the 'brunovariables' overlay mode and returns the
+// CSS token type CodeMirror assigned to each character (undefined = untouched).
+const tokenizeLine = (line, pathParams) => {
+  defineCodeMirrorBrunoVariablesMode({ pathParams }, 'text/plain', true, true);
+  const mode = CodeMirror.getMode({ indentUnit: 2 }, 'brunovariables');
+  const stream = new CodeMirror.StringStream(line);
+  const state = CodeMirror.startState(mode);
+  const types = [];
+
+  while (!stream.eol()) {
+    stream.start = stream.pos;
+    const start = stream.pos;
+    const type = mode.token(stream, state);
+    types.push({ text: line.slice(start, stream.pos), type });
+  }
+
+  return types;
+};
+
+describe('urlPathParamsOverlay (via brunovariables mode)', () => {
+  it('highlights the full path param when there is no escaped colon', () => {
+    const tokens = tokenizeLine('/:id', { id: '123' });
+
+    expect(tokens).toEqual([
+      { text: '/:id', type: expect.stringContaining('variable-valid') }
+    ]);
+  });
+
+  it('only highlights the name before an escaped colon, leaving the literal suffix untouched', () => {
+    const tokens = tokenizeLine('/:id\\:reactivate', { id: '123' });
+
+    expect(tokens[0]).toEqual({
+      text: '/:id',
+      type: expect.stringContaining('variable-valid')
+    });
+
+    const suffix = tokens
+      .slice(1)
+      .map((t) => t.text)
+      .join('');
+    expect(suffix).toBe('\\:reactivate');
+    tokens.slice(1).forEach((token) => expect(token.type).toBeFalsy());
+  });
+
+  it('marks an unresolved param name before the escaped colon as invalid', () => {
+    const tokens = tokenizeLine('/:unknown\\:literal', { id: '123' });
+
+    expect(tokens[0]).toEqual({
+      text: '/:unknown',
+      type: expect.stringContaining('variable-invalid')
+    });
+  });
+});

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -20,6 +20,24 @@ const hasLength = (str) => {
   return str.length > 0;
 };
 
+// A `\:` in the URL bar lets a user write a literal colon that shouldn't be
+// parsed as a path param (e.g. `:bar\:publish` -> param `bar` followed by
+// literal `:publish`). The WHATWG URL parser normalizes any *other* backslash
+// into an extra `/` for special schemes, so `\:` is swapped for this
+// alphanumeric placeholder before the URL is parsed, and swapped back to `:`
+// in the final string once parsing/splitting is done.
+const ESCAPED_COLON_TOKEN = 'zzzBRUNOESCAPEDCOLONzzz';
+const protectEscapedColons = (str) => str.replace(/\\:/g, ESCAPED_COLON_TOKEN);
+const restoreEscapedColons = (str) => str.split(ESCAPED_COLON_TOKEN).join(':');
+
+const splitEscapedParamName = (segment) => {
+  const escapeIdx = segment.indexOf(ESCAPED_COLON_TOKEN);
+  return {
+    name: escapeIdx === -1 ? segment.slice(1) : segment.slice(1, escapeIdx),
+    suffix: escapeIdx === -1 ? '' : segment.slice(escapeIdx)
+  };
+};
+
 const hasResolvablePathParamValue = (pathParam) => {
   if (!pathParam || pathParam.enabled === false) {
     return false;
@@ -45,6 +63,8 @@ export const parsePathParams = (url) => {
     return [];
   }
 
+  uri = protectEscapedColons(uri);
+
   if (!uri.startsWith('http://') && !uri.startsWith('https://')) {
     uri = `http://${uri}`;
   }
@@ -63,7 +83,7 @@ export const parsePathParams = (url) => {
   paths.forEach((segment) => {
     // traditional path parameters
     if (segment.startsWith(':')) {
-      const name = segment.slice(1);
+      const { name } = splitEscapedParamName(segment);
       if (name && !foundParams.has(name)) {
         foundParams.add(name);
       }
@@ -177,10 +197,12 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
       .map((segment) => {
         // traditional path parameters
         if (segment.startsWith(':')) {
-          const name = segment.slice(1);
+          const { name, suffix } = splitEscapedParamName(segment);
           const pathParam = params.find((p) => p?.name === name && p?.type === 'path');
-          return hasResolvablePathParamValue(pathParam) ? substituteValue(pathParam.value) : segment;
-          // return pathParam ? substituteValue(pathParam.value) : segment;
+          if (!hasResolvablePathParamValue(pathParam)) {
+            return segment;
+          }
+          return substituteValue(pathParam.value) + suffix;
         }
 
         // for OData-style parameters (parameters inside parentheses)
@@ -218,12 +240,16 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
     url = `http://${url}`;
   }
 
+  // Protect user-typed `\:` before any URL parsing/splitting below, then restore
+  // it as a literal `:` on every return path.
+  url = protectEscapedColons(url);
+
   // When raw is true, resolve :params via pure string manipulation without
   // passing through new URL(), which would percent-encode characters like spaces.
   // This preserves the user's original encoding choices for snippet generation.
   if (options.raw) {
     const enabledPathParams = (params || []).filter((p) => p.enabled !== false && p.type === 'path');
-    if (enabledPathParams.length === 0) return url;
+    if (enabledPathParams.length === 0) return restoreEscapedColons(url);
 
     const separatorIdx = url.search(/[?#]/);
     const pathPart = separatorIdx >= 0 ? url.substring(0, separatorIdx) : url;
@@ -231,7 +257,7 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
 
     // resolvedPath includes the origin (scheme + host) since pathPart is the full URL before ?/#
     const resolvedPath = getInterpolatedBasePath(pathPart, enabledPathParams);
-    return `${resolvedPath}${rest}`;
+    return restoreEscapedColons(`${resolvedPath}${rest}`);
   }
 
   let uri;
@@ -240,10 +266,10 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
     uri = new URL(url);
   } catch (error) {
     // if the URL is invalid, return the URL as is
-    return url;
+    return restoreEscapedColons(url);
   }
 
   const basePath = getInterpolatedBasePath(uri.pathname, params);
 
-  return `${uri.origin}${basePath}${uri?.search || ''}`;
+  return restoreEscapedColons(`${uri.origin}${basePath}${uri?.search || ''}`);
 };

--- a/packages/bruno-app/src/utils/url/index.js
+++ b/packages/bruno-app/src/utils/url/index.js
@@ -23,15 +23,22 @@ const hasLength = (str) => {
 // A `\:` in the URL bar lets a user write a literal colon that shouldn't be
 // parsed as a path param (e.g. `:bar\:publish` -> param `bar` followed by
 // literal `:publish`). The WHATWG URL parser normalizes any *other* backslash
-// into an extra `/` for special schemes, so `\:` is swapped for this
-// alphanumeric placeholder before the URL is parsed, and swapped back to `:`
-// in the final string once parsing/splitting is done.
-const ESCAPED_COLON_TOKEN = 'zzzBRUNOESCAPEDCOLONzzz';
-const protectEscapedColons = (str) => str.replace(/\\:/g, ESCAPED_COLON_TOKEN);
-const restoreEscapedColons = (str) => str.split(ESCAPED_COLON_TOKEN).join(':');
+// into an extra `/` for special schemes, so `\:` is swapped for an alphanumeric
+// placeholder token before the URL is parsed, and swapped back to `:` in the
+// final string once parsing/splitting is done. The token is generated per call
+// and verified absent from the input, so it can never collide with real content.
+const makeEscapedColonToken = (str) => {
+  let token;
+  do {
+    token = `zzzBRUNOESCAPEDCOLON${Math.random().toString(36).slice(2)}zzz`;
+  } while (str.includes(token));
+  return token;
+};
+const protectEscapedColons = (str, token) => str.replace(/\\:/g, token);
+const restoreEscapedColons = (str, token) => str.split(token).join(':');
 
-const splitEscapedParamName = (segment) => {
-  const escapeIdx = segment.indexOf(ESCAPED_COLON_TOKEN);
+const splitEscapedParamName = (segment, token) => {
+  const escapeIdx = segment.indexOf(token);
   return {
     name: escapeIdx === -1 ? segment.slice(1) : segment.slice(1, escapeIdx),
     suffix: escapeIdx === -1 ? '' : segment.slice(escapeIdx)
@@ -63,7 +70,8 @@ export const parsePathParams = (url) => {
     return [];
   }
 
-  uri = protectEscapedColons(uri);
+  const token = makeEscapedColonToken(uri);
+  uri = protectEscapedColons(uri, token);
 
   if (!uri.startsWith('http://') && !uri.startsWith('https://')) {
     uri = `http://${uri}`;
@@ -83,7 +91,7 @@ export const parsePathParams = (url) => {
   paths.forEach((segment) => {
     // traditional path parameters
     if (segment.startsWith(':')) {
-      const { name } = splitEscapedParamName(segment);
+      const { name } = splitEscapedParamName(segment, token);
       if (name && !foundParams.has(name)) {
         foundParams.add(name);
       }
@@ -191,13 +199,13 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
     return options.encodeUrl ? encodeURIComponent(v) : v;
   };
 
-  const getInterpolatedBasePath = (pathname, params) => {
+  const getInterpolatedBasePath = (pathname, params, token) => {
     let replacedPathname = pathname
       .split('/')
       .map((segment) => {
         // traditional path parameters
         if (segment.startsWith(':')) {
-          const { name, suffix } = splitEscapedParamName(segment);
+          const { name, suffix } = splitEscapedParamName(segment, token);
           const pathParam = params.find((p) => p?.name === name && p?.type === 'path');
           if (!hasResolvablePathParamValue(pathParam)) {
             return segment;
@@ -242,22 +250,23 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
 
   // Protect user-typed `\:` before any URL parsing/splitting below, then restore
   // it as a literal `:` on every return path.
-  url = protectEscapedColons(url);
+  const escapedColonToken = makeEscapedColonToken(url);
+  url = protectEscapedColons(url, escapedColonToken);
 
   // When raw is true, resolve :params via pure string manipulation without
   // passing through new URL(), which would percent-encode characters like spaces.
   // This preserves the user's original encoding choices for snippet generation.
   if (options.raw) {
     const enabledPathParams = (params || []).filter((p) => p.enabled !== false && p.type === 'path');
-    if (enabledPathParams.length === 0) return restoreEscapedColons(url);
+    if (enabledPathParams.length === 0) return restoreEscapedColons(url, escapedColonToken);
 
     const separatorIdx = url.search(/[?#]/);
     const pathPart = separatorIdx >= 0 ? url.substring(0, separatorIdx) : url;
     const rest = separatorIdx >= 0 ? url.substring(separatorIdx) : '';
 
     // resolvedPath includes the origin (scheme + host) since pathPart is the full URL before ?/#
-    const resolvedPath = getInterpolatedBasePath(pathPart, enabledPathParams);
-    return restoreEscapedColons(`${resolvedPath}${rest}`);
+    const resolvedPath = getInterpolatedBasePath(pathPart, enabledPathParams, escapedColonToken);
+    return restoreEscapedColons(`${resolvedPath}${rest}`, escapedColonToken);
   }
 
   let uri;
@@ -266,10 +275,10 @@ export const interpolateUrlPathParams = (url, params, variables = {}, options = 
     uri = new URL(url);
   } catch (error) {
     // if the URL is invalid, return the URL as is
-    return restoreEscapedColons(url);
+    return restoreEscapedColons(url, escapedColonToken);
   }
 
-  const basePath = getInterpolatedBasePath(uri.pathname, params);
+  const basePath = getInterpolatedBasePath(uri.pathname, params, escapedColonToken);
 
-  return restoreEscapedColons(`${uri.origin}${basePath}${uri?.search || ''}`);
+  return restoreEscapedColons(`${uri.origin}${basePath}${uri?.search || ''}`, escapedColonToken);
 };

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -477,6 +477,18 @@ describe('Url Utils - interpolateUrl, interpolateUrlPathParams', () => {
 
     expect(result).toEqual('https://example.com/foo/:literal');
   });
+
+  it('should not corrupt a path param value that looks like the internal escape placeholder', () => {
+    const url = 'https://example.com/:foo/:bar\\:publish';
+    const params = [
+      { name: 'foo', type: 'path', enabled: true, value: 'zzzBRUNOESCAPEDCOLONabc123zzz' },
+      { name: 'bar', type: 'path', enabled: true, value: 'b' }
+    ];
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual('https://example.com/zzzBRUNOESCAPEDCOLONabc123zzz/b:publish');
+  });
 });
 
 describe('Url Utils - interpolateUrlPathParams with { raw: true }', () => {

--- a/packages/bruno-app/src/utils/url/index.spec.js
+++ b/packages/bruno-app/src/utils/url/index.spec.js
@@ -186,6 +186,19 @@ describe('Url Utils - parsePathParams', () => {
     const params = parsePathParams('https://example.com/start/1:2:AHLS-HASD/form');
     expect(params).toEqual([]);
   });
+
+  it('should support escaping a colon that follows a path param in the same segment', () => {
+    const params = parsePathParams('https://example.com/:foo/:bar\\:publish');
+    expect(params).toEqual([
+      { name: 'foo', value: '' },
+      { name: 'bar', value: '' }
+    ]);
+  });
+
+  it('should NOT treat an escaped colon segment as a path param', () => {
+    const params = parsePathParams('https://example.com/foo/\\:literal');
+    expect(params).toEqual([]);
+  });
 });
 
 describe('Url Utils - URN parsing', () => {
@@ -434,6 +447,35 @@ describe('Url Utils - interpolateUrl, interpolateUrlPathParams', () => {
     const result = interpolateUrlPathParams(url, []);
 
     expect(result).toEqual('https://httpbin.org/anything/:analyze-text');
+  });
+
+  it('should support an escaped colon after a resolved path param', () => {
+    const url = 'https://example.com/:foo/:bar\\:publish';
+    const params = [
+      { name: 'foo', type: 'path', enabled: true, value: 'a' },
+      { name: 'bar', type: 'path', enabled: true, value: 'b' }
+    ];
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual('https://example.com/a/b:publish');
+  });
+
+  it('should keep the escaped colon segment unchanged when the path param has no value', () => {
+    const url = 'https://example.com/:bar\\:publish';
+    const params = [{ name: 'bar', type: 'path', enabled: true, value: '' }];
+
+    const result = interpolateUrlPathParams(url, params);
+
+    expect(result).toEqual('https://example.com/:bar:publish');
+  });
+
+  it('should resolve a fully escaped literal segment to a plain colon', () => {
+    const url = 'https://example.com/foo/\\:literal';
+
+    const result = interpolateUrlPathParams(url, []);
+
+    expect(result).toEqual('https://example.com/foo/:literal');
   });
 });
 

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -34,6 +34,23 @@ const getContentType = (headers = {}) => {
   return typeof contentType === 'string' ? contentType : '';
 };
 
+// A `\:` in the URL lets a user write a literal colon that shouldn't be parsed as a
+// path param (e.g. `:bar\:publish` -> param `bar` followed by literal `:publish`). The
+// WHATWG URL parser normalizes any *other* backslash into an extra `/` for special
+// schemes, so `\:` is swapped for this alphanumeric placeholder before the URL is
+// parsed, and swapped back to `:` in the final string once parsing/splitting is done.
+const ESCAPED_COLON_TOKEN = 'zzzBRUNOESCAPEDCOLONzzz';
+const protectEscapedColons = (str) => str.replace(/\\:/g, ESCAPED_COLON_TOKEN);
+const restoreEscapedColons = (str) => str.split(ESCAPED_COLON_TOKEN).join(':');
+
+const splitEscapedParamName = (path) => {
+  const escapeIdx = path.indexOf(ESCAPED_COLON_TOKEN);
+  return {
+    name: escapeIdx === -1 ? path.slice(1) : path.slice(1, escapeIdx),
+    suffix: escapeIdx === -1 ? '' : path.slice(escapeIdx)
+  };
+};
+
 const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, processEnvVars = {}) => {
   const globalEnvironmentVariables = request?.globalEnvironmentVariables || {};
   const collectionVariables = request?.collectionVariables || {};
@@ -139,12 +156,17 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     param.value = _interpolate(param.value);
   });
 
-  if (request?.pathParams?.length) {
+  // an escaped colon can appear even without any configured path params
+  const hasEscapedColon = typeof request.url === 'string' && request.url.includes('\\:');
+
+  if (request?.pathParams?.length || hasEscapedColon) {
+    const pathParams = request.pathParams || [];
     let url = request.url;
 
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
       url = `http://${url}`;
     }
+    url = protectEscapedColons(url);
 
     try {
       url = new URL(url);
@@ -158,12 +180,12 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .map((path) => {
         // traditional path parameters
         if (path.startsWith(':')) {
-          const paramName = path.slice(1);
-          const existingPathParam = request.pathParams.find((param) => param.name === paramName);
+          const { name: paramName, suffix } = splitEscapedParamName(path);
+          const existingPathParam = pathParams.find((param) => param.name === paramName);
           if (!hasResolvablePathParamValue(existingPathParam)) {
             return '/' + path;
           }
-          return '/' + existingPathParam.value;
+          return '/' + existingPathParam.value + suffix;
         }
 
         // for OData-style parameters (parameters inside parentheses)
@@ -180,7 +202,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
               let name = match[1].replace(/[')"`]+$/, '');
               name = name.replace(/^[('"`]+/, '');
               if (name) {
-                const existingPathParam = request.pathParams.find((param) => param.name === name);
+                const existingPathParam = pathParams.find((param) => param.name === name);
                 if (hasResolvablePathParamValue(existingPathParam)) {
                   result = result.replace(':' + match[1], existingPathParam.value);
                 }
@@ -194,7 +216,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .join('');
 
     const trailingSlash = url.pathname.endsWith('/') ? '/' : '';
-    request.url = url.origin + interpolatedUrlPath + trailingSlash + url.search;
+    request.url = restoreEscapedColons(url.origin + interpolatedUrlPath + trailingSlash + url.search);
   }
 
   if (request.proxy) {

--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -37,14 +37,22 @@ const getContentType = (headers = {}) => {
 // A `\:` in the URL lets a user write a literal colon that shouldn't be parsed as a
 // path param (e.g. `:bar\:publish` -> param `bar` followed by literal `:publish`). The
 // WHATWG URL parser normalizes any *other* backslash into an extra `/` for special
-// schemes, so `\:` is swapped for this alphanumeric placeholder before the URL is
+// schemes, so `\:` is swapped for an alphanumeric placeholder token before the URL is
 // parsed, and swapped back to `:` in the final string once parsing/splitting is done.
-const ESCAPED_COLON_TOKEN = 'zzzBRUNOESCAPEDCOLONzzz';
-const protectEscapedColons = (str) => str.replace(/\\:/g, ESCAPED_COLON_TOKEN);
-const restoreEscapedColons = (str) => str.split(ESCAPED_COLON_TOKEN).join(':');
+// The token is generated per call and verified absent from the input, so it can never
+// collide with real content.
+const makeEscapedColonToken = (str) => {
+  let token;
+  do {
+    token = `zzzBRUNOESCAPEDCOLON${Math.random().toString(36).slice(2)}zzz`;
+  } while (str.includes(token));
+  return token;
+};
+const protectEscapedColons = (str, token) => str.replace(/\\:/g, token);
+const restoreEscapedColons = (str, token) => str.split(token).join(':');
 
-const splitEscapedParamName = (path) => {
-  const escapeIdx = path.indexOf(ESCAPED_COLON_TOKEN);
+const splitEscapedParamName = (path, token) => {
+  const escapeIdx = path.indexOf(token);
   return {
     name: escapeIdx === -1 ? path.slice(1) : path.slice(1, escapeIdx),
     suffix: escapeIdx === -1 ? '' : path.slice(escapeIdx)
@@ -166,7 +174,8 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
       url = `http://${url}`;
     }
-    url = protectEscapedColons(url);
+    const token = makeEscapedColonToken(url);
+    url = protectEscapedColons(url, token);
 
     try {
       url = new URL(url);
@@ -180,7 +189,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .map((path) => {
         // traditional path parameters
         if (path.startsWith(':')) {
-          const { name: paramName, suffix } = splitEscapedParamName(path);
+          const { name: paramName, suffix } = splitEscapedParamName(path, token);
           const existingPathParam = pathParams.find((param) => param.name === paramName);
           if (!hasResolvablePathParamValue(existingPathParam)) {
             return '/' + path;
@@ -216,7 +225,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .join('');
 
     const trailingSlash = url.pathname.endsWith('/') ? '/' : '';
-    request.url = restoreEscapedColons(url.origin + interpolatedUrlPath + trailingSlash + url.search);
+    request.url = restoreEscapedColons(url.origin + interpolatedUrlPath + trailingSlash + url.search, token);
   }
 
   if (request.proxy) {

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -98,6 +98,20 @@ describe('interpolate-vars: path params', () => {
     const result = interpolateVars(request, {}, null, null);
     expect(result.url).toBe('https://example.com/foo/:literal');
   });
+
+  it('does not corrupt a path param value that looks like the internal escape placeholder', () => {
+    const request = {
+      method: 'GET',
+      url: 'https://example.com/:foo/:bar\\:publish',
+      pathParams: [
+        { type: 'path', name: 'foo', value: 'zzzBRUNOESCAPEDCOLONabc123zzz' },
+        { type: 'path', name: 'bar', value: 'b' }
+      ]
+    };
+
+    const result = interpolateVars(request, {}, null, null);
+    expect(result.url).toBe('https://example.com/zzzBRUNOESCAPEDCOLONabc123zzz/b:publish');
+  });
 });
 
 describe('interpolate-vars: api key header name sidecar', () => {

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -73,6 +73,33 @@ describe('interpolate-vars: interpolateVars', () => {
   });
 });
 
+describe('interpolate-vars: path params', () => {
+  it('supports an escaped colon after a resolved path param (issue #3810)', () => {
+    const request = {
+      method: 'GET',
+      url: 'https://example.com/:foo/:bar\\:publish',
+      pathParams: [
+        { type: 'path', name: 'foo', value: 'a' },
+        { type: 'path', name: 'bar', value: 'b' }
+      ]
+    };
+
+    const result = interpolateVars(request, {}, null, null);
+    expect(result.url).toBe('https://example.com/a/b:publish');
+  });
+
+  it('resolves an escaped colon literal even without any configured path params', () => {
+    const request = {
+      method: 'GET',
+      url: 'https://example.com/foo/\\:literal',
+      pathParams: []
+    };
+
+    const result = interpolateVars(request, {}, null, null);
+    expect(result.url).toBe('https://example.com/foo/:literal');
+  });
+});
+
 describe('interpolate-vars: api key header name sidecar', () => {
   it('interpolates apiKeyHeaderName in lockstep with interpolated header keys', () => {
     const request = {

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -41,14 +41,22 @@ const getRawQueryString = (url) => {
 // A `\:` in the URL lets a user write a literal colon that shouldn't be parsed as a
 // path param (e.g. `:bar\:publish` -> param `bar` followed by literal `:publish`). The
 // WHATWG URL parser normalizes any *other* backslash into an extra `/` for special
-// schemes, so `\:` is swapped for this alphanumeric placeholder before the URL is
+// schemes, so `\:` is swapped for an alphanumeric placeholder token before the URL is
 // parsed, and swapped back to `:` in the final string once parsing/splitting is done.
-const ESCAPED_COLON_TOKEN = 'zzzBRUNOESCAPEDCOLONzzz';
-const protectEscapedColons = (str) => str.replace(/\\:/g, ESCAPED_COLON_TOKEN);
-const restoreEscapedColons = (str) => str.split(ESCAPED_COLON_TOKEN).join(':');
+// The token is generated per call and verified absent from the input, so it can never
+// collide with real content.
+const makeEscapedColonToken = (str) => {
+  let token;
+  do {
+    token = `zzzBRUNOESCAPEDCOLON${Math.random().toString(36).slice(2)}zzz`;
+  } while (str.includes(token));
+  return token;
+};
+const protectEscapedColons = (str, token) => str.replace(/\\:/g, token);
+const restoreEscapedColons = (str, token) => str.split(token).join(':');
 
-const splitEscapedParamName = (path) => {
-  const escapeIdx = path.indexOf(ESCAPED_COLON_TOKEN);
+const splitEscapedParamName = (path, token) => {
+  const escapeIdx = path.indexOf(token);
   return {
     name: escapeIdx === -1 ? path.slice(1) : path.slice(1, escapeIdx),
     suffix: escapeIdx === -1 ? '' : path.slice(escapeIdx)
@@ -200,11 +208,13 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
   if (request?.pathParams?.length || hasEscapedColon) {
     const pathParams = request.pathParams || [];
     let url = request.url;
-    const urlSearchRaw = getRawQueryString(request.url);
+    let urlSearchRaw = getRawQueryString(request.url);
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
       url = `http://${url}`;
     }
-    url = protectEscapedColons(url);
+    const token = makeEscapedColonToken(url);
+    url = protectEscapedColons(url, token);
+    urlSearchRaw = protectEscapedColons(urlSearchRaw, token);
 
     try {
       url = new URL(url);
@@ -218,7 +228,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .map((path) => {
         // traditional path parameters
         if (path.startsWith(':')) {
-          const { name: paramName, suffix } = splitEscapedParamName(path);
+          const { name: paramName, suffix } = splitEscapedParamName(path, token);
           const existingPathParam = pathParams.find((param) => param.name === paramName);
           if (!hasResolvablePathParamValue(existingPathParam)) {
             return '/' + path;
@@ -254,7 +264,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .join('');
 
     const trailingSlash = url.pathname.endsWith('/') ? '/' : '';
-    request.url = restoreEscapedColons(url.origin + urlPathnameInterpolatedWithPathParams + trailingSlash + urlSearchRaw);
+    request.url = restoreEscapedColons(url.origin + urlPathnameInterpolatedWithPathParams + trailingSlash + urlSearchRaw, token);
   }
 
   if (request.proxy) {

--- a/packages/bruno-electron/src/ipc/network/interpolate-vars.js
+++ b/packages/bruno-electron/src/ipc/network/interpolate-vars.js
@@ -38,6 +38,23 @@ const getRawQueryString = (url) => {
   return queryIndex !== -1 ? url.slice(queryIndex) : '';
 };
 
+// A `\:` in the URL lets a user write a literal colon that shouldn't be parsed as a
+// path param (e.g. `:bar\:publish` -> param `bar` followed by literal `:publish`). The
+// WHATWG URL parser normalizes any *other* backslash into an extra `/` for special
+// schemes, so `\:` is swapped for this alphanumeric placeholder before the URL is
+// parsed, and swapped back to `:` in the final string once parsing/splitting is done.
+const ESCAPED_COLON_TOKEN = 'zzzBRUNOESCAPEDCOLONzzz';
+const protectEscapedColons = (str) => str.replace(/\\:/g, ESCAPED_COLON_TOKEN);
+const restoreEscapedColons = (str) => str.split(ESCAPED_COLON_TOKEN).join(':');
+
+const splitEscapedParamName = (path) => {
+  const escapeIdx = path.indexOf(ESCAPED_COLON_TOKEN);
+  return {
+    name: escapeIdx === -1 ? path.slice(1) : path.slice(1, escapeIdx),
+    suffix: escapeIdx === -1 ? '' : path.slice(escapeIdx)
+  };
+};
+
 const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, processEnvVars = {}, promptVariables = {}) => {
   const globalEnvironmentVariables = request?.globalEnvironmentVariables || {};
   const oauth2CredentialVariables = request?.oauth2CredentialVariables || {};
@@ -177,12 +194,17 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     param.value = _interpolate(param.value);
   });
 
-  if (request?.pathParams?.length) {
+  // an escaped colon can appear even without any configured path params
+  const hasEscapedColon = typeof request.url === 'string' && request.url.includes('\\:');
+
+  if (request?.pathParams?.length || hasEscapedColon) {
+    const pathParams = request.pathParams || [];
     let url = request.url;
     const urlSearchRaw = getRawQueryString(request.url);
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
       url = `http://${url}`;
     }
+    url = protectEscapedColons(url);
 
     try {
       url = new URL(url);
@@ -196,12 +218,12 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .map((path) => {
         // traditional path parameters
         if (path.startsWith(':')) {
-          const paramName = path.slice(1);
-          const existingPathParam = request.pathParams.find((param) => param.name === paramName);
+          const { name: paramName, suffix } = splitEscapedParamName(path);
+          const existingPathParam = pathParams.find((param) => param.name === paramName);
           if (!hasResolvablePathParamValue(existingPathParam)) {
             return '/' + path;
           }
-          return '/' + existingPathParam.value;
+          return '/' + existingPathParam.value + suffix;
         }
 
         // for OData-style parameters (parameters inside parentheses)
@@ -218,7 +240,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
               let name = match[1].replace(/[')"`]+$/, '');
               name = name.replace(/^[('"`]+/, '');
               if (name) {
-                const existingPathParam = request.pathParams.find((param) => param.name === name);
+                const existingPathParam = pathParams.find((param) => param.name === name);
                 if (hasResolvablePathParamValue(existingPathParam)) {
                   result = result.replace(':' + match[1], existingPathParam.value);
                 }
@@ -232,7 +254,7 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
       .join('');
 
     const trailingSlash = url.pathname.endsWith('/') ? '/' : '';
-    request.url = url.origin + urlPathnameInterpolatedWithPathParams + trailingSlash + urlSearchRaw;
+    request.url = restoreEscapedColons(url.origin + urlPathnameInterpolatedWithPathParams + trailingSlash + urlSearchRaw);
   }
 
   if (request.proxy) {

--- a/packages/bruno-electron/tests/network/interpolate-vars.spec.js
+++ b/packages/bruno-electron/tests/network/interpolate-vars.spec.js
@@ -241,6 +241,31 @@ describe('interpolate-vars: interpolateVars', () => {
         const result = interpolateVars(request, null, null, null);
         expect(result.url).toBe('https://example.com/foo/:literal');
       });
+
+      it('does not corrupt a path param value that looks like the internal escape placeholder', async () => {
+        const request = {
+          method: 'GET',
+          url: 'https://example.com/:foo/:bar\\:publish',
+          pathParams: [
+            { type: 'path', name: 'foo', value: 'zzzBRUNOESCAPEDCOLONabc123zzz' },
+            { type: 'path', name: 'bar', value: 'b' }
+          ]
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('https://example.com/zzzBRUNOESCAPEDCOLONabc123zzz/b:publish');
+      });
+
+      it('resolves an escaped colon in the query string', async () => {
+        const request = {
+          method: 'GET',
+          url: 'https://example.com/:foo?q=a\\:b',
+          pathParams: [{ type: 'path', name: 'foo', value: 'x' }]
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('https://example.com/x?q=a:b');
+      });
     });
 
     describe('With process environment variables', () => {

--- a/packages/bruno-electron/tests/network/interpolate-vars.spec.js
+++ b/packages/bruno-electron/tests/network/interpolate-vars.spec.js
@@ -216,6 +216,31 @@ describe('interpolate-vars: interpolateVars', () => {
         const result = interpolateVars(request, null, null, null);
         expect(result.url).toBe('https://httpbin.org/anything/:test-segment');
       });
+
+      it('supports an escaped colon after a resolved path param (issue #3810)', async () => {
+        const request = {
+          method: 'GET',
+          url: 'https://example.com/:foo/:bar\\:publish',
+          pathParams: [
+            { type: 'path', name: 'foo', value: 'a' },
+            { type: 'path', name: 'bar', value: 'b' }
+          ]
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('https://example.com/a/b:publish');
+      });
+
+      it('resolves an escaped colon literal even without any configured path params', async () => {
+        const request = {
+          method: 'GET',
+          url: 'https://example.com/foo/\\:literal',
+          pathParams: []
+        };
+
+        const result = interpolateVars(request, null, null, null);
+        expect(result.url).toBe('https://example.com/foo/:literal');
+      });
     });
 
     describe('With process environment variables', () => {


### PR DESCRIPTION
Ref: BRU-3736

### Description

Adds support for escaping a literal `:` in a URL segment with `\:`, so it isn't mistaken for the start of a path param. For example `/schedules/:id\:reactivate` now resolves to a path param `id` followed by the literal suffix `:reactivate`, instead of `reactivate` being wrongly parsed as another path param.

This kind of literal colon shows up when APIs follow the [custom methods convention from Google AIP-136](https://google.aip.dev/136) (e.g. `POST /v1/schedules/{id}:reactivate`), where `:` is used to suffix a resource path with a custom method name rather than to declare a new path variable.

### Problem

Closes #3810

Bruno's URL bar always treated `:` as the start of a path param, so URLs like `/schedules/:id:reactivate` (AIP-136 style custom methods) couldn't be expressed correctly — `reactivate` was parsed as its own (empty) path param.

### Fix

- `\:` is now recognized as an escaped, literal colon across the whole path-param pipeline:
  - `packages/bruno-app/src/utils/url/index.js`: `parsePathParams` / `interpolateUrlPathParams` (Params tab + URL bar preview + code snippets)
  - `packages/bruno-electron/src/ipc/network/interpolate-vars.js`: actual GUI request sending
  - `packages/bruno-cli/src/runner/interpolate-vars.js`: actual CLI/runner request sending
  - `packages/bruno-app/src/utils/codemirror/brunoVarInfo.js`: variable info tooltip now only validates/looks up the name before the escaped colon
  - `packages/bruno-app/src/utils/common/codemirror.js`: URL bar syntax highlighting now only colors the param name, leaving the literal `\:suffix` unstyled
- Added/updated unit tests in all of the above.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  | <img width="1330" height="348" alt="Capture d’écran du 2026-08-10 13-20-43" src="https://github.com/user-attachments/assets/294182d2-4336-4e7f-8fd9-075cd07f764a" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path parameters containing escaped colons (`\:`).
  * Preserved escaped colons as literal characters during URL parsing and interpolation.
  * Retained suffixes after escaped colons without including them in parameter names.
  * Improved handling of standalone escaped-colon segments and unresolved parameters.
  * Updated syntax highlighting so escaped-colon suffixes are not incorrectly highlighted as parameters.

* **Tests**
  * Added coverage for escaped colons across URL parsing, interpolation, query parameters, and editor highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->