### PR TITLE
feat(CI-OAuth2): add Keycloak IdP setup and OAuth2 state validation e2e tests

### DIFF
--- a/.github/actions/auth/oauth2/collect-keycloak-logs/action.yml
+++ b/.github/actions/auth/oauth2/collect-keycloak-logs/action.yml
@@ -1,0 +1,33 @@
+name: 'Collect Keycloak Logs'
+description: 'Stage and upload the Keycloak server logs from an OAuth2 e2e run (Linux, macOS, Windows)'
+
+inputs:
+  artifact-suffix:
+    description: 'Suffix for the uploaded log artifact name (linux, macos, windows)'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # Keycloak logs live in RUNNER_TEMP (outside the workspace), so stage them into the
+    # workspace where upload-artifact can pick them up. bash is available on all three runner
+    # OSes (Git Bash on Windows), so one script covers them all.
+    - name: Stage Keycloak logs
+      shell: bash
+      run: |
+        set -uo pipefail
+        mkdir -p keycloak-logs
+        shopt -s nullglob
+        logs=("$RUNNER_TEMP"/keycloak*.log)
+        if (( ${#logs[@]} )); then
+          cp "${logs[@]}" keycloak-logs/
+        else
+          echo "No Keycloak logs found in $RUNNER_TEMP."
+        fi
+
+    - name: Upload Keycloak logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: keycloak-logs-oauth2-${{ inputs.artifact-suffix }}
+        path: keycloak-logs/
+        retention-days: 30

--- a/.github/actions/auth/oauth2/run-oauth2-e2e-tests/action.yml
+++ b/.github/actions/auth/oauth2/run-oauth2-e2e-tests/action.yml
@@ -1,0 +1,79 @@
+name: 'Run OAuth2 E2E Tests'
+description: 'Start Keycloak and run the OAuth2 (Keycloak) E2E tests on Linux, macOS and Windows'
+
+inputs:
+  use-xvfb:
+    description: 'Wrap the test run in xvfb-run (needed on headless Linux)'
+    required: false
+    default: 'false'
+  port:
+    description: 'HTTP port Keycloak listens on'
+    required: false
+    default: '8090'
+  artifact-suffix:
+    description: 'Suffix for the uploaded Playwright report artifact name (linux, macos, windows)'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # Keycloak is started HERE — in the same step as the tests — on purpose. On Windows,
+    # GitHub Actions kills a step's child-process tree when the step ends (Job Object), so a
+    # server started in an earlier step is dead by the time tests run. Doing the same on every
+    # OS keeps a single script. KC_HOME comes from the setup-keycloak step. bash is available
+    # on all three runner OSes (Git Bash on Windows); kc.bat vs kc.sh is the only OS switch.
+    - name: Start Keycloak and run OAuth2 E2E tests
+      shell: bash
+      env:
+        USE_XVFB: ${{ inputs.use-xvfb }}
+        KEYCLOAK_PORT: ${{ inputs.port }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${KC_HOME:-}" ]; then
+          echo "::error::KC_HOME is not set; setup-keycloak must run first"
+          exit 1
+        fi
+
+        if [ "${RUNNER_OS}" = "Windows" ]; then
+          kc_bin="${KC_HOME}/bin/kc.bat"
+        else
+          kc_bin="${KC_HOME}/bin/kc.sh"
+        fi
+        log="${RUNNER_TEMP}/keycloak.log"
+
+        "${kc_bin}" start-dev --http-port="${KEYCLOAK_PORT}" --import-realm > "${log}" 2>&1 &
+        kc_pid=$!
+        trap 'kill "${kc_pid}" 2>/dev/null || true' EXIT
+
+        echo "Waiting for Keycloak (realm bruno) on :${KEYCLOAK_PORT} ..."
+        ready=false
+        for i in $(seq 1 60); do
+          if curl -fsS "http://127.0.0.1:${KEYCLOAK_PORT}/realms/bruno/.well-known/openid-configuration" > /dev/null 2>&1; then
+            ready=true
+            break
+          fi
+          sleep 2
+        done
+        if [ "${ready}" != "true" ]; then
+          echo "::error::Keycloak did not become ready in time"
+          tail -n 100 "${log}" || true
+          exit 1
+        fi
+        echo "Keycloak is ready."
+
+        if [ "${USE_XVFB}" = "true" ]; then
+          xvfb-run npm run test:e2e:auth:oauth2
+        else
+          npm run test:e2e:auth:oauth2
+        fi
+
+    - name: Upload Playwright Report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-oauth2-${{ inputs.artifact-suffix }}
+        path: |
+          playwright-report/
+          test-results/
+        retention-days: 30

--- a/.github/actions/auth/oauth2/setup-keycloak/action.yml
+++ b/.github/actions/auth/oauth2/setup-keycloak/action.yml
@@ -21,8 +21,7 @@ runs:
     # step completes — so a server started in this step would be killed before the test step
     # runs. It is downloaded/prepared here and started in the shared step that runs the tests
     # (run-oauth2-e2e-tests). KC_HOME is exported for that step. bash is available on all three
-    # runner OSes (Git Bash on Windows). Keycloak ships a .tar.gz alongside the .zip, which every
-    # runner's tar can extract. The archive is addressed by a relative name from inside
+    # runner OSes (Git Bash on Windows). The tarball is addressed by a relative name from inside
     # RUNNER_TEMP because GNU tar (Linux, Git Bash) reads the colon in a Windows path such as
     # D:\a\_temp\keycloak.tar.gz as a remote host and fails with "Cannot connect to D".
     - name: Download and prepare Keycloak

--- a/.github/actions/auth/oauth2/setup-keycloak/action.yml
+++ b/.github/actions/auth/oauth2/setup-keycloak/action.yml
@@ -21,7 +21,8 @@ runs:
     # step completes — so a server started in this step would be killed before the test step
     # runs. It is downloaded/prepared here and started in the shared step that runs the tests
     # (run-oauth2-e2e-tests). KC_HOME is exported for that step. bash is available on all three
-    # runner OSes (Git Bash on Windows); tar extracts zips everywhere, unlike unzip.
+    # runner OSes (Git Bash on Windows). unzip exists on Linux/macOS and in Git Bash; GNU tar on
+    # Linux cannot read zips, so tar (bsdtar on macOS/Windows) is only the fallback.
     - name: Download and prepare Keycloak
       shell: bash
       env:
@@ -31,7 +32,11 @@ runs:
 
         curl -fsSL -o "${RUNNER_TEMP}/keycloak.zip" \
           "https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.zip"
-        tar -xf "${RUNNER_TEMP}/keycloak.zip" -C "${RUNNER_TEMP}"
+        if command -v unzip > /dev/null 2>&1; then
+          unzip -qo "${RUNNER_TEMP}/keycloak.zip" -d "${RUNNER_TEMP}"
+        else
+          tar -xf "${RUNNER_TEMP}/keycloak.zip" -C "${RUNNER_TEMP}"
+        fi
         KC_HOME="${RUNNER_TEMP}/keycloak-${KEYCLOAK_VERSION}"
 
         mkdir -p "${KC_HOME}/data/import"

--- a/.github/actions/auth/oauth2/setup-keycloak/action.yml
+++ b/.github/actions/auth/oauth2/setup-keycloak/action.yml
@@ -1,0 +1,42 @@
+name: 'Setup Keycloak'
+description: 'Provision Keycloak (download + realm import prep) for the OAuth2 e2e tests on Linux, macOS and Windows'
+
+inputs:
+  keycloak-version:
+    description: 'Keycloak release to download'
+    required: false
+    default: '26.3.3'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Java 21 (Temurin)
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+
+    # NOTE: Keycloak is intentionally NOT started here. On Windows, GitHub Actions runs each
+    # step inside a Job Object that terminates the step's entire child-process tree when the
+    # step completes — so a server started in this step would be killed before the test step
+    # runs. It is downloaded/prepared here and started in the shared step that runs the tests
+    # (run-oauth2-e2e-tests). KC_HOME is exported for that step. bash is available on all three
+    # runner OSes (Git Bash on Windows); tar extracts zips everywhere, unlike unzip.
+    - name: Download and prepare Keycloak
+      shell: bash
+      env:
+        KEYCLOAK_VERSION: ${{ inputs.keycloak-version }}
+      run: |
+        set -euo pipefail
+
+        curl -fsSL -o "${RUNNER_TEMP}/keycloak.zip" \
+          "https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.zip"
+        tar -xf "${RUNNER_TEMP}/keycloak.zip" -C "${RUNNER_TEMP}"
+        KC_HOME="${RUNNER_TEMP}/keycloak-${KEYCLOAK_VERSION}"
+
+        mkdir -p "${KC_HOME}/data/import"
+        cp "${GITHUB_WORKSPACE}/tests/auth/oauth2/fixtures/keycloak/realm-export.json" \
+          "${KC_HOME}/data/import/realm-export.json"
+
+        echo "KC_HOME=${KC_HOME}" >> "${GITHUB_ENV}"
+        echo "Keycloak prepared at ${KC_HOME}"

--- a/.github/actions/auth/oauth2/setup-keycloak/action.yml
+++ b/.github/actions/auth/oauth2/setup-keycloak/action.yml
@@ -21,9 +21,10 @@ runs:
     # step completes — so a server started in this step would be killed before the test step
     # runs. It is downloaded/prepared here and started in the shared step that runs the tests
     # (run-oauth2-e2e-tests). KC_HOME is exported for that step. bash is available on all three
-    # runner OSes (Git Bash on Windows). Keycloak ships a .tar.gz alongside the .zip, and
-    # `tar -xzf` behaves identically on GNU tar (Linux) and bsdtar (macOS, Windows), so no
-    # per-OS extraction branch is needed.
+    # runner OSes (Git Bash on Windows). Keycloak ships a .tar.gz alongside the .zip, which every
+    # runner's tar can extract. The archive is addressed by a relative name from inside
+    # RUNNER_TEMP because GNU tar (Linux, Git Bash) reads the colon in a Windows path such as
+    # D:\a\_temp\keycloak.tar.gz as a remote host and fails with "Cannot connect to D".
     - name: Download and prepare Keycloak
       shell: bash
       env:
@@ -31,9 +32,10 @@ runs:
       run: |
         set -euo pipefail
 
-        curl -fsSL -o "${RUNNER_TEMP}/keycloak.tar.gz" \
+        cd "${RUNNER_TEMP}"
+        curl -fsSL -o keycloak.tar.gz \
           "https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.tar.gz"
-        tar -xzf "${RUNNER_TEMP}/keycloak.tar.gz" -C "${RUNNER_TEMP}"
+        tar -xzf keycloak.tar.gz
         KC_HOME="${RUNNER_TEMP}/keycloak-${KEYCLOAK_VERSION}"
 
         mkdir -p "${KC_HOME}/data/import"

--- a/.github/actions/auth/oauth2/setup-keycloak/action.yml
+++ b/.github/actions/auth/oauth2/setup-keycloak/action.yml
@@ -21,8 +21,9 @@ runs:
     # step completes — so a server started in this step would be killed before the test step
     # runs. It is downloaded/prepared here and started in the shared step that runs the tests
     # (run-oauth2-e2e-tests). KC_HOME is exported for that step. bash is available on all three
-    # runner OSes (Git Bash on Windows). unzip exists on Linux/macOS and in Git Bash; GNU tar on
-    # Linux cannot read zips, so tar (bsdtar on macOS/Windows) is only the fallback.
+    # runner OSes (Git Bash on Windows). Keycloak ships a .tar.gz alongside the .zip, and
+    # `tar -xzf` behaves identically on GNU tar (Linux) and bsdtar (macOS, Windows), so no
+    # per-OS extraction branch is needed.
     - name: Download and prepare Keycloak
       shell: bash
       env:
@@ -30,13 +31,9 @@ runs:
       run: |
         set -euo pipefail
 
-        curl -fsSL -o "${RUNNER_TEMP}/keycloak.zip" \
-          "https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.zip"
-        if command -v unzip > /dev/null 2>&1; then
-          unzip -qo "${RUNNER_TEMP}/keycloak.zip" -d "${RUNNER_TEMP}"
-        else
-          tar -xf "${RUNNER_TEMP}/keycloak.zip" -C "${RUNNER_TEMP}"
-        fi
+        curl -fsSL -o "${RUNNER_TEMP}/keycloak.tar.gz" \
+          "https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.tar.gz"
+        tar -xzf "${RUNNER_TEMP}/keycloak.tar.gz" -C "${RUNNER_TEMP}"
         KC_HOME="${RUNNER_TEMP}/keycloak-${KEYCLOAK_VERSION}"
 
         mkdir -p "${KC_HOME}/data/import"

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -227,3 +227,34 @@ jobs:
 
       - name: Run OAuth1 CLI Tests
         uses: ./.github/actions/auth/oauth1/linux/run-oauth1-cli-tests
+
+  oauth2-tests:
+    name: OAuth 2.0 Auth Tests (Linux)
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/common/setup-node-deps
+
+      - name: Setup Feature Dependencies
+        uses: ./.github/actions/auth/oauth1/linux/setup-feature-specific-deps
+
+      - name: Setup Keycloak
+        uses: ./.github/actions/auth/oauth2/setup-keycloak
+
+      - name: Run OAuth2 E2E Tests
+        uses: ./.github/actions/auth/oauth2/run-oauth2-e2e-tests
+        with:
+          use-xvfb: 'true'
+          artifact-suffix: linux
+
+      # Runs even when setup-keycloak or the test step failed, so a broken IdP is debuggable.
+      - name: Collect Keycloak Logs
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/auth/oauth2/collect-keycloak-logs
+        with:
+          artifact-suffix: linux

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -159,3 +159,30 @@ jobs:
 
       - name: Run OAuth1 CLI Tests
         uses: ./.github/actions/auth/oauth1/macos/run-oauth1-cli-tests
+
+  oauth2-tests:
+    name: OAuth 2.0 Auth Tests (macOS)
+    timeout-minutes: 60
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/common/setup-node-deps
+
+      - name: Setup Keycloak
+        uses: ./.github/actions/auth/oauth2/setup-keycloak
+
+      - name: Run OAuth2 E2E Tests
+        uses: ./.github/actions/auth/oauth2/run-oauth2-e2e-tests
+        with:
+          artifact-suffix: macos
+
+      # Runs even when setup-keycloak or the test step failed, so a broken IdP is debuggable.
+      - name: Collect Keycloak Logs
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/auth/oauth2/collect-keycloak-logs
+        with:
+          artifact-suffix: macos

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -171,3 +171,30 @@ jobs:
 
       - name: Run OAuth1 CLI Tests
         uses: ./.github/actions/auth/oauth1/windows/run-oauth1-cli-tests
+
+  oauth2-tests:
+    name: OAuth 2.0 Auth Tests (Windows)
+    timeout-minutes: 60
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/common/setup-node-deps
+
+      - name: Setup Keycloak
+        uses: ./.github/actions/auth/oauth2/setup-keycloak
+
+      - name: Run OAuth2 E2E Tests
+        uses: ./.github/actions/auth/oauth2/run-oauth2-e2e-tests
+        with:
+          artifact-suffix: windows
+
+      # Runs even when setup-keycloak or the test step failed, so a broken IdP is debuggable.
+      - name: Collect Keycloak Logs
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/auth/oauth2/collect-keycloak-logs
+        with:
+          artifact-suffix: windows

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/keycloak-logs/
 
 #dev editor
 bruno.iml

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "test:e2e:ssl": "playwright test --project=ssl",
     "test:e2e:auth": "playwright test --project=auth",
     "test:e2e:mock-server": "playwright test --project=mock-server",
+    "test:e2e:auth:oauth2": "playwright test --project=oauth2",
     "test:e2e:sanity": "playwright test --project=default --project=system-pac --grep @sanity",
     "test:benchmark": "playwright test --config=playwright.benchmark.config.ts",
     "lint": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096\" npx eslint",

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
@@ -5,7 +5,7 @@ import { cloneDeep, find, get } from 'lodash';
 import { IconLoader2, IconX } from '@tabler/icons';
 import { interpolate } from '@usebruno/common';
 import { fetchOauth2Credentials, clearOauth2Cache, refreshOauth2Credentials, cancelOauth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } from 'providers/ReduxStore/slices/collections/actions';
-import { responseReceived } from 'providers/ReduxStore/slices/collections';
+import { responseReceived, responseCleared } from 'providers/ReduxStore/slices/collections';
 import { updateResponsePaneTab } from 'providers/ReduxStore/slices/tabs';
 import { getAllVariables } from 'utils/collections/index';
 import { formatIpcError } from 'utils/common/error';

--- a/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.js
@@ -5,7 +5,7 @@ import { cloneDeep, find, get } from 'lodash';
 import { IconLoader2, IconX } from '@tabler/icons';
 import { interpolate } from '@usebruno/common';
 import { fetchOauth2Credentials, clearOauth2Cache, refreshOauth2Credentials, cancelOauth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } from 'providers/ReduxStore/slices/collections/actions';
-import { responseReceived, responseCleared } from 'providers/ReduxStore/slices/collections';
+import { responseReceived } from 'providers/ReduxStore/slices/collections';
 import { updateResponsePaneTab } from 'providers/ReduxStore/slices/tabs';
 import { getAllVariables } from 'utils/collections/index';
 import { formatIpcError } from 'utils/common/error';

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -713,8 +713,8 @@ const generateCodeVerifier = () => {
 };
 
 // Build an OAuth2 state string to help prevent CSRF and forged auth codes.
-// If the user passes a state, it goes first; we append random bytes after it.
-// The user keeps their custom data, and the random suffix keeps the flow secure.
+// If the user supplies a non-empty state, it is used as-is; otherwise a
+// cryptographically random value is generated.
 const generateState = ({ userState }) => {
   const trimmedUserState = userState?.trim();
   if (trimmedUserState && trimmedUserState.length > 0) {

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -713,8 +713,8 @@ const generateCodeVerifier = () => {
 };
 
 // Build an OAuth2 state string to help prevent CSRF and forged auth codes.
-// If the user supplies a non-empty state, it is used as-is; otherwise a
-// cryptographically random value is generated.
+// A user-supplied state is trimmed and used if anything remains; a missing or
+// whitespace-only state falls back to a cryptographically random value.
 const generateState = ({ userState }) => {
   const trimmedUserState = userState?.trim();
   if (trimmedUserState && trimmedUserState.length > 0) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,12 @@ export default defineConfig({
     },
     {
       name: 'auth',
-      testDir: './tests/auth'
+      testDir: './tests/auth',
+      testIgnore: ['oauth2/**'] // oauth2 specs run in their own project (needs a Keycloak IdP)
+    },
+    {
+      name: 'oauth2',
+      testDir: './tests/auth/oauth2'
     },
     {
       name: 'ssl',

--- a/tests/auth/oauth2/fixtures/collection/AuthCodeUserSuppliedState.bru
+++ b/tests/auth/oauth2/fixtures/collection/AuthCodeUserSuppliedState.bru
@@ -1,0 +1,31 @@
+meta {
+  name: AuthCodeUserSuppliedState
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{userinfo_url}}
+  body: none
+  auth: oauth2
+}
+
+auth:oauth2 {
+  grant_type: authorization_code
+  callback_url: bruno://app/oauth2/callback
+  authorization_url: {{host}}/realms/{{realm}}/protocol/openid-connect/auth
+  access_token_url: {{host}}/realms/{{realm}}/protocol/openid-connect/token
+  refresh_token_url:
+  client_id: bruno
+  client_secret: {{client_secret}}
+  scope: openid
+  state: brunoUserState
+  pkce: false
+  credentials_placement: body
+  credentials_id: credentials
+  token_source: access_token
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+  auto_refresh_token: false
+}

--- a/tests/auth/oauth2/fixtures/collection/AuthorizationCode.bru
+++ b/tests/auth/oauth2/fixtures/collection/AuthorizationCode.bru
@@ -1,0 +1,31 @@
+meta {
+  name: AuthorizationCode
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{userinfo_url}}
+  body: none
+  auth: oauth2
+}
+
+auth:oauth2 {
+  grant_type: authorization_code
+  callback_url: bruno://app/oauth2/callback
+  authorization_url: {{host}}/realms/{{realm}}/protocol/openid-connect/auth
+  access_token_url: {{host}}/realms/{{realm}}/protocol/openid-connect/token
+  refresh_token_url:
+  client_id: bruno
+  client_secret: {{client_secret}}
+  scope: openid
+  state:
+  pkce: false
+  credentials_placement: body
+  credentials_id: credentials
+  token_source: access_token
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+  auto_refresh_token: false
+}

--- a/tests/auth/oauth2/fixtures/collection/AuthorizationImplicit.bru
+++ b/tests/auth/oauth2/fixtures/collection/AuthorizationImplicit.bru
@@ -1,0 +1,25 @@
+meta {
+  name: AuthorizationImplicit
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{userinfo_url}}
+  body: none
+  auth: oauth2
+}
+
+auth:oauth2 {
+  grant_type: implicit
+  callback_url: bruno://app/oauth2/callback
+  authorization_url: {{host}}/realms/{{realm}}/protocol/openid-connect/auth
+  client_id: bruno
+  scope: openid
+  state:
+  credentials_id: credentials
+  token_source: access_token
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+}

--- a/tests/auth/oauth2/fixtures/collection/ImplicitUserSuppliedState.bru
+++ b/tests/auth/oauth2/fixtures/collection/ImplicitUserSuppliedState.bru
@@ -1,0 +1,25 @@
+meta {
+  name: ImplicitUserSuppliedState
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{userinfo_url}}
+  body: none
+  auth: oauth2
+}
+
+auth:oauth2 {
+  grant_type: implicit
+  callback_url: bruno://app/oauth2/callback
+  authorization_url: {{host}}/realms/{{realm}}/protocol/openid-connect/auth
+  client_id: bruno
+  scope: openid
+  state: brunoUserState
+  credentials_id: credentials
+  token_source: access_token
+  token_placement: header
+  token_header_prefix: Bearer
+  auto_fetch_token: true
+}

--- a/tests/auth/oauth2/fixtures/collection/bruno.json
+++ b/tests/auth/oauth2/fixtures/collection/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "oauth2-state",
+  "type": "collection"
+}

--- a/tests/auth/oauth2/fixtures/collection/environments/Local.bru
+++ b/tests/auth/oauth2/fixtures/collection/environments/Local.bru
@@ -1,0 +1,6 @@
+vars {
+  host: http://127.0.0.1:8090
+  realm: bruno
+  client_secret: DSH25NOw5mMOCEIMrmm31EtUad4TbRLM
+  userinfo_url: http://127.0.0.1:8090/realms/bruno/protocol/openid-connect/userinfo
+}

--- a/tests/auth/oauth2/fixtures/keycloak/realm-export.json
+++ b/tests/auth/oauth2/fixtures/keycloak/realm-export.json
@@ -1,0 +1,53 @@
+{
+  "realm": "bruno",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "clients": [
+    {
+      "clientId": "bruno",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "DSH25NOw5mMOCEIMrmm31EtUad4TbRLM",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "redirectUris": [
+        "bruno://app/oauth2/callback",
+        "bruno://app/oauth2/callback/*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "testuser@example.com",
+      "firstName": "Test",
+      "lastName": "User",
+      "requiredActions": [],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpassword",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/auth/oauth2/init-user-data/preferences.json
+++ b/tests/auth/oauth2/init-user-data/preferences.json
@@ -1,0 +1,11 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": ["{{collectionPath}}"],
+  "preferences": {
+    "request": {
+      "oauth2": {
+        "useSystemBrowser": true
+      }
+    }
+  }
+}

--- a/tests/auth/oauth2/oauth2-state-validation.spec.ts
+++ b/tests/auth/oauth2/oauth2-state-validation.spec.ts
@@ -1,0 +1,351 @@
+// use this command to start the keycloak server: and make sure that you update the path of the realm-export.json file
+// docker run -d --name bruno-keycloak \
+//   -p 8090:8080 \
+//   -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+//   -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+//   -v <paste path of the file here>:/opt/keycloak/data/import/realm-export.json:ro \
+//   quay.io/keycloak/keycloak:26.0 \
+//   start-dev --http-port=8080 --import-realm
+
+import type { ElectronApplication } from 'playwright';
+import { test, expect, waitForReadyPage } from '../../../playwright';
+import { openRequest, selectRequestPaneTab, selectEnvironment } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const COLLECTION = 'oauth2-state';
+const KEYCLOAK = 'http://127.0.0.1:8090';
+const KEYCLOAK_REALM = 'bruno';
+const KEYCLOAK_USER = 'testuser';
+const KEYCLOAK_PASSWORD = 'testpassword';
+const CALLBACK = 'bruno://app/oauth2/callback';
+const PROVIDER_AUTH_CODE = 'provider-auth-code';
+const PROVIDER_ACCESS_TOKEN = 'provider-access-token';
+const WRONG_STATE = 'not-the-issued-state';
+const STATE_MISMATCH_ERROR
+  = 'OAuth2 state mismatch: the returned state does not match the issued state.';
+
+test.beforeAll(async () => {
+  const response = await fetch(`${KEYCLOAK}/realms/${KEYCLOAK_REALM}/.well-known/openid-configuration`);
+  expect(
+    response.ok,
+    `Keycloak realm "${KEYCLOAK_REALM}" should be reachable at ${KEYCLOAK}`
+  ).toBeTruthy();
+});
+
+const loginToKeycloakForAuthCode = async (authorizationUrl: string): Promise<string> => {
+  const loginPage = await fetch(authorizationUrl, { redirect: 'manual' });
+  expect(loginPage.ok, 'Keycloak authorize should return a login page').toBeTruthy();
+
+  const cookies = ((loginPage.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [])
+    .map((c) => c.split(';')[0])
+    .join('; ');
+
+  const html = await loginPage.text();
+  const formActionMatch = html.match(/action="([^"]+login-actions\/authenticate[^"]*)"/); // extract the form action URL from the login page
+  expect(formActionMatch, 'Keycloak login page should expose a form action').toBeTruthy();
+  const formAction = formActionMatch![1].replace(/&amp;/g, '&'); // replace &amp; with & to avoid URL encoding issues
+
+  const submission = await fetch(formAction, {
+    method: 'POST',
+    redirect: 'manual',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...(cookies ? { cookie: cookies } : {})
+    },
+    body: new URLSearchParams({
+      username: KEYCLOAK_USER,
+      password: KEYCLOAK_PASSWORD,
+      credentialId: ''
+    }).toString()
+  });
+
+  const location = submission.headers.get('location');
+  expect(location, 'Keycloak login should redirect to the callback URL').toBeTruthy();
+  const code = new URL(location as string).searchParams.get('code');
+  expect(code, 'Keycloak callback redirect should carry an auth code').toBeTruthy();
+  return code as string;
+};
+
+/** Fire a deep-link callback through the real protocol handler (cross-platform path). */
+const fireCallback = (app: ElectronApplication, url: string) =>
+  app.evaluate(({ app: electronApp }, callbackUrl) => {
+    electronApp.emit('second-instance', {}, [callbackUrl]);
+  }, url);
+
+/**
+ * Wrap the real `second-instance` listener so callback URLs are recorded when Bruno
+ * receives them — same argv path as `getAppProtocolUrlFromArgv` in index.js.
+ */
+const installCallbackCapture = (app: ElectronApplication) => {
+  return app.evaluate(({ app: electronApp }) => {
+    (globalThis as any).__brunoCapturedCallbackUrl = null;
+
+    electronApp.prependListener('second-instance', (_event, commandLine) => {
+      const url = commandLine?.find((arg: string) => arg?.startsWith('bruno://'));
+      if (url) {
+        (globalThis as any).__brunoCapturedCallbackUrl = url;
+      }
+    });
+  });
+};
+
+const getCapturedCallbackUrl = (app: ElectronApplication): Promise<string | null> =>
+  app.evaluate(() => (globalThis as any).__brunoCapturedCallbackUrl ?? null);
+
+// This block stubs Electron's shell.openExternal inside the Bruno app
+// so the OAuth2 test can intercept the authorization URL
+// instead of opening a real browser.
+const stubOpenExternal = (app: ElectronApplication) =>
+  app.evaluate(({ shell }) => {
+    (globalThis as any).__brunoCapturedAuthUrl = null;
+    shell.openExternal = async (url: string) => {
+      (globalThis as any).__brunoCapturedAuthUrl = url;
+    };
+  });
+
+const getCapturedAuthUrl = (app: ElectronApplication): Promise<string | null> =>
+  app.evaluate(() => (globalThis as any).__brunoCapturedAuthUrl ?? null);
+
+const waitForAuthorizationStarted = async (app: ElectronApplication) => {
+  await expect.poll(() => getCapturedAuthUrl(app), { timeout: 15_000 }).toBeTruthy();
+};
+
+type CallbackStyle = 'query' | 'hash';
+
+const stateFromAuthorizationUrl = (url: string) => new URL(url).searchParams.get('state');
+
+/** `state` Bruno sent on the authorization URL (stored internally as expectedState). */
+const getIssuedState = async (app: ElectronApplication): Promise<string> => {
+  const authUrl = await getCapturedAuthUrl(app);
+  expect(authUrl, 'authorization URL should have been opened').toBeTruthy();
+  const state = stateFromAuthorizationUrl(authUrl as string);
+  expect(state, 'issued state should be present on the authorization URL').toBeTruthy();
+  // expect((state as string).length).toBeGreaterThanOrEqual(STATE_NONCE_HEX_LENGTH);
+  return state as string;
+};
+
+const clickGetAccessToken = async (page: Parameters<typeof openRequest>[0], requestName: string) => {
+  await openRequest(page, COLLECTION, requestName);
+  await selectEnvironment(page, 'Local', 'collection');
+  await selectRequestPaneTab(page, 'Auth');
+  await page.getByRole('button', { name: 'Get Access Token' }).click();
+};
+
+/**
+ * Common flow bootstrap shared by every test: restart the app, wait for a ready page,
+ * stub `shell.openExternal`, install the callback capture, click "Get Access Token" for
+ * the given request, and wait for the authorization URL to be captured.
+ */
+const startOAuth2Flow = async (
+  restartApp: (options?: { initUserDataPath?: string }) => Promise<ElectronApplication>,
+  requestName: string
+) => {
+  const app = await restartApp();
+  const page = await waitForReadyPage(app);
+
+  await stubOpenExternal(app); // fake opening the browser so we can read the login URL
+  await installCallbackCapture(app);
+  await clickGetAccessToken(page, requestName);
+  await waitForAuthorizationStarted(app);
+
+  return { app, page };
+};
+
+const getCallbackParams = (callbackUrl: string, style: CallbackStyle = 'query') => {
+  const url = new URL(callbackUrl);
+  if (style === 'hash') {
+    const hashParams = new URLSearchParams(url.hash.slice(1));
+    return {
+      state: hashParams.get('state'),
+      code: null,
+      access_token: hashParams.get('access_token')
+    };
+  }
+  return {
+    state: url.searchParams.get('state'),
+    code: url.searchParams.get('code'),
+    access_token: null
+  };
+};
+
+test.describe('OAuth2 callback state validation', () => {
+  test('authorization code: (user-supplied state): issues userState accepts matching callback', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const USER_STATE = 'brunoUserState';
+    const { app, page } = await startOAuth2Flow(restartApp, 'AuthCodeUserSuppliedState');
+
+    const authUrl = await getCapturedAuthUrl(app);
+
+    expect(authUrl).toBeTruthy();
+
+    const issuedState = await test.step('capture and verify the issued state carries userState', async () => {
+      const state = await getIssuedState(app);
+      expect(state).toBe(USER_STATE);
+      return state;
+    });
+
+    const authCode = await test.step('obtain a valid auth code from Keycloak', () =>
+      loginToKeycloakForAuthCode(authUrl as string));
+
+    const callbackUrl = `${CALLBACK}?code=${authCode}&state=${encodeURIComponent(issuedState)}`;
+
+    await test.step('deliver a callback with the matching state', async () => {
+      await fireCallback(app, callbackUrl);
+
+      const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+      expect(receivedCallbackUrl).toBe(callbackUrl);
+
+      const { state: returnedState, code } = getCallbackParams(receivedCallbackUrl as string);
+      expect(returnedState).toBe(issuedState);
+      expect(code).toBe(authCode);
+    });
+
+    await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('authorization code: (no state): issues a random state accepts matching callback', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const { app, page } = await startOAuth2Flow(restartApp, 'AuthorizationCode');
+
+    const authUrl = await getCapturedAuthUrl(app);
+
+    expect(authUrl).toBeTruthy();
+
+    const issuedState = await test.step('capture and verify a cryptographically random state was issued', async () => {
+      const state = await getIssuedState(app);
+      // No user state was configured, so Bruno must generate a random 32-char hex string
+      // (crypto.randomBytes(16).toString('hex')).
+      expect(state).toMatch(/^[0-9a-f]{32}$/);
+      return state;
+    });
+
+    const authCode = await test.step('obtain a valid auth code from Keycloak', () =>
+      loginToKeycloakForAuthCode(authUrl as string));
+
+    const callbackUrl = `${CALLBACK}?code=${authCode}&state=${encodeURIComponent(issuedState)}`;
+
+    await test.step('deliver a callback with the matching state', async () => {
+      await fireCallback(app, callbackUrl);
+
+      const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+      expect(receivedCallbackUrl).toBe(callbackUrl);
+
+      const { state: returnedState, code } = getCallbackParams(receivedCallbackUrl as string);
+      expect(returnedState).toBe(issuedState);
+      expect(code).toBe(authCode);
+    });
+
+    await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('authorization code: rejects callback when returned state does not match issued state', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+
+    const { app, page } = await startOAuth2Flow(restartApp, 'AuthorizationCode');
+
+    const issuedState = await getIssuedState(app);
+
+    const callbackUrl = `${CALLBACK}?code=${PROVIDER_AUTH_CODE}&state=${WRONG_STATE}`;
+    await test.step('deliver a callback with a mismatched state', async () => {
+      await fireCallback(app, callbackUrl);
+
+      const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+      expect(receivedCallbackUrl).toBe(callbackUrl);
+
+      const { state: returnedState, code } = getCallbackParams(receivedCallbackUrl as string);
+      expect(returnedState).toBe(WRONG_STATE);
+      expect(returnedState).not.toBe(issuedState);
+      expect(code).toBe(PROVIDER_AUTH_CODE);
+    });
+
+    await test.step('Check for mismatch error in the response pane', async () => {
+      await expect(
+        buildCommonLocators(page).response.pane().getByText(STATE_MISMATCH_ERROR)
+      ).toBeVisible({ timeout: 15_000 });
+    });
+  });
+
+  test('implicit grant: (user-supplied state): issues userState accepts matching callback', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const USER_STATE = 'brunoUserState';
+    const { app, page } = await startOAuth2Flow(restartApp, 'ImplicitUserSuppliedState');
+
+    const issuedState = await test.step('capture and verify the issued state carries userState', async () => {
+      const state = await getIssuedState(app);
+      expect(state).toBe(USER_STATE);
+      return state;
+    });
+
+    const callbackUrl
+      = `${CALLBACK}#access_token=${PROVIDER_ACCESS_TOKEN}&token_type=Bearer&expires_in=3600&state=${encodeURIComponent(issuedState)}`;
+
+    await test.step('deliver a callback with the matching state', async () => {
+      await fireCallback(app, callbackUrl);
+
+      const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+      expect(receivedCallbackUrl).toBe(callbackUrl);
+
+      const { state: returnedState, access_token } = getCallbackParams(receivedCallbackUrl as string, 'hash');
+      expect(returnedState).toBe(issuedState);
+      expect(access_token).toBe(PROVIDER_ACCESS_TOKEN);
+    });
+
+    await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('implicit grant: (no state): issues a random state accepts matching callback', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const { app, page } = await startOAuth2Flow(restartApp, 'AuthorizationImplicit');
+
+    const issuedState = await test.step('capture and verify a cryptographically random state was issued', async () => {
+      const state = await getIssuedState(app);
+      // No user state was configured, so Bruno must generate a random 32-char hex string
+      // (crypto.randomBytes(16).toString('hex')).
+      expect(state).toMatch(/^[0-9a-f]{32}$/);
+      return state;
+    });
+
+    const callbackUrl
+      = `${CALLBACK}#access_token=${PROVIDER_ACCESS_TOKEN}&token_type=Bearer&expires_in=3600&state=${encodeURIComponent(issuedState)}`;
+
+    await test.step('deliver a callback with the matching state', async () => {
+      await fireCallback(app, callbackUrl);
+
+      const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+      expect(receivedCallbackUrl).toBe(callbackUrl);
+
+      const { state: returnedState, access_token } = getCallbackParams(receivedCallbackUrl as string, 'hash');
+      expect(returnedState).toBe(issuedState);
+      expect(access_token).toBe(PROVIDER_ACCESS_TOKEN);
+    });
+
+    await expect(page.getByText('Token fetched successfully!')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('implicit grant: rejects callback when returned state does not match issued state', async ({ restartApp }) => {
+    test.setTimeout(60_000);
+    const { app, page } = await startOAuth2Flow(restartApp, 'AuthorizationImplicit');
+
+    const issuedState = await test.step('capture the issued state', () => getIssuedState(app));
+
+    const callbackUrl = `${CALLBACK}#access_token=${PROVIDER_ACCESS_TOKEN}&token_type=Bearer&state=${WRONG_STATE}`;
+
+    await test.step('deliver a callback with a mismatched state', async () => {
+      await fireCallback(app, callbackUrl);
+
+      const receivedCallbackUrl = await getCapturedCallbackUrl(app);
+      expect(receivedCallbackUrl).toBe(callbackUrl);
+
+      const { state: returnedState, access_token } = getCallbackParams(receivedCallbackUrl as string, 'hash');
+      expect(returnedState).toBe(WRONG_STATE);
+      expect(returnedState).not.toBe(issuedState);
+      expect(access_token).toBe(PROVIDER_ACCESS_TOKEN);
+    });
+
+    await test.step('surface a state mismatch error', async () => {
+      await expect(
+        buildCommonLocators(page).response.pane().getByText(STATE_MISMATCH_ERROR)
+      ).toBeVisible({ timeout: 15_000 });
+    });
+  });
+});

--- a/tests/auth/oauth2/oauth2-state-validation.spec.ts
+++ b/tests/auth/oauth2/oauth2-state-validation.spec.ts
@@ -1,11 +1,9 @@
-// use this command to start the keycloak server: and make sure that you update the path of the realm-export.json file
-// docker run -d --name bruno-keycloak \
-//   -p 8090:8080 \
-//   -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
-//   -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
-//   -v <paste path of the file here>:/opt/keycloak/data/import/realm-export.json:ro \
-//   quay.io/keycloak/keycloak:26.0 \
-//   start-dev --http-port=8080 --import-realm
+// These tests need a Keycloak with the fixture realm imported, listening on 127.0.0.1:8090.
+// CI provisions it via .github/actions/auth/oauth2/setup-keycloak. Locally, from the repo root:
+//   docker run -d --name bruno-keycloak -p 8090:8080 \
+//     -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+//     -v "$PWD/tests/auth/oauth2/fixtures/keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro" \
+//     quay.io/keycloak/keycloak:26.0 start-dev --http-port=8080 --import-realm
 
 import type { ElectronApplication } from 'playwright';
 import { test, expect, waitForReadyPage } from '../../../playwright';
@@ -120,7 +118,6 @@ const getIssuedState = async (app: ElectronApplication): Promise<string> => {
   expect(authUrl, 'authorization URL should have been opened').toBeTruthy();
   const state = stateFromAuthorizationUrl(authUrl as string);
   expect(state, 'issued state should be present on the authorization URL').toBeTruthy();
-  // expect((state as string).length).toBeGreaterThanOrEqual(STATE_NONCE_HEX_LENGTH);
   return state as string;
 };
 


### PR DESCRIPTION
BRU-3817

### Description

Adds Keycloak to the CI pipeline so the OAuth 2.0 flows are tested against a real identity
provider on all three platforms (Linux, macOS, Windows)

### Problem

Until now the only way to test OAuth 2.0 was to stand up a mock server that imitated how an
IdP is *expected* to respond. That gave us coverage of our own code paths but not of the
protocol: the mock reflected our assumptions, so any misreading of the spec was baked into
both the implementation and the test. 

 It could not tell us whether Bruno is actually compliant  as per  RFC or PKCE

### Fix

We add Keycloak to the CI pipeline with a pre-configured realm setup so that the OAuth 2.0 test cases can run against a consistent authentication server.

GitHub Actions supports Docker-based setups on Linux, but Docker cannot be configured in the same way on macOS and Windows runners due to platform limitations. Since our test suite runs across Linux, macOS, and Windows, relying on Docker would make the Keycloak setup inconsistent across operating systems.

To address this, we now:

- Download the Keycloak tarball distribution directly in the CI pipeline and prepare it with the fixture realm.
- Start Keycloak in the same step that runs the tests, wait until the realm is ready, and shut it down when the tests finish.
- Use three shared composite actions (`setup-keycloak`, `run-oauth2-e2e-tests`, `collect-keycloak-logs`) written in bash, so Linux, macOS, and Windows run the same scripts with no per-OS copies.
- Capture Keycloak output to a log and upload it as an artifact even when the job fails, so startup or configuration issues can be debugged without rerunning CI.

Also in this PR

OAuth2.0 test cases 

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Authentication**
  - Expanded OAuth 2.0 coverage for authorization-code and implicit flows.
  - Supports validation of matching and mismatched callback state values, including user-supplied and generated states.

- **Quality Improvements**
  - Added cross-platform end-to-end coverage for OAuth 2.0 authentication.
  - Improved diagnostic reporting for authentication test failures across Linux, macOS, and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->