### PR TITLE
fix: mock server minor bug fixes

### DIFF
--- a/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
@@ -21,7 +21,9 @@ import {
   resolveTabCollectionUid,
   saveMockServerInstance,
   suggestAvailableMockServerPort,
-  updateMockServerTabName
+  updateMockServerTabName,
+  toMockServerDelayInputValue,
+  blockMockServerDelayKeys
 } from 'utils/mock-server/mock-server-instances';
 
 const resolveSelectedSpecUid = (editingInstance, apiSpecs) => {
@@ -565,7 +567,8 @@ const CreateMockServerModal = ({
                     min={0}
                     step={100}
                     value={formik.values.globalDelay}
-                    onChange={formik.handleChange}
+                    onChange={(event) => formik.setFieldValue('globalDelay', toMockServerDelayInputValue(event.target.value))}
+                    onKeyDown={blockMockServerDelayKeys}
                     onBlur={formik.handleBlur}
                     data-testid="mock-server-settings-delay-input"
                   />

--- a/packages/bruno-app/src/components/MockServer/MockResponse/CreateMockResponseModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/CreateMockResponseModal/index.js
@@ -5,8 +5,9 @@ import statusCodePhraseMap from 'components/ResponsePane/StatusCode/get-status-c
 import {
   collectCollectionExamples,
   getMockResponseNameError,
-  isMockResponseNameTaken,
-  MOCK_RESPONSE_NAME_MAX_LENGTH
+  getMockResponseNameLengthError,
+  getMockResponseDescriptionError,
+  isMockResponseNameTaken
 } from 'utils/mock-server/mock-responses';
 
 const BODY_TYPES = [
@@ -15,8 +16,6 @@ const BODY_TYPES = [
   { value: 'xml', label: 'XML' },
   { value: 'html', label: 'HTML' }
 ];
-
-const DESCRIPTION_MAX_LENGTH = 1000;
 
 const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate, onClose }) => {
   const nameInputRef = useRef();
@@ -47,6 +46,7 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
   const nameValue = name || linkedExample?.example?.name || '';
   const statusValue = Number(linkedExample?.example?.response?.status) || statusCode;
   const bodyTypeValue = linkedExample?.example?.response?.body?.type || bodyType;
+  const descriptionError = getMockResponseDescriptionError(description);
 
   useEffect(() => {
     if (nameInputRef.current) {
@@ -65,6 +65,10 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
 
     if (isMockResponseNameTaken(existingResponses, trimmedName)) {
       setNameError('A mock response with this name already exists');
+      return;
+    }
+
+    if (descriptionError) {
       return;
     }
 
@@ -117,13 +121,10 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
               autoCorrect="off"
               autoCapitalize="off"
               spellCheck="false"
-              maxLength={MOCK_RESPONSE_NAME_MAX_LENGTH}
               value={nameValue}
               onChange={(event) => {
                 setName(event.target.value);
-                if (nameError) {
-                  setNameError('');
-                }
+                setNameError(getMockResponseNameLengthError(event.target.value) || '');
               }}
               data-testid="mock-response-create-name-input"
             />
@@ -141,10 +142,12 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
               className="block textbox w-full mt-2"
               rows={2}
               value={description}
-              maxLength={DESCRIPTION_MAX_LENGTH}
-              onChange={(event) => setDescription(event.target.value.slice(0, DESCRIPTION_MAX_LENGTH))}
+              onChange={(event) => setDescription(event.target.value)}
               data-testid="mock-response-create-description-input"
             />
+            {descriptionError ? (
+              <div className="text-red-500 mt-1">{descriptionError}</div>
+            ) : null}
           </div>
 
           <div className="mt-4 grid grid-cols-2 gap-4">

--- a/packages/bruno-app/src/components/MockServer/MockResponse/MockResponseTopBar/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/MockResponseTopBar/index.js
@@ -10,8 +10,7 @@ import {
 } from 'providers/ReduxStore/slices/collections';
 import get from 'lodash/get';
 import Button from 'ui/Button';
-
-const DESCRIPTION_MAX_LENGTH = 1000;
+import { getMockResponseDescriptionError, getMockResponseNameLengthError } from 'utils/mock-server/mock-responses';
 
 const MockResponseTopBar = ({
   item,
@@ -46,13 +45,16 @@ const MockResponseTopBar = ({
       itemUid: item.uid,
       collectionUid: collection.uid,
       exampleUid,
-      description: event.target.value.slice(0, DESCRIPTION_MAX_LENGTH)
+      description: event.target.value
     }));
   };
 
   if (!example || !exampleUid) {
     return null;
   }
+
+  const nameError = getMockResponseNameLengthError(example.name);
+  const descriptionError = getMockResponseDescriptionError(example.description);
 
   if (editMode) {
     return (
@@ -71,6 +73,9 @@ const MockResponseTopBar = ({
                     autoFocus
                     data-testid="mock-response-name-input"
                   />
+                  {nameError ? (
+                    <div className="text-red-500 text-xs mt-1">{nameError}</div>
+                  ) : null}
                 </div>
                 <div>
                   <textarea
@@ -79,9 +84,11 @@ const MockResponseTopBar = ({
                     className="example-input example-input-description"
                     placeholder="Description"
                     rows={3}
-                    maxLength={DESCRIPTION_MAX_LENGTH}
                     data-testid="mock-response-description-input"
                   />
+                  {descriptionError ? (
+                    <div className="text-red-500 text-xs mt-1">{descriptionError}</div>
+                  ) : null}
                 </div>
                 {copiedFrom?.exampleName ? (
                   <div className="text-xs opacity-60">
@@ -105,6 +112,7 @@ const MockResponseTopBar = ({
                 size="sm"
                 icon={<IconDeviceFloppy size={16} />}
                 onClick={onSave}
+                disabled={Boolean(nameError || descriptionError)}
                 data-testid="mock-response-save-btn"
               >
                 Save

--- a/packages/bruno-app/src/components/MockServer/MockResponse/RenameMockResponseModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/RenameMockResponseModal/index.js
@@ -3,8 +3,8 @@ import Portal from 'components/Portal';
 import Modal from 'components/Modal';
 import {
   getMockResponseNameError,
-  isMockResponseNameTaken,
-  MOCK_RESPONSE_NAME_MAX_LENGTH
+  getMockResponseNameLengthError,
+  isMockResponseNameTaken
 } from 'utils/mock-server/mock-responses';
 
 const RenameMockResponseModal = ({
@@ -63,13 +63,10 @@ const RenameMockResponseModal = ({
             ref={inputRef}
             type="text"
             className="textbox mt-2 w-full"
-            maxLength={MOCK_RESPONSE_NAME_MAX_LENGTH}
             value={name}
             onChange={(event) => {
               setName(event.target.value);
-              if (nameError) {
-                setNameError('');
-              }
+              setNameError(getMockResponseNameLengthError(event.target.value) || '');
             }}
             data-testid="mock-response-rename-name-input"
           />

--- a/packages/bruno-app/src/components/MockServer/MockResponse/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/index.js
@@ -11,7 +11,7 @@ import {
 } from 'providers/ReduxStore/slices/collections';
 import { saveMockResponse, deleteMockResponse, loadMockResponses, startMockServer, syncMockServerState } from 'providers/ReduxStore/slices/mock-server/index';
 import { closeTabs, updateTabMeta, updateResponsePaneTab } from 'providers/ReduxStore/slices/tabs';
-import { resolveMockResponseLocation, resolveMockResponseCollection, resolveMockResponseEditorCollection, tryMockResponseRequest } from 'utils/mock-server/mock-responses';
+import { resolveMockResponseLocation, resolveMockResponseCollection, resolveMockResponseEditorCollection, tryMockResponseRequest, getMockResponseNameError, getMockResponseDescriptionError } from 'utils/mock-server/mock-responses';
 import {
   findMockServerInstance,
   resolveMockServerStartPayload,
@@ -225,8 +225,10 @@ const MockResponse = ({ instance, collection, responseUid }) => {
         editor.savedMockResponse
       );
 
-      if (!mockResponse.name?.trim()) {
-        toast.error('Mock response name is required');
+      const validationError = getMockResponseNameError(mockResponse.name)
+        || getMockResponseDescriptionError(mockResponse.description);
+      if (validationError) {
+        toast.error(validationError);
         return;
       }
 

--- a/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
@@ -18,7 +18,9 @@ import {
   saveMockServerInstance,
   resolveMockServerStartPayload,
   resolveMockServerWorkspacePath,
-  updateMockServerTabName
+  updateMockServerTabName,
+  toMockServerDelayInputValue,
+  blockMockServerDelayKeys
 } from 'utils/mock-server/mock-server-instances';
 import MockResponsesList from 'components/MockServer/MockResponse/MockResponsesList';
 import Tab from 'components/Tab';
@@ -216,7 +218,7 @@ const MockServerDashboard = ({ instance, collection }) => {
   };
 
   const handleDelayChange = (event) => {
-    setDelayDraft(Number(event.target.value) || 0);
+    setDelayDraft(toMockServerDelayInputValue(event.target.value));
   };
 
   const handleDelayBlur = async () => {
@@ -368,6 +370,7 @@ const MockServerDashboard = ({ instance, collection }) => {
                 type="number"
                 value={delayValue}
                 onChange={handleDelayChange}
+                onKeyDown={blockMockServerDelayKeys}
                 onBlur={handleDelayBlur}
                 disabled={isStarting}
                 min={0}

--- a/packages/bruno-app/src/components/MockServer/Sidebar/MockServers/MockResponseSidebarItem/index.js
+++ b/packages/bruno-app/src/components/MockServer/Sidebar/MockServers/MockResponseSidebarItem/index.js
@@ -182,7 +182,7 @@ const MockResponseSidebarItem = ({
         <button
           type="button"
           className={classnames(
-            'flex-1 min-w-0 text-left py-1 pl-2 pr-1 text-xs hover:opacity-100 opacity-80 flex items-center gap-2',
+            'flex-1 min-w-0 text-left py-1 pl-3 pr-1 text-xs hover:opacity-100 opacity-80 flex items-center gap-2',
             { 'font-medium': activeTabUid === response.uid }
           )}
           onClick={() => openResponseTab(response)}

--- a/packages/bruno-app/src/components/ResponseExample/ResponseExampleResponsePane/ResponseExampleStatusInput/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponseExample/ResponseExampleResponsePane/ResponseExampleStatusInput/StyledWrapper.js
@@ -11,8 +11,8 @@ const StyledWrapper = styled.div`
     font-size: ${(props) => props.theme.font.size.base};
     font-weight: 500;
     color: ${(props) => props.theme.text.primary};
-    min-width: 140px;
-    max-width: 220px;
+    min-width: 160px;
+    max-width: 250px;
     cursor: pointer;
 
     &:focus {

--- a/packages/bruno-app/src/components/ResponseExample/ResponseExampleTopBar/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponseExample/ResponseExampleTopBar/StyledWrapper.js
@@ -10,6 +10,8 @@ const StyledWrapper = styled.div`
 
   .response-example-description {
     color: ${(props) => props.theme.colors.text.muted};
+    max-height: 10rem;
+    overflow-y: auto;
   }
 
   .primary-btn {

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -228,6 +228,18 @@ export const resolveMockResponseEditorCollection = ({
 
 export const MOCK_RESPONSE_NAME_MAX_LENGTH = 255;
 
+export const MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH = 1000;
+
+export const getMockResponseNameLengthError = (name) => {
+  const value = name == null ? '' : String(name).trim();
+
+  if (value.length > MOCK_RESPONSE_NAME_MAX_LENGTH) {
+    return `Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`;
+  }
+
+  return null;
+};
+
 export const getMockResponseNameError = (name) => {
   const value = name == null ? '' : String(name).trim();
 
@@ -235,8 +247,14 @@ export const getMockResponseNameError = (name) => {
     return 'Mock response name is required';
   }
 
-  if (value.length > MOCK_RESPONSE_NAME_MAX_LENGTH) {
-    return `Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`;
+  return getMockResponseNameLengthError(value);
+};
+
+export const getMockResponseDescriptionError = (description) => {
+  const value = description == null ? '' : String(description).trim();
+
+  if (value.length > MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH) {
+    return `Description must be ${MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH} characters or less`;
   }
 
   return null;

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
@@ -11,8 +11,10 @@ jest.mock('utils/common', () => {
 
 import {
   cloneMockResponseRecord,
+  getMockResponseDescriptionError,
   getMockResponseNameError,
   isMockResponseNameTaken,
+  MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH,
   MOCK_RESPONSE_NAME_MAX_LENGTH,
   resolveMockResponseCollection,
   resolveMockResponseEditorCollection
@@ -143,6 +145,20 @@ describe('resolveMockResponseEditorCollection', () => {
       expect(getMockResponseNameError(paddedAtLimit)).toBeNull();
       expect(getMockResponseNameError(paddedOverLimit))
         .toBe(`Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`);
+    });
+  });
+
+  describe('getMockResponseDescriptionError', () => {
+    it('flags descriptions longer than the max length after trimming', () => {
+      const overflow = 'a'.repeat(MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH + 1);
+      expect(getMockResponseDescriptionError(overflow))
+        .toBe(`Description must be ${MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH} characters or less`);
+    });
+
+    it('accepts empty and in-bounds descriptions', () => {
+      expect(getMockResponseDescriptionError('')).toBeNull();
+      expect(getMockResponseDescriptionError(null)).toBeNull();
+      expect(getMockResponseDescriptionError('a'.repeat(MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH))).toBeNull();
     });
   });
 

--- a/packages/bruno-app/src/utils/mock-server/mock-server-instances.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-server-instances.js
@@ -406,6 +406,15 @@ export const getMockServerNameError = (name) => {
   return '';
 };
 
+// keeps the raw text so the field can be cleared while typing — callers coerce to a number on commit
+export const toMockServerDelayInputValue = (value) => String(value ?? '').replace(/\D/g, '');
+
+export const blockMockServerDelayKeys = (event) => {
+  if (['e', 'E', '+', '-', '.', ','].includes(event.key)) {
+    event.preventDefault();
+  }
+};
+
 export const isMockServerPortTaken = (instances, port, excludeUid = null) => {
   const normalizedPort = Number(port);
   if (!normalizedPort) {

--- a/packages/bruno-app/src/utils/mock-server/mock-server-instances.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-server-instances.js
@@ -406,7 +406,6 @@ export const getMockServerNameError = (name) => {
   return '';
 };
 
-// keeps the raw text so the field can be cleared while typing — callers coerce to a number on commit
 export const toMockServerDelayInputValue = (value) => String(value ?? '').replace(/\D/g, '');
 
 export const blockMockServerDelayKeys = (event) => {

--- a/packages/bruno-electron/src/app/mock-server/mock-response-store.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-response-store.js
@@ -414,7 +414,9 @@ const saveMockResponse = (location, response) => {
   const responses = [...getMockServerResponses(location)];
 
   const normalizedName = nextResponse.name?.trim().toLowerCase();
-  if (normalizedName) {
+  const currentName = responses.find((item) => item.uid === nextResponse.uid)?.name?.trim().toLowerCase();
+
+  if (normalizedName && normalizedName !== currentName) {
     const isDuplicate = responses.some((item) => (
       item.uid !== nextResponse.uid && item.name?.trim().toLowerCase() === normalizedName
     ));

--- a/packages/bruno-electron/tests/mock-response-store.test.js
+++ b/packages/bruno-electron/tests/mock-response-store.test.js
@@ -12,7 +12,8 @@ const {
   listMockServers,
   readWorkspaceStore,
   saveMockResponse,
-  saveMockServer
+  saveMockServer,
+  setMockServerResponses
 } = require('../src/app/mock-server/mock-response-store');
 
 describe('mock-response-store', () => {
@@ -118,6 +119,42 @@ describe('mock-response-store', () => {
     })).not.toThrow();
 
     expect(listMockResponses(location)).toHaveLength(1);
+  });
+
+  // append/generate can create sibling responses that already share a name
+  it('allows saving an existing response when a sibling already has the same name', () => {
+    const location = {
+      mockServerUid: 'mock-1',
+      sourceType: 'spec',
+      workspacePath
+    };
+
+    setMockServerResponses(location, [
+      {
+        uid: 'response-1',
+        name: 'Users',
+        request: { url: '/users', method: 'GET' },
+        response: { status: 200, body: { type: 'json', content: '{}' } },
+        rules: { operator: 'AND', conditions: [] }
+      },
+      {
+        uid: 'response-2',
+        name: 'Users',
+        request: { url: '/users/me', method: 'GET' },
+        response: { status: 200, body: { type: 'json', content: '{}' } },
+        rules: { operator: 'AND', conditions: [] }
+      }
+    ]);
+
+    expect(() => saveMockResponse(location, {
+      uid: 'response-1',
+      name: 'Users',
+      request: { url: '/users', method: 'POST' },
+      response: { status: 201, body: { type: 'json', content: '{}' } },
+      rules: { operator: 'AND', conditions: [] }
+    })).not.toThrow();
+
+    expect(listMockResponses(location).find((item) => item.uid === 'response-1').request.method).toBe('POST');
   });
 
   it('removes a mock server block from workspace mockserver.yml on delete', () => {


### PR DESCRIPTION
### Description

Small mock-server and response example polish pass: validation feedback for name/description limits, a layout fix for long descriptions, delay input decimals, and two UI spacing tweaks

### Problem

 - Mock response name/description used silent maxLength hard stops (no inline error on create/edit/rename).
 - Edit name could fail to save when a sibling response already shared the same name (duplicate check ran even when the name was unchanged).
 - Long descriptions + View More pushed the header/Edit CTA out of reach (page felt stuck).
 - Mock server delay input accepted decimal values.
 - Sidebar mock-response rows and the response status dropdown needed tighter spacing/width.
 
### Fix

- Shared validators (getMockResponseNameLengthError, getMockResponseDescriptionError) show inline errors and validate on save.
- Skip duplicate name check on save when the name is unchanged so edits still remain.
- Cap expanded description height (max-height + overflow-y: auto).
- Restrict decimal delay values in create modal + dashboard.
- Slightly more sidebar item padding; wider status dropdown.

### Screenshots

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for mock response names and descriptions, including a 1,000-character description limit.
  * Improved mock server delay fields to accept valid numeric input only.
  * Expanded response status fields and added scrolling for long response descriptions.
* **Bug Fixes**
  * Existing mock responses can now be saved without triggering false duplicate-name errors.
  * Invalid response details prevent saving and display clear validation errors.
* **Style**
  * Improved mock response sidebar spacing and form layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->