### PR TITLE
fix(editor): add guessed language in language dropdown picker

### DIFF
--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorCodeBlock/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorCodeBlock/index.js
@@ -35,6 +35,7 @@ const LANGUAGES = [
 
 const EditorCodeBlock = ({ node, updateAttributes, editor }) => {
   const language = node.attrs.language || 'auto';
+  const isAutoLanguage = language === 'auto';
   const preRef = useRef(null);
   const pasteTimeoutRef = useRef(null);
   const { copied, copyToClipboard } = useCopyToClipboard();
@@ -78,13 +79,26 @@ const EditorCodeBlock = ({ node, updateAttributes, editor }) => {
     updateAttributes({ language: lang === 'auto' ? null : lang });
   }, [updateAttributes]);
 
+  const guessedLanguage = useMemo(() => {
+    if (!isAutoLanguage) return null;
+
+    const text = node.textContent;
+    if (!text || !text.trim()) return null;
+
+    const result = lowlight.highlightAuto(text);
+    return (result && result.data && result.data.language) || null;
+  }, [isAutoLanguage, node.textContent]);
+
+  const autoLabel = guessedLanguage ? `auto (${guessedLanguage})` : 'auto';
+  const languageLabel = isAutoLanguage ? autoLabel : language;
+
   const languageItems = useMemo(() => (
     ['auto', ...LANGUAGES].map((lang) => ({
       id: lang,
-      label: lang,
+      label: lang === 'auto' ? autoLabel : lang,
       onClick: () => setLanguage(lang)
     }))
-  ), [setLanguage]);
+  ), [setLanguage, autoLabel]);
 
   const handleCopy = useCallback((e) => {
     e.stopPropagation();
@@ -110,7 +124,7 @@ const EditorCodeBlock = ({ node, updateAttributes, editor }) => {
               className="editor-code-block-lang-selector flex items-center gap-1 cursor-pointer px-2 py-1 rounded transition-colors duration-150"
               data-testid="code-block-lang-selector"
             >
-              <span>{language}</span>
+              <span>{languageLabel}</span>
               <IconChevronDown size={14} />
             </div>
           </MenuDropdown>


### PR DESCRIPTION
### Description

BRU-4252

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
In text editor we have langauage dropdown to pick the code block language. 

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
When auto is selected there is no way for user to know which language is guessed and whether its picking the right language.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
Added the guessed language if auto is selected by the user.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| auto was there without the guessed language  | <img width="1264" height="337" alt="image" src="https://github.com/user-attachments/assets/88aace78-4651-40c1-9aa4-5ab6f0f29c9c" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block language detection and display.
  * Automatically detected languages now appear in the menu and selector, while explicitly selected languages retain their configured names.
  * Code blocks continue to display “auto” when no language can be detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->