### PR TITLE
fix(editor): tab indentation on code blocks

### DIFF
--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
@@ -32,6 +32,7 @@ const EditorCodeBlockExtension = CodeBlockLowlight.extend({
   // Tiptap doesn't support Tab in codeblock. added a literal tab.
   addKeyboardShortcuts() {
     return {
+      ...this.parent?.(),
       Tab: () => {
         if (!this.editor.isActive('codeBlock')) {
           return false;

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
@@ -28,10 +28,28 @@ import { lowlight } from 'lowlight';
 const EditorCodeBlockExtension = CodeBlockLowlight.extend({
   addNodeView() {
     return ReactNodeViewRenderer(EditorCodeBlock);
+  },
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => {
+        if (!this.editor.isActive('codeBlock')) {
+          return false;
+        }
+        const { state, view } = this.editor;
+        const { tr, selection } = state;
+        tr.insertText('\t', selection.from, selection.to);
+        view.dispatch(tr);
+        return true;
+      }
+    };
   }
-}).configure({ lowlight, enableTabIndentation: true, tabSize: 2 });
+}).configure({
+  lowlight,
+  enableTabIndentation: false // Off to keep internal tab logic out of the way
+});
 
 const createExtensions = ({ allowHtml = true, collectionPath = '' } = {}) => [
+  EditorCodeBlockExtension,
   TextStyle.configure({ types: [EditorListItem.name] }),
   StarterKit.configure({
     bulletList: false,
@@ -55,7 +73,6 @@ const createExtensions = ({ allowHtml = true, collectionPath = '' } = {}) => [
   }),
   EditorListItem,
   EditorGapCursor,
-  EditorCodeBlockExtension,
   EditorTaskList,
   EditorTaskItem.configure({
     nested: true,

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
@@ -29,6 +29,7 @@ const EditorCodeBlockExtension = CodeBlockLowlight.extend({
   addNodeView() {
     return ReactNodeViewRenderer(EditorCodeBlock);
   },
+  // Tiptap doesn't support Tab in codeblock. added a literal tab.
   addKeyboardShortcuts() {
     return {
       Tab: () => {

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
@@ -44,8 +44,7 @@ const EditorCodeBlockExtension = CodeBlockLowlight.extend({
     };
   }
 }).configure({
-  lowlight,
-  enableTabIndentation: false // Off to keep internal tab logic out of the way
+  lowlight
 });
 
 const createExtensions = ({ allowHtml = true, collectionPath = '' } = {}) => [

--- a/tests/richtext-editor/code-block.spec.ts
+++ b/tests/richtext-editor/code-block.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../playwright';
 import { closeAllCollections } from '../utils/page/actions';
 import { setupRequestDocs } from './actions';
+import { modifier, pressShortcut } from '../shortcuts/helpers';
 
 test.describe('Rich Text Docs Editor Edge Cases - Code Blocks', () => {
   test.beforeEach(async ({ page }) => {
@@ -147,6 +148,97 @@ test.describe('Rich Text Docs Editor Edge Cases - Code Blocks', () => {
       await page.keyboard.type('# Heading');
 
       await expect(locators.docs.codeEditor().locator('.cm-header')).toBeVisible();
+    });
+  });
+
+  test('Tab inserts a tab character instead of moving focus out of the code block', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-code-tab');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Create a code block and type before the tab', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await locators.docs.toolbarBtn('Code block').click();
+      await page.keyboard.type('const x =');
+    });
+
+    await test.step('Press Tab, then keep typing', async () => {
+      await page.keyboard.press('Tab');
+      await page.keyboard.type('1;');
+    });
+
+    await test.step('A literal tab character was inserted', async () => {
+      await expect(locators.docs.codeBlockContent()).toHaveText('const x =\t1;');
+    });
+
+    await test.step('Focus stayed inside the editor, so the second line still lands in the code block', async () => {
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('const y = 2;');
+      await expect(locators.docs.codeBlockContent()).toContainText('const y = 2;');
+    });
+  });
+
+  test('Backspace on an empty code block still removes it', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-code-backspace-remove');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Insert an empty code block', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await locators.docs.toolbarBtn('Code block').click();
+      await expect(locators.docs.codeBlockPre()).toBeVisible();
+    });
+
+    await test.step('Backspace on the empty block removes it', async () => {
+      await page.keyboard.press('Backspace');
+      await expect(locators.docs.codeBlockPre()).toHaveCount(0);
+    });
+  });
+
+  test('Three consecutive Enters at the end of a code block exits it into a new paragraph', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-code-triple-enter');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Create a code block with content', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await locators.docs.toolbarBtn('Code block').click();
+      await page.keyboard.type('const x = 1;');
+    });
+
+    await test.step('Press Enter three times in a row', async () => {
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
+      await page.keyboard.press('Enter');
+    });
+
+    await test.step('The cursor exits into a paragraph after the code block, instead of adding blank lines inside it', async () => {
+      await expect(prosemirror.locator('pre')).toHaveCount(1);
+      await page.keyboard.type('after code block');
+      await expect(prosemirror.locator('p').last()).toContainText('after code block');
+    });
+  });
+
+  test('Cmd/Ctrl+Alt+C toggles the current block in and out of a code block', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-code-toggle-shortcut');
+    const prosemirror = locators.docs.proseMirror();
+
+    await test.step('Type a paragraph, then toggle it into a code block via the shortcut', async () => {
+      await expect(prosemirror).toBeVisible();
+      await prosemirror.click();
+      await page.keyboard.type('const x = 1;');
+      await pressShortcut(page, modifier, 'Alt', 'KeyC');
+    });
+
+    await test.step('It becomes a code block', async () => {
+      await expect(locators.docs.codeBlockPre()).toBeVisible();
+      await expect(locators.docs.codeBlockContent()).toContainText('const x = 1;');
+    });
+
+    await test.step('The same shortcut toggles it back to a paragraph', async () => {
+      await pressShortcut(page, modifier, 'Alt', 'KeyC');
+      await expect(locators.docs.codeBlockPre()).toHaveCount(0);
+      await expect(prosemirror.locator('p')).toContainText('const x = 1;');
     });
   });
 });

--- a/tests/richtext-editor/code-block.spec.ts
+++ b/tests/richtext-editor/code-block.spec.ts
@@ -214,6 +214,7 @@ test.describe('Rich Text Docs Editor Edge Cases - Code Blocks', () => {
 
     await test.step('The cursor exits into a paragraph after the code block, instead of adding blank lines inside it', async () => {
       await expect(prosemirror.locator('pre')).toHaveCount(1);
+      await expect(locators.docs.codeBlockContent()).toHaveText('const x = 1;');
       await page.keyboard.type('after code block');
       await expect(prosemirror.locator('p').last()).toContainText('after code block');
     });


### PR DESCRIPTION
### Description

BRU-4251

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Tiptap doesn't support Tab idnentation inside the codeblock. So pressing tab inside the codeblock shifts focus to the other focusable element. 

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
Tiptap doesn't support Tab idnentation inside the codeblock

### Fix

inserts a literal tab character instead of shifting focus, by adding a manual keyboard shortcut and reordering the extension ahead of StarterKit so it takes priority.

<!-- How does this PR fix the problem? Briefly describe your approach. -->

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved code block editing so Tab inserts a tab character only when the code block is active.
* Prevented Tab handling from affecting other editor content.
* Improved Backspace behavior for empty code blocks.
* Improved exiting code blocks after multiple trailing line breaks.

## New Features
* Added a keyboard shortcut to toggle between paragraph and code block formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->