### PR TITLE
fix(editor): fixed search and replace input border

### DIFF
--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -61,22 +61,22 @@ const StyledWrapper = styled.div`
   }
 
   /* Each input gets its own bordered box */
-  .bruno-search-bar input {
+  .bruno-search-bar input[type='text'] {
     width: 180px;
     flex: 0 0 180px;
     background: transparent;
     color: ${(props) => props.theme.colors.text.subtext2};
-    border: 1px solid ${(props) => props.theme.border.border2} !important;
+    border: 1px solid ${(props) => props.theme.border.border2};
     border-radius: ${(props) => props.theme.border.radius.sm};
-    outline: none !important;
+    outline: none;
     padding: 2px 6px;
     font-size: ${(props) => props.theme.font.size.base};
     height: 26px;
     font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important;
   }
 
-  .bruno-search-bar input:focus {
-    border-color: ${(props) => props.theme.brand} !important;
+  .bruno-search-bar input[type='text']:focus {
+    border-color: ${(props) => props.theme.brand};
   }
 
   .searchbar-icon-btn {

--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -66,9 +66,9 @@ const StyledWrapper = styled.div`
     flex: 0 0 180px;
     background: transparent;
     color: ${(props) => props.theme.colors.text.subtext2};
-    border: 1px solid ${(props) => props.theme.border.border2};
+    border: 1px solid ${(props) => props.theme.border.border2} !important;
     border-radius: ${(props) => props.theme.border.radius.sm};
-    outline: none;
+    outline: none !important;
     padding: 2px 6px;
     font-size: ${(props) => props.theme.font.size.base};
     height: 26px;
@@ -76,7 +76,7 @@ const StyledWrapper = styled.div`
   }
 
   .bruno-search-bar input:focus {
-    border-color: ${(props) => props.theme.brand};
+    border-color: ${(props) => props.theme.brand} !important;
   }
 
   .searchbar-icon-btn {


### PR DESCRIPTION
### Description

BRU-4253

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Codemirror search and replace input borders are not visible in Request Header.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
RequestHeaders/StyledWrapper.js applies border: solid 1px transparent to all input[type='text'], overriding the search bar's visible border.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
change the selector from .`bruno-search-bar input` to `.bruno-search-bar input[type='text']` which will increase the specificity of the code mirror search input border.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="433" height="109" alt="image" src="https://github.com/user-attachments/assets/e58420be-6119-4f5c-af77-2c75675345f8" />| <img width="441" height="128" alt="image" src="https://github.com/user-attachments/assets/87a05dc2-a7e9-42b2-864d-b397ee7b5894" />|

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated search field styling to apply only to text inputs.
  * Prevented unrelated input elements within the search area from inheriting search field styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->