### PR TITLE
fix(workspace): showing only the remove option for the failed collection in workspace overview

### DIFF
--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -374,73 +374,77 @@ const CollectionsList = ({ workspace }) => {
                   icon={<IconDots size={18} strokeWidth={1.5} />}
                 >
                   <div className="collection-dropdown">
-                    <div
-                      className="dropdown-item"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleRenameCollection(collection);
-                      }}
-                    >
-                      <IconEdit size={16} strokeWidth={1.5} />
-                      <span>Rename</span>
-                    </div>
-                    <div
-                      className="dropdown-item"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleShareCollection(collection);
-                      }}
-                    >
-                      <IconShare size={16} strokeWidth={1.5} />
-                      <span>Share</span>
-                    </div>
-                    <div
-                      className="dropdown-item"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleShowInFolder(collection);
-                      }}
-                    >
-                      <IconFolder size={16} strokeWidth={1.5} />
-                      <span>{getRevealInFolderLabel()}</span>
-                    </div>
-                    {!isDefaultWorkspace && (
+                    {!collection.failedToOpen && (
                       <>
-                        {collection.isGitBacked && (
-                          <div
-                            className="dropdown-item"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleCopyGitUrl(collection);
-                            }}
-                          >
-                            <IconCopy size={16} strokeWidth={1.5} />
-                            <span>Copy Git URL</span>
-                          </div>
-                        )}
-                        {!collection.isGitBacked && collection.isLoaded !== false && (
-                          <div
-                            className="dropdown-item"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleConnectGit(collection);
-                            }}
-                          >
-                            <IconBrandGit size={16} strokeWidth={1.5} />
-                            <span>Connect to Git</span>
-                          </div>
-                        )}
-                        {collection.isGitBacked && (
-                          <div
-                            className="dropdown-item"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleRemoveGit(collection);
-                            }}
-                          >
-                            <IconUnlink size={16} strokeWidth={1.5} />
-                            <span>Remove Git Remote</span>
-                          </div>
+                        <div
+                          className="dropdown-item"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleRenameCollection(collection);
+                          }}
+                        >
+                          <IconEdit size={16} strokeWidth={1.5} />
+                          <span>Rename</span>
+                        </div>
+                        <div
+                          className="dropdown-item"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleShareCollection(collection);
+                          }}
+                        >
+                          <IconShare size={16} strokeWidth={1.5} />
+                          <span>Share</span>
+                        </div>
+                        <div
+                          className="dropdown-item"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleShowInFolder(collection);
+                          }}
+                        >
+                          <IconFolder size={16} strokeWidth={1.5} />
+                          <span>{getRevealInFolderLabel()}</span>
+                        </div>
+                        {!isDefaultWorkspace && (
+                          <>
+                            {collection.isGitBacked && (
+                              <div
+                                className="dropdown-item"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleCopyGitUrl(collection);
+                                }}
+                              >
+                                <IconCopy size={16} strokeWidth={1.5} />
+                                <span>Copy Git URL</span>
+                              </div>
+                            )}
+                            {!collection.isGitBacked && collection.isLoaded !== false && (
+                              <div
+                                className="dropdown-item"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleConnectGit(collection);
+                                }}
+                              >
+                                <IconBrandGit size={16} strokeWidth={1.5} />
+                                <span>Connect to Git</span>
+                              </div>
+                            )}
+                            {collection.isGitBacked && (
+                              <div
+                                className="dropdown-item"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleRemoveGit(collection);
+                                }}
+                              >
+                                <IconUnlink size={16} strokeWidth={1.5} />
+                                <span>Remove Git Remote</span>
+                              </div>
+                            )}
+                          </>
                         )}
                       </>
                     )}
@@ -454,16 +458,18 @@ const CollectionsList = ({ workspace }) => {
                       <IconX size={16} strokeWidth={1.5} />
                       <span>Remove</span>
                     </div>
-                    <div
-                      className="dropdown-item delete-item"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDeleteCollection(collection);
-                      }}
-                    >
-                      <IconTrash size={16} strokeWidth={1.5} />
-                      <span>Delete</span>
-                    </div>
+                    {!collection.failedToOpen && (
+                      <div
+                        className="dropdown-item delete-item"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteCollection(collection);
+                        }}
+                      >
+                        <IconTrash size={16} strokeWidth={1.5} />
+                        <span>Delete</span>
+                      </div>
+                    )}
                   </div>
                 </Dropdown>
               </div>

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -15,6 +15,7 @@ import { buildToastLocators } from './toast';
 import { buildRequestLocators } from '../request';
 import { buildCollectionHeaderLocators } from './collection/collection-header';
 import { buildEnvironmentLocators } from './environments';
+import { buildWorkspaceOverviewLocators } from './workspace/workspace-overview';
 
 export type PresetRequestType = 'http' | 'graphql' | 'grpc' | 'ws';
 
@@ -36,6 +37,7 @@ export const buildCommonLocators = (page: Page) => ({
   settingsSaveButton: () => page.getByRole('button', { name: 'Save' }),
   openPreferences: () => page.getByRole('button', { name: 'Open Preferences' }),
   sidebar: buildSidebarLocators(page),
+  workspaceOverview: buildWorkspaceOverviewLocators(page),
   deleteCollectionItemModal: buildDeleteCollectionItemModalLocators(page),
   migrateToYml: buildMigrateToYmlLocators(page),
   environment: buildEnvironmentLocators(page),

--- a/tests/utils/page/workspace/workspace-overview.ts
+++ b/tests/utils/page/workspace/workspace-overview.ts
@@ -1,0 +1,12 @@
+import { Page } from '../../../../playwright';
+
+export const buildWorkspaceOverviewLocators = (page: Page) => {
+  const collectionCard = (collectionName: string) =>
+    page.locator('.collection-card').filter({ hasText: collectionName });
+
+  return {
+    collectionCard,
+    collectionCardMenu: (collectionName: string) => collectionCard(collectionName).locator('.collection-menu'),
+    collectionCardMenuItems: (collectionName: string) => collectionCard(collectionName).locator('.dropdown-item')
+  };
+};

--- a/tests/workspace/unopenable-collections/unopenable-collections.spec.ts
+++ b/tests/workspace/unopenable-collections/unopenable-collections.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import { test, expect, closeElectronApp, Page } from '../../../playwright';
+import { test, expect, closeElectronApp } from '../../../playwright';
 import { switchWorkspace, waitForReadyPage, buildCommonLocators } from '../../utils/page';
 
 const initUserDataPath = path.join(__dirname, 'init-user-data');
@@ -13,15 +13,6 @@ const MISSING_COLL = 'Missing Coll';
 const EMPTY_COLL = 'Empty Coll';
 const GHOST_COLL = 'Ghost Coll';
 
-const collectionCard = (page: Page, collectionName: string) =>
-  page.locator('.collection-card').filter({ hasText: collectionName });
-
-const collectionCardMenu = (page: Page, collectionName: string) =>
-  collectionCard(page, collectionName).locator('.collection-menu');
-
-const collectionCardMenuItems = (page: Page, collectionName: string) =>
-  collectionCard(page, collectionName).locator('.dropdown-item');
-
 test.describe('Collections that cannot be opened', () => {
   test('switching into the workspace reports how many collections failed to open', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createTmpDir('unopenable-coll-toast');
@@ -29,7 +20,7 @@ test.describe('Collections that cannot be opened', () => {
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
     const page = await waitForReadyPage(app);
-    const { toast, sidebar } = buildCommonLocators(page);
+    const { toast, sidebar, workspaceOverview } = buildCommonLocators(page);
 
     await test.step('The missing folder and the folder without a collection config are both counted', async () => {
       await switchWorkspace(page, WORKSPACE_NAME);
@@ -46,14 +37,14 @@ test.describe('Collections that cannot be opened', () => {
 
     await test.step('Both failed collections stay listed on the overview, badged as failed', async () => {
       for (const name of [MISSING_COLL, EMPTY_COLL]) {
-        await expect(collectionCard(page, name)).toBeVisible();
-        await expect(collectionCard(page, name).getByText('Failed to open')).toBeVisible();
+        await expect(workspaceOverview.collectionCard(name)).toBeVisible();
+        await expect(workspaceOverview.collectionCard(name).getByText('Failed to open')).toBeVisible();
       }
     });
 
     await test.step('The healthy and git-backed cards carry no failure badge', async () => {
-      await expect(collectionCard(page, HEALTHY_COLL).getByText('Failed to open')).toHaveCount(0);
-      await expect(collectionCard(page, GHOST_COLL).getByText('Failed to open')).toHaveCount(0);
+      await expect(workspaceOverview.collectionCard(HEALTHY_COLL).getByText('Failed to open')).toHaveCount(0);
+      await expect(workspaceOverview.collectionCard(GHOST_COLL).getByText('Failed to open')).toHaveCount(0);
     });
 
     await test.step('The collections count excludes the failed collections', async () => {
@@ -62,7 +53,7 @@ test.describe('Collections that cannot be opened', () => {
     });
 
     await test.step('Clicking a failed collection reports the failure and opens no tab', async () => {
-      await collectionCard(page, MISSING_COLL).click();
+      await workspaceOverview.collectionCard(MISSING_COLL).click();
       await expect(toast.byMessage(`Collection "${MISSING_COLL}" could not be opened`)).toBeVisible();
     });
 
@@ -75,7 +66,7 @@ test.describe('Collections that cannot be opened', () => {
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
     const page = await waitForReadyPage(app);
-    const { toast, sidebar } = buildCommonLocators(page);
+    const { toast, sidebar, workspaceOverview } = buildCommonLocators(page);
 
     await test.step('The broken collection is reported on switch', async () => {
       await switchWorkspace(page, 'Local Only WS');
@@ -83,8 +74,8 @@ test.describe('Collections that cannot be opened', () => {
     });
 
     await test.step('It is listed on the overview with a failure badge', async () => {
-      await expect(collectionCard(page, MISSING_COLL)).toBeVisible();
-      await expect(collectionCard(page, MISSING_COLL).getByText('Failed to open')).toBeVisible();
+      await expect(workspaceOverview.collectionCard(MISSING_COLL)).toBeVisible();
+      await expect(workspaceOverview.collectionCard(MISSING_COLL).getByText('Failed to open')).toBeVisible();
     });
 
     await test.step('The count reflects only the collection that opened', async () => {
@@ -138,18 +129,18 @@ test.describe('Collections that cannot be opened', () => {
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
     const page = await waitForReadyPage(app);
-    const { toast } = buildCommonLocators(page);
+    const { toast, workspaceOverview } = buildCommonLocators(page);
 
     await test.step('Choose Remove from the failed collection card menu', async () => {
       await switchWorkspace(page, WORKSPACE_NAME);
-      await expect(collectionCard(page, MISSING_COLL)).toBeVisible({ timeout: 10000 });
-      await collectionCard(page, MISSING_COLL).locator('.collection-menu').click();
-      await page.locator('.dropdown-item').getByText('Remove', { exact: true }).click();
+      await expect(workspaceOverview.collectionCard(MISSING_COLL)).toBeVisible({ timeout: 10000 });
+      await workspaceOverview.collectionCardMenu(MISSING_COLL).click();
+      await workspaceOverview.collectionCardMenuItems(MISSING_COLL).getByText('Remove', { exact: true }).click();
     });
 
     await test.step('The card disappears without a confirmation modal', async () => {
       await expect(toast.byMessage('Collection removed from workspace')).toBeVisible();
-      await expect(collectionCard(page, MISSING_COLL)).toHaveCount(0, { timeout: 5000 });
+      await expect(workspaceOverview.collectionCard(MISSING_COLL)).toHaveCount(0, { timeout: 5000 });
     });
 
     await test.step('workspace.yml no longer lists the entry, and the others survive', async () => {
@@ -169,7 +160,7 @@ test.describe('Collections that cannot be opened', () => {
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
     const page = await waitForReadyPage(app);
-    const { sidebar } = buildCommonLocators(page);
+    const { sidebar, workspaceOverview } = buildCommonLocators(page);
 
     await test.step('Switch into the workspace and let the healthy collection finish loading', async () => {
       await switchWorkspace(page, WORKSPACE_NAME);
@@ -177,13 +168,13 @@ test.describe('Collections that cannot be opened', () => {
     });
 
     await test.step('The failed collection card menu holds Remove and nothing else', async () => {
-      await collectionCardMenu(page, MISSING_COLL).click();
-      await expect(collectionCardMenuItems(page, MISSING_COLL)).toHaveText(['Remove']);
+      await workspaceOverview.collectionCardMenu(MISSING_COLL).click();
+      await expect(workspaceOverview.collectionCardMenuItems(MISSING_COLL)).toHaveText(['Remove']);
     });
 
     await test.step('A collection that opened keeps its full menu in the same workspace', async () => {
-      await collectionCardMenu(page, HEALTHY_COLL).click();
-      await expect(collectionCardMenuItems(page, HEALTHY_COLL)).toHaveText([
+      await workspaceOverview.collectionCardMenu(HEALTHY_COLL).click();
+      await expect(workspaceOverview.collectionCardMenuItems(HEALTHY_COLL)).toHaveText([
         'Rename',
         'Share',
         /^Reveal in /,

--- a/tests/workspace/unopenable-collections/unopenable-collections.spec.ts
+++ b/tests/workspace/unopenable-collections/unopenable-collections.spec.ts
@@ -16,6 +16,12 @@ const GHOST_COLL = 'Ghost Coll';
 const collectionCard = (page: Page, collectionName: string) =>
   page.locator('.collection-card').filter({ hasText: collectionName });
 
+const collectionCardMenu = (page: Page, collectionName: string) =>
+  collectionCard(page, collectionName).locator('.collection-menu');
+
+const collectionCardMenuItems = (page: Page, collectionName: string) =>
+  collectionCard(page, collectionName).locator('.dropdown-item');
+
 test.describe('Collections that cannot be opened', () => {
   test('switching into the workspace reports how many collections failed to open', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createTmpDir('unopenable-coll-toast');
@@ -152,6 +158,39 @@ test.describe('Collections that cannot be opened', () => {
       expect(raw).toContain(HEALTHY_COLL);
       expect(raw).toContain(EMPTY_COLL);
       expect(raw).toContain(GHOST_COLL);
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('a failed collection card offers Remove and no other action', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createTmpDir('unopenable-coll-menu');
+    await fs.promises.cp(fixturePath, workspacePath, { recursive: true });
+
+    const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
+    const page = await waitForReadyPage(app);
+    const { sidebar } = buildCommonLocators(page);
+
+    await test.step('Switch into the workspace and let the healthy collection finish loading', async () => {
+      await switchWorkspace(page, WORKSPACE_NAME);
+      await expect(sidebar.collection(HEALTHY_COLL)).toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('The failed collection card menu holds Remove and nothing else', async () => {
+      await collectionCardMenu(page, MISSING_COLL).click();
+      await expect(collectionCardMenuItems(page, MISSING_COLL)).toHaveText(['Remove']);
+    });
+
+    await test.step('A collection that opened keeps its full menu in the same workspace', async () => {
+      await collectionCardMenu(page, HEALTHY_COLL).click();
+      await expect(collectionCardMenuItems(page, HEALTHY_COLL)).toHaveText([
+        'Rename',
+        'Share',
+        /^Reveal in /,
+        'Connect to Git',
+        'Remove',
+        'Delete'
+      ]);
     });
 
     await closeElectronApp(app);


### PR DESCRIPTION
### Description
**BRU-4246**

For collections that fail to open, the workspace overview currently shows all context-menu options. However, most of these actions are not supported for failed collections and will fail when selected. The **Remove** option is the only action that works correctly.

### Problem

When a collection cannot be opened, users can still see actions such as **Rename, Share, Delete**, and other options in the context menu. These actions do not work for failed collections, which can be confusing and prevent users from properly managing invalid collections.

### Fix

For collections that failed to open, only showing the **Remove** option in the dropdown.

### Screenshots

**Before**

<img width="1271" height="734" alt="Screenshot 2026-08-11 at 4 23 45 PM" src="https://github.com/user-attachments/assets/7d352179-d3f6-4a21-948d-8d53c1773d4d" />


**After**

<img width="1269" height="738" alt="Screenshot 2026-08-11 at 4 23 19 PM" src="https://github.com/user-attachments/assets/e2aae78f-67e9-4f42-ada4-bc9c8035b8e4" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated collection menus to hide unavailable actions for collections that fail to open, including Rename, Share, Delete, Show in Folder, and Git options.
  * Kept the Remove option available for failed collections.
  * Preserved the full set of actions for collections that open successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->