### PR TITLE
fix(oauth2): overwrite standard authorization params instead of appending

### DIFF
--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -314,22 +314,24 @@ const getOAuth2AuthorizationCode = (request, codeChallenge, collectionUid) => {
     const effectiveState = generateState({ userState: state });
 
     const authorizationUrlWithQueryParams = new URL(authorizationUrl);
-    authorizationUrlWithQueryParams.searchParams.append('response_type', 'code');
-    authorizationUrlWithQueryParams.searchParams.append('client_id', clientId);
+    // Use set (not append) for standard single-valued params so re-running after editing a value
+    // (e.g. clientId) overwrites it instead of duplicating it in the authorization URL.
+    authorizationUrlWithQueryParams.searchParams.set('response_type', 'code');
+    authorizationUrlWithQueryParams.searchParams.set('client_id', clientId);
 
     if (effectiveCallbackUrl) {
-      authorizationUrlWithQueryParams.searchParams.append('redirect_uri', effectiveCallbackUrl);
+      authorizationUrlWithQueryParams.searchParams.set('redirect_uri', effectiveCallbackUrl);
     }
 
     if (scope) {
-      authorizationUrlWithQueryParams.searchParams.append('scope', scope);
+      authorizationUrlWithQueryParams.searchParams.set('scope', scope);
     }
     if (pkce) {
-      authorizationUrlWithQueryParams.searchParams.append('code_challenge', codeChallenge);
-      authorizationUrlWithQueryParams.searchParams.append('code_challenge_method', 'S256');
+      authorizationUrlWithQueryParams.searchParams.set('code_challenge', codeChallenge);
+      authorizationUrlWithQueryParams.searchParams.set('code_challenge_method', 'S256');
     }
     if (effectiveState) {
-      authorizationUrlWithQueryParams.searchParams.append('state', effectiveState);
+      authorizationUrlWithQueryParams.searchParams.set('state', effectiveState);
     }
     if (additionalParameters?.authorization?.length) {
       additionalParameters.authorization.forEach((param) => {
@@ -854,17 +856,19 @@ const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid, forceF
   }
 
   const authorizationUrlWithQueryParams = new URL(authorizationUrl);
-  authorizationUrlWithQueryParams.searchParams.append('response_type', 'token');
-  authorizationUrlWithQueryParams.searchParams.append('client_id', clientId);
+  // Use set (not append) for standard single-valued params so re-running after editing a value
+  // (e.g. clientId) overwrites it instead of duplicating it in the authorization URL.
+  authorizationUrlWithQueryParams.searchParams.set('response_type', 'token');
+  authorizationUrlWithQueryParams.searchParams.set('client_id', clientId);
 
   if (effectiveCallbackUrl) {
-    authorizationUrlWithQueryParams.searchParams.append('redirect_uri', effectiveCallbackUrl);
+    authorizationUrlWithQueryParams.searchParams.set('redirect_uri', effectiveCallbackUrl);
   }
 
   if (scope) {
-    authorizationUrlWithQueryParams.searchParams.append('scope', scope);
+    authorizationUrlWithQueryParams.searchParams.set('scope', scope);
   }
-  authorizationUrlWithQueryParams.searchParams.append('state', effectiveState);
+  authorizationUrlWithQueryParams.searchParams.set('state', effectiveState);
 
   if (additionalParameters?.authorization?.length) {
     additionalParameters.authorization.forEach((param) => {


### PR DESCRIPTION
### Description

The Authorization Code and Implicit OAuth 2.0 flows build the authorization URL using `URLSearchParams.append` for the standard single-valued parameters (`response_type`, `client_id`, `redirect_uri`, `scope`, `code_challenge`, `state`). When one of these is already present on the configured authorization endpoint — or when the user edits a value such as the Client ID and re-runs — the value is appended, producing a duplicated parameter in the authorization request.

This changes those single-valued params to `URLSearchParams.set` so they overwrite. User-defined additional authorization params are left as `append` (they may legitimately be multi-valued).

Fixes #8933.

### How it was tested

- Existing `bruno-electron` oauth2 tests pass.
- Manually: configured an Authorization URL already containing `client_id`, set a different Client ID field, and confirmed the resulting authorization request now carries a single `client_id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 authorization URL handling by preventing duplicate standard parameters when URLs are reused or edited.
  * Preserved support for adding additional custom query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->