### PR TITLE
fix(variables): improve large collection editor performance

### DIFF
--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -148,10 +148,10 @@ class MultiLineEditor extends Component {
 
     // Update collection and item when they change
     if (this.props.enableBrunoVarInfo !== false && this.editor.options.brunoVarInfo) {
-      if (!isEqual(this.props.collection, this.editor.options.brunoVarInfo.collection)) {
+      if (this.props.collection !== this.editor.options.brunoVarInfo.collection) {
         this.editor.options.brunoVarInfo.collection = this.props.collection;
       }
-      if (!isEqual(this.props.item, this.editor.options.brunoVarInfo.item)) {
+      if (this.props.item !== this.editor.options.brunoVarInfo.item) {
         this.editor.options.brunoVarInfo.item = this.props.item;
       }
     }

--- a/packages/bruno-app/src/components/MultiLineEditor/index.spec.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.spec.js
@@ -1,0 +1,74 @@
+import MultiLineEditor from './index';
+import { getAllVariables } from 'utils/collections';
+
+jest.mock('codemirror', () => jest.fn());
+
+jest.mock('utils/collections', () => ({
+  getAllVariables: jest.fn()
+}));
+
+jest.mock('utils/common/codemirror', () => ({
+  defineCodeMirrorBrunoVariablesMode: jest.fn()
+}));
+
+jest.mock('utils/codemirror/autocomplete', () => ({
+  setupAutoComplete: jest.fn()
+}));
+
+jest.mock('utils/common/masked-editor', () => ({
+  MaskedEditor: jest.fn()
+}));
+
+jest.mock('utils/codemirror/linkAware', () => ({
+  setupLinkAware: jest.fn()
+}));
+
+describe('MultiLineEditor', () => {
+  it('updates collection variable info without traversing collection items', () => {
+    const createCollection = () => {
+      const getItems = jest.fn(() => []);
+      const collection = { uid: 'collection-1' };
+      Object.defineProperty(collection, 'items', {
+        enumerable: true,
+        get: getItems
+      });
+      return { collection, getItems };
+    };
+
+    const previous = createCollection();
+    const current = createCollection();
+    const variables = { baseUrl: 'https://example.com' };
+    const previousProps = {
+      collection: previous.collection,
+      value: '',
+      theme: 'light',
+      isSecret: false,
+      readOnly: false,
+      placeholder: ''
+    };
+    const editor = new MultiLineEditor(previousProps);
+
+    editor.variables = variables;
+    editor.editor = {
+      options: {
+        brunoVarInfo: {
+          collection: previous.collection,
+          item: undefined,
+          variables
+        }
+      },
+      setOption: jest.fn()
+    };
+    editor.props = {
+      ...previousProps,
+      collection: current.collection
+    };
+    getAllVariables.mockReturnValue(variables);
+
+    editor.componentDidUpdate(previousProps);
+
+    expect(editor.editor.options.brunoVarInfo.collection).toBe(current.collection);
+    expect(previous.getItems).not.toHaveBeenCalled();
+    expect(current.getItems).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-app/src/components/MultiLineEditor/index.spec.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.spec.js
@@ -71,4 +71,42 @@ describe('MultiLineEditor', () => {
     expect(previous.getItems).not.toHaveBeenCalled();
     expect(current.getItems).not.toHaveBeenCalled();
   });
+
+  it('updates item variable info when the item reference changes', () => {
+    const previousItem = { uid: 'request-1' };
+    const currentItem = { uid: 'request-1' };
+    const collection = { uid: 'collection-1' };
+    const variables = { baseUrl: 'https://example.com' };
+    const previousProps = {
+      collection,
+      item: previousItem,
+      value: '',
+      theme: 'light',
+      isSecret: false,
+      readOnly: false,
+      placeholder: ''
+    };
+    const editor = new MultiLineEditor(previousProps);
+
+    editor.variables = variables;
+    editor.editor = {
+      options: {
+        brunoVarInfo: {
+          collection,
+          item: previousItem,
+          variables
+        }
+      },
+      setOption: jest.fn()
+    };
+    editor.props = {
+      ...previousProps,
+      item: currentItem
+    };
+    getAllVariables.mockReturnValue(variables);
+
+    editor.componentDidUpdate(previousProps);
+
+    expect(editor.editor.options.brunoVarInfo.item).toBe(currentItem);
+  });
 });

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1301,7 +1301,7 @@ export const getTotalRequestCountInCollection = (collection) => {
 export const getAllVariables = (collection, item) => {
   if (!collection) return {};
   const envVariables = getEnvironmentVariables(collection);
-  const requestTreePath = getTreePathFromCollectionToItem(collection, item);
+  const requestTreePath = item?.uid ? getTreePathFromCollectionToItem(collection, item) : [];
   let { collectionVariables, folderVariables, requestVariables } = mergeVars(collection, requestTreePath);
   const pathParams = getPathParams(item);
   const { globalEnvironmentVariables = {} } = collection;

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -2,7 +2,10 @@ const { describe, it, expect } = require('@jest/globals');
 import { getAllVariables, mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
 
 describe('getAllVariables', () => {
-  it('resolves collection variables without reading request items when no item is provided', () => {
+  it.each([
+    ['no item is provided', undefined],
+    ['the item has no uid', {}]
+  ])('resolves collection variables without reading request items when %s', (_, item) => {
     const collection = {
       root: {
         request: {
@@ -25,7 +28,7 @@ describe('getAllVariables', () => {
       }
     });
 
-    expect(getAllVariables(collection)).toMatchObject({
+    expect(getAllVariables(collection, item)).toMatchObject({
       baseUrl: 'https://example.com'
     });
   });

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,35 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
+import { getAllVariables, mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
+
+describe('getAllVariables', () => {
+  it('resolves collection variables without reading request items when no item is provided', () => {
+    const collection = {
+      root: {
+        request: {
+          vars: {
+            req: [
+              {
+                name: 'baseUrl',
+                value: 'https://example.com',
+                enabled: true
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    Object.defineProperty(collection, 'items', {
+      get: () => {
+        throw new Error('collection items should not be accessed');
+      }
+    });
+
+    expect(getAllVariables(collection)).toMatchObject({
+      baseUrl: 'https://example.com'
+    });
+  });
+});
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {


### PR DESCRIPTION
### Description

Reduces the cost of updating variable editors for collections containing a large number of requests.

Related to #8928.

### Problem

Collection-level variable editors call `getAllVariables(collection)` without a request item. The function previously called `getTreePathFromCollectionToItem` unconditionally, recursively flattening and searching every request even though folder and request variables cannot apply without an item.

The multiline editors also deep-compared the entire collection whenever their props changed, which traversed the request tree again.

### Relationship to #8931

#8931 addresses the main typing delay reported in #8928 by preventing unchanged rows and editors in `EnvironmentVariablesTable` from re-rendering on every keystroke.

This PR is complementary: when a variable editor does update, it avoids request-tree traversal and deep collection comparisons. The two PRs reduce different parts of the same update path.

### Fix

- Skip request-tree traversal when no valid `item.uid` is provided.
- Compare collection and item references instead of deep-comparing them when refreshing multiline editor metadata.
- Continue resolving collection, environment, global, runtime, and process variables normally.
- Add regression coverage for missing items, items without a UID, and collection/item reference updates without traversing collection items.

### Verification

- `npm test --workspace=packages/bruno-app -- --runInBand src/components/MultiLineEditor/index.spec.js src/utils/collections/index.spec.js`
- `npm run lint -- packages/bruno-app/src/components/MultiLineEditor/index.spec.js packages/bruno-app/src/utils/collections/index.spec.js`
- `npm run build:web`

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collection variables now resolve correctly when no specific item is selected.
  * Prevented unnecessary lookups for unavailable collection items, improving reliability.
  * Variable metadata now updates correctly when switching collections or items in the multiline editor.

* **Tests**
  * Added coverage for collection variable resolution and multiline editor updates without traversing collection items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->