### PR TITLE
test(opencollection): cover multipart after yml reload

### DIFF
--- a/tests/collection/opencollection/multipart-file-path.spec.ts
+++ b/tests/collection/opencollection/multipart-file-path.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect, closeElectronApp } from '../../../playwright';
 import {
   addMultipartFileToLastRow,
+  buildCommonLocators,
   openRequest,
   removeFirstMultipartFile,
   saveRequest,
   selectRequestBodyMode,
-  selectRequestPaneTab
+  selectRequestPaneTab,
+  sendRequestAndWaitForResponse
 } from '../../utils/page';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -50,7 +52,7 @@ const setupOpenCollection = async (collectionDir: string, userDataDir: string) =
       '',
       'http:',
       '  method: POST',
-      '  url: https://example.com/upload',
+      '  url: http://localhost:8081/api/echo/everything',
       '',
       'settings:',
       '  encodeUrl: true',
@@ -96,10 +98,13 @@ const expectRequestFileNotToContainPayload = async (requestFilePath: string, pay
 };
 
 test.describe('OpenCollection multipart file paths', () => {
-  test('keeps an in-collection multipart file relative after restart, OpenCollection edit, remove, and re-add', async ({
+  // Regression coverage for https://github.com/usebruno/bruno/issues/8937
+  test('keeps a multipart file relative and sends it as multipart after restart', async ({
     launchElectronApp,
     createTmpDir
   }) => {
+    test.setTimeout(120_000);
+
     const collectionDir = path.join(await createTmpDir('opencollection-multipart'), collectionName);
     const userDataDir = await createTmpDir('opencollection-multipart-userdata');
     const payloadPath = path.join(collectionDir, relativePayloadPath);
@@ -120,8 +125,11 @@ test.describe('OpenCollection multipart file paths', () => {
     await selectRequestBodyMode(page, 'Multipart Form');
 
     await addMultipartFileToLastRow(page, electronApp, payloadPath);
+    const multipartTable = buildCommonLocators(page).table('multipart-form-table');
+    await multipartTable.rowCell('name', 0).getByRole('textbox').fill('payload');
     await saveRequest(page);
     await expectRequestFileToContainRelativePayload(requestFilePath, payloadPath);
+    await expect.poll(async () => fs.promises.readFile(requestFilePath, 'utf-8')).toContain('type: multipart-form');
 
     await closeElectronApp(electronApp);
     await fs.promises.appendFile(path.join(collectionDir, 'opencollection.yml'), '\n\n', 'utf-8');
@@ -133,6 +141,16 @@ test.describe('OpenCollection multipart file paths', () => {
 
     await openRequest(page, collectionName, requestName, { persist: true });
     await selectRequestPaneTab(page, 'Body');
+
+    const locators = buildCommonLocators(page);
+    await expect(locators.request.bodyModeSelector()).toContainText('Multipart Form');
+
+    await sendRequestAndWaitForResponse(page, 200, { timeout: 30000 });
+    const responseBody = locators.response.previewContainer();
+    await expect(responseBody).toContainText(/multipart\/form-data;\s*boundary=/i);
+    await expect(responseBody).not.toContainText(/"content-type":\s*"application\/json"/i);
+    await expect(responseBody).toContainText('payload.json');
+
     await removeFirstMultipartFile(page);
     await saveRequest(page);
     await expectRequestFileNotToContainPayload(requestFilePath, payloadPath);

--- a/tests/collection/opencollection/multipart-file-path.spec.ts
+++ b/tests/collection/opencollection/multipart-file-path.spec.ts
@@ -149,7 +149,10 @@ test.describe('OpenCollection multipart file paths', () => {
     const responseBody = locators.response.previewContainer();
     await expect(responseBody).toContainText(/multipart\/form-data;\s*boundary=/i);
     await expect(responseBody).not.toContainText(/"content-type":\s*"application\/json"/i);
-    await expect(responseBody).toContainText('payload.json');
+    await expect(responseBody).toContainText(
+      /Content-Disposition:[\s\S]*form-data;[\s\S]*name=\\?"payload\\?"[\s\S]*filename=\\?"payload\.json\\?"/i
+    );
+    await expect(responseBody).toContainText(/\\?"ok\\?"\s*:\s*true/i);
 
     await removeFirstMultipartFile(page);
     await saveRequest(page);


### PR DESCRIPTION
### Description

Adds regression coverage for #8937.

The existing OpenCollection multipart file-path E2E test now verifies the complete save and reload flow against the local echo server:

- the saved YML body remains `multipart-form`
- the request body mode remains `Multipart Form` after an application restart
- the outgoing request uses `multipart/form-data` with a boundary instead of `application/json`
- the selected file is present in the transmitted multipart body

### Problem

Bruno v4.0.0 was reported to send a saved OpenCollection multipart request as JSON after the request or application was reopened. The editor still displayed Multipart Form, but the outgoing payload could contain Bruno's internal multipart parameter array.

Current `main` already preserves and sends the multipart body correctly for the reported save and restart flow, but the existing E2E test only checked persistence of the relative file path and did not verify the actual outgoing request.

### Fix

Extended the existing OpenCollection multipart file-path test to send the reloaded request to the local `/api/echo/everything` endpoint and assert the body mode, persisted YML type, Content-Type boundary, and transmitted file name.

No production code is changed because the reported behavior is not reproducible on current `main`.

### Screenshots

Not applicable; this change adds automated regression coverage and does not change the UI.

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for multipart file-path requests.
  * Verified multipart requests retain their type, include the expected filename and JSON payload, and return the correct response after restart.
  * Improved test reliability with updated timing and clearer issue traceability.

* **User Impact**
  * No direct changes to end-user functionality.
  * Existing multipart file-path behavior is now covered more thoroughly to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->