### PR TITLE
fix(assertions): isTruthy/isFalsy now evaluate truthiness, not strict boolean equality

### DIFF
--- a/packages/bruno-js/src/runtime/assert-runtime.js
+++ b/packages/bruno-js/src/runtime/assert-runtime.js
@@ -530,10 +530,10 @@ class AssertRuntime {
             expect(lhs).to.not.be.undefined;
             break;
           case 'isTruthy':
-            expect(lhs).to.be.true;
+            expect(lhs).to.be.ok;
             break;
           case 'isFalsy':
-            expect(lhs).to.be.false;
+            expect(lhs).to.not.be.ok;
             break;
           case 'isJson':
             expect(lhs).to.be.json;

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -531,6 +531,86 @@ describe('runtime', () => {
       });
     });
 
+    describe('isTruthy / isFalsy', () => {
+      it('isTruthy should pass for a truthy non-boolean value (status 200)', () => {
+        const results = runAssertions(
+          [{ name: 'res.status', value: 'isTruthy', enabled: true }],
+          { status: 200, statusText: 'OK', data: {}, headers: {} }
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('isTruthy should pass for truthy numbers, strings and objects', () => {
+        const results = runAssertions(
+          [
+            { name: 'res.body.count', value: 'isTruthy', enabled: true },
+            { name: 'res.body.name', value: 'isTruthy', enabled: true },
+            { name: 'res.body.tags', value: 'isTruthy', enabled: true }
+          ],
+          makeResponse({ count: 5, name: 'x', tags: ['a'] })
+        );
+        expect(results[0].status).toBe('pass');
+        expect(results[1].status).toBe('pass');
+        expect(results[2].status).toBe('pass');
+      });
+
+      it('isTruthy should still pass for the boolean true', () => {
+        const results = runAssertions(
+          [{ name: 'res.body.active', value: 'isTruthy', enabled: true }],
+          makeResponse({ active: true })
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('isTruthy should fail for falsy values', () => {
+        const results = runAssertions(
+          [
+            { name: 'res.body.zero', value: 'isTruthy', enabled: true },
+            { name: 'res.body.empty', value: 'isTruthy', enabled: true },
+            { name: 'res.body.active', value: 'isTruthy', enabled: true }
+          ],
+          makeResponse({ zero: 0, empty: '', active: false })
+        );
+        expect(results[0].status).toBe('fail');
+        expect(results[1].status).toBe('fail');
+        expect(results[2].status).toBe('fail');
+      });
+
+      it('isFalsy should pass for falsy non-boolean values (0, "", null)', () => {
+        const results = runAssertions(
+          [
+            { name: 'res.body.zero', value: 'isFalsy', enabled: true },
+            { name: 'res.body.empty', value: 'isFalsy', enabled: true },
+            { name: 'res.body.nul', value: 'isFalsy', enabled: true }
+          ],
+          makeResponse({ zero: 0, empty: '', nul: null })
+        );
+        expect(results[0].status).toBe('pass');
+        expect(results[1].status).toBe('pass');
+        expect(results[2].status).toBe('pass');
+      });
+
+      it('isFalsy should still pass for the boolean false', () => {
+        const results = runAssertions(
+          [{ name: 'res.body.active', value: 'isFalsy', enabled: true }],
+          makeResponse({ active: false })
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('isFalsy should fail for truthy values', () => {
+        const results = runAssertions(
+          [
+            { name: 'res.body.count', value: 'isFalsy', enabled: true },
+            { name: 'res.body.name', value: 'isFalsy', enabled: true }
+          ],
+          makeResponse({ count: 5, name: 'x' })
+        );
+        expect(results[0].status).toBe('fail');
+        expect(results[1].status).toBe('fail');
+      });
+    });
+
     describe('jsonSchema', () => {
       const chai = require('chai');
 


### PR DESCRIPTION
## Summary

The `isTruthy` and `isFalsy` assertion operators tested strict boolean identity instead of truthiness, so they failed for every non-boolean value.

## Problem

In `packages/bruno-js/src/runtime/assert-runtime.js`, the two operators were implemented as:

```js
case 'isTruthy':
  expect(lhs).to.be.true;   // asserts lhs === true
  break;
case 'isFalsy':
  expect(lhs).to.be.false;  // asserts lhs === false
  break;
```

Chai's `.to.be.true` asserts strict identity with the boolean literal `true`, not truthiness. So a perfectly reasonable assertion like `res.status` `isTruthy` (status `200`) failed with `expected 200 to be true`. Likewise `isFalsy` failed for `0`, `""` and `null`.

This contradicts both the operator list comment in the same file (`isTruthy : is truthy`) and the UI labels in `AssertionOperator` / `AssertionRow`. A separate `isBoolean` operator already exists for strict boolean type checks, which makes a strict-equality `isTruthy` both mislabeled and redundant.

## Fix

Use the truthiness assertors:

```js
case 'isTruthy':
  expect(lhs).to.be.ok;       // !!lhs
  break;
case 'isFalsy':
  expect(lhs).to.not.be.ok;   // !lhs
  break;
```

The only inputs the old code happened to accept (`true` / `false`) keep working; every truthy/falsy value now works as documented.

## Tests

Added an `isTruthy / isFalsy` block to `packages/bruno-js/tests/runtime.spec.js`. On `main`, three of the cases fail (e.g. `expected 200 to be true`); after this change all of them pass.

```
✓ isTruthy should pass for a truthy non-boolean value (status 200)
✓ isTruthy should pass for truthy numbers, strings and objects
✓ isTruthy should still pass for the boolean true
✓ isTruthy should fail for falsy values
✓ isFalsy should pass for falsy non-boolean values (0, "", null)
✓ isFalsy should still pass for the boolean false
✓ isFalsy should fail for truthy values
```

`npm test --workspace=packages/bruno-js` — 620 passed.

## Checklist

- [x] I've used AI significantly to create this pull request
- [ ] I have added screenshots or gifs to help explain the change if applicable.
- [x] I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).
- [x] I've run the claude code review skill locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated truthiness assertions to correctly accept any truthy or falsy value, including numbers, strings, objects, booleans, zero, empty strings, and null.

* **Tests**
  * Added coverage for truthiness and falsiness checks across common value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->