### PR TITLE
fix(mock) : mock server remains enabled by default in the preferences

### DIFF
--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -55,7 +55,7 @@ const defaultPreferences = {
   },
   beta: {
     'openapi-sync': false,
-    'mock-server': true
+    'mock-server': false
   },
   onboarding: {
     hasLaunchedBefore: false,


### PR DESCRIPTION
BRU-4264

### Description

The mock server remains enabled by default for a new user in the default preferences.

### Problem

For any new user, the mock server sidebar and other options would start showing up by default without the user explicitly setting it true. This was happening since the preferences had mock-server enabled by default.

### Fix

Changed the defaultPreferences in the preferences json to have beta[mock-server] as false. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Mock server functionality is now disabled by default for new installations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->