### PR TITLE
perf(runner): store runner request and response payloads in sqlite

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/RunnerResults/ResponsePane/index.js
@@ -21,9 +21,8 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
 
   const { testResults, assertionResults, preRequestTestResults, postResponseTestResults, error } = item;
 
-  const stored = useStoredRunnerExchange(item);
-  const requestSent = stored.requestSent ?? item.requestSent;
-  const responseReceived = stored.responseReceived ?? item.responseReceived ?? {};
+  const { requestSent, responseReceived: storedResponse } = useStoredRunnerExchange(item);
+  const responseReceived = storedResponse ?? item.responseReceived ?? {};
 
   useEffect(() => {
     if (item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage || item?.testScriptErrorMessage) {

--- a/packages/bruno-app/src/components/RunnerResults/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/RunnerResults/ResponsePane/index.js
@@ -21,8 +21,8 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
 
   const { testResults, assertionResults, preRequestTestResults, postResponseTestResults, error } = item;
 
-  const { requestSent, responseReceived: storedResponse } = useStoredRunnerExchange(item);
-  const responseReceived = storedResponse ?? item.responseReceived ?? {};
+  const { requestSent, responseReceived: exchangeResponse } = useStoredRunnerExchange(item);
+  const responseReceived = exchangeResponse ?? {};
 
   useEffect(() => {
     if (item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage || item?.testScriptErrorMessage) {

--- a/packages/bruno-app/src/components/RunnerResults/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/RunnerResults/ResponsePane/index.js
@@ -13,12 +13,17 @@ import SkippedRequest from 'components/ResponsePane/SkippedRequest';
 import RunnerTimeline from 'components/ResponsePane/RunnerTimeline';
 import ScriptError from 'components/ResponsePane/ScriptError';
 import ScriptErrorIcon from 'components/ResponsePane/ScriptErrorIcon';
+import useStoredRunnerExchange from 'hooks/useStoredRunnerExchange';
 
 const ResponsePane = ({ rightPaneWidth, item, collection }) => {
   const [selectedTab, setSelectedTab] = useState('response');
   const [showScriptErrorCard, setShowScriptErrorCard] = useState(false);
 
-  const { requestSent, responseReceived, testResults, assertionResults, preRequestTestResults, postResponseTestResults, error } = item;
+  const { testResults, assertionResults, preRequestTestResults, postResponseTestResults, error } = item;
+
+  const stored = useStoredRunnerExchange(item);
+  const requestSent = stored.requestSent ?? item.requestSent;
+  const responseReceived = stored.responseReceived ?? item.responseReceived ?? {};
 
   useEffect(() => {
     if (item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage || item?.testScriptErrorMessage) {
@@ -26,10 +31,10 @@ const ResponsePane = ({ rightPaneWidth, item, collection }) => {
     }
   }, [item?.preRequestScriptErrorMessage, item?.postResponseScriptErrorMessage, item?.testScriptErrorMessage]);
 
-  const headers = get(item, 'responseReceived.headers', []);
-  const status = get(item, 'responseReceived.status', 0);
-  const size = get(item, 'responseReceived.size', 0);
-  const duration = get(item, 'responseReceived.duration', 0);
+  const headers = get(responseReceived, 'headers', []);
+  const status = get(responseReceived, 'status', 0);
+  const size = get(responseReceived, 'size', 0);
+  const duration = get(responseReceived, 'duration', 0);
 
   const hasScriptError = item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage || item?.testScriptErrorMessage;
 

--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import path from 'utils/common/path';
 import { useDispatch } from 'react-redux';
+import useClearStoredRunnerExchanges from 'hooks/useClearStoredRunnerExchanges';
 import { get } from 'lodash';
 import { runCollectionFolder, cancelRunnerExecution, mountCollection, updateRunnerConfiguration } from 'providers/ReduxStore/slices/collections/actions';
 import { resetCollectionRunner } from 'providers/ReduxStore/slices/collections';
@@ -84,6 +85,8 @@ export default function RunnerResults({ collection }) {
   const isReRunningRef = useRef(false);
   // ref for the runner output body
   const runnerBodyRef = useRef();
+
+  const clearStoredRunnerExchanges = useClearStoredRunnerExchanges(collection.uid);
 
   const collectionCopy = collection;
   const runnerInfo = get(collection, 'runnerResult.info', {});
@@ -184,19 +187,21 @@ export default function RunnerResults({ collection }) {
     }));
   };
 
-  const runCollection = () => {
+  const runCollection = async () => {
     const savedOrder = get(collection, 'runnerConfiguration.requestItemsOrder', selectedRequestItems);
     dispatch(updateRunnerConfiguration(collection.uid, selectedRequestItems, savedOrder, delay));
+    await clearStoredRunnerExchanges();
     dispatch(runCollectionFolder(collection.uid, null, true, Number(delay), tags, selectedRequestItems));
   };
 
-  const runAgain = () => {
+  const runAgain = async () => {
     ensureCollectionIsMounted();
     isReRunningRef.current = true;
     // Get the saved configuration to determine what to run
     const savedConfiguration = get(collection, 'runnerConfiguration', null);
     const savedSelectedItems = savedConfiguration?.selectedRequestItems || [];
     const savedDelay = savedConfiguration?.delay !== undefined ? savedConfiguration.delay : delay;
+    await clearStoredRunnerExchanges();
     dispatch(
       runCollectionFolder(
         collection.uid,
@@ -211,6 +216,7 @@ export default function RunnerResults({ collection }) {
 
   const resetRunner = () => {
     isReRunningRef.current = false;
+    clearStoredRunnerExchanges();
     dispatch(
       resetCollectionRunner({
         collectionUid: collection.uid

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RunCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RunCollectionItem/index.js
@@ -3,6 +3,7 @@ import get from 'lodash/get';
 import { uuid } from 'utils/common';
 import Modal from 'components/Modal';
 import { useDispatch, useSelector } from 'react-redux';
+import useClearStoredRunnerExchanges from 'hooks/useClearStoredRunnerExchanges';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import { runCollectionFolder } from 'providers/ReduxStore/slices/collections/actions';
 import { flattenItems } from 'utils/collections';
@@ -22,7 +23,9 @@ const RunCollectionItem = ({ collectionUid, item, onClose }) => {
   // tags for the collection run
   const tags = get(collection, 'runnerTags', { include: [], exclude: [] });
 
-  const onSubmit = (recursive) => {
+  const clearStoredRunnerExchanges = useClearStoredRunnerExchanges(collection.uid);
+
+  const onSubmit = async (recursive) => {
     dispatch(
       addTab({
         uid: uuid(),
@@ -31,6 +34,7 @@ const RunCollectionItem = ({ collectionUid, item, onClose }) => {
       })
     );
     if (!isCollectionRunInProgress) {
+      await clearStoredRunnerExchanges();
       dispatch(runCollectionFolder(collection.uid, item ? item.uid : null, recursive, delay ? Number(delay) : null, tags));
     }
     onClose();

--- a/packages/bruno-app/src/hooks/useClearStoredRunnerExchanges/index.js
+++ b/packages/bruno-app/src/hooks/useClearStoredRunnerExchanges/index.js
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useSqliteMutation } from '@usebruno/sqlite/web';
+
+const useClearStoredRunnerExchanges = (collectionUid) => {
+  const { mutateAsync } = useSqliteMutation('delete_runner_responses_for_collection');
+
+  return useCallback(async () => {
+    try {
+      await mutateAsync({ collection_uid: collectionUid });
+    } catch (error) {
+      console.error('Failed to clear stored runner payloads', error);
+    }
+  }, [mutateAsync, collectionUid]);
+};
+
+export default useClearStoredRunnerExchanges;

--- a/packages/bruno-app/src/hooks/useStoredRunnerExchange/index.js
+++ b/packages/bruno-app/src/hooks/useStoredRunnerExchange/index.js
@@ -14,9 +14,9 @@ const useStoredRunnerExchange = (item) => {
   });
 
   return useMemo(() => ({
-    requestSent: data?.request ? safeParseJSON(data.request) : null,
-    responseReceived: data?.response ? safeParseJSON(data.response) : null
-  }), [data?.request, data?.response]);
+    requestSent: data?.request ? safeParseJSON(data.request) : item?.requestSent ?? null,
+    responseReceived: data?.response ? safeParseJSON(data.response) : item?.responseReceived ?? null
+  }), [data?.request, data?.response, item?.requestSent, item?.responseReceived]);
 };
 
 export default useStoredRunnerExchange;

--- a/packages/bruno-app/src/hooks/useStoredRunnerExchange/index.js
+++ b/packages/bruno-app/src/hooks/useStoredRunnerExchange/index.js
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useSqliteQuery } from '@usebruno/sqlite/web';
+import { safeParseJSON } from 'utils/common';
+
+const useStoredRunnerExchange = (item) => {
+  const requestUid = item?.requestUid;
+  // A row is written in two steps (request, then response) and is final once the item settles.
+  // Reading earlier would refetch on every runner write, because any mutation to runner_responses
+  // invalidates every active query against that table.
+  const hasSettled = item?.status === 'completed' || item?.status === 'error';
+
+  const { data } = useSqliteQuery('get_runner_response', { request_uid: requestUid }, {
+    enabled: Boolean(requestUid) && hasSettled
+  });
+
+  return useMemo(() => ({
+    requestSent: data?.request ? safeParseJSON(data.request) : null,
+    responseReceived: data?.response ? safeParseJSON(data.response) : null
+  }), [data?.request, data?.response]);
+};
+
+export default useStoredRunnerExchange;

--- a/packages/bruno-app/src/hooks/useStoredRunnerExchange/index.spec.js
+++ b/packages/bruno-app/src/hooks/useStoredRunnerExchange/index.spec.js
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react';
+import { useSqliteQuery } from '@usebruno/sqlite/web';
+import useStoredRunnerExchange from './index';
+
+jest.mock('@usebruno/sqlite/web', () => ({ useSqliteQuery: jest.fn() }));
+
+const REQUEST_SENT = { method: 'GET', url: 'https://example.com/userinfo', headers: {} };
+
+const RESPONSE_RECEIVED = {
+  status: 200,
+  statusText: 'OK',
+  headers: { 'content-type': 'application/json' },
+  data: { ok: true },
+  size: 12,
+  duration: 34
+};
+
+const settledItem = (overrides = {}) => ({
+  uid: 'item-1',
+  requestUid: 'run-1',
+  status: 'completed',
+  ...overrides
+});
+
+describe('useStoredRunnerExchange', () => {
+  beforeEach(() => {
+    useSqliteQuery.mockReset();
+  });
+
+  describe('when the row is in sqlite', () => {
+    beforeEach(() => {
+      useSqliteQuery.mockReturnValue({
+        data: { request: JSON.stringify(REQUEST_SENT), response: JSON.stringify(RESPONSE_RECEIVED) }
+      });
+    });
+
+    it('returns the stored payloads', () => {
+      const { result } = renderHook(() => useStoredRunnerExchange(settledItem()));
+
+      expect(result.current.requestSent).toEqual(REQUEST_SENT);
+      expect(result.current.responseReceived).toEqual(RESPONSE_RECEIVED);
+    });
+
+    it('prefers the stored payload over the reduced one on the item', () => {
+      const item = settledItem({ responseReceived: { status: 200, statusText: 'OK' } });
+      const { result } = renderHook(() => useStoredRunnerExchange(item));
+
+      expect(result.current.responseReceived).toEqual(RESPONSE_RECEIVED);
+    });
+  });
+
+  describe('when the write failed and no row exists', () => {
+    beforeEach(() => {
+      useSqliteQuery.mockReturnValue({ data: undefined });
+    });
+
+    it('falls back to the payloads the runner event put on the item', () => {
+      const item = settledItem({ requestSent: REQUEST_SENT, responseReceived: RESPONSE_RECEIVED });
+      const { result } = renderHook(() => useStoredRunnerExchange(item));
+
+      expect(result.current.requestSent).toEqual(REQUEST_SENT);
+      expect(result.current.responseReceived).toEqual(RESPONSE_RECEIVED);
+    });
+
+    it('returns nulls when the item carries no payload either', () => {
+      const { result } = renderHook(() => useStoredRunnerExchange(settledItem()));
+
+      expect(result.current.requestSent).toBeNull();
+      expect(result.current.responseReceived).toBeNull();
+    });
+  });
+
+  it('does not read until the item settles', () => {
+    useSqliteQuery.mockReturnValue({ data: undefined });
+
+    renderHook(() => useStoredRunnerExchange(settledItem({ status: 'running' })));
+
+    expect(useSqliteQuery).toHaveBeenCalledWith(
+      'get_runner_response',
+      { request_uid: 'run-1' },
+      { enabled: false }
+    );
+  });
+
+  it('reads once the item has settled', () => {
+    useSqliteQuery.mockReturnValue({ data: undefined });
+
+    renderHook(() => useStoredRunnerExchange(settledItem({ status: 'error' })));
+
+    expect(useSqliteQuery).toHaveBeenCalledWith(
+      'get_runner_response',
+      { request_uid: 'run-1' },
+      { enabled: true }
+    );
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3434,6 +3434,7 @@ export const collectionsSlice = createSlice({
         if (type === 'request-sent') {
           const item = collection.runnerResult.items.findLast((i) => i.uid === request.uid);
           item.status = 'running';
+          item.requestSent = action.payload.requestSent;
         }
 
         if (type === 'response-received') {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3434,7 +3434,6 @@ export const collectionsSlice = createSlice({
         if (type === 'request-sent') {
           const item = collection.runnerResult.items.findLast((i) => i.uid === request.uid);
           item.status = 'running';
-          item.requestSent = action.payload.requestSent;
         }
 
         if (type === 'response-received') {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3426,6 +3426,7 @@ export const collectionsSlice = createSlice({
 
           collection.runnerResult.items.push({
             uid: request.uid,
+            requestUid: action.payload.requestUid,
             status: 'queued'
           });
         }

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/runner-exchange-events.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/runner-exchange-events.spec.js
@@ -1,0 +1,113 @@
+import reducer, { runFolderEvent } from 'providers/ReduxStore/slices/collections';
+
+const COLLECTION_UID = 'col-1';
+const ITEM_UID = 'req-1';
+const REQUEST_UID = 'run-1';
+
+const REQUEST_SENT = { method: 'GET', url: 'https://example.com/userinfo', headers: {} };
+
+const FULL_RESPONSE = {
+  status: 200,
+  statusText: 'OK',
+  headers: { 'content-type': 'application/json' },
+  data: { ok: true },
+  size: 12,
+  duration: 34
+};
+
+const REDUCED_RESPONSE = { status: 200, statusText: 'OK' };
+
+const makeInitialState = () => ({
+  collections: [
+    {
+      uid: COLLECTION_UID,
+      pathname: '/coll',
+      items: [
+        {
+          uid: ITEM_UID,
+          name: 'user_info',
+          type: 'http-request',
+          request: { url: 'https://example.com/userinfo', method: 'GET' }
+        }
+      ]
+    }
+  ],
+  collectionSortOrder: 'default',
+  activeWorkspaceUid: null
+});
+
+const seedRunner = (state) => {
+  state = reducer(state, runFolderEvent({
+    type: 'testrun-started',
+    collectionUid: COLLECTION_UID,
+    folderUid: null,
+    isRecursive: false,
+    cancelTokenUid: 'cancel-1'
+  }));
+  return reducer(state, runFolderEvent({
+    type: 'request-queued',
+    collectionUid: COLLECTION_UID,
+    folderUid: null,
+    itemUid: ITEM_UID,
+    requestUid: REQUEST_UID
+  }));
+};
+
+const emit = (state, payload) => reducer(state, runFolderEvent({
+  collectionUid: COLLECTION_UID,
+  folderUid: null,
+  itemUid: ITEM_UID,
+  ...payload
+}));
+
+const runnerItem = (state) => state.collections[0].runnerResult.items.find((i) => i.uid === ITEM_UID);
+
+describe('runFolderEvent — runner exchange events', () => {
+  describe('request-queued', () => {
+    it('keeps the requestUid the payloads are stored under', () => {
+      expect(runnerItem(seedRunner(makeInitialState())).requestUid).toBe(REQUEST_UID);
+    });
+  });
+
+  describe('request-sent', () => {
+    it('leaves requestSent unset when the payload was stored', () => {
+      const state = emit(seedRunner(makeInitialState()), { type: 'request-sent' });
+
+      const item = runnerItem(state);
+      expect(item.status).toBe('running');
+      expect(item.requestSent).toBeUndefined();
+    });
+
+    it('attaches requestSent when the store failed and the event carries it', () => {
+      const state = emit(seedRunner(makeInitialState()), { type: 'request-sent', requestSent: REQUEST_SENT });
+
+      const item = runnerItem(state);
+      expect(item.status).toBe('running');
+      expect(item.requestSent).toEqual(REQUEST_SENT);
+    });
+  });
+
+  describe('response-received', () => {
+    it('attaches only the list fields when the payload was stored', () => {
+      const state = emit(seedRunner(makeInitialState()), {
+        type: 'response-received',
+        responseReceived: REDUCED_RESPONSE
+      });
+
+      const item = runnerItem(state);
+      expect(item.status).toBe('completed');
+      expect(item.responseReceived).toEqual(REDUCED_RESPONSE);
+    });
+
+    it('attaches the full response when the store failed and the event carries it', () => {
+      const state = emit(seedRunner(makeInitialState()), {
+        type: 'response-received',
+        responseReceived: FULL_RESPONSE
+      });
+
+      const item = runnerItem(state);
+      expect(item.status).toBe('completed');
+      expect(item.responseReceived).toEqual(FULL_RESPONSE);
+    });
+  });
+});

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -469,14 +469,52 @@ const registerNetworkIpc = (mainWindow) => {
     });
   };
 
-  const sendRunnerResponseReceived = ({ requestUid, responseReceived, error, eventData }) => {
+  const runnerRow = ({ requestUid, eventData }) => ({
+    request_uid: requestUid,
+    collection_uid: eventData.collectionUid,
+    iteration_index: eventData.iterationIndex,
+    item_uid: eventData.itemUid
+  });
+
+  const sendRunnerRequestSent = ({ requestUid, requestSent, eventData }) => {
+    const request = safeStringifyJSON(requestSent);
+
     // TODO (chirag): DB storage comes here
-    console.log('[runner:response-received]', {
+    console.log('[runner:request -> db]', {
+      ...runnerRow({ requestUid, eventData }),
+      bytes: Buffer.byteLength(request || ''),
+      request
+    });
+
+    // TODO (chirag): once requests are read from the DB, this is all the renderer gets
+    console.log('[runner:request -> renderer]', {
+      ...eventData,
+      requestUid
+    });
+
+    mainWindow.webContents.send('main:run-folder-event', {
+      type: 'request-sent',
+      requestSent,
+      ...eventData
+    });
+  };
+
+  const sendRunnerResponseReceived = ({ requestUid, responseReceived, error, eventData }) => {
+    const response = safeStringifyJSON(responseReceived);
+
+    // TODO (chirag): DB storage comes here
+    console.log('[runner:response -> db]', {
+      ...runnerRow({ requestUid, eventData }),
+      bytes: Buffer.byteLength(response || ''),
+      response
+    });
+
+    // TODO (chirag): once responses are read from the DB, this is all the renderer gets
+    console.log('[runner:response -> renderer]', {
       ...eventData,
       requestUid,
       status: responseReceived?.status,
-      bodySize: responseReceived?.size,
-      payloadSize: Buffer.byteLength(safeStringifyJSON(responseReceived) || '')
+      statusText: responseReceived?.statusText
     });
 
     mainWindow.webContents.send('main:run-folder-event', {
@@ -1819,11 +1857,7 @@ const registerNetworkIpc = (mainWindow) => {
             // todo:
             // i have no clue why electron can't send the request object
             // without safeParseJSON(safeStringifyJSON(request.data))
-            mainWindow.webContents.send('main:run-folder-event', {
-              type: 'request-sent',
-              requestSent,
-              ...eventData
-            });
+            sendRunnerRequestSent({ requestUid, requestSent, eventData });
 
             currentAbortController = new AbortController();
             request.signal = currentAbortController.signal;

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -473,7 +473,7 @@ const registerNetworkIpc = (mainWindow) => {
   const runnerRow = ({ requestUid, eventData }) => ({
     request_uid: requestUid,
     collection_uid: eventData.collectionUid,
-    iteration_index: eventData.iterationIndex,
+    iteration_index: eventData.iterationIndex ?? 0,
     item_uid: eventData.itemUid
   });
 

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -40,6 +40,7 @@ const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
 const { getCertsAndProxyConfig, buildCertsAndProxyConfig } = require('./cert-utils');
 const { easterEggResponse } = require('../../utils/woof');
+const { getStatements } = require('../sqlite');
 const { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } = require('@usebruno/common').utils;
 
 const ERROR_OCCURRED_WHILE_EXECUTING_REQUEST = 'Error occurred while executing the request!';
@@ -476,15 +477,23 @@ const registerNetworkIpc = (mainWindow) => {
     item_uid: eventData.itemUid
   });
 
-  const sendRunnerRequestSent = ({ requestUid, requestSent, eventData }) => {
-    const request = safeStringifyJSON(requestSent);
+  const storeRunnerExchange = ({ requestUid, eventData, request = null, response = null }) => {
+    const statements = getStatements();
+    if (!statements) return;
 
-    // TODO (chirag): DB storage comes here
-    console.log('[runner:request -> db]', {
-      ...runnerRow({ requestUid, eventData }),
-      bytes: Buffer.byteLength(request || ''),
-      request
-    });
+    try {
+      statements.execute('upsert_runner_response', {
+        ...runnerRow({ requestUid, eventData }),
+        request,
+        response
+      });
+    } catch (error) {
+      console.error('[runner] failed to store exchange', requestUid, error);
+    }
+  };
+
+  const sendRunnerRequestSent = ({ requestUid, requestSent, eventData }) => {
+    storeRunnerExchange({ requestUid, eventData, request: safeStringifyJSON(requestSent) });
 
     // TODO (chirag): once requests are read from the DB, this is all the renderer gets
     console.log('[runner:request -> renderer]', {
@@ -500,14 +509,7 @@ const registerNetworkIpc = (mainWindow) => {
   };
 
   const sendRunnerResponseReceived = ({ requestUid, responseReceived, error, eventData }) => {
-    const response = safeStringifyJSON(responseReceived);
-
-    // TODO (chirag): DB storage comes here
-    console.log('[runner:response -> db]', {
-      ...runnerRow({ requestUid, eventData }),
-      bytes: Buffer.byteLength(response || ''),
-      response
-    });
+    storeRunnerExchange({ requestUid, eventData, response: safeStringifyJSON(responseReceived) });
 
     // TODO (chirag): once responses are read from the DB, this is all the renderer gets
     console.log('[runner:response -> renderer]', {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -470,20 +470,14 @@ const registerNetworkIpc = (mainWindow) => {
     });
   };
 
-  const runnerRow = ({ requestUid, eventData }) => ({
-    request_uid: requestUid,
-    collection_uid: eventData.collectionUid,
-    iteration_index: eventData.iterationIndex ?? 0,
-    item_uid: eventData.itemUid
-  });
-
   const storeRunnerExchange = ({ requestUid, eventData, request = null, response = null }) => {
     const statements = getStatements();
     if (!statements) return;
 
     try {
       statements.execute('upsert_runner_response', {
-        ...runnerRow({ requestUid, eventData }),
+        request_uid: requestUid,
+        collection_uid: eventData.collectionUid,
         request,
         response
       });

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -469,6 +469,24 @@ const registerNetworkIpc = (mainWindow) => {
     });
   };
 
+  const sendRunnerResponseReceived = ({ requestUid, responseReceived, error, eventData }) => {
+    // TODO (chirag): DB storage comes here
+    console.log('[runner:response-received]', {
+      ...eventData,
+      requestUid,
+      status: responseReceived?.status,
+      bodySize: responseReceived?.size,
+      payloadSize: Buffer.byteLength(safeStringifyJSON(responseReceived) || '')
+    });
+
+    mainWindow.webContents.send('main:run-folder-event', {
+      type: 'response-received',
+      ...(error ? { error } : {}),
+      responseReceived,
+      ...eventData
+    });
+  };
+
   const notifyScriptExecution = ({
     channel, // 'main:run-request-event' | 'main:run-folder-event'
     basePayload, // request-level or runner-level identifiers
@@ -1894,8 +1912,8 @@ const registerNetworkIpc = (mainWindow) => {
 
               mainWindow.webContents.send('main:cookies-update', safeParseJSON(safeStringifyJSON(domainsWithCookies)));
 
-              mainWindow.webContents.send('main:run-folder-event', {
-                type: 'response-received',
+              sendRunnerResponseReceived({
+                requestUid,
                 responseReceived: {
                   status: response.status,
                   statusText: response.statusText,
@@ -1908,7 +1926,7 @@ const registerNetworkIpc = (mainWindow) => {
                   timeline: response.timeline,
                   url: response.request ? response.request.protocol + '//' + response.request.host + response.request.path : null
                 },
-                ...eventData
+                eventData
               });
             } catch (error) {
               // Skip further processing if request was cancelled
@@ -1943,11 +1961,11 @@ const registerNetworkIpc = (mainWindow) => {
                 };
 
                 // if we get a response from the server, we consider it as a success
-                mainWindow.webContents.send('main:run-folder-event', {
-                  type: 'response-received',
+                sendRunnerResponseReceived({
+                  requestUid,
                   error: error ? error.message : 'An error occurred while running the request',
                   responseReceived: response,
-                  ...eventData
+                  eventData
                 });
               } else {
                 await executeRequestOnFailHandler(request, error, (onFailScriptResult) => {

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -40,7 +40,7 @@ const registerGrpcEventHandlers = require('./grpc-event-handlers');
 const { registerWsEventHandlers } = require('./ws-event-handlers');
 const { getCertsAndProxyConfig, buildCertsAndProxyConfig } = require('./cert-utils');
 const { easterEggResponse } = require('../../utils/woof');
-const { getStatements } = require('../sqlite');
+const { createRunnerExchangeEmitters } = require('./runner-exchange');
 const { buildFormUrlEncodedPayload, isFormData, extractBoundaryFromContentType } = require('@usebruno/common').utils;
 
 const ERROR_OCCURRED_WHILE_EXECUTING_REQUEST = 'Error occurred while executing the request!';
@@ -470,46 +470,7 @@ const registerNetworkIpc = (mainWindow) => {
     });
   };
 
-  const storeRunnerExchange = ({ requestUid, eventData, request = null, response = null }) => {
-    const statements = getStatements();
-    if (!statements) return;
-
-    try {
-      statements.execute('upsert_runner_response', {
-        request_uid: requestUid,
-        collection_uid: eventData.collectionUid,
-        request,
-        response
-      });
-    } catch (error) {
-      console.error('[runner] failed to store exchange', requestUid, error);
-    }
-  };
-
-  const sendRunnerRequestSent = ({ requestUid, requestSent, eventData }) => {
-    storeRunnerExchange({ requestUid, eventData, request: safeStringifyJSON(requestSent) });
-
-    mainWindow.webContents.send('main:run-folder-event', {
-      type: 'request-sent',
-      ...eventData
-    });
-  };
-
-  // The renderer only needs what the runner list renders; it reads the payloads back out of sqlite
-  // by requestUid when a row is expanded.
-  const sendRunnerResponseReceived = ({ requestUid, responseReceived, error, eventData }) => {
-    storeRunnerExchange({ requestUid, eventData, response: safeStringifyJSON(responseReceived) });
-
-    mainWindow.webContents.send('main:run-folder-event', {
-      type: 'response-received',
-      ...(error ? { error } : {}),
-      responseReceived: {
-        status: responseReceived?.status,
-        statusText: responseReceived?.statusText
-      },
-      ...eventData
-    });
-  };
+  const { sendRunnerRequestSent, sendRunnerResponseReceived } = createRunnerExchangeEmitters(mainWindow);
 
   const notifyScriptExecution = ({
     channel, // 'main:run-request-event' | 'main:run-folder-event'

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -495,34 +495,24 @@ const registerNetworkIpc = (mainWindow) => {
   const sendRunnerRequestSent = ({ requestUid, requestSent, eventData }) => {
     storeRunnerExchange({ requestUid, eventData, request: safeStringifyJSON(requestSent) });
 
-    // TODO (chirag): once requests are read from the DB, this is all the renderer gets
-    console.log('[runner:request -> renderer]', {
-      ...eventData,
-      requestUid
-    });
-
     mainWindow.webContents.send('main:run-folder-event', {
       type: 'request-sent',
-      requestSent,
       ...eventData
     });
   };
 
+  // The renderer only needs what the runner list renders; it reads the payloads back out of sqlite
+  // by requestUid when a row is expanded.
   const sendRunnerResponseReceived = ({ requestUid, responseReceived, error, eventData }) => {
     storeRunnerExchange({ requestUid, eventData, response: safeStringifyJSON(responseReceived) });
-
-    // TODO (chirag): once responses are read from the DB, this is all the renderer gets
-    console.log('[runner:response -> renderer]', {
-      ...eventData,
-      requestUid,
-      status: responseReceived?.status,
-      statusText: responseReceived?.statusText
-    });
 
     mainWindow.webContents.send('main:run-folder-event', {
       type: 'response-received',
       ...(error ? { error } : {}),
-      responseReceived,
+      responseReceived: {
+        status: responseReceived?.status,
+        statusText: responseReceived?.statusText
+      },
       ...eventData
     });
   };

--- a/packages/bruno-electron/src/ipc/network/runner-exchange.js
+++ b/packages/bruno-electron/src/ipc/network/runner-exchange.js
@@ -1,0 +1,52 @@
+const { safeStringifyJSON } = require('../../utils/common');
+const { getStatements } = require('../sqlite');
+
+const storeRunnerExchange = ({ requestUid, eventData, request = null, response = null }) => {
+  const statements = getStatements();
+  if (!statements) return false;
+
+  try {
+    statements.execute('upsert_runner_response', {
+      request_uid: requestUid,
+      collection_uid: eventData.collectionUid,
+      request,
+      response
+    });
+    return true;
+  } catch (error) {
+    console.error('[runner] failed to store exchange', requestUid, error);
+    return false;
+  }
+};
+
+const createRunnerExchangeEmitters = (mainWindow) => {
+  const sendRunnerRequestSent = ({ requestUid, requestSent, eventData }) => {
+    const stored = storeRunnerExchange({ requestUid, eventData, request: safeStringifyJSON(requestSent) });
+
+    mainWindow.webContents.send('main:run-folder-event', {
+      type: 'request-sent',
+      ...(stored ? {} : { requestSent }),
+      ...eventData
+    });
+  };
+
+  const sendRunnerResponseReceived = ({ requestUid, responseReceived, error, eventData }) => {
+    const stored = storeRunnerExchange({ requestUid, eventData, response: safeStringifyJSON(responseReceived) });
+
+    mainWindow.webContents.send('main:run-folder-event', {
+      type: 'response-received',
+      ...(error ? { error } : {}),
+      responseReceived: stored
+        ? {
+            status: responseReceived?.status,
+            statusText: responseReceived?.statusText
+          }
+        : responseReceived,
+      ...eventData
+    });
+  };
+
+  return { sendRunnerRequestSent, sendRunnerResponseReceived };
+};
+
+module.exports = { storeRunnerExchange, createRunnerExchangeEmitters };

--- a/packages/bruno-electron/src/ipc/network/runner-exchange.spec.js
+++ b/packages/bruno-electron/src/ipc/network/runner-exchange.spec.js
@@ -1,0 +1,149 @@
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn(), on: jest.fn() },
+  app: {
+    on: jest.fn(),
+    getPath: jest.fn(() => require('node:os').tmpdir()),
+    getVersion: jest.fn(() => '1.0.0')
+  }
+}));
+
+jest.mock('../sqlite', () => ({ getStatements: jest.fn() }));
+
+const EVENT_DATA = { collectionUid: 'col-1', itemUid: 'item-1' };
+
+const REQUEST_SENT = { method: 'GET', url: 'https://example.com/userinfo', headers: {} };
+
+const RESPONSE_RECEIVED = {
+  status: 200,
+  statusText: 'OK',
+  headers: { 'content-type': 'application/json' },
+  data: { ok: true },
+  size: 12,
+  duration: 34
+};
+
+describe('runner-exchange', () => {
+  let getStatements;
+  let createRunnerExchangeEmitters;
+  let mainWindow;
+  let error;
+
+  const lastEvent = () => mainWindow.webContents.send.mock.calls.at(-1)[1];
+
+  beforeEach(() => {
+    jest.resetModules();
+    ({ getStatements } = require('../sqlite'));
+    ({ createRunnerExchangeEmitters } = require('./runner-exchange'));
+    mainWindow = { webContents: { send: jest.fn() } };
+    error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    error.mockRestore();
+  });
+
+  describe('when the exchange is stored', () => {
+    let execute;
+
+    beforeEach(() => {
+      execute = jest.fn();
+      getStatements.mockReturnValue({ execute });
+    });
+
+    it('writes the request payload and keeps it out of the event', () => {
+      const { sendRunnerRequestSent } = createRunnerExchangeEmitters(mainWindow);
+
+      sendRunnerRequestSent({ requestUid: 'run-1', requestSent: REQUEST_SENT, eventData: EVENT_DATA });
+
+      expect(execute).toHaveBeenCalledWith('upsert_runner_response', {
+        request_uid: 'run-1',
+        collection_uid: 'col-1',
+        request: JSON.stringify(REQUEST_SENT),
+        response: null
+      });
+      expect(lastEvent()).toEqual({ type: 'request-sent', ...EVENT_DATA });
+    });
+
+    it('reduces the response on the event to what the runner list renders', () => {
+      const { sendRunnerResponseReceived } = createRunnerExchangeEmitters(mainWindow);
+
+      sendRunnerResponseReceived({ requestUid: 'run-1', responseReceived: RESPONSE_RECEIVED, eventData: EVENT_DATA });
+
+      expect(execute).toHaveBeenCalledWith('upsert_runner_response', {
+        request_uid: 'run-1',
+        collection_uid: 'col-1',
+        request: null,
+        response: JSON.stringify(RESPONSE_RECEIVED)
+      });
+      expect(lastEvent().responseReceived).toEqual({ status: 200, statusText: 'OK' });
+    });
+  });
+
+  describe('when the upsert throws', () => {
+    beforeEach(() => {
+      getStatements.mockReturnValue({
+        execute: jest.fn(() => {
+          throw new Error('database or disk is full');
+        })
+      });
+    });
+
+    it('carries the full request payload on the event instead', () => {
+      const { sendRunnerRequestSent } = createRunnerExchangeEmitters(mainWindow);
+
+      sendRunnerRequestSent({ requestUid: 'run-1', requestSent: REQUEST_SENT, eventData: EVENT_DATA });
+
+      expect(lastEvent().requestSent).toEqual(REQUEST_SENT);
+      expect(error).toHaveBeenCalled();
+    });
+
+    it('carries the full response payload on the event instead', () => {
+      const { sendRunnerResponseReceived } = createRunnerExchangeEmitters(mainWindow);
+
+      sendRunnerResponseReceived({ requestUid: 'run-1', responseReceived: RESPONSE_RECEIVED, eventData: EVENT_DATA });
+
+      expect(lastEvent().responseReceived).toEqual(RESPONSE_RECEIVED);
+      expect(error).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the database is unavailable', () => {
+    beforeEach(() => {
+      getStatements.mockReturnValue(null);
+    });
+
+    it('carries the full request payload on the event instead', () => {
+      const { sendRunnerRequestSent } = createRunnerExchangeEmitters(mainWindow);
+
+      sendRunnerRequestSent({ requestUid: 'run-1', requestSent: REQUEST_SENT, eventData: EVENT_DATA });
+
+      expect(lastEvent().requestSent).toEqual(REQUEST_SENT);
+    });
+
+    it('carries the full response payload on the event instead', () => {
+      const { sendRunnerResponseReceived } = createRunnerExchangeEmitters(mainWindow);
+
+      sendRunnerResponseReceived({ requestUid: 'run-1', responseReceived: RESPONSE_RECEIVED, eventData: EVENT_DATA });
+
+      expect(lastEvent().responseReceived).toEqual(RESPONSE_RECEIVED);
+    });
+  });
+
+  it('keeps the error alongside the response payload', () => {
+    getStatements.mockReturnValue({ execute: jest.fn() });
+    const { sendRunnerResponseReceived } = createRunnerExchangeEmitters(mainWindow);
+
+    sendRunnerResponseReceived({
+      requestUid: 'run-1',
+      responseReceived: RESPONSE_RECEIVED,
+      error: 'socket hang up',
+      eventData: EVENT_DATA
+    });
+
+    expect(lastEvent()).toMatchObject({
+      type: 'response-received',
+      error: 'socket hang up',
+      responseReceived: { status: 200, statusText: 'OK' }
+    });
+  });
+});

--- a/packages/bruno-sqlite/migrations/0000001_runner_responses.ts
+++ b/packages/bruno-sqlite/migrations/0000001_runner_responses.ts
@@ -3,17 +3,13 @@ export const up = (): string => {
     CREATE TABLE runner_responses (
       request_uid TEXT PRIMARY KEY,
       collection_uid TEXT NOT NULL,
-      iteration_index INTEGER NOT NULL,
-      item_uid TEXT NOT NULL,
       request TEXT,
       response TEXT
     );
-    CREATE INDEX idx_runner_responses_scope ON runner_responses (collection_uid, iteration_index);
   `;
 };
 export const down = (): string => {
   return `
-    DROP INDEX IF EXISTS idx_runner_responses_scope;
     DROP TABLE IF EXISTS runner_responses;
   `;
 };

--- a/packages/bruno-sqlite/migrations/0000001_runner_responses.ts
+++ b/packages/bruno-sqlite/migrations/0000001_runner_responses.ts
@@ -1,0 +1,19 @@
+export const up = (): string => {
+  return `
+    CREATE TABLE runner_responses (
+      request_uid TEXT PRIMARY KEY,
+      collection_uid TEXT NOT NULL,
+      iteration_index INTEGER NOT NULL,
+      item_uid TEXT NOT NULL,
+      request TEXT,
+      response TEXT
+    );
+    CREATE INDEX idx_runner_responses_scope ON runner_responses (collection_uid, iteration_index);
+  `;
+};
+export const down = (): string => {
+  return `
+    DROP INDEX IF EXISTS idx_runner_responses_scope;
+    DROP TABLE IF EXISTS runner_responses;
+  `;
+};

--- a/packages/bruno-sqlite/statements/runner_responses.sql
+++ b/packages/bruno-sqlite/statements/runner_responses.sql
@@ -10,9 +10,5 @@ INSERT OR REPLACE INTO runner_responses (
 -- name: get_runner_response :one
 SELECT request, response FROM runner_responses WHERE request_uid = @request_uid;
 
--- name: list_runner_responses_for_iteration :many
-SELECT item_uid, request, response FROM runner_responses
-WHERE collection_uid = @collection_uid AND iteration_index = @iteration_index;
-
 -- name: delete_runner_responses_for_collection :exec
 DELETE FROM runner_responses WHERE collection_uid = @collection_uid;

--- a/packages/bruno-sqlite/statements/runner_responses.sql
+++ b/packages/bruno-sqlite/statements/runner_responses.sql
@@ -1,0 +1,18 @@
+-- name: upsert_runner_response :exec
+INSERT OR REPLACE INTO runner_responses (
+  request_uid, collection_uid, iteration_index, item_uid, request, response
+) VALUES (
+  @request_uid, @collection_uid, @iteration_index, @item_uid,
+  COALESCE(@request, (SELECT request FROM runner_responses WHERE request_uid = @request_uid)),
+  COALESCE(@response, (SELECT response FROM runner_responses WHERE request_uid = @request_uid))
+);
+
+-- name: get_runner_response :one
+SELECT request, response FROM runner_responses WHERE request_uid = @request_uid;
+
+-- name: list_runner_responses_for_iteration :many
+SELECT item_uid, request, response FROM runner_responses
+WHERE collection_uid = @collection_uid AND iteration_index = @iteration_index;
+
+-- name: delete_runner_responses_for_collection :exec
+DELETE FROM runner_responses WHERE collection_uid = @collection_uid;

--- a/packages/bruno-sqlite/statements/runner_responses.sql
+++ b/packages/bruno-sqlite/statements/runner_responses.sql
@@ -1,8 +1,8 @@
 -- name: upsert_runner_response :exec
 INSERT OR REPLACE INTO runner_responses (
-  request_uid, collection_uid, iteration_index, item_uid, request, response
+  request_uid, collection_uid, request, response
 ) VALUES (
-  @request_uid, @collection_uid, @iteration_index, @item_uid,
+  @request_uid, @collection_uid,
   COALESCE(@request, (SELECT request FROM runner_responses WHERE request_uid = @request_uid)),
   COALESCE(@response, (SELECT response FROM runner_responses WHERE request_uid = @request_uid))
 );

--- a/packages/bruno-sqlite/tests/node/create-database.spec.ts
+++ b/packages/bruno-sqlite/tests/node/create-database.spec.ts
@@ -1,6 +1,17 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+const validMigrations = {
+  migrations: [
+    {
+      sequence: 1,
+      name: 'valid',
+      up: 'CREATE TABLE valid (id INTEGER PRIMARY KEY)',
+      down: 'DROP TABLE valid'
+    }
+  ]
+};
 
 const brokenMigrations = {
   migrations: [
@@ -55,6 +66,7 @@ describe('createDatabase', () => {
 
   it('backs up an unusable database file and rebuilds it', () => {
     writeFileSync(dbPath, 'this is not a sqlite database');
+    jest.doMock('../../src/generated/node/migrations', () => validMigrations);
     const { createDatabase } = require('../../src/node/index');
 
     const { db, statements } = createDatabase(dbPath);
@@ -62,7 +74,7 @@ describe('createDatabase', () => {
     expect(db).toBeDefined();
     expect(statements).toBeDefined();
     expect(existsSync(dbPath)).toBe(true);
-    expect(db._db.prepare('SELECT name FROM _migrations').all()).toEqual([]);
+    expect(db._db.prepare('SELECT name FROM _migrations').all()).toEqual([{ name: 'valid' }]);
     db.close();
   });
 


### PR DESCRIPTION
The collection runner puts every request and response into the redux store, so a big run holds all
of it in memory and reserialises it on every runner event.

Those payloads now go into sqlite instead, keyed on collection uid + iteration index + request uid.
The runner list only receives the status and status text it actually renders, and the response pane
reads the full payload back when you expand a row. Rows are cleared per collection on Reset and at
the start of every run, so the table does not grow across runs.

Ticket - BRU-1071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runner results now retain complete request and response details for completed or failed items.
  * Response panels display stored results when available, with reliable fallback behavior.
  * Results remain available throughout collection-run workflows for more consistent viewing.
  * Test results now clearly distinguish passed and failed requests.

* **Bug Fixes**
  * Prevented outdated runner results from appearing after rerunning or resetting collections.
  * Collection runs now clear previous results before starting, ensuring displayed data matches the latest execution.
  * Improved handling of failed requests so their responses are displayed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->