### PR TITLE
fix: mock server default disabled test case fail fix

### DIFF
--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -55,7 +55,7 @@ const defaultPreferences = {
   },
   beta: {
     'openapi-sync': false,
-    'mock-server': true
+    'mock-server': false
   },
   onboarding: {
     hasLaunchedBefore: false,

--- a/packages/bruno-electron/tests/mock-server-port.test.js
+++ b/packages/bruno-electron/tests/mock-server-port.test.js
@@ -4,6 +4,12 @@ jest.mock('electron', () => ({
   }
 }));
 
+jest.mock('../src/store/preferences', () => ({
+  preferencesUtil: {
+    isBetaFeatureEnabled: () => true
+  }
+}));
+
 const net = require('net');
 const path = require('path');
 const os = require('os');

--- a/packages/bruno-electron/tests/mock-server-port.test.js
+++ b/packages/bruno-electron/tests/mock-server-port.test.js
@@ -6,7 +6,7 @@ jest.mock('electron', () => ({
 
 jest.mock('../src/store/preferences', () => ({
   preferencesUtil: {
-    isBetaFeatureEnabled: () => true
+    isBetaFeatureEnabled: (featureName) => featureName === 'mock-server'
   }
 }));
 


### PR DESCRIPTION
BRU-4264

### Description

Mock server default disabled test case fail fix

### Problem

test case failing for mock server default value change

### Fix

Added preferences -> mock server -> true for test cases

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Improved mock server test coverage by simulating Electron preferences.
- Added support for verifying behavior when the mock server beta feature is enabled.
- Updated the test environment to distinguish the mock server feature from other beta features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->