### PR TITLE
fix(workspace): stopped the same collection from rendering twice with conflicting status

### DIFF
--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -194,7 +194,7 @@ const CollectionsList = ({ workspace }) => {
 
   const handleRemoveCollection = (collection) => {
     dropdownRefs.current[collection.uid]?.hide();
-    if (collection.failedToOpen) {
+    if (collection.failedToOpen || collection.notFoundLocally) {
       dispatch(removeCollectionFromWorkspaceAction(workspace.uid, collection.pathname))
         .then(() => toast.success('Collection removed from workspace'))
         .catch(() => toast.error('An error occurred while removing the collection'));
@@ -380,7 +380,7 @@ const CollectionsList = ({ workspace }) => {
                   icon={<IconDots size={18} strokeWidth={1.5} />}
                 >
                   <div className="collection-dropdown">
-                    {!collection.failedToOpen && (
+                    {!collection.failedToOpen && !collection.notFoundLocally && (
                       <>
                         <div
                           className="dropdown-item"
@@ -412,6 +412,10 @@ const CollectionsList = ({ workspace }) => {
                           <IconFolder size={16} strokeWidth={1.5} />
                           <span>{getRevealInFolderLabel()}</span>
                         </div>
+                      </>
+                    )}
+                    {!collection.failedToOpen && (
+                      <>
                         {!isDefaultWorkspace && (
                           <>
                             {collection.isGitBacked && (
@@ -464,7 +468,7 @@ const CollectionsList = ({ workspace }) => {
                       <IconX size={16} strokeWidth={1.5} />
                       <span>Remove</span>
                     </div>
-                    {!collection.failedToOpen && (
+                    {!collection.failedToOpen && !collection.notFoundLocally && (
                       <div
                         className="dropdown-item delete-item"
                         onClick={(e) => {

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -118,7 +118,12 @@ const CollectionsList = ({ workspace }) => {
       };
     });
 
-    return [...resolvedCollections, ...unopenableCollections];
+    const unopenablePaths = new Set(unopenableCollections.map((c) => normalizePath(c.pathname)));
+
+    return [
+      ...resolvedCollections.filter((c) => !unopenablePaths.has(normalizePath(c.pathname))),
+      ...unopenableCollections
+    ];
   }, [workspace.collections, workspace.scratchTempDirectory, collections, unopenableCollections]);
 
   const handleOpenCollectionClick = (collection, event) => {

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -44,6 +44,8 @@ const CollectionsList = ({ workspace }) => {
 
   const isDefaultWorkspace = workspace?.type === 'default';
 
+  const isNotCloned = (collection) => !isDefaultWorkspace && collection.notFoundLocally;
+
   const unopenableCollections = useMemo(() => {
     return (workspace.unopenableCollections || []).map((wc) => ({
       uid: `unopenable-${wc.path}`,
@@ -360,7 +362,7 @@ const CollectionsList = ({ workspace }) => {
                   {collection.failedToOpen && (
                     <StatusBadge status="danger" size="xs">Failed to open</StatusBadge>
                   )}
-                  {!isDefaultWorkspace && collection.notFoundLocally && (
+                  {isNotCloned(collection) && (
                     <StatusBadge status="warning" size="xs">Not cloned</StatusBadge>
                   )}
                 </div>
@@ -380,7 +382,7 @@ const CollectionsList = ({ workspace }) => {
                   icon={<IconDots size={18} strokeWidth={1.5} />}
                 >
                   <div className="collection-dropdown">
-                    {!collection.failedToOpen && !collection.notFoundLocally && (
+                    {!collection.failedToOpen && !isNotCloned(collection) && (
                       <>
                         <div
                           className="dropdown-item"
@@ -468,7 +470,7 @@ const CollectionsList = ({ workspace }) => {
                       <IconX size={16} strokeWidth={1.5} />
                       <span>Remove</span>
                     </div>
-                    {!collection.failedToOpen && !collection.notFoundLocally && (
+                    {!collection.failedToOpen && !isNotCloned(collection) && (
                       <div
                         className="dropdown-item delete-item"
                         onClick={(e) => {

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceOverview/CollectionsList/index.js
@@ -102,6 +102,7 @@ const CollectionsList = ({ workspace }) => {
         environments: [],
         isGitBacked: !!wc.remote,
         isLoaded: false,
+        notFoundLocally: !!wc.notFoundLocally,
         gitRemoteUrl: wc.remote,
         git: { gitRootPath: null },
         brunoConfig: {},
@@ -359,7 +360,7 @@ const CollectionsList = ({ workspace }) => {
                   {collection.failedToOpen && (
                     <StatusBadge status="danger" size="xs">Failed to open</StatusBadge>
                   )}
-                  {!isDefaultWorkspace && collection.isLoaded === false && !collection.failedToOpen && (
+                  {!isDefaultWorkspace && collection.notFoundLocally && (
                     <StatusBadge status="warning" size="xs">Not cloned</StatusBadge>
                   )}
                 </div>

--- a/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -364,8 +364,7 @@ const loadWorkspaceCollectionsForSwitch = async (dispatch, workspace) => {
   const unopenedCollectionPaths = new Set();
 
   try {
-    const shouldRefreshCollections = workspace.collections?.some((collection) => collection.notFoundLocally);
-    await dispatch(loadWorkspaceCollections(workspace.uid, shouldRefreshCollections));
+    await dispatch(loadWorkspaceCollections(workspace.uid, true));
     updatedWorkspace = await dispatch((_, getState) => getState().workspaces.workspaces.find((w) => w.uid === workspace.uid));
 
     if (updatedWorkspace?.collections?.length > 0) {


### PR DESCRIPTION
### Description
BRU-4261

After moving a collection to another workspace, the source workspace showed the same collection twice , for `Failed to open` and  `Not cloned`. The `Not cloned` entry also showed actions that didn’t work and causing errors.

### Problem

The move didn’t update the source workspace, causing duplicate collection entries. The `Not cloned` status was also based on whether the collection was open, instead of whether it was actually missing locally. 

### Fix

The workspace now refreshes the collection list from disk and removes duplicates, so each collection appears only once with the correct `Failed to open` status. The missing-local flag is also read correctly, removing the badge flicker. Missing collections now show only valid actions, and Remove works as expected.

### Screenshots
**Before:**

<img width="1174" height="528" alt="Screenshot 2026-08-12 at 4 18 02 PM" src="https://github.com/user-attachments/assets/77ac33c9-5949-4cc0-813a-aa07ef5fe410" />


**After:**

<img width="1511" height="552" alt="Screenshot 2026-08-12 at 4 33 04 PM" src="https://github.com/user-attachments/assets/15eddd3f-70e7-4b41-9dae-f8b89e70eb1e" />

<img width="1269" height="743" alt="Screenshot 2026-08-12 at 6 46 26 PM" src="https://github.com/user-attachments/assets/7e2547b0-d892-438c-97ca-527f273fbd01" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of collections that are missing locally or cannot be opened.
  - Prevented duplicate unopenable collections from appearing in workspace lists.
  - Removing failed or locally missing collections now updates the workspace correctly.
  - Workspace collections now reload reliably when switching workspaces.

- **Improvements**
  - Git actions remain available for locally missing collections.
  - Actions unavailable for missing collections are now hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->