### PR TITLE
fix(app): keep app code when a collection mounts from the file cache

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/app-code-tree.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/app-code-tree.spec.js
@@ -1,0 +1,30 @@
+import reducer, { collectionLoadedFromTree } from 'providers/ReduxStore/slices/collections';
+
+const COLLECTION_UID = 'col-1';
+
+const treeItem = (app) => ({
+  uid: 'item-1',
+  name: 'req',
+  type: 'http-request',
+  seq: 1,
+  request: { method: 'GET', url: 'https://example.com', headers: [], params: [] },
+  pathname: '/coll/req.yml',
+  filename: 'req.yml',
+  app
+});
+
+const stateWith = (item) => ({
+  collections: [{ uid: COLLECTION_UID, pathname: '/coll', format: 'yml', items: [item], environments: [] }]
+});
+
+describe('app code loaded from the mount tree', () => {
+  it('takes the app block from the tree when merging over an already loaded item', () => {
+    const app = { enabled: true, code: '<h1>on disk</h1>' };
+    const state = reducer(
+      stateWith(treeItem({ enabled: true, code: '<h1>stale</h1>' })),
+      collectionLoadedFromTree({ collectionUid: COLLECTION_UID, tree: { items: [treeItem(app)] } })
+    );
+
+    expect(state.collections[0].items[0].app).toEqual(app);
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -37,6 +37,7 @@ const FILE_DERIVED_REQUEST_FIELDS = [
   'request',
   'settings',
   'examples',
+  'app',
   'raw',
   'filename',
   'pathname',

--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -130,6 +130,7 @@ const buildRequestNode = (absolutePath, basename, entry, uidOverrides, uidFor) =
     request: data.request || {},
     settings: data.settings,
     examples: data.examples,
+    app: data.app ?? null,
     raw: entry.raw ?? null,
     size: sizeInMB(entry.raw ? Buffer.byteLength(entry.raw, 'utf8') : 0),
     filename: basename,

--- a/packages/bruno-electron/src/services/mount/tree-builder.spec.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.spec.js
@@ -33,6 +33,30 @@ const requestWithEveryList = () => {
   return data;
 };
 
+describe('buildTree — app code', () => {
+  it('carries a request app block so the App view survives a cold mount', () => {
+    const app = { enabled: true, code: '<h1>hello</h1>' };
+    const node = buildSingleRequest('req.yml', { name: 'req', type: 'http-request', request: {}, app });
+
+    expect(node.app).toEqual(app);
+  });
+
+  it('carries the app code of a standalone app item', () => {
+    const node = buildSingleRequest('my-app.yml', {
+      name: 'my-app',
+      type: 'app',
+      request: null,
+      app: { code: '<h1>standalone</h1>' }
+    });
+
+    expect(node.app).toEqual({ code: '<h1>standalone</h1>' });
+  });
+
+  it('leaves app null for a request without one', () => {
+    expect(buildSingleRequest('req.yml', { name: 'req', type: 'http-request', request: {} }).app).toBeNull();
+  });
+});
+
 describe('buildTree — uid hydration', () => {
   it('hydrates exactly the request lists this spec covers', () => {
     expect(REQUEST_UID_PATHS.map(([dotPath]) => dotPath).sort()).toEqual(

--- a/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
+++ b/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
@@ -169,6 +169,83 @@ body:json {
 }
 `;
 
+const appBru = `meta {
+  name: App Request
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://example.com
+  body: none
+  auth: none
+}
+
+app {
+  enabled: true
+  code: '''
+    <div id="x">hi</div>
+    <style>
+    body {
+      color: red;
+    }
+    </style>
+    <script>
+      function go() {
+        return { ok: 1 };
+      }
+    </script>
+  '''
+}
+
+docs {
+  # Docs after the app block
+}
+`;
+
+const standaloneAppBru = `meta {
+  name: Dashboard
+  type: app
+  seq: 2
+}
+
+app {
+  code: '''
+    <div id="app">standalone</div>
+  '''
+}
+`;
+
+const appWithoutCodeBru = `meta {
+  name: No Code
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://example.com
+  body: none
+  auth: none
+}
+
+app {
+  enabled: true
+}
+`;
+
+const appEmptyCodeBru = `meta {
+  name: Empty Code
+  type: http
+  seq: 1
+}
+
+app {
+  enabled: true
+  code: '''
+  '''
+}
+`;
+
 describe('redactLargeBruTextBlocks', () => {
   describe('matches a normal parse (ohm oracle)', () => {
     const requestCases = [
@@ -177,7 +254,12 @@ describe('redactLargeBruTextBlocks', () => {
       ['xml + sparql bodies', xmlSparqlBru],
       ['CRLF request', toCRLF(requestBru)],
       ['leading + trailing blank lines in body', blankLinesBru],
-      ['CRLF leading + trailing blank lines', toCRLF(blankLinesBru)]
+      ['CRLF leading + trailing blank lines', toCRLF(blankLinesBru)],
+      ['request-level app code', appBru],
+      ['CRLF request-level app code', toCRLF(appBru)],
+      ['standalone app item', standaloneAppBru],
+      ['app block without code', appWithoutCodeBru],
+      ['app block with an empty code value', appEmptyCodeBru]
     ];
 
     it.each(requestCases)('%s', (_name, content) => {
@@ -226,6 +308,22 @@ body:json {
     expect(bru.length).toBeGreaterThan(4 * 1024 * 1024);
     expect(skeleton.length).toBeLessThan(1024);
     expect(blocks[0].value).toContain(blob);
+  });
+
+  it('keeps huge app code out of the skeleton, pair and delimiters intact', () => {
+    const blob = 'x'.repeat(4 * 1024 * 1024);
+    const bru = appBru.replace('<div id="x">hi</div>', `<div>${blob}</div>`);
+
+    const { skeleton, blocks } = redactLargeBruTextBlocks(bru);
+    expect(skeleton.length).toBeLessThan(1024);
+    expect(skeleton).toMatch(/code: '''\n\s+__BRU_REDACTED_TEXT_BLOCK_\w+__\n\s+'''/);
+    expect(skeleton).toContain('enabled: true');
+    expect(blocks.some((block) => block.value.includes(blob))).toBe(true);
+  });
+
+  it('leaves an app block whose code has no value untouched', () => {
+    const { blocks } = redactLargeBruTextBlocks(appEmptyCodeBru);
+    expect(blocks).toEqual([]);
   });
 
   it('leaves dictionary body blocks untouched', () => {

--- a/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
+++ b/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
@@ -41,6 +41,34 @@ const tokenFor = (content: string): string => {
 const blockValue = (content: string[]): string =>
   outdentString(content.join('\n').replace(/^(?:\r?\n)+/, '').replace(/\r$/, ''));
 
+const MULTILINE_DELIMITER = '\'\'\'';
+const APP_CODE_PAIR = `code: ${MULTILINE_DELIMITER}`;
+
+const appCodeValue = (code: string[]): string =>
+  code.map((line) => line.slice(4)).join('\n').trim();
+
+const redactAppCode = (source: string, blocks: RedactedBlock[]): string => {
+  const lines = source.split('\n');
+  const opening = lines.findIndex((line) => line.trim() === APP_CODE_PAIR);
+  if (opening === -1) {
+    return source;
+  }
+  const closing = lines.findIndex((line, index) => index > opening && line.trim() === MULTILINE_DELIMITER);
+  if (closing === -1) {
+    return source;
+  }
+
+  const code = lines.slice(opening + 1, closing);
+  const value = appCodeValue(code);
+  if (!value.length) {
+    return source;
+  }
+
+  const token = tokenFor(code.join('\n'));
+  blocks.push({ token, value });
+  return [...lines.slice(0, opening + 1), `    ${token}`, ...lines.slice(closing)].join('\n');
+};
+
 export const redactLargeBruTextBlocks = (content: string): RedactionResult => {
   const source = content || '';
   const skeleton: string[] = [];
@@ -49,7 +77,7 @@ export const redactLargeBruTextBlocks = (content: string): RedactionResult => {
   let openTag: string | null = null;
   let openContent: string[] = [];
 
-  for (const line of source.split('\n')) {
+  for (const line of redactAppCode(source, blocks).split('\n')) {
     if (openTag === null && isOpening(line)) {
       openTag = line;
       openContent = [];

--- a/tests/collection/migrate-to-yml-app/init-user-data/preferences.json
+++ b/tests/collection/migrate-to-yml-app/init-user-data/preferences.json
@@ -1,0 +1,9 @@
+{
+  "preferences": {
+    "cache": {
+      "file": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/tests/collection/migrate-to-yml-app/migrate-app-to-yml.spec.ts
+++ b/tests/collection/migrate-to-yml-app/migrate-app-to-yml.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../../../playwright';
+import {
+  activeAppView,
+  closeAllCollections,
+  confirmMigration,
+  createCollection,
+  createRequest,
+  getAppWebviewHtml,
+  openMigrateToYmlModalFromOverview,
+  openRequest,
+  saveRequest,
+  setAppCode
+} from '../../utils/page';
+
+const COLLECTION_NAME = 'app-migration';
+const APP_CODE = '<div id="request-app">Hello from the request app</div>';
+
+test.describe('Migrating a collection with app code from bru to yml', () => {
+  test.afterAll(async ({ pageWithUserData: page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('keeps the request app enabled with its code after migration', async ({
+    pageWithUserData: page,
+    createTmpDir
+  }) => {
+    await test.step('Write app code into a bru collection', async () => {
+      await createCollection(page, COLLECTION_NAME, await createTmpDir('migrate-app'), 'bru');
+      await createRequest(page, 'app-req', COLLECTION_NAME, { url: 'https://example.com', method: 'GET' });
+      await openRequest(page, COLLECTION_NAME, 'app-req', { persist: true });
+      await setAppCode(page, APP_CODE);
+      await saveRequest(page);
+    });
+
+    await test.step('Migrate the collection to yml', async () => {
+      await openMigrateToYmlModalFromOverview(page, COLLECTION_NAME);
+      await confirmMigration(page);
+      await expect(page.getByText('Collection migrated to YML format successfully')).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('Reopening the request still lands in its app view, code intact', async () => {
+      await openRequest(page, COLLECTION_NAME, 'app-req', { persist: true });
+      await expect(activeAppView(page)).toBeVisible({ timeout: 10000 });
+      expect(await getAppWebviewHtml(page)).toContain(APP_CODE);
+    });
+  });
+});


### PR DESCRIPTION
### Description

App code disappeared from a collection once it was migrated from bru to yml with the file cache (mount path v2) enabled.

### Problem

The mount v2 tree builder never copied the `app` block onto the items it sends the renderer, so `app.enabled` read as `false` and the code editor was empty. Migration made this visible because it unmounts and reopens the collection, but any cold mount with the file cache on dropped app code the same way. The files on disk were always correct.

Separately, the large-file `.bru` parse path redacted every big text block except app code, because the app block is a dictionary (`enabled` + `code`) rather than a text block, so big apps were still parsed inline by the grammar.

### Fix

- Carry `app` on the mount tree node, and refresh it from disk on a tree merge like every other file-derived field.
- Redact the app `code` value on the large-file path, keeping its pair and `'''` delimiters so the skeleton still parses.

Ticket - BRU-4243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Application code and metadata now remain intact when collections are loaded or migrated.
  - Improved handling of standalone application-code items and requests without application code.
  - Large application-code blocks are safely redacted while preserving surrounding metadata and formatting.
  - Empty or incomplete code blocks are handled without introducing unwanted redactions.

- **Reliability**
  - Collection migration now preserves the application view and existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->