### PR TITLE
fix(sqlite): write generated artifacts as TypeScript literals

### DIFF
--- a/packages/bruno-sqlite/scripts/generate-artifacts.ts
+++ b/packages/bruno-sqlite/scripts/generate-artifacts.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import { loadMigrations, loadStatements } from './lib/sources';
+import { literal } from './lib/literal';
 
 const GENERATED_DIR = path.join(process.cwd(), 'src', 'generated');
 const NODE_DIR = path.join(GENERATED_DIR, 'node');
@@ -19,12 +20,12 @@ const main = () => {
 
   writeFile(
     path.join(NODE_DIR, 'migrations.ts'),
-    `${BANNER}\nimport type { Migration } from '../../shared/types';\n\nexport const migrations: Migration[] = ${JSON.stringify(migrations, null, 2)};\n`
+    `${BANNER}\nimport type { Migration } from '../../shared/types';\n\nexport const migrations: Migration[] = ${literal(migrations)};\n`
   );
 
   writeFile(
     path.join(NODE_DIR, 'statements.ts'),
-    `${BANNER}\nimport type { StatementDef } from '../../shared/types';\n\nexport const statements: StatementDef[] = ${JSON.stringify(statements, null, 2)};\n`
+    `${BANNER}\nimport type { StatementDef } from '../../shared/types';\n\nexport const statements: StatementDef[] = ${literal(statements)};\n`
   );
 
   const typeMap: Record<string, string> = {};
@@ -37,9 +38,9 @@ const main = () => {
   writeFile(
     path.join(WEB_DIR, 'statements.ts'),
     `${BANNER}\n\n`
-    + `export const statementTypes = ${JSON.stringify(typeMap, null, 2)} as const;\n\n`
+    + `export const statementTypes = ${literal(typeMap)} as const;\n\n`
     + `export type StatementName = ${statementName};\n\n`
-    + `export const statementTables: Record<string, readonly string[]> = ${JSON.stringify(tableMap, null, 2)};\n`
+    + `export const statementTables: Record<string, readonly string[]> = ${literal(tableMap)};\n`
   );
 
   console.log(`Generated ${migrations.length} migration(s) and ${statements.length} statement(s).`);

--- a/packages/bruno-sqlite/scripts/lib/literal.ts
+++ b/packages/bruno-sqlite/scripts/lib/literal.ts
@@ -1,0 +1,28 @@
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+const quote = (value: string): string =>
+  `'${value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\n/g, '\\n').replace(/\r/g, '\\r')}'`;
+
+// A `__proto__` property name in an object initializer invokes the prototype setter, quoted or
+// not; only a computed key emits it as a data property.
+const key = (name: string): string => {
+  if (name === '__proto__') return `[${quote(name)}]`;
+  return IDENTIFIER.test(name) ? name : quote(name);
+};
+
+export const literal = (value: unknown, indent = ''): string => {
+  if (typeof value === 'string') return quote(value);
+
+  if (Array.isArray(value)) {
+    const items = value.map((item) => `${indent}  ${literal(item, `${indent}  `)}`);
+    return items.length ? `[\n${items.join(',\n')}\n${indent}]` : '[]';
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const properties = Object.entries(value).map(([name, item]) =>
+      `${indent}  ${key(name)}: ${literal(item, `${indent}  `)}`);
+    return properties.length ? `{\n${properties.join(',\n')}\n${indent}}` : '{}';
+  }
+
+  return String(value);
+};

--- a/packages/bruno-sqlite/tests/node/literal.spec.ts
+++ b/packages/bruno-sqlite/tests/node/literal.spec.ts
@@ -1,0 +1,72 @@
+import { literal } from '../../scripts/lib/literal';
+
+const evaluate = (source: string): unknown => new Function(`return ${source};`)();
+
+describe('literal', () => {
+  it('single-quotes strings and leaves identifier keys bare', () => {
+    expect(literal({ name: 'get_thing', type: 'one' })).toBe(`{\n  name: 'get_thing',\n  type: 'one'\n}`);
+  });
+
+  it('quotes keys that are not valid identifiers', () => {
+    expect(literal({ 'get-thing': 1 })).toBe(`{\n  'get-thing': 1\n}`);
+  });
+
+  it('indents nested values by two spaces', () => {
+    expect(literal({ tables: ['things', 'notes'] })).toBe(
+      `{\n  tables: [\n    'things',\n    'notes'\n  ]\n}`
+    );
+  });
+
+  it('keeps empty objects and arrays inline', () => {
+    expect(literal({})).toBe('{}');
+    expect(literal([])).toBe('[]');
+    expect(literal({ statements: [], types: {} })).toBe(`{\n  statements: [],\n  types: {}\n}`);
+  });
+
+  it('emits non-string values as-is', () => {
+    expect(literal({ sequence: 1, applied: true, note: null })).toBe(
+      `{\n  sequence: 1,\n  applied: true,\n  note: null\n}`
+    );
+  });
+
+  it('emits a __proto__ key as an own property, not a prototype assignment', () => {
+    const source = JSON.parse('{"__proto__":"x"}');
+    expect(Object.getOwnPropertyDescriptor(source, '__proto__')?.value).toBe('x');
+
+    const evaluated = evaluate(literal(source)) as object;
+    expect(Object.getOwnPropertyDescriptor(evaluated, '__proto__')?.value).toBe('x');
+    expect(Object.getPrototypeOf(evaluated)).toBe(Object.prototype);
+  });
+
+  it('does not let a __proto__ key replace the prototype of the generated object', () => {
+    const source = JSON.parse('{"__proto__":{"injected":true},"name":"get_thing"}');
+
+    const evaluated = evaluate(literal(source)) as object;
+    expect(Object.getOwnPropertyDescriptor(evaluated, '__proto__')?.value).toEqual({ injected: true });
+    expect(Object.getPrototypeOf(evaluated)).toBe(Object.prototype);
+  });
+
+  it('round-trips a statement definition holding quoted sql', () => {
+    const statements = [
+      {
+        name: 'get_thing_by_slug',
+        type: 'one',
+        sql: 'SELECT id, name, note\nFROM things\nWHERE slug = ? AND note != \'n/a\'\nLIMIT 1',
+        tables: ['things']
+      }
+    ];
+
+    const source = literal(statements);
+    expect(source).not.toContain('"');
+    expect(evaluate(source)).toEqual(statements);
+  });
+
+  it.each([
+    ['sql literals', `SELECT * FROM t WHERE type = 'table' AND note = 'it''s fine'`],
+    ['backslashes', 'C:\\path\\to\\db'],
+    ['newlines and carriage returns', 'SELECT 1\nUNION\r\nSELECT 2'],
+    ['a quoted backslash', `\\'`]
+  ])('round-trips %s', (_name, sql) => {
+    expect(evaluate(literal({ sql }))).toEqual({ sql });
+  });
+});


### PR DESCRIPTION
The generator built src/generated/*.ts with JSON.stringify, which double
quotes every string and key. That trips our lint rules, so a freshly
generated tree came out dirty until someone ran lint:fix over it.

Replace that with a small literal() helper that emits TS source directly:
single quoted strings, bare identifier keys, two space indent.

Tests cover the quoting and escaping round trip (single quotes inside
SQL, backslashes, newlines) and both __proto__ cases.

Ticket - BRU-4266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQLite artifact generation to preserve strings, backslashes, line endings, and nested data accurately.
  - Added safer handling for special characters and object keys, reducing the risk of malformed generated SQL or migration data.
  - Improved formatting and readability of generated arrays and objects while keeping empty collections compact.
  - Added more consistent serialization for generated migration and statement artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->