### PR TITLE
refactor(mock-server): remove updateMockDelay functionality

### DIFF
--- a/packages/bruno-app/src/components/MockServer/MockServerDashboard/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MockServer/MockServerDashboard/StyledWrapper.js
@@ -95,7 +95,7 @@ const StyledWrapper = styled.div`
         }
 
         input {
-          width: 70px;
+          width: calc(8ch + 32px);
           padding: 6px 8px;
           font-size: ${(props) => props.theme.font.size.sm};
           line-height: 1.2;

--- a/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { startMockServer, stopMockServer, refreshMockRoutes, updateMockDelay, syncMockServerState } from 'providers/ReduxStore/slices/mock-server/index';
+import { startMockServer, stopMockServer, refreshMockRoutes, syncMockServerState } from 'providers/ReduxStore/slices/mock-server/index';
 import { IconRefresh, IconCopy, IconCheck, IconPlayerPlay, IconPlayerStop, IconSettings } from '@tabler/icons';
 import toast from 'react-hot-toast';
 import RouteTable from './RouteTable';
@@ -230,10 +230,6 @@ const MockServerDashboard = ({ instance, collection }) => {
     }
 
     try {
-      if (isRunning) {
-        await dispatch(updateMockDelay({ mockServerUid, delay: newDelay })).unwrap();
-      }
-
       await persistInstance({ globalDelay: newDelay });
     } catch (err) {
       toast.error(err.message || 'Failed to update delay');
@@ -372,7 +368,7 @@ const MockServerDashboard = ({ instance, collection }) => {
                 onChange={handleDelayChange}
                 onKeyDown={blockMockServerDelayKeys}
                 onBlur={handleDelayBlur}
-                disabled={isStarting}
+                disabled={isRunning || isStarting || isStopping}
                 min={0}
                 step={100}
                 data-testid="mock-server-delay-input"

--- a/packages/bruno-app/src/providers/ReduxStore/slices/mock-server/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/mock-server/index.js
@@ -82,22 +82,6 @@ export const refreshMockRoutes = createAsyncThunk(
   }
 );
 
-export const updateMockDelay = createAsyncThunk(
-  'mockServer/updateDelay',
-  async (payload) => {
-    const mockServerUid = resolveMockServerUid(payload);
-    const { delay } = payload;
-    const result = await window.ipcRenderer.invoke('renderer:mock-server-set-delay', {
-      mockServerUid,
-      delay: Number(delay) || 0
-    });
-    if (!result.success) {
-      throw new Error(result.error);
-    }
-    return { mockServerUid, delay: Number(delay) || 0 };
-  }
-);
-
 export const clearMockLog = createAsyncThunk(
   'mockServer/clearLog',
   async (payload) => {
@@ -376,12 +360,6 @@ export const mockServerSlice = createSlice({
           globalDelay: 0
         };
         state.requestLogs[mockServerUid] = [];
-      })
-      .addCase(updateMockDelay.fulfilled, (state, action) => {
-        const { mockServerUid, delay } = action.payload;
-        if (state.servers[mockServerUid]) {
-          state.servers[mockServerUid].globalDelay = delay;
-        }
       })
       .addCase(clearMockLog.fulfilled, (state, action) => {
         const { mockServerUid } = action.payload;

--- a/packages/bruno-electron/src/app/mock-server/mock-server.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server.js
@@ -648,12 +648,6 @@ const getLog = (mockServerUid) => {
   return collection ? collection.requestLog : [];
 };
 
-const setDelay = (mockServerUid, delay) => {
-  const collection = collections.get(mockServerUid);
-  if (!collection) throw new Error('Mock server is not running.');
-  collection.globalDelay = Math.max(0, Number(delay) || 0);
-};
-
 const clearLog = (mockServerUid) => {
   const collection = collections.get(mockServerUid);
   if (collection) collection.requestLog = [];
@@ -682,7 +676,6 @@ module.exports = {
   getStatus,
   refreshRoutes,
   getLog,
-  setDelay,
   clearLog,
   suggestPort,
   checkPortAvailable,

--- a/packages/bruno-electron/src/ipc/mock-server/index.js
+++ b/packages/bruno-electron/src/ipc/mock-server/index.js
@@ -115,15 +115,6 @@ const registerMockServerIpc = (mainWindow) => {
     }
   });
 
-  ipcMain.handle('renderer:mock-server-set-delay', async (_event, { mockServerUid, collectionUid, delay }) => {
-    try {
-      mockServer.setDelay(mockServerUid || collectionUid, delay);
-      return { success: true };
-    } catch (err) {
-      return { success: false, error: err.message };
-    }
-  });
-
   ipcMain.handle('renderer:mock-server-clear-log', async (_event, { mockServerUid, collectionUid }) => {
     mockServer.clearLog(mockServerUid || collectionUid);
     return { success: true };

--- a/tests/mock-server/collection-mock-server.spec.ts
+++ b/tests/mock-server/collection-mock-server.spec.ts
@@ -340,34 +340,44 @@ test.describe.serial('Mock Server', () => {
     await expect(ms.logCount()).not.toBeVisible();
   });
 
+  test('should disable delay input while server is running', async ({ pageWithUserData: page }) => {
+    const ms = buildMockServerLocators(page);
+    await openMockServerTab(page, COLLECTION_NAME);
+    await expect(ms.statusText()).toContainText('Running on port');
+    await expect(ms.delayInput()).toBeDisabled();
+  });
+
   test('should apply global delay to matched responses', async ({ pageWithUserData: page }) => {
     const ms = buildMockServerLocators(page);
     await openMockServerTab(page, COLLECTION_NAME);
+    await stopMockServer(page);
     await ms.delayInput().fill('500');
     await ms.delayInput().blur();
+    currentMockPort = await startMockServer(page);
 
     const start = Date.now();
     await mockFetch('/health');
     const elapsed = Date.now() - start;
     expect(elapsed).toBeGreaterThanOrEqual(400);
-
-    await ms.delayInput().fill('0');
-    await ms.delayInput().blur();
   });
 
   test('should not delay 404 responses', async ({ pageWithUserData: page }) => {
     const ms = buildMockServerLocators(page);
     await openMockServerTab(page, COLLECTION_NAME);
+    await stopMockServer(page);
     await ms.delayInput().fill('1000');
     await ms.delayInput().blur();
+    currentMockPort = await startMockServer(page);
 
     const start = Date.now();
     await mockFetch('/nonexistent');
     const elapsed = Date.now() - start;
     expect(elapsed).toBeLessThan(500);
 
+    await stopMockServer(page);
     await ms.delayInput().fill('0');
     await ms.delayInput().blur();
+    currentMockPort = await startMockServer(page);
   });
 
   test('should show refresh toast with correct route count', async ({ pageWithUserData: page }) => {


### PR DESCRIPTION
### Description

BRU-4193

On the mock server dashboard, Delay (ms) stays editable after Start Server is clicked. Changes made while the server is running remain in the field after Stop, so the displayed delay does not clearly reflect what the running server used. While the server is running, delay should be read-only.

### Screenshots


https://github.com/user-attachments/assets/4d54a662-cc3b-4682-9b50-6b56357af383



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Mock server delay settings can now be changed only when the server is stopped.
  * Delay changes persist reliably and apply after restarting the mock server.
  * The server control input now adjusts its width to better fit its contents.

* **Bug Fixes**
  * Prevented delay updates while the mock server is starting, running, or stopping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->