### PR TITLE
refactor(ws-client): add proper cleanup for all data structs

### DIFF
--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -26,7 +26,7 @@ const brunoConverters = require('@usebruno/converters');
 const { postmanToBruno } = brunoConverters;
 const { cookiesStore } = require('../store/cookies');
 const { parseLargeRequestWithRedaction } = require('../utils/parse');
-const wsEventHandlers = require('../ipc/network/ws-event-handlers');
+const { getWsClient } = require('../ipc/network/ws-event-handlers');
 const { hasSubDirectories } = require('../utils/filesystem');
 const { transformProxyConfig } = require('@usebruno/requests');
 
@@ -362,9 +362,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       // tear down the old watcher before moving the collection directory
       if (watcher && mainWindow) {
         watcher.removeWatcher(collectionPath, mainWindow, collectionUid);
-        if (wsEventHandlers.wsClient) {
-          wsEventHandlers.wsClient.closeForCollection(collectionUid);
-        }
+        getWsClient()?.closeForCollection(collectionUid);
       }
 
       // move the collection directory into the workspace
@@ -1321,10 +1319,6 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
   ipcMain.handle('renderer:remove-collection', async (event, collectionPath, collectionUid, workspacePath) => {
     if (watcher && mainWindow) {
       watcher.removeWatcher(collectionPath, mainWindow, collectionUid);
-
-      if (wsEventHandlers.wsClient) {
-        wsEventHandlers.wsClient.closeForCollection(collectionUid);
-      }
     }
 
     await require('./mount').unmount(collectionUid).catch(() => {});

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -26,7 +26,7 @@ const brunoConverters = require('@usebruno/converters');
 const { postmanToBruno } = brunoConverters;
 const { cookiesStore } = require('../store/cookies');
 const { parseLargeRequestWithRedaction } = require('../utils/parse');
-const { wsClient } = require('../ipc/network/ws-event-handlers');
+const wsEventHandlers = require('../ipc/network/ws-event-handlers');
 const { hasSubDirectories } = require('../utils/filesystem');
 const { transformProxyConfig } = require('@usebruno/requests');
 
@@ -362,8 +362,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       // tear down the old watcher before moving the collection directory
       if (watcher && mainWindow) {
         watcher.removeWatcher(collectionPath, mainWindow, collectionUid);
-        if (wsClient) {
-          wsClient.closeForCollection(collectionUid);
+        if (wsEventHandlers.wsClient) {
+          wsEventHandlers.wsClient.closeForCollection(collectionUid);
         }
       }
 
@@ -1322,8 +1322,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
     if (watcher && mainWindow) {
       watcher.removeWatcher(collectionPath, mainWindow, collectionUid);
 
-      if (wsClient) {
-        wsClient.closeForCollection(collectionUid);
+      if (wsEventHandlers.wsClient) {
+        wsEventHandlers.wsClient.closeForCollection(collectionUid);
       }
     }
 

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
@@ -481,10 +481,10 @@ const registerWsEventHandlers = (window) => {
   });
 };
 
+const getWsClient = () => wsClient;
+
 module.exports = {
   registerWsEventHandlers,
-  get wsClient() {
-    return wsClient;
-  },
+  getWsClient,
   prepareWsRequest
 };

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
@@ -1,6 +1,5 @@
 const { ipcMain, app } = require('electron');
 const { WsClient } = require('@usebruno/requests');
-const { safeParseJSON, safeStringifyJSON } = require('../../utils/common');
 const { cloneDeep, each, get } = require('lodash');
 const interpolateVars = require('./interpolate-vars');
 const { preferencesUtil } = require('../../store/preferences');
@@ -94,7 +93,7 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
   wsRequest = setAuthHeaders(wsRequest, request, collection);
 
   if (wsRequest.oauth2) {
-    let requestCopy = cloneDeep(wsRequest);
+    const requestCopy = cloneDeep(wsRequest);
     const { oauth2: { grantType, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, accessTokenUrl, refreshTokenUrl } = {}, collectionVariables, folderVariables, requestVariables } = requestCopy || {};
 
     // Get cert/proxy configs for token and refresh URLs
@@ -470,10 +469,22 @@ const registerWsEventHandlers = (window) => {
       return { success: false, error: error.message, status: 'disconnected' };
     }
   });
+
+  app.on('window-all-closed', () => {
+    if (wsClient && typeof wsClient.clearAllConnections === 'function') {
+      try {
+        wsClient.clearAllConnections();
+      } catch (error) {
+        console.error('Error clearing WebSocket connections:', error);
+      }
+    }
+  });
 };
 
 module.exports = {
   registerWsEventHandlers,
-  wsClient,
+  get wsClient() {
+    return wsClient;
+  },
   prepareWsRequest
 };

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.spec.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.spec.js
@@ -1,0 +1,43 @@
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn(), on: jest.fn() },
+  app: {
+    on: jest.fn(),
+    getPath: jest.fn(() => require('node:os').tmpdir()),
+    getVersion: jest.fn(() => '1.0.0')
+  }
+}));
+
+const { app } = require('electron');
+const { getWsClient, registerWsEventHandlers } = require('./ws-event-handlers');
+
+const fakeWindow = {
+  isDestroyed: () => false,
+  webContents: { isDestroyed: () => false, send: jest.fn() }
+};
+
+const lastWindowAllClosedHandler = () => {
+  const calls = app.on.mock.calls.filter(([event]) => event === 'window-all-closed');
+  return calls.at(-1)?.[1];
+};
+
+describe('getWsClient', () => {
+  it('returns the instance created at register time, not a require-time snapshot', () => {
+    expect(typeof getWsClient).toBe('function');
+    expect(getWsClient()).toBeUndefined();
+
+    registerWsEventHandlers(fakeWindow);
+
+    expect(typeof getWsClient()?.closeForCollection).toBe('function');
+  });
+});
+
+describe('window-all-closed', () => {
+  it('clears leftover websocket connections', () => {
+    registerWsEventHandlers(fakeWindow);
+    const clearAllConnections = jest.spyOn(getWsClient(), 'clearAllConnections');
+
+    lastWindowAllClosedHandler()();
+
+    expect(clearAllConnections).toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.spec.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.spec.js
@@ -7,36 +7,37 @@ jest.mock('electron', () => ({
   }
 }));
 
-const { app } = require('electron');
-const { getWsClient, registerWsEventHandlers } = require('./ws-event-handlers');
-
 const fakeWindow = {
   isDestroyed: () => false,
   webContents: { isDestroyed: () => false, send: jest.fn() }
 };
 
-const lastWindowAllClosedHandler = () => {
-  const calls = app.on.mock.calls.filter(([event]) => event === 'window-all-closed');
-  return calls.at(-1)?.[1];
-};
+describe('ws-event-handlers', () => {
+  let app;
+  let getWsClient;
+  let registerWsEventHandlers;
 
-describe('getWsClient', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ({ app } = require('electron'));
+    app.on.mockClear();
+    ({ getWsClient, registerWsEventHandlers } = require('./ws-event-handlers'));
+  });
+
   it('returns the instance created at register time, not a require-time snapshot', () => {
-    expect(typeof getWsClient).toBe('function');
     expect(getWsClient()).toBeUndefined();
 
     registerWsEventHandlers(fakeWindow);
 
     expect(typeof getWsClient()?.closeForCollection).toBe('function');
   });
-});
 
-describe('window-all-closed', () => {
-  it('clears leftover websocket connections', () => {
+  it('clears leftover websocket connections on window-all-closed', () => {
     registerWsEventHandlers(fakeWindow);
     const clearAllConnections = jest.spyOn(getWsClient(), 'clearAllConnections');
+    const handler = app.on.mock.calls.find(([event]) => event === 'window-all-closed')?.[1];
 
-    lastWindowAllClosedHandler()();
+    handler();
 
     expect(clearAllConnections).toHaveBeenCalled();
   });

--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -4,6 +4,7 @@ const { JobType, getPool, destroyPool } = require('../pool');
 const { FileIndex } = require('./file-index');
 const { buildTree } = require('./tree-builder');
 const { defaultClassify, uidForSeed } = require('../../utils/mount');
+const { wsClient } = require('../../ipc/network/ws-event-handlers');
 
 // cold start only — collection-watcher handles live changes and writes through to the cache
 
@@ -125,6 +126,9 @@ class MountManager {
     const collectionWatcher = require('../../app/collection-watcher');
     try {
       collectionWatcher.removeWatcher(entry.collectionPath, entry.win, collectionUid);
+    } catch (_) {}
+    try {
+      wsClient?.closeForCollection(collectionUid);
     } catch (_) {}
   }
 

--- a/packages/bruno-electron/src/services/mount/manager.js
+++ b/packages/bruno-electron/src/services/mount/manager.js
@@ -4,7 +4,7 @@ const { JobType, getPool, destroyPool } = require('../pool');
 const { FileIndex } = require('./file-index');
 const { buildTree } = require('./tree-builder');
 const { defaultClassify, uidForSeed } = require('../../utils/mount');
-const { wsClient } = require('../../ipc/network/ws-event-handlers');
+const { getWsClient } = require('../../ipc/network/ws-event-handlers');
 
 // cold start only — collection-watcher handles live changes and writes through to the cache
 
@@ -120,15 +120,16 @@ class MountManager {
   }
 
   async unmount(collectionUid) {
+    try {
+      getWsClient()?.closeForCollection(collectionUid);
+    } catch (_) {}
+
     const entry = this.#mounts.get(collectionUid);
     if (!entry) return;
     this.#mounts.delete(collectionUid);
     const collectionWatcher = require('../../app/collection-watcher');
     try {
       collectionWatcher.removeWatcher(entry.collectionPath, entry.win, collectionUid);
-    } catch (_) {}
-    try {
-      wsClient?.closeForCollection(collectionUid);
     } catch (_) {}
   }
 

--- a/packages/bruno-electron/src/services/mount/manager.spec.js
+++ b/packages/bruno-electron/src/services/mount/manager.spec.js
@@ -1,0 +1,46 @@
+jest.mock('electron', () => ({
+  app: { getPath: jest.fn(() => require('node:os').tmpdir()) }
+}));
+
+jest.mock('./file-index', () => ({ FileIndex: jest.fn() }));
+jest.mock('../pool', () => ({
+  JobType: {},
+  getPool: jest.fn(),
+  destroyPool: jest.fn(async () => {})
+}));
+
+const mockCloseForCollection = jest.fn();
+jest.mock('../../ipc/network/ws-event-handlers', () => ({
+  get wsClient() {
+    return { closeForCollection: mockCloseForCollection };
+  }
+}));
+
+jest.mock('../../app/collection-watcher', () => ({
+  removeWatcher: jest.fn()
+}));
+
+const { MountManager } = require('./manager');
+
+describe('MountManager.unmount', () => {
+  beforeEach(() => {
+    mockCloseForCollection.mockClear();
+  });
+
+  it('closes websocket connections even when the collection was never v2-mounted', async () => {
+    const manager = new MountManager();
+
+    await manager.unmount('col-1');
+
+    expect(mockCloseForCollection).toHaveBeenCalledWith('col-1');
+  });
+
+  it('still unmounts if closeForCollection throws', async () => {
+    mockCloseForCollection.mockImplementation(() => {
+      throw new Error('ws down');
+    });
+    const manager = new MountManager();
+
+    await expect(manager.unmount('col-1')).resolves.toBeUndefined();
+  });
+});

--- a/packages/bruno-electron/src/services/mount/manager.spec.js
+++ b/packages/bruno-electron/src/services/mount/manager.spec.js
@@ -2,7 +2,17 @@ jest.mock('electron', () => ({
   app: { getPath: jest.fn(() => require('node:os').tmpdir()) }
 }));
 
-jest.mock('./file-index', () => ({ FileIndex: jest.fn() }));
+jest.mock('./file-index', () => ({
+  FileIndex: jest.fn().mockImplementation(() => ({
+    entries: () => new Map(),
+    status: async () => ({ added: [], updated: [], removed: [] }),
+    stage: jest.fn(),
+    transaction: (fn) => fn(),
+    clear: jest.fn(),
+    clearCollection: jest.fn(),
+    close: jest.fn()
+  }))
+}));
 jest.mock('../pool', () => ({
   JobType: {},
   getPool: jest.fn(),
@@ -14,15 +24,40 @@ jest.mock('../../ipc/network/ws-event-handlers', () => ({
   getWsClient: () => ({ closeForCollection: mockCloseForCollection })
 }));
 
+const mockRemoveWatcher = jest.fn();
 jest.mock('../../app/collection-watcher', () => ({
-  removeWatcher: jest.fn()
+  addWatcher: jest.fn(),
+  addTempDirectoryWatcher: jest.fn(),
+  removeWatcher: (...args) => mockRemoveWatcher(...args)
 }));
 
+jest.mock('../../cache/requestUids', () => ({
+  getRequestUid: (collectionPath, relativePath) => `${collectionPath}:${relativePath}`
+}));
+
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
 const { MountManager } = require('./manager');
+
+const mountCollection = async (manager, collectionUid = 'col-1') => {
+  const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-mount-'));
+  const win = {};
+  const emit = { tree: jest.fn(), loading: jest.fn(), config: jest.fn() };
+  await manager.mount({
+    win,
+    collectionPath,
+    collectionUid,
+    brunoConfig: {},
+    emit
+  });
+  return { collectionPath, win };
+};
 
 describe('MountManager.unmount', () => {
   beforeEach(() => {
-    mockCloseForCollection.mockClear();
+    mockCloseForCollection.mockReset();
+    mockRemoveWatcher.mockReset();
   });
 
   it('closes websocket connections even when the collection was never v2-mounted', async () => {
@@ -31,14 +66,27 @@ describe('MountManager.unmount', () => {
     await manager.unmount('col-1');
 
     expect(mockCloseForCollection).toHaveBeenCalledWith('col-1');
+    expect(mockRemoveWatcher).not.toHaveBeenCalled();
   });
 
-  it('still unmounts if closeForCollection throws', async () => {
+  it('removes the watcher when unmounting a mounted collection', async () => {
+    const manager = new MountManager();
+    const { collectionPath, win } = await mountCollection(manager);
+
+    await manager.unmount('col-1');
+
+    expect(mockCloseForCollection).toHaveBeenCalledWith('col-1');
+    expect(mockRemoveWatcher).toHaveBeenCalledWith(collectionPath, win, 'col-1');
+  });
+
+  it('still removes the watcher if closeForCollection throws', async () => {
     mockCloseForCollection.mockImplementation(() => {
       throw new Error('ws down');
     });
     const manager = new MountManager();
+    const { collectionPath, win } = await mountCollection(manager);
 
     await expect(manager.unmount('col-1')).resolves.toBeUndefined();
+    expect(mockRemoveWatcher).toHaveBeenCalledWith(collectionPath, win, 'col-1');
   });
 });

--- a/packages/bruno-electron/src/services/mount/manager.spec.js
+++ b/packages/bruno-electron/src/services/mount/manager.spec.js
@@ -11,9 +11,7 @@ jest.mock('../pool', () => ({
 
 const mockCloseForCollection = jest.fn();
 jest.mock('../../ipc/network/ws-event-handlers', () => ({
-  get wsClient() {
-    return { closeForCollection: mockCloseForCollection };
-  }
+  getWsClient: () => ({ closeForCollection: mockCloseForCollection })
 }));
 
 jest.mock('../../app/collection-watcher', () => ({

--- a/packages/bruno-requests/src/ws/ws-client.js
+++ b/packages/bruno-requests/src/ws/ws-client.js
@@ -250,6 +250,13 @@ class WsClient {
       const resolver = this.closingResolvers.get(requestId);
       if (resolver) {
         this.closingResolvers.delete(requestId);
+        // Emit before forget — a late 'close' from terminate will miss the map and skip emit.
+        this.eventCallback('main:ws:close', requestId, collectionUid, {
+          code: 1006,
+          reason: '',
+          seq: seq.next(requestId, collectionUid),
+          timestamp: Date.now()
+        });
         this.#forgetRequest(requestId);
         resolve();
       }

--- a/packages/bruno-requests/src/ws/ws-client.js
+++ b/packages/bruno-requests/src/ws/ws-client.js
@@ -2,26 +2,6 @@ import ws from 'ws';
 import { hexy as hexdump } from 'hexy';
 import { getParsedWsUrlObject } from './ws-url';
 
-/**
- * Safely parse JSON string with error handling
- * @param {string} jsonString - The JSON string to parse
- * @param {string} context - Context for error messages
- * @returns {Object} Parsed object or throws error with context
- * @throws {Error} If JSON parsing fails
- */
-const safeParseJSON = (jsonString, context = 'JSON string') => {
-  try {
-    return JSON.parse(jsonString);
-  } catch (error) {
-    const errorMessage = `Failed to parse ${context}: ${error.message}`;
-    console.error(errorMessage, {
-      originalString: jsonString,
-      parseError: error
-    });
-    throw new Error(errorMessage);
-  }
-};
-
 const normalizeMessageByFormat = (message, format) => {
   if (!message) {
     return '';
@@ -66,10 +46,12 @@ const createSequencer = () => {
     if (!seq[requestId]) return;
     if (collectionId) {
       delete seq[requestId][collectionId];
+      if (!Object.keys(seq[requestId]).length) {
+        delete seq[requestId];
+      }
+      return;
     }
-    if (!Object.keys(seq[requestId]).length) {
-      delete seq[requestId];
-    }
+    delete seq[requestId];
   };
 
   return {
@@ -117,6 +99,9 @@ class WsClient {
     const existing = this.activeConnections.get(requestId)?.connection;
     if (existing && (existing.readyState === ws.WebSocket.CONNECTING || existing.readyState === ws.WebSocket.OPEN)) {
       return existing;
+    }
+    if (existing) {
+      this.#discard(requestId);
     }
 
     try {
@@ -182,9 +167,11 @@ class WsClient {
 
     const mqKey = this.#getMessageQueueId(requestId);
     this.messageQueues[mqKey] ||= [];
+    this.messageQueues[mqKey].collectionUid = collectionUid;
     this.messageQueues[mqKey].push({
       message,
-      format
+      format,
+      collectionUid
     });
 
     if (connectionMeta && connectionMeta.connection && connectionMeta.connection.readyState === WebSocket.OPEN) {
@@ -255,7 +242,7 @@ class WsClient {
     }
 
     if (!connectionMeta?.connection) {
-      seq.clean(requestId);
+      this.#removeConnection(requestId);
       return Promise.resolve();
     }
 
@@ -265,6 +252,8 @@ class WsClient {
     });
 
     const collectionUid = connectionMeta.collectionUid;
+
+    this.#clearClientState(requestId);
 
     // Notify the UI that we're actively disconnecting so it can show a blink state
     this.eventCallback('main:ws:disconnecting', requestId, collectionUid);
@@ -281,7 +270,6 @@ class WsClient {
       if (resolver) {
         this.closingResolvers.delete(requestId);
         this.#removeConnection(requestId);
-        seq.clean(requestId, collectionUid);
         resolve();
       }
     }, 5000);
@@ -310,31 +298,35 @@ class WsClient {
   }
 
   closeForCollection(collectionUid) {
-    [...this.activeConnections.keys()].forEach((k) => {
-      const meta = this.activeConnections.get(k);
-      if (meta.collectionUid === collectionUid) {
-        meta.connection.close();
-        this.activeConnections.delete(k);
+    for (const requestId of [...this.activeConnections.keys()]) {
+      if (this.activeConnections.get(requestId)?.collectionUid === collectionUid) {
+        this.close(requestId);
       }
-    });
+    }
+    for (const [requestId, queue] of Object.entries(this.messageQueues)) {
+      if (queue.collectionUid === collectionUid) {
+        this.#removeConnection(requestId);
+      }
+    }
   }
 
   /**
    * Clear all active connections
    */
   clearAllConnections() {
-    const connectionIds = this.getActiveConnectionIds();
+    const requestIds = new Set([...this.activeConnections.keys(), ...Object.keys(this.messageQueues)]);
 
-    this.activeConnections.forEach((connection) => {
-      if (connection.readyState === WebSocket.OPEN) {
-        connection.close(1000, 'Client clearing all connections');
-      }
-    });
+    for (const requestId of requestIds) {
+      this.#discard(requestId);
+    }
 
-    this.activeConnections.clear();
+    for (const [requestId, resolver] of this.closingResolvers) {
+      clearTimeout(resolver.timeoutId);
+      this.closingResolvers.delete(requestId);
+      resolver.resolve();
+    }
 
-    // Emit an event with empty active connection IDs
-    if (connectionIds.length > 0) {
+    if (requestIds.size > 0) {
       this.eventCallback('main:ws:connections-changed', {
         type: 'cleared',
         activeConnectionIds: []
@@ -435,7 +427,6 @@ class WsClient {
         seq: seq.next(requestId, collectionUid),
         timestamp: Date.now()
       });
-      seq.clean(requestId, collectionUid);
       this.#removeConnection(requestId);
     });
 
@@ -466,21 +457,33 @@ class WsClient {
     });
   }
 
+  #discard(requestId) {
+    const conn = this.activeConnections.get(requestId)?.connection;
+    if (conn) {
+      try {
+        conn.terminate();
+      } catch (_) {
+      }
+    }
+    this.#removeConnection(requestId);
+  }
+
+  #clearClientState(requestId) {
+    if (this.connectionKeepAlive.has(requestId)) {
+      clearInterval(this.connectionKeepAlive.get(requestId));
+      this.connectionKeepAlive.delete(requestId);
+    }
+    delete this.messageQueues[this.#getMessageQueueId(requestId)];
+  }
+
   /**
    * Remove a connection from the active connections map and emit an event
    * @param {string} requestId - The request ID
    * @private
    */
   #removeConnection(requestId) {
-    if (this.connectionKeepAlive.has(requestId)) {
-      clearInterval(this.connectionKeepAlive.get(requestId));
-      this.connectionKeepAlive.delete(requestId);
-    }
-
-    const mqId = this.#getMessageQueueId(requestId);
-    if (mqId in this.messageQueues) {
-      this.messageQueues[mqId] = [];
-    }
+    this.#clearClientState(requestId);
+    seq.clean(requestId);
 
     if (this.activeConnections.has(requestId)) {
       this.activeConnections.delete(requestId);

--- a/packages/bruno-requests/src/ws/ws-client.js
+++ b/packages/bruno-requests/src/ws/ws-client.js
@@ -90,15 +90,7 @@ class WsClient {
       return existing;
     }
     if (existing) {
-      meta.connection = null;
-      try {
-        existing.terminate();
-      } catch (_) {
-      }
-      if (this.connectionKeepAlive.has(requestId)) {
-        clearInterval(this.connectionKeepAlive.get(requestId));
-        this.connectionKeepAlive.delete(requestId);
-      }
+      this.#detachSocket(requestId);
       this.activeConnections.delete(requestId);
     }
 
@@ -156,33 +148,23 @@ class WsClient {
     }
   }
 
-  #getMessageQueueId(requestId) {
-    return `${requestId}`;
-  }
-
   queueMessage(requestId, collectionUid, message, format = 'raw') {
     const connectionMeta = this.activeConnections.get(requestId);
 
-    const mqKey = this.#getMessageQueueId(requestId);
-    this.messageQueues[mqKey] ||= [];
-    this.messageQueues[mqKey].collectionUid = collectionUid;
-    this.messageQueues[mqKey].push({
-      message,
-      format,
-      collectionUid
-    });
+    const queue = (this.messageQueues[requestId] ||= { collectionUid, messages: [] });
+    queue.collectionUid = collectionUid;
+    queue.messages.push({ message, format });
 
     if (connectionMeta && connectionMeta.connection && connectionMeta.connection.readyState === WebSocket.OPEN) {
       this.#flushQueue(requestId, collectionUid);
-      return;
     }
   }
 
   #flushQueue(requestId, collectionUid) {
-    const mqKey = this.#getMessageQueueId(requestId);
-    if (!(mqKey in this.messageQueues)) return;
-    while (this.messageQueues[mqKey].length > 0) {
-      const { message, format } = this.messageQueues[mqKey].shift();
+    const queue = this.messageQueues[requestId];
+    if (!queue) return;
+    while (queue.messages.length > 0) {
+      const { message, format } = queue.messages.shift();
       this.sendMessage(requestId, collectionUid, message, format);
     }
   }
@@ -240,7 +222,7 @@ class WsClient {
     }
 
     if (!connectionMeta?.connection) {
-      this.#removeConnection(requestId);
+      this.#forgetRequest(requestId);
       return Promise.resolve();
     }
 
@@ -251,6 +233,7 @@ class WsClient {
 
     const collectionUid = connectionMeta.collectionUid;
 
+    // Drop the queue before the handshake so a late 'open' cannot flush it.
     this.#clearClientState(requestId);
 
     // Notify the UI that we're actively disconnecting so it can show a blink state
@@ -267,7 +250,7 @@ class WsClient {
       const resolver = this.closingResolvers.get(requestId);
       if (resolver) {
         this.closingResolvers.delete(requestId);
-        this.#removeConnection(requestId);
+        this.#forgetRequest(requestId);
         resolve();
       }
     }, 5000);
@@ -303,7 +286,7 @@ class WsClient {
     }
     for (const [requestId, queue] of Object.entries(this.messageQueues)) {
       if (queue.collectionUid === collectionUid) {
-        this.#removeConnection(requestId);
+        this.#forgetRequest(requestId);
       }
     }
   }
@@ -425,7 +408,7 @@ class WsClient {
         seq: seq.next(requestId, collectionUid),
         timestamp: Date.now()
       });
-      this.#removeConnection(requestId);
+      this.#forgetRequest(requestId);
     });
 
     ws.on('error', (error) => {
@@ -455,10 +438,10 @@ class WsClient {
     });
   }
 
-  #discard(requestId) {
+  #detachSocket(requestId) {
     const meta = this.activeConnections.get(requestId);
     const conn = meta?.connection;
-    // Detach before terminate so a sync close does not re-enter #removeConnection.
+    // Detach before terminate so a sync close does not re-enter #forgetRequest.
     if (meta) meta.connection = null;
     if (conn) {
       try {
@@ -466,7 +449,15 @@ class WsClient {
       } catch (_) {
       }
     }
-    this.#removeConnection(requestId);
+    if (this.connectionKeepAlive.has(requestId)) {
+      clearInterval(this.connectionKeepAlive.get(requestId));
+      this.connectionKeepAlive.delete(requestId);
+    }
+  }
+
+  #discard(requestId) {
+    this.#detachSocket(requestId);
+    this.#forgetRequest(requestId);
   }
 
   #clearClientState(requestId) {
@@ -474,22 +465,22 @@ class WsClient {
       clearInterval(this.connectionKeepAlive.get(requestId));
       this.connectionKeepAlive.delete(requestId);
     }
-    delete this.messageQueues[this.#getMessageQueueId(requestId)];
+    delete this.messageQueues[requestId];
   }
 
   /**
-   * Remove a connection from the active connections map and emit an event
-   * @param {string} requestId - The request ID
+   * Drop queue, keepalive, sequencer, and any map entry for this request.
+   * Safe to call when there is no live connection.
+   * @param {string} requestId
    * @private
    */
-  #removeConnection(requestId) {
+  #forgetRequest(requestId) {
     this.#clearClientState(requestId);
     seq.clean(requestId);
 
     if (this.activeConnections.has(requestId)) {
       this.activeConnections.delete(requestId);
 
-      // Emit an event with all active connection IDs
       this.eventCallback('main:ws:connections-changed', {
         type: 'removed',
         requestId,

--- a/packages/bruno-requests/src/ws/ws-client.js
+++ b/packages/bruno-requests/src/ws/ws-client.js
@@ -38,19 +38,7 @@ const createSequencer = () => {
     return ++seq[requestId][collectionId];
   };
 
-  /**
-   * @param {string} requestId
-   * @param {string} [collectionId]
-   */
-  const clean = (requestId, collectionId = undefined) => {
-    if (!seq[requestId]) return;
-    if (collectionId) {
-      delete seq[requestId][collectionId];
-      if (!Object.keys(seq[requestId]).length) {
-        delete seq[requestId];
-      }
-      return;
-    }
+  const clean = (requestId) => {
     delete seq[requestId];
   };
 
@@ -96,12 +84,22 @@ class WsClient {
     }
 
     // Reuse in-flight / open socket so ensure+connect races don't open a second connection.
-    const existing = this.activeConnections.get(requestId)?.connection;
+    const meta = this.activeConnections.get(requestId);
+    const existing = meta?.connection;
     if (existing && (existing.readyState === ws.WebSocket.CONNECTING || existing.readyState === ws.WebSocket.OPEN)) {
       return existing;
     }
     if (existing) {
-      this.#discard(requestId);
+      meta.connection = null;
+      try {
+        existing.terminate();
+      } catch (_) {
+      }
+      if (this.connectionKeepAlive.has(requestId)) {
+        clearInterval(this.connectionKeepAlive.get(requestId));
+        this.connectionKeepAlive.delete(requestId);
+      }
+      this.activeConnections.delete(requestId);
     }
 
     try {
@@ -458,7 +456,10 @@ class WsClient {
   }
 
   #discard(requestId) {
-    const conn = this.activeConnections.get(requestId)?.connection;
+    const meta = this.activeConnections.get(requestId);
+    const conn = meta?.connection;
+    // Detach before terminate so a sync close does not re-enter #removeConnection.
+    if (meta) meta.connection = null;
     if (conn) {
       try {
         conn.terminate();

--- a/packages/bruno-requests/src/ws/ws-client.spec.js
+++ b/packages/bruno-requests/src/ws/ws-client.spec.js
@@ -214,5 +214,237 @@ describe('WsClient', () => {
       expect(mockSockets).toHaveLength(2);
       expect(client.connectionStatus('req-1')).toBe('connecting');
     });
+
+    it('drops a queued message when close is called with no live socket', async () => {
+      client.queueMessage('req-1', 'col-1', 'stale', 'raw');
+
+      await client.close('req-1');
+
+      await start();
+      mockSockets[0].open();
+
+      expect(mockSockets[0].sent).toEqual([]);
+    });
+  });
+
+  describe('closeForCollection', () => {
+    const startWithKeepAlive = () =>
+      client.startConnection({
+        request: { uid: 'req-1', url: 'ws://localhost:9', headers: {} },
+        collection: { uid: 'col-1' },
+        options: { keepAlive: true, keepAliveInterval: 1000 }
+      });
+
+    it('stops keepalive pings immediately', async () => {
+      jest.useFakeTimers();
+      await startWithKeepAlive();
+      mockSockets[0].ping = jest.fn();
+      mockSockets[0].open();
+
+      jest.advanceTimersByTime(1000);
+      expect(mockSockets[0].ping).toHaveBeenCalledTimes(1);
+
+      client.closeForCollection('col-1');
+      mockSockets[0].ping.mockClear();
+      jest.advanceTimersByTime(1000);
+
+      expect(mockSockets[0].ping).not.toHaveBeenCalled();
+      expect(client.connectionKeepAlive.size).toBe(0);
+      jest.useRealTimers();
+    });
+
+    it('does not flush an orphaned queue after the collection is closed', async () => {
+      client.queueMessage('req-1', 'col-1', 'stale', 'raw');
+
+      client.closeForCollection('col-1');
+
+      await start();
+      mockSockets[0].open();
+
+      expect(mockSockets[0].sent).toEqual([]);
+    });
+
+    it('does not flush a live connection queue after the collection is closed', async () => {
+      await start();
+      client.queueMessage('req-1', 'col-1', 'stale', 'raw');
+
+      client.closeForCollection('col-1');
+      mockSockets[0].finishClose();
+
+      await start();
+      mockSockets[1].open();
+
+      expect(mockSockets[1].sent).toEqual([]);
+    });
+
+    it('resets seq so a reconnect does not continue the old counter', async () => {
+      await start();
+      mockSockets[0].open();
+
+      client.closeForCollection('col-1');
+      mockSockets[0].finishClose();
+
+      await start();
+      mockSockets[1].open();
+
+      const openSeqs = events.filter((e) => e.eventName === 'main:ws:open').map((e) => e.args[2].seq);
+      // add + open, same as a brand-new request — not the pre-close counter
+      expect(openSeqs.at(-1)).toBe(2);
+    });
+
+    it('leaves other collections alone', async () => {
+      await start('req-1');
+      await client.startConnection({
+        request: { uid: 'req-2', url: 'ws://localhost:9', headers: {} },
+        collection: { uid: 'col-2' },
+        options: {}
+      });
+      mockSockets[1].open();
+
+      client.closeForCollection('col-1');
+      mockSockets[0].finishClose();
+
+      expect(client.connectionStatus('req-2')).toBe('connected');
+      expect(client.activeConnections.get('req-2').connection).toBe(mockSockets[1]);
+    });
+
+    it('uses the close handshake: disconnecting until the socket emits close', async () => {
+      await start();
+      mockSockets[0].open();
+
+      client.closeForCollection('col-1');
+
+      expect(events.some((e) => e.eventName === 'main:ws:disconnecting')).toBe(true);
+      expect(client.connectionStatus('req-1')).toBe('disconnecting');
+      expect(mockSockets[0].readyState).toBe(CLOSING);
+
+      mockSockets[0].finishClose();
+
+      expect(client.connectionStatus('req-1')).toBe('disconnected');
+      expect(events.some((e) => e.eventName === 'main:ws:close')).toBe(true);
+      expect(
+        events.some((e) => e.eventName === 'main:ws:connections-changed' && e.args[0].type === 'removed')
+      ).toBe(true);
+    });
+
+    it('closes every live socket in the collection', async () => {
+      await start('req-1');
+      await start('req-2');
+      mockSockets[0].open();
+      mockSockets[1].open();
+
+      client.closeForCollection('col-1');
+
+      expect(client.connectionStatus('req-1')).toBe('disconnecting');
+      expect(client.connectionStatus('req-2')).toBe('disconnecting');
+
+      mockSockets[0].finishClose();
+      mockSockets[1].finishClose();
+
+      expect(client.connectionStatus('req-1')).toBe('disconnected');
+      expect(client.connectionStatus('req-2')).toBe('disconnected');
+    });
+
+    it('is a no-op for an unknown collection', async () => {
+      await start();
+      mockSockets[0].open();
+
+      client.closeForCollection('missing-col');
+
+      expect(client.connectionStatus('req-1')).toBe('connected');
+      expect(events.some((e) => e.eventName === 'main:ws:disconnecting')).toBe(false);
+    });
+
+    it('coalesces with an in-flight close instead of starting a second handshake', async () => {
+      await start();
+      mockSockets[0].open();
+
+      const closing = client.close('req-1');
+      client.closeForCollection('col-1');
+
+      expect(events.filter((e) => e.eventName === 'main:ws:disconnecting')).toHaveLength(1);
+
+      mockSockets[0].finishClose();
+      await closing;
+      expect(client.connectionStatus('req-1')).toBe('disconnected');
+    });
+  });
+
+  describe('clearAllConnections', () => {
+    it('terminates sockets and drops map, queues, and keepalive', async () => {
+      await client.startConnection({
+        request: { uid: 'req-1', url: 'ws://localhost:9', headers: {} },
+        collection: { uid: 'col-1' },
+        options: { keepAlive: true, keepAliveInterval: 1000 }
+      });
+      mockSockets[0].open();
+      client.queueMessage('req-2', 'col-1', 'orphaned', 'raw');
+
+      client.clearAllConnections();
+
+      expect(mockSockets[0].readyState).toBe(CLOSED);
+      expect(client.activeConnections.size).toBe(0);
+      expect(client.messageQueues).toEqual({});
+      expect(client.connectionKeepAlive.size).toBe(0);
+    });
+
+    it('does not flush leftover queues on a later connect', async () => {
+      await start();
+      client.queueMessage('req-1', 'col-1', 'stale', 'raw');
+
+      client.clearAllConnections();
+
+      await start();
+      mockSockets[1].open();
+
+      expect(mockSockets[1].sent).toEqual([]);
+    });
+
+    it('resolves an in-flight close instead of leaving disconnecting status', async () => {
+      await start();
+      mockSockets[0].open();
+
+      const closing = client.close('req-1');
+      client.clearAllConnections();
+
+      await expect(closing).resolves.toBeUndefined();
+      expect(client.connectionStatus('req-1')).toBe('disconnected');
+      expect(client.closingResolvers.size).toBe(0);
+    });
+
+    it('drops orphaned queues when there are no live sockets', async () => {
+      client.queueMessage('req-1', 'col-1', 'stale', 'raw');
+
+      client.clearAllConnections();
+
+      expect(client.messageQueues).toEqual({});
+      await start();
+      mockSockets[0].open();
+      expect(mockSockets[0].sent).toEqual([]);
+    });
+  });
+
+  describe('stale socket replace', () => {
+    it('does not keep pinging a CLOSED socket left in the map', async () => {
+      jest.useFakeTimers();
+      await client.startConnection({
+        request: { uid: 'req-1', url: 'ws://localhost:9', headers: {} },
+        collection: { uid: 'col-1' },
+        options: { keepAlive: true, keepAliveInterval: 1000 }
+      });
+      mockSockets[0].ping = jest.fn();
+      mockSockets[0].open();
+      mockSockets[0].readyState = CLOSED;
+
+      await start();
+      mockSockets[1].open();
+
+      mockSockets[0].ping.mockClear();
+      jest.advanceTimersByTime(1000);
+
+      expect(mockSockets[0].ping).not.toHaveBeenCalled();
+      expect(client.activeConnections.get('req-1').connection).toBe(mockSockets[1]);
+      jest.useRealTimers();
+    });
   });
 });

--- a/packages/bruno-requests/src/ws/ws-client.spec.js
+++ b/packages/bruno-requests/src/ws/ws-client.spec.js
@@ -225,6 +225,19 @@ describe('WsClient', () => {
 
       expect(mockSockets[0].sent).toEqual([]);
     });
+
+    it('does not flush a queued message if the socket opens after close is called', async () => {
+      await start();
+      client.queueMessage('req-1', 'col-1', 'hello', 'raw');
+
+      const closing = client.close('req-1');
+      mockSockets[0].open();
+
+      expect(mockSockets[0].sent).toEqual([]);
+
+      mockSockets[0].finishClose();
+      await closing;
+    });
   });
 
   describe('closeForCollection', () => {
@@ -422,6 +435,22 @@ describe('WsClient', () => {
       mockSockets[0].open();
       expect(mockSockets[0].sent).toEqual([]);
     });
+
+    it('emits connections-changed cleared when anything was tracked', async () => {
+      client.queueMessage('req-1', 'col-1', 'stale', 'raw');
+
+      client.clearAllConnections();
+
+      expect(
+        events.some((e) => e.eventName === 'main:ws:connections-changed' && e.args[0].type === 'cleared')
+      ).toBe(true);
+    });
+
+    it('does not emit cleared when there is nothing to clear', () => {
+      client.clearAllConnections();
+
+      expect(events).toEqual([]);
+    });
   });
 
   describe('stale socket replace', () => {
@@ -445,6 +474,29 @@ describe('WsClient', () => {
       expect(mockSockets[0].ping).not.toHaveBeenCalled();
       expect(client.activeConnections.get('req-1').connection).toBe(mockSockets[1]);
       jest.useRealTimers();
+    });
+
+    it('keeps messages queued before replacing a stale socket', async () => {
+      await start();
+      mockSockets[0].readyState = CLOSED;
+
+      client.queueMessage('req-1', 'col-1', 'hello', 'raw');
+      client.queueMessage('req-1', 'col-1', 'again', 'raw');
+
+      await start();
+      mockSockets[1].open();
+
+      expect(mockSockets[1].sent).toEqual(['hello', 'again']);
+    });
+
+    it('does not emit close for a discarded stale socket', async () => {
+      await start();
+      mockSockets[0].readyState = CLOSED;
+
+      await start();
+
+      expect(events.filter((e) => e.eventName === 'main:ws:close')).toHaveLength(0);
+      expect(client.connectionStatus('req-1')).toBe('connecting');
     });
   });
 });

--- a/packages/bruno-requests/src/ws/ws-client.spec.js
+++ b/packages/bruno-requests/src/ws/ws-client.spec.js
@@ -41,10 +41,10 @@ jest.mock('ws', () => {
       this.emit('close', 1000, Buffer.from('closed'));
     }
 
-    // Match `ws`: terminate destroys immediately and emits close.
+    // Match `ws`: terminate destroys immediately; 'close' arrives a tick later.
     terminate() {
       this.readyState = CLOSED;
-      this.emit('close', 1006, Buffer.from(''));
+      process.nextTick(() => this.emit('close', 1006, Buffer.from('')));
     }
 
     ping() {}
@@ -75,6 +75,10 @@ describe('WsClient', () => {
     client = new WsClient((eventName, ...args) => {
       events.push({ eventName, args });
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   const start = (requestId = 'req-1') =>
@@ -160,9 +164,10 @@ describe('WsClient', () => {
 
       jest.advanceTimersByTime(5000);
       await closed;
+      await Promise.resolve();
 
       expect(client.connectionStatus('req-1')).toBe('disconnected');
-      jest.useRealTimers();
+      expect(events.some((e) => e.eventName === 'main:ws:close')).toBe(true);
     });
 
     it('does not let a timed-out socket close remove a replacement connection', async () => {
@@ -193,7 +198,6 @@ describe('WsClient', () => {
 
       expect(client.activeConnections.get('req-1').connection).toBe(replacement);
       expect(client.connectionStatus('req-1')).toBe('connected');
-      jest.useRealTimers();
     });
 
     it('waits for an in-flight close before opening a new socket', async () => {
@@ -263,7 +267,6 @@ describe('WsClient', () => {
 
       expect(mockSockets[0].ping).not.toHaveBeenCalled();
       expect(client.connectionKeepAlive.size).toBe(0);
-      jest.useRealTimers();
     });
 
     it('does not flush an orphaned queue after the collection is closed', async () => {
@@ -473,7 +476,6 @@ describe('WsClient', () => {
 
       expect(mockSockets[0].ping).not.toHaveBeenCalled();
       expect(client.activeConnections.get('req-1').connection).toBe(mockSockets[1]);
-      jest.useRealTimers();
     });
 
     it('keeps messages queued before replacing a stale socket', async () => {


### PR DESCRIPTION
### Description

BRU-4282

Websocket has added a quite a few structs to manage collection and requests, the PR adds in any stale data that's left around during collection removal and app closure

### Problem

Stale information left in memory with regards to websocket connections and meta used to store messages and sequences. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved WebSocket cleanup when collections are removed, moved, unmounted, or cleared.
* Closed stale connections before starting new ones to prevent outdated sockets from lingering.
* Ensured queued messages, pending requests, keepalive activity, and sequencing state are cleared consistently during shutdown.
* Automatically closes active WebSocket connections when all application windows are closed.
* Improved handling of connection close events and replacement connections while preserving queued messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->