### PR TITLE
refactor(mock): rename validation functions and improve error handling

### DIFF
--- a/packages/bruno-app/src/components/MockServer/MockResponse/CreateMockResponseModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/CreateMockResponseModal/index.js
@@ -5,7 +5,7 @@ import statusCodePhraseMap from 'components/ResponsePane/StatusCode/get-status-c
 import {
   collectCollectionExamples,
   getMockResponseNameError,
-  getMockResponseNameLengthError,
+  getMockResponseNameInputError,
   getMockResponseDescriptionError,
   isMockResponseNameTaken
 } from 'utils/mock-server/mock-responses';
@@ -23,7 +23,7 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
   const [description, setDescription] = useState('');
   const [statusCode, setStatusCode] = useState(200);
   const [bodyType, setBodyType] = useState('json');
-  const [nameError, setNameError] = useState('');
+  const [submitError, setSubmitError] = useState('');
   const [exampleError, setExampleError] = useState('');
   const [useExample, setUseExample] = useState(false);
   const [selectedExampleKey, setSelectedExampleKey] = useState('');
@@ -44,9 +44,16 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
   // A picked example owns the response shape, so its values drive the (disabled) fields
   const linkedExample = useExample ? selectedExample : null;
   const nameValue = name || linkedExample?.example?.name || '';
+  const trimmedName = nameValue.trim();
   const statusValue = Number(linkedExample?.example?.response?.status) || statusCode;
   const bodyTypeValue = linkedExample?.example?.response?.body?.type || bodyType;
   const descriptionError = getMockResponseDescriptionError(description);
+
+  const inputNameError = getMockResponseNameInputError(nameValue)
+    || (trimmedName && isMockResponseNameTaken(existingResponses, trimmedName)
+      ? 'A mock response with this name already exists'
+      : null);
+  const nameError = inputNameError || submitError;
 
   useEffect(() => {
     if (nameInputRef.current) {
@@ -55,16 +62,14 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
   }, []);
 
   const handleConfirm = async () => {
-    const trimmedName = nameValue.trim();
-
     const validationError = getMockResponseNameError(trimmedName);
     if (validationError) {
-      setNameError(validationError);
+      setSubmitError(validationError);
       return;
     }
 
     if (isMockResponseNameTaken(existingResponses, trimmedName)) {
-      setNameError('A mock response with this name already exists');
+      setSubmitError('A mock response with this name already exists');
       return;
     }
 
@@ -98,7 +103,7 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
         size="md"
         title="Create Mock Response"
         confirmText={isSaving ? 'Creating...' : 'Create'}
-        confirmDisabled={isSaving}
+        confirmDisabled={isSaving || !trimmedName || Boolean(inputNameError) || Boolean(descriptionError)}
         handleConfirm={handleConfirm}
         handleCancel={() => {
           if (!isSaving) {
@@ -124,7 +129,7 @@ const CreateMockResponseModal = ({ collection, existingResponses = [], onCreate,
               value={nameValue}
               onChange={(event) => {
                 setName(event.target.value);
-                setNameError(getMockResponseNameLengthError(event.target.value) || '');
+                setSubmitError('');
               }}
               data-testid="mock-response-create-name-input"
             />

--- a/packages/bruno-app/src/components/MockServer/MockResponse/MockResponseTopBar/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/MockResponseTopBar/index.js
@@ -10,7 +10,7 @@ import {
 } from 'providers/ReduxStore/slices/collections';
 import get from 'lodash/get';
 import Button from 'ui/Button';
-import { getMockResponseDescriptionError, getMockResponseNameLengthError } from 'utils/mock-server/mock-responses';
+import { getMockResponseDescriptionError, getMockResponseNameInputError } from 'utils/mock-server/mock-responses';
 
 const MockResponseTopBar = ({
   item,
@@ -53,7 +53,7 @@ const MockResponseTopBar = ({
     return null;
   }
 
-  const nameError = getMockResponseNameLengthError(example.name);
+  const nameError = getMockResponseNameInputError(example.name);
   const descriptionError = getMockResponseDescriptionError(example.description);
 
   if (editMode) {

--- a/packages/bruno-app/src/components/MockServer/MockResponse/RenameMockResponseModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/RenameMockResponseModal/index.js
@@ -3,7 +3,7 @@ import Portal from 'components/Portal';
 import Modal from 'components/Modal';
 import {
   getMockResponseNameError,
-  getMockResponseNameLengthError,
+  getMockResponseNameInputError,
   isMockResponseNameTaken
 } from 'utils/mock-server/mock-responses';
 
@@ -16,7 +16,14 @@ const RenameMockResponseModal = ({
 }) => {
   const inputRef = useRef();
   const [name, setName] = useState(response?.name || '');
-  const [nameError, setNameError] = useState('');
+  const [submitError, setSubmitError] = useState('');
+
+  const trimmedName = name.trim();
+  const inputNameError = getMockResponseNameInputError(name)
+    || (trimmedName && isMockResponseNameTaken(existingResponses, trimmedName, response?.uid)
+      ? 'A mock response with this name already exists'
+      : null);
+  const nameError = inputNameError || submitError;
 
   useEffect(() => {
     if (inputRef.current) {
@@ -26,16 +33,14 @@ const RenameMockResponseModal = ({
   }, []);
 
   const handleConfirm = () => {
-    const trimmedName = name.trim();
-
     const validationError = getMockResponseNameError(trimmedName);
     if (validationError) {
-      setNameError(validationError);
+      setSubmitError(validationError);
       return;
     }
 
     if (isMockResponseNameTaken(existingResponses, trimmedName, response?.uid)) {
-      setNameError('A mock response with this name already exists');
+      setSubmitError('A mock response with this name already exists');
       return;
     }
 
@@ -51,7 +56,7 @@ const RenameMockResponseModal = ({
         cancelText="Cancel"
         handleConfirm={handleConfirm}
         handleCancel={onClose}
-        confirmDisabled={isSaving || !name.trim()}
+        confirmDisabled={isSaving || !trimmedName || Boolean(inputNameError)}
         dataTestId="rename-mock-response-modal"
       >
         <div>
@@ -66,7 +71,7 @@ const RenameMockResponseModal = ({
             value={name}
             onChange={(event) => {
               setName(event.target.value);
-              setNameError(getMockResponseNameLengthError(event.target.value) || '');
+              setSubmitError('');
             }}
             data-testid="mock-response-rename-name-input"
           />

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -5,6 +5,7 @@ import {
   getGlobalEnvironmentVariablesMasked
 } from 'utils/collections';
 import { resolveMockServerWorkspacePath } from 'utils/mock-server/mock-server-instances';
+import { validateName, validateNameError } from 'utils/common/regex';
 import { extractMockRoutePath, getMockResponseRouteKey } from '@usebruno/common/utils';
 
 export { extractMockRoutePath as extractMockResponseRoutePath, getMockResponseRouteKey };
@@ -230,24 +231,24 @@ export const MOCK_RESPONSE_NAME_MAX_LENGTH = 255;
 
 export const MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH = 1000;
 
-export const getMockResponseNameLengthError = (name) => {
+export const getMockResponseNameError = (name) => {
   const value = name == null ? '' : String(name).trim();
 
-  if (value.length > MOCK_RESPONSE_NAME_MAX_LENGTH) {
-    return `Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`;
+  if (!validateName(value)) {
+    return validateNameError(value);
   }
 
   return null;
 };
 
-export const getMockResponseNameError = (name) => {
+export const getMockResponseNameInputError = (name) => {
   const value = name == null ? '' : String(name).trim();
 
   if (!value) {
-    return 'Mock response name is required';
+    return null;
   }
 
-  return getMockResponseNameLengthError(value);
+  return getMockResponseNameError(value);
 };
 
 export const getMockResponseDescriptionError = (description) => {

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.spec.js
@@ -13,6 +13,7 @@ import {
   cloneMockResponseRecord,
   getMockResponseDescriptionError,
   getMockResponseNameError,
+  getMockResponseNameInputError,
   isMockResponseNameTaken,
   MOCK_RESPONSE_DESCRIPTION_MAX_LENGTH,
   MOCK_RESPONSE_NAME_MAX_LENGTH,
@@ -120,20 +121,32 @@ describe('resolveMockResponseEditorCollection', () => {
 
   describe('getMockResponseNameError', () => {
     it('flags empty and whitespace-only names', () => {
-      expect(getMockResponseNameError('')).toBe('Mock response name is required');
-      expect(getMockResponseNameError('   ')).toBe('Mock response name is required');
-      expect(getMockResponseNameError(null)).toBe('Mock response name is required');
-      expect(getMockResponseNameError(undefined)).toBe('Mock response name is required');
+      expect(getMockResponseNameError('')).toBe('Name cannot be empty.');
+      expect(getMockResponseNameError('   ')).toBe('Name cannot be empty.');
+      expect(getMockResponseNameError(null)).toBe('Name cannot be empty.');
+      expect(getMockResponseNameError(undefined)).toBe('Name cannot be empty.');
     });
 
     it('flags names longer than the max length after trimming', () => {
       const overflow = 'a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH + 1);
-      expect(getMockResponseNameError(overflow))
-        .toBe(`Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`);
+      expect(getMockResponseNameError(overflow)).toBe('Name cannot exceed 255 characters.');
+    });
+
+    it('rejects Bruno-disallowed special characters', () => {
+      expect(getMockResponseNameError('bad/name'))
+        .toBe('Special characters aren\'t allowed in the name. Invalid character \'/\'.');
+      expect(getMockResponseNameError('what?'))
+        .toBe('Special characters aren\'t allowed in the name. Invalid character \'?\'.');
+    });
+
+    it('rejects Windows reserved device names', () => {
+      expect(getMockResponseNameError('CON')).toBe('Name cannot be a reserved device name.');
+      expect(getMockResponseNameError('com1')).toBe('Name cannot be a reserved device name.');
     });
 
     it('accepts names within bounds', () => {
       expect(getMockResponseNameError('Order 200')).toBeNull();
+      expect(getMockResponseNameError('#$$@##$#@')).toBeNull();
       expect(getMockResponseNameError('a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH))).toBeNull();
       // trailing spaces are ignored — they get trimmed on save
       expect(getMockResponseNameError('Order 200   ')).toBeNull();
@@ -143,8 +156,23 @@ describe('resolveMockResponseEditorCollection', () => {
       const paddedAtLimit = `   ${'a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH)}   `;
       const paddedOverLimit = `   ${'a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH + 1)}   `;
       expect(getMockResponseNameError(paddedAtLimit)).toBeNull();
-      expect(getMockResponseNameError(paddedOverLimit))
-        .toBe(`Name must be ${MOCK_RESPONSE_NAME_MAX_LENGTH} characters or less`);
+      expect(getMockResponseNameError(paddedOverLimit)).toBe('Name cannot exceed 255 characters.');
+    });
+  });
+
+  describe('getMockResponseNameInputError', () => {
+    it('stays quiet for empty and whitespace-only values so the input does not flash while typing', () => {
+      expect(getMockResponseNameInputError('')).toBeNull();
+      expect(getMockResponseNameInputError('   ')).toBeNull();
+      expect(getMockResponseNameInputError(null)).toBeNull();
+    });
+
+    it('still surfaces character, length and reserved-name violations', () => {
+      expect(getMockResponseNameInputError('bad/name'))
+        .toBe('Special characters aren\'t allowed in the name. Invalid character \'/\'.');
+      expect(getMockResponseNameInputError('a'.repeat(MOCK_RESPONSE_NAME_MAX_LENGTH + 1)))
+        .toBe('Name cannot exceed 255 characters.');
+      expect(getMockResponseNameInputError('CON')).toBe('Name cannot be a reserved device name.');
     });
   });
 


### PR DESCRIPTION
### Description

BRU-4196

### Problem

When creating a mock response (Responses tab), the Name field has multiple validation gaps: special characters are accepted, there is no 255-character cap matching Bruno's other naming rules, duplicate names are allowed on the same mock server, and leading or trailing spaces are accepted.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time validation for mock response names, including invalid characters, length limits, and reserved names.
  * Create and Rename actions are disabled when names or descriptions are invalid.
* **Bug Fixes**
  * Improved validation error handling during mock response creation and renaming.
  * Errors now clear automatically when users edit the affected name.
* **Tests**
  * Expanded coverage for empty names, trimmed input, boundary lengths, and reserved names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->