### PR TITLE
fix(mock-server): fix collapsed query params pane in mock response

### DIFF
--- a/packages/bruno-app/src/components/MockServer/MockResponse/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/index.js
@@ -25,7 +25,7 @@ import StyledWrapper from 'components/ResponseExample/StyledWrapper';
 
 const MIN_LEFT_PANE_WIDTH = 300;
 const MIN_RIGHT_PANE_WIDTH = 350;
-const MIN_TOP_PANE_HEIGHT = 150;
+const MIN_TOP_PANE_HEIGHT = 210;
 const MIN_BOTTOM_PANE_HEIGHT = 150;
 
 const MockResponse = ({ instance, collection, responseUid }) => {


### PR DESCRIPTION
### Description

Opening a mock response in vertical layout cut off the Query parameters table so only its title was visible. It now opens with enough height to show the Name/Value headers and first row without resizing.

Ref: BRU-4153


### Problem

In vertical layout, the mock response panel didn't have enough room for the Query parameters section. Only the section title was visible, the column headers and rows were clipped, so users had a hard time telling whether the query parameters section exists.


### Fix

Increased the minimum height of the top pane from 150px to 210px. Only affects vertical layout, horizontal layout is unchanged.


### Screenshots

| Before | After |
| --- | --- |
|  <img width="1415" height="557" alt="image" src="https://github.com/user-attachments/assets/5636a9d5-28ba-4bbf-904b-d2a4439cc0d1" /> |  <img width="1415" height="557" alt="image" src="https://github.com/user-attachments/assets/d4925e11-bd26-4f2c-a80c-5257d7462558" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the minimum height of the mock response panel’s top section for improved layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->