### PR TITLE
fix(mock-server): review fixes on mock-server

### DIFF
--- a/packages/bruno-app/src/components/MockServer/CloneMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/CloneMockServerModal/index.js
@@ -8,9 +8,11 @@ import Modal from 'components/Modal';
 import { loadMockResponses } from 'providers/ReduxStore/slices/mock-server/index';
 import {
   cloneMockServerInstancePayload,
+  checkMockServerPortAvailable,
   DEFAULT_MOCK_SERVER_PORT,
   getMockServerInstances,
   getMockServerNameError,
+  getMockServerPortError,
   isMockServerNameTaken,
   isMockServerPortTaken,
   openMockServerDashboard,
@@ -52,21 +54,38 @@ const CloneMockServerModal = ({
           !isMockServerNameTaken(existingInstances, value)
         )),
       port: Yup.number()
+        .typeError('Port is required')
+        .required('Port is required')
+        .integer('Port must be a whole number')
         .min(1, 'Port must be at least 1')
         .max(65535, 'Port must be 65535 or less')
-        .test('duplicate-port', 'This port is already used by another mock server', (value) => (
-          !isMockServerPortTaken(configuredInstances, value)
-        ))
+        .test('duplicate-port', 'This port is already used by another mock server', (value) => {
+          const normalizedPort = Number(value);
+          if (!normalizedPort) {
+            return true;
+          }
+
+          return !isMockServerPortTaken(configuredInstances, normalizedPort);
+        })
     }),
-    onSubmit: async (values) => {
+    onSubmit: async (values, { setFieldError }) => {
       if (!workspacePath) {
         toast.error('Workspace path is required to clone mock responses');
         return;
       }
 
+      const resolvedPort = Number(values.port);
+      const portCheck = await checkMockServerPortAvailable(resolvedPort, configuredInstances);
+      const portError = getMockServerPortError(portCheck, resolvedPort);
+      if (portError) {
+        setFieldError('port', portError);
+        toast.error(portError);
+        return;
+      }
+
       const newInstance = cloneMockServerInstancePayload(instance, {
         name: values.name.trim(),
-        port: Number(values.port),
+        port: resolvedPort,
         workspaceUid: activeWorkspaceUid
       });
 

--- a/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { startMockServer, stopMockServer, refreshMockRoutes, syncMockServerState } from 'providers/ReduxStore/slices/mock-server/index';
+import { startMockServer, stopMockServer, refreshMockRoutes, loadMockResponses, syncMockServerState } from 'providers/ReduxStore/slices/mock-server/index';
 import { IconRefresh, IconCopy, IconCheck, IconPlayerPlay, IconPlayerStop, IconSettings } from '@tabler/icons';
 import toast from 'react-hot-toast';
 import RouteTable from './RouteTable';
@@ -169,7 +169,8 @@ const MockServerDashboard = ({ instance, collection }) => {
   const handleRefresh = async () => {
     try {
       await dispatch(refreshMockRoutes(location)).unwrap();
-      toast.success(`Routes refreshed: ${routeCount} routes, ${exampleCount} responses`);
+      const { responses } = await dispatch(loadMockResponses(location)).unwrap();
+      toast.success(`Routes refreshed: ${countMockRoutes(responses)} routes, ${responses.length} responses`);
     } catch (err) {
       toast.error(err.message || 'Failed to refresh routes');
     }

--- a/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockServerDashboard/index.js
@@ -26,7 +26,7 @@ import MockResponsesList from 'components/MockServer/MockResponse/MockResponsesL
 import Tab from 'components/Tab';
 import ActionIcon from 'ui/ActionIcon';
 import Button from 'ui/Button';
-import { resolveMockResponseCollection, resolveMockResponseLocation } from 'utils/mock-server/mock-responses';
+import { resolveMockResponseCollection, resolveMockResponseLocation, countMockRoutes } from 'utils/mock-server/mock-responses';
 import StyledWrapper from './StyledWrapper';
 
 const MockServerLogCount = ({ mockServerUid }) => {
@@ -57,6 +57,9 @@ const MockServerDashboard = ({ instance, collection }) => {
     findMockServerInstance(state, mockServerUid) || instance
   ));
   const workspaceInstances = useSelector((state) => getMockServerInstances(state, activeWorkspaceUid));
+  const mockResponses = useSelector((state) => state.mockServer.mockResponses[mockServerUid]) || [];
+  const routeCount = useMemo(() => countMockRoutes(mockResponses), [mockResponses]);
+  const exampleCount = mockResponses.length;
 
   const activeWorkspace = useMemo(() => (
     workspaces.find((workspace) => workspace.uid === activeWorkspaceUid) || null
@@ -79,8 +82,6 @@ const MockServerDashboard = ({ instance, collection }) => {
     status: 'stopped',
     port: null,
     baseUrl: null,
-    routeCount: 0,
-    exampleCount: 0,
     globalDelay: instance.globalDelay || 0
   };
 
@@ -167,8 +168,8 @@ const MockServerDashboard = ({ instance, collection }) => {
 
   const handleRefresh = async () => {
     try {
-      const result = await dispatch(refreshMockRoutes(location)).unwrap();
-      toast.success(`Routes refreshed: ${result.routeCount} routes, ${result.exampleCount} responses`);
+      await dispatch(refreshMockRoutes(location)).unwrap();
+      toast.success(`Routes refreshed: ${routeCount} routes, ${exampleCount} responses`);
     } catch (err) {
       toast.error(err.message || 'Failed to refresh routes');
     }
@@ -357,8 +358,8 @@ const MockServerDashboard = ({ instance, collection }) => {
 
           {isRunning && (
             <div className="server-stats" data-testid="mock-server-stats">
-              <span>{serverState.routeCount} routes</span>
-              <span>{serverState.exampleCount} responses</span>
+              <span>{routeCount} routes</span>
+              <span>{exampleCount} responses</span>
             </div>
           )}
 
@@ -434,7 +435,7 @@ const MockServerDashboard = ({ instance, collection }) => {
         <Tab
           name="routes"
           label="Routes"
-          count={serverState.routeCount}
+          count={routeCount}
           isActive={activeTab === 'routes'}
           onClick={setActiveTab}
           data-testid="mock-server-tab-routes"

--- a/packages/bruno-app/src/providers/ReduxStore/slices/mock-server/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/mock-server/index.js
@@ -23,8 +23,6 @@ export const startMockServer = createAsyncThunk(
       status: 'starting',
       port,
       error: null,
-      routeCount: 0,
-      exampleCount: 0,
       globalDelay: globalDelay || 0
     }));
 
@@ -36,8 +34,6 @@ export const startMockServer = createAsyncThunk(
         status: 'error',
         port: null,
         error: result.error,
-        routeCount: 0,
-        exampleCount: 0,
         globalDelay: 0
       }));
       throw new Error(result.error);
@@ -48,8 +44,6 @@ export const startMockServer = createAsyncThunk(
       status: 'running',
       port: result.port,
       baseUrl: result.baseUrl,
-      routeCount: result.routeCount,
-      exampleCount: result.exampleCount,
       globalDelay: globalDelay || 0,
       error: null
     }));
@@ -299,6 +293,8 @@ export const mockServerSlice = createSlice({
   reducers: {
     updateServerStatus: (state, action) => {
       const { mockServerUid, collectionUid, ...status } = action.payload;
+      delete status.routeCount;
+      delete status.exampleCount;
       const uid = mockServerUid || collectionUid;
       state.servers[uid] = {
         ...(state.servers[uid] || {}),
@@ -371,8 +367,6 @@ export const mockServerSlice = createSlice({
           port: null,
           baseUrl: null,
           error: null,
-          routeCount: 0,
-          exampleCount: 0,
           globalDelay: 0
         };
         state.requestLogs[mockServerUid] = [];

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -367,6 +367,8 @@ export const buildMockRouteTable = (responses = []) => {
     ));
 };
 
+export const countMockRoutes = (responses = []) => buildMockRouteTable(responses).length;
+
 export const countMatchedRouteHits = (entries = []) => {
   const hitCounts = {};
 

--- a/packages/bruno-electron/src/app/mock-server/mock-response-store.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-response-store.js
@@ -154,19 +154,18 @@ const readWorkspaceStoreFromDisk = (workspacePath) => {
 
   try {
     const content = fs.readFileSync(filePath, 'utf8');
-    const parsed = parseStoreContent(content, filePath);
+    const parsed = yaml.load(content);
 
-    if (parsed.mockServers) {
-      return {
-        version: parsed.version || STORE_VERSION,
-        mockServers: parsed.mockServers
-      };
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.mockServers !== 'object') {
+      throw new Error('invalid store format');
     }
 
-    return createEmptyStore();
+    return {
+      version: parsed.version || STORE_VERSION,
+      mockServers: parsed.mockServers
+    };
   } catch (err) {
-    console.warn(`[MockResponseStore] Failed to read ${filePath}: ${err.message}`);
-    return createEmptyStore();
+    throw new Error(`Failed to read mock server store (${filePath}): ${err.message}`);
   }
 };
 
@@ -187,6 +186,18 @@ const writeWorkspaceStoreToDisk = (workspacePath, store) => {
 };
 
 const getWorkspaceCacheKey = (workspacePath) => resolveWorkspacePath(workspacePath);
+
+const invalidateWorkspaceStoreCache = (workspacePath) => {
+  const cacheKey = getWorkspaceCacheKey(workspacePath);
+  const pendingTimer = workspaceWriteTimers.get(cacheKey);
+
+  if (pendingTimer) {
+    clearTimeout(pendingTimer);
+    workspaceWriteTimers.delete(cacheKey);
+  }
+
+  workspaceStoreCache.delete(cacheKey);
+};
 
 const readWorkspaceStore = (workspacePath) => {
   const cacheKey = getWorkspaceCacheKey(workspacePath);
@@ -535,6 +546,7 @@ module.exports = {
   flushWorkspaceStore,
   getStorePath: getWorkspaceStorePath,
   getWorkspaceStorePath,
+  invalidateWorkspaceStoreCache,
   listMockResponses,
   listMockServers,
   readWorkspaceStore,

--- a/packages/bruno-electron/src/app/mock-server/mock-response-store.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-response-store.js
@@ -156,7 +156,14 @@ const readWorkspaceStoreFromDisk = (workspacePath) => {
     const content = fs.readFileSync(filePath, 'utf8');
     const parsed = yaml.load(content);
 
-    if (!parsed || typeof parsed !== 'object' || typeof parsed.mockServers !== 'object') {
+    if (
+      !parsed
+      || typeof parsed !== 'object'
+      || Array.isArray(parsed)
+      || parsed.mockServers == null
+      || typeof parsed.mockServers !== 'object'
+      || Array.isArray(parsed.mockServers)
+    ) {
       throw new Error('invalid store format');
     }
 

--- a/packages/bruno-electron/src/app/mock-server/mock-response-store.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-response-store.js
@@ -194,18 +194,6 @@ const writeWorkspaceStoreToDisk = (workspacePath, store) => {
 
 const getWorkspaceCacheKey = (workspacePath) => resolveWorkspacePath(workspacePath);
 
-const invalidateWorkspaceStoreCache = (workspacePath) => {
-  const cacheKey = getWorkspaceCacheKey(workspacePath);
-  const pendingTimer = workspaceWriteTimers.get(cacheKey);
-
-  if (pendingTimer) {
-    clearTimeout(pendingTimer);
-    workspaceWriteTimers.delete(cacheKey);
-  }
-
-  workspaceStoreCache.delete(cacheKey);
-};
-
 const readWorkspaceStore = (workspacePath) => {
   const cacheKey = getWorkspaceCacheKey(workspacePath);
 
@@ -222,15 +210,22 @@ const flushWorkspaceStore = (workspacePath) => {
   const cacheKey = getWorkspaceCacheKey(workspacePath);
   const pendingTimer = workspaceWriteTimers.get(cacheKey);
 
-  if (pendingTimer) {
-    clearTimeout(pendingTimer);
-    workspaceWriteTimers.delete(cacheKey);
+  if (!pendingTimer) {
+    return;
   }
+
+  clearTimeout(pendingTimer);
+  workspaceWriteTimers.delete(cacheKey);
 
   const store = workspaceStoreCache.get(cacheKey);
   if (store) {
     writeWorkspaceStoreToDisk(workspacePath, store);
   }
+};
+
+const invalidateWorkspaceStoreCache = (workspacePath) => {
+  flushWorkspaceStore(workspacePath);
+  workspaceStoreCache.delete(getWorkspaceCacheKey(workspacePath));
 };
 
 const flushAllWorkspaceStores = () => {

--- a/packages/bruno-electron/src/app/mock-server/mock-server.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server.js
@@ -398,8 +398,17 @@ const handleRequest = (mockServerUid, req, res) => {
     }
   };
 
+  // addign a try-catch block to handle any errors that may occur during the response
   if (delay > 0) {
-    setTimeout(sendResponse, delay);
+    setTimeout(() => {
+      try {
+        sendResponse();
+      } catch (err) {
+        if (!res.headersSent) {
+          res.status(500).json({ error: err.message || 'Mock response failed' });
+        }
+      }
+    }, delay);
   } else {
     sendResponse();
   }

--- a/packages/bruno-electron/src/app/mock-server/mock-server.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server.js
@@ -398,7 +398,7 @@ const handleRequest = (mockServerUid, req, res) => {
     }
   };
 
-  // addign a try-catch block to handle any errors that may occur during the response
+  // adding a try-catch block to handle any errors that may occur during the response
   if (delay > 0) {
     setTimeout(() => {
       try {

--- a/packages/bruno-electron/src/app/workspace-watcher.js
+++ b/packages/bruno-electron/src/app/workspace-watcher.js
@@ -10,7 +10,7 @@ const { parseValueByDataType } = require('@usebruno/common/utils');
 const EnvironmentSecretsStore = require('../store/env-secrets');
 const { decryptStringSafe } = require('../utils/encryption');
 const dotEnvWatcher = require('./dotenv-watcher');
-const { getWorkspaceStorePath } = require('./mock-server/mock-response-store');
+const { getWorkspaceStorePath, invalidateWorkspaceStoreCache } = require('./mock-server/mock-response-store');
 
 const environmentSecretsStore = new EnvironmentSecretsStore();
 
@@ -121,6 +121,7 @@ const handleMockServerStoreUpdated = (win, workspacePath, workspaceUid) => {
     return;
   }
 
+  invalidateWorkspaceStoreCache(workspacePath);
   win.webContents.send('main:mock-server-store-updated', workspacePath, workspaceUid);
 };
 

--- a/packages/bruno-electron/src/ipc/mock-server/index.js
+++ b/packages/bruno-electron/src/ipc/mock-server/index.js
@@ -169,6 +169,8 @@ const registerMockServerIpc = (mainWindow) => {
 
   ipcMain.handle('renderer:mock-server-create-response', async (_event, payload) => {
     try {
+      validateWorkspacePath(payload?.workspacePath);
+
       const response = createEmptyMockResponse(payload?.name);
       if (payload?.description) {
         response.description = payload.description;
@@ -190,6 +192,9 @@ const registerMockServerIpc = (mainWindow) => {
   ipcMain.handle('renderer:mock-server-save-response', async (_event, payload) => {
     try {
       const { response, ...location } = payload;
+
+      validateWorkspacePath(location.workspacePath);
+
       const savedResponse = saveMockResponse(location, response);
       const routeResult = await mockServer.reloadRoutesFromStore(location.mockServerUid, location);
       return { success: true, response: savedResponse, routes: routeResult?.routes || [] };
@@ -201,6 +206,9 @@ const registerMockServerIpc = (mainWindow) => {
   ipcMain.handle('renderer:mock-server-delete-response', async (_event, payload) => {
     try {
       const { responseUid, ...location } = payload;
+
+      validateWorkspacePath(location.workspacePath);
+
       deleteMockResponse(location, responseUid);
       const routeResult = await mockServer.reloadRoutesFromStore(location.mockServerUid, location);
       return { success: true, responseUid, routes: routeResult?.routes || [] };
@@ -212,6 +220,9 @@ const registerMockServerIpc = (mainWindow) => {
   ipcMain.handle('renderer:mock-server-replace-responses', async (_event, payload) => {
     try {
       const { responses, ...location } = payload;
+
+      validateWorkspacePath(location.workspacePath);
+
       setMockServerResponses(location, responses || []);
       const routeResult = await mockServer.reloadRoutesFromStore(location.mockServerUid, location);
       return { success: true, responses: responses || [], routes: routeResult?.routes || [] };
@@ -252,6 +263,8 @@ const registerMockServerIpc = (mainWindow) => {
 
   ipcMain.handle('renderer:mock-server-delete', async (_event, payload) => {
     try {
+      validateWorkspacePath(payload?.workspacePath);
+
       deleteMockServer(payload);
       await mockServer.reloadRoutesFromStore(payload.mockServerUid, payload);
       return { success: true, mockServerUid: payload.mockServerUid };

--- a/packages/bruno-electron/src/ipc/mock-server/index.js
+++ b/packages/bruno-electron/src/ipc/mock-server/index.js
@@ -160,16 +160,16 @@ const registerMockServerIpc = (mainWindow) => {
 
   ipcMain.handle('renderer:mock-server-create-response', async (_event, payload) => {
     try {
-      validateWorkspacePath(payload?.workspacePath);
+      validateWorkspacePath(payload.workspacePath);
 
-      const response = createEmptyMockResponse(payload?.name);
-      if (payload?.description) {
+      const response = createEmptyMockResponse(payload.name);
+      if (payload.description) {
         response.description = payload.description;
       }
-      if (payload?.statusCode) {
+      if (payload.statusCode) {
         response.response.status = Number(payload.statusCode) || 200;
       }
-      if (payload?.bodyType) {
+      if (payload.bodyType) {
         response.response.body.type = payload.bodyType;
       }
       const savedResponse = saveMockResponse(payload, response);
@@ -254,7 +254,7 @@ const registerMockServerIpc = (mainWindow) => {
 
   ipcMain.handle('renderer:mock-server-delete', async (_event, payload) => {
     try {
-      validateWorkspacePath(payload?.workspacePath);
+      validateWorkspacePath(payload.workspacePath);
 
       deleteMockServer(payload);
       await mockServer.reloadRoutesFromStore(payload.mockServerUid, payload);

--- a/packages/bruno-electron/tests/mock-response-store.test.js
+++ b/packages/bruno-electron/tests/mock-response-store.test.js
@@ -13,7 +13,8 @@ const {
   readWorkspaceStore,
   saveMockResponse,
   saveMockServer,
-  setMockServerResponses
+  setMockServerResponses,
+  invalidateWorkspaceStoreCache
 } = require('../src/app/mock-server/mock-response-store');
 
 describe('mock-response-store', () => {
@@ -25,6 +26,51 @@ describe('mock-response-store', () => {
 
   afterEach(() => {
     fs.rmSync(workspacePath, { recursive: true, force: true });
+  });
+
+  it('re-reads mockserver.yml from disk after cache invalidation', () => {
+    const location = {
+      mockServerUid: 'mock-1',
+      sourceType: 'spec',
+      workspacePath
+    };
+
+    saveMockResponse(location, {
+      uid: 'response-1',
+      name: 'Users',
+      request: { url: '/users', method: 'GET' },
+      response: { status: 200, body: { type: 'json', content: '{}' } },
+      rules: { operator: 'AND', conditions: [] }
+    });
+
+    const storePath = getWorkspaceStorePath(workspacePath);
+    fs.writeFileSync(storePath, yaml.dump({
+      version: 1,
+      mockServers: {
+        'mock-2': {
+          name: 'Pulled Server',
+          responses: []
+        }
+      }
+    }), 'utf8');
+
+    expect(readWorkspaceStore(workspacePath).mockServers['mock-1']).toBeTruthy();
+
+    invalidateWorkspaceStoreCache(workspacePath);
+
+    const reloaded = readWorkspaceStore(workspacePath);
+    expect(reloaded.mockServers['mock-2']).toBeTruthy();
+    expect(reloaded.mockServers['mock-1']).toBeUndefined();
+  });
+
+  it('throws when mockserver.yml is corrupt instead of replacing it with an empty store', () => {
+    const storePath = getWorkspaceStorePath(workspacePath);
+    const corruptContent = 'mockServers:\n  broken: [';
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(storePath, corruptContent, 'utf8');
+
+    expect(() => readWorkspaceStore(workspacePath)).toThrow(/Failed to read mock server store/);
+    expect(fs.readFileSync(storePath, 'utf8')).toBe(corruptContent);
   });
 
   it('stores all mock servers in workspace/mocks/mockserver.yml', () => {

--- a/packages/bruno-electron/tests/mock-response-store.test.js
+++ b/packages/bruno-electron/tests/mock-response-store.test.js
@@ -63,6 +63,26 @@ describe('mock-response-store', () => {
     expect(reloaded.mockServers['mock-1']).toBeUndefined();
   });
 
+  it('keeps a debounced write when the watcher invalidates the cache', () => {
+    const jestWorkerId = process.env.JEST_WORKER_ID;
+    delete process.env.JEST_WORKER_ID;
+    jest.useFakeTimers();
+
+    try {
+      const location = { mockServerUid: 'mock-1', sourceType: 'spec', workspacePath };
+      saveMockResponse(location, { uid: 'response-1', name: 'Users', request: { url: '/users', method: 'GET' } });
+
+      invalidateWorkspaceStoreCache(workspacePath);
+      jest.runAllTimers();
+
+      const written = yaml.load(fs.readFileSync(getWorkspaceStorePath(workspacePath), 'utf8'));
+      expect(written.mockServers['mock-1'].responses).toHaveLength(1);
+    } finally {
+      jest.useRealTimers();
+      process.env.JEST_WORKER_ID = jestWorkerId;
+    }
+  });
+
   it('throws when mockserver.yml is corrupt instead of replacing it with an empty store', () => {
     const storePath = getWorkspaceStorePath(workspacePath);
     const corruptContent = 'mockServers:\n  broken: [';


### PR DESCRIPTION
JIRA - BRU-4283

### Description

After the review skill, there have been few issues that were flagged. These included 
- Any mock request kills the main process once a delay is set.
- Five write handlers skip the workspace-path guard their siblings use.
- A corrupt store file erases every mock server for the workspace
- A git pull of the store file is silently overwritten.
- BRU-4157 root cause found
- BRU-4190 root cause found
- Clone's port schema has no required

### Problem

- setTimeout(sendResponse, delay) moves response writing outside Express's error boundary, and there is no process.on('uncaughtException') anywhere in bruno-electron. 
- create/save/delete/replace-responses and delete omit validateWorkspacePath, while list-instances, save-instance and clone-responses in the same file call it
- A malformed mockserver.yml is swallowed into createEmptyStore(), cached, and written back by the next save
- The store is cached for the process lifetime with no invalidation, so the watcher's store-updated round trip re-reads stale data and the next save clobbers the pulled file
- routeCount is a second, independent derivation of a number the route table already computes from mockResponses
- an async suggestAvailableMockServerPort().then(setFieldValue) effect overwrites whatever the user typed and re-runs on any configuredInstances identity change.
- Clone's port schema has no required() or integer check and the taken-port test returns false for empty, so clearing the field clears the error and the clone persists on the default port

### Fix

- Wrap the setTimeout callback in try/catch so invalid headers/status codes return a 500 JSON error instead of an uncaught exception that kills the main process.
- Call validateWorkspacePath on the five write handlers that were missing it.
- Stop swallowing parse failures into createEmptyStore(). Throw Failed to read mock server store (...) so nothing is cached and disk is not overwritten on the next save.
- Add invalidateWorkspaceStoreCache to drop the in-memory store and cancel pending debounced writes
- Derive routeCount from mockResponses via countMockRoutes() and stop storing routeCount/exampleCount in servers state.
- Add typeError, required, and integer to the port schema; guard the duplicate-port test so empty values defer to required; run


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mock server cloning now checks that ports are valid, available, and not duplicated before proceeding.
  - Mock server dashboards now display accurate route and response counts.
- **Bug Fixes**
  - Improved synchronization when mock server data changes externally.
  - Invalid or corrupted mock server configuration now reports a clear error instead of silently resetting.
  - Delayed response failures now return a structured server error.
  - Added validation to prevent invalid mock server data changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->