### PR TITLE
feat(pm-migration):handle-pm.sendrequest-script-chaining

### DIFF
--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -550,8 +550,7 @@ const sendRequestTransformer = (path, j) => {
 
   const wasParentAwaited = callPath.parent.value.type === 'AwaitExpression';
 
-  // the only shape that does is `(await bru.sendRequest(req)).then(h)`, which calls `.then` on
-  // a plain response object and throws at runtime regardless of what we emit.
+  // Already inside an `await`, so no promise chain can legitimately follow: `(await bru.sendRequest(req)).then(h)`
   if (wasParentAwaited) return sendRequestCall;
 
   const chainLinks = getPromiseChainLinks(callPath);

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -284,9 +284,9 @@ const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
     }
   }).forEach((memberPath) => {
     const propertyName = getStaticPropertyName(memberPath.value);
-    if (!Object.hasOwn(responsePropertyMap, propertyName)) return;
-
+    if (!propertyName) return;
     const bruProperty = responsePropertyMap[propertyName];
+    if (typeof bruProperty !== 'string') return;
 
     // skip references shadowed by a nested re-declaration of the name
     if (!resolvesToHandlerParam(memberPath, responseVarName, handler)) return;

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -516,9 +516,6 @@ const sendRequestTransformer = (path, j) => {
   const requestOptions = args[0];
   const callback = args[1];
 
-  // Check if original call was awaited
-  const wasParentAwaited = callPath.parent.value.type === 'AwaitExpression';
-
   // transform the request config options
   if (requestOptions.type === 'ObjectExpression') {
     // Transform headers
@@ -550,6 +547,8 @@ const sendRequestTransformer = (path, j) => {
     j.identifier('bru.sendRequest'),
     transformedCallback ? [requestOptions, transformedCallback] : [requestOptions]
   );
+
+  const wasParentAwaited = callPath.parent.value.type === 'AwaitExpression';
 
   // the only shape that does is `(await bru.sendRequest(req)).then(h)`, which calls `.then` on
   // a plain response object and throws at runtime regardless of what we emit.

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -214,10 +214,7 @@ const getPromiseChainLinks = (callPath) => {
 };
 
 /**
- * Whether a function is a `.then`/`.catch`/`.finally` handler argument. Such a
- * handler's return value is already promise-wrapped by the chain, so turning it
- * async is transparent to its caller — unlike an arbitrary callback, where the
- * caller would start receiving a promise in place of the value it expects.
+ * Whether a function is a `.then`/`.catch`/`.finally` handler argument
  * @param {Object} functionPath - Path of the function to test
  * @returns {boolean}
  */
@@ -285,9 +282,6 @@ const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
 
     const replacement = j.memberExpression(j.identifier(responseVarName), j.identifier(bruProperty));
 
-    // response.json() collapses to response.data — the call goes away with it.
-    // Only when the member is the callee: in console.log(response.code) the
-    // parent is also a CallExpression, and replacing it would eat the log.
     const parentPath = memberPath.parent;
     if (parentPath.value.type === 'CallExpression' && parentPath.value.callee === memberPath.value) {
       j(parentPath).replaceWith(replacement);
@@ -311,11 +305,8 @@ const resolvesToHandlerParam = (path, name, handler) => {
 };
 
 /**
- * The return statements belonging to the handler itself. `find` reaches into nested functions too,
- * so a `return res.data` inside a callback declared in the handler would be mistaken for the
- * handler's own return; keep only the returns whose nearest enclosing function is the handler.
- *
- * @example
+ * The return statements belonging to the handler itself.
+* @example
  * sendRequest(req).then((res) => {
  *   const extract = () => {
  *     return res.data;      // nested function's return — not the handler's
@@ -323,7 +314,6 @@ const resolvesToHandlerParam = (path, name, handler) => {
  *   console.log(extract());
  *   return res;             // the handler's actual return
  * });
- *
  * @param {Object} j - jscodeshift API
  * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
  * @returns {Object[]} Paths of the handler's own return statements
@@ -335,9 +325,7 @@ const findOwnReturns = (j, handlerPath) =>
     .filter((returnPath) => j(returnPath).closest(j.Function).get().value === handlerPath.value);
 
 /**
- * Whether every value the handler can return is its own response parameter, so the
- * next `.then` in the chain still receives the response. A path that falls through
- * to an implicit undefined does not qualify.
+ * Whether every value the handler can return is its own response parameter
  * @param {Object} j - jscodeshift API
  * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
  * @returns {boolean}
@@ -353,9 +341,8 @@ const returnsParamUnchanged = (j, handlerPath) => {
     return body.type === 'Identifier' && body.name === paramName;
   }
 
-  // a body that can complete without returning forwards an implicit undefined, so the last
-  // statement must be a return — this also rejects handlers with no return at all, which the
-  // `every` check below would treat as vacuously passing
+  // Every path must end in a return: a body that can fall through forwards an implicit undefined,
+  // and a handler with no returns at all would pass the `every` check below vacuously.
   const lastStatement = body.body[body.body.length - 1];
   if (!lastStatement || lastStatement.type !== 'ReturnStatement') return false;
 

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -223,8 +223,8 @@ const getPromiseChainLinks = (callPath) => {
  */
 const isPromiseChainHandler = (functionPath) => {
   const parent = functionPath.parent;
-  if (!parent || parent.value.type !== 'CallExpression') return false;
-  if (!parent.value.arguments.includes(functionPath.value)) return false;
+  if (!parent || parent.value.type !== 'CallExpression') return false; // means the function is not a handler
+  if (!parent.value.arguments.includes(functionPath.value)) return false; // means the function is not a handler
 
   const callee = parent.value.callee;
   return callee.type === 'MemberExpression' && PROMISE_CHAIN_METHODS.has(getStaticPropertyName(callee));
@@ -325,18 +325,19 @@ const returnsParamUnchanged = (j, handlerPath) => {
   const paramName = handler.params[0].name;
   const body = handler.body;
 
-  // if the body is not a block statement then check if the body is an
-  // identifier and the name is the same as the parameter name
+  // a concise arrow body is the returned expression itself, so it only forwards the
+  // response when that expression is the parameter — `res => res` yes, `res => res.data` no
   if (body.type !== 'BlockStatement') {
     return body.type === 'Identifier' && body.name === paramName;
   }
 
-  // if the body is a block statement then check if the last statement is
-  // a return statement and the argument is an identifier and the name is the same as the parameter name
+  // if the body is a block statement then check if the last statement isna return statement
+  // and the argument is an identifier and the name is the same as the parameter name
   const lastStatement = body.body[body.body.length - 1];
   if (!lastStatement || lastStatement.type !== 'ReturnStatement') return false;
 
-  // check if the return statement is the own return statement of the handler
+  // check that decides whether a .then(handler) is a pass-through (every value it can return is the untouched response param),
+  // so the rewrite can keep flowing down the chain.
   const ownReturns = j(handlerPath)
     .find(j.ReturnStatement)
     .paths()
@@ -362,22 +363,27 @@ const isResponseParamReassigned = (j, handlerPath) => {
   const handler = handlerPath.value;
   const paramName = handler.params[0].name;
 
+  // check if code overwriting the handler's response parameter itself
   const isRebind = (path, target) =>
     target.type === 'Identifier'
     && target.name === paramName
     && resolvesToHandlerParam(path, paramName, handler);
 
-  const assigned = j(handlerPath)
+  // `res = ...`, `res += ...`, `res ||= ...`
+  const assignedByAssignmentExpression = j(handlerPath)
     .find(j.AssignmentExpression)
     .paths()
     .some((path) => isRebind(path, path.value.left));
 
-  if (assigned) return true;
+  if (assignedByAssignmentExpression) return true;
 
-  return j(handlerPath)
+  // `res++` / `--res` — a separate node type, with its target under `argument`
+  const assignedByUpdateExpression = j(handlerPath)
     .find(j.UpdateExpression)
     .paths()
     .some((path) => isRebind(path, path.value.argument));
+
+  return assignedByUpdateExpression;
 };
 
 /**

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -238,10 +238,12 @@ const makeAwaitable = (j, path) => {
 
   const functionPath = enclosingFunction.get();
   if (functionPath.value.async === true) return true;
-  if (!isPromiseChainHandler(functionPath)) return false;
+  if (isPromiseChainHandler(functionPath)) {
+    functionPath.value.async = true;
+    return true;
+  }
 
-  functionPath.value.async = true;
-  return true;
+  return false;
 };
 
 /**

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -291,6 +291,87 @@ const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
 };
 
 /**
+ * Whether an identifier reference inside a handler resolves to the handler's own
+ * parameter rather than a nested re-declaration of the same name.
+ * @param {Object} path - Path of the reference
+ * @param {string} name - Parameter name
+ * @param {Object} handler - Handler function node owning the parameter
+ * @returns {boolean}
+ */
+const resolvesToHandlerParam = (path, name, handler) => {
+  const declaringScope = path.scope.lookup(name);
+  return Boolean(declaringScope) && declaringScope.node === handler;
+};
+
+/**
+ * Whether every value the handler can return is its own response parameter, so the
+ * next `.then` in the chain still receives the response. A path that falls through
+ * to an implicit undefined does not qualify.
+ * @param {Object} j - jscodeshift API
+ * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
+ * @returns {boolean}
+ */
+const returnsParamUnchanged = (j, handlerPath) => {
+  const handler = handlerPath.value;
+  const paramName = handler.params[0].name;
+  const body = handler.body;
+
+  // if the body is not a block statement then check if the body is an
+  // identifier and the name is the same as the parameter name
+  if (body.type !== 'BlockStatement') {
+    return body.type === 'Identifier' && body.name === paramName;
+  }
+
+  // if the body is a block statement then check if the last statement is
+  // a return statement and the argument is an identifier and the name is the same as the parameter name
+  const lastStatement = body.body[body.body.length - 1];
+  if (!lastStatement || lastStatement.type !== 'ReturnStatement') return false;
+
+  // check if the return statement is the own return statement of the handler
+  const ownReturns = j(handlerPath)
+    .find(j.ReturnStatement)
+    .paths()
+    .filter((returnPath) => j(returnPath).closest(j.Function).get().value === handler);
+
+  return ownReturns.every((returnPath) => {
+    const argument = returnPath.value.argument;
+    return argument
+      && argument.type === 'Identifier'
+      && argument.name === paramName
+      && resolvesToHandlerParam(returnPath, paramName, handler);
+  });
+};
+
+/**
+ * Whether the handler rebinds its response parameter, so what it forwards is no
+ * longer the response mapped for Bruno.
+ * @param {Object} j - jscodeshift API
+ * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
+ * @returns {boolean}
+ */
+const isResponseParamReassigned = (j, handlerPath) => {
+  const handler = handlerPath.value;
+  const paramName = handler.params[0].name;
+
+  const isRebind = (path, target) =>
+    target.type === 'Identifier'
+    && target.name === paramName
+    && resolvesToHandlerParam(path, paramName, handler);
+
+  const assigned = j(handlerPath)
+    .find(j.AssignmentExpression)
+    .paths()
+    .some((path) => isRebind(path, path.value.left));
+
+  if (assigned) return true;
+
+  return j(handlerPath)
+    .find(j.UpdateExpression)
+    .paths()
+    .some((path) => isRebind(path, path.value.argument));
+};
+
+/**
  * Transform callback function to Bruno format
  * @param {Object} j - jscodeshift API
  * @param {Object} callback - Callback function expression
@@ -454,11 +535,28 @@ const sendRequestTransformer = (path, j) => {
     return makeAwaitable(j, callPath) ? j.awaitExpression(sendRequestCall) : sendRequestCall;
   }
 
-  // only the innermost `.then` receives the response — later handlers see what
-  // it returned, and `.catch`/`.finally` handlers an error or nothing
-  const [firstLink] = chainLinks;
-  if (firstLink.methodName === 'then' && firstLink.callPath.value.arguments.length) {
-    rewriteThenHandlerResponseAccess(j, firstLink.callPath.get('arguments', 0));
+  // the innermost `.then` receives the response; each later handler does too only
+  // while the one before it forwards its response parameter unchanged. `.catch` and
+  // `.finally` handlers see an error or nothing, so the chain stops being traceable there.
+  for (const link of chainLinks) {
+    if (link.methodName !== 'then') break;
+
+    const [handler] = link.callPath.value.arguments;
+    if (!handler) break;
+    if (handler.type !== 'FunctionExpression' && handler.type !== 'ArrowFunctionExpression') break;
+    if (handler.params[0]?.type !== 'Identifier') break; // if the handler does not have a parameter then break
+
+    const handlerPath = link.callPath.get('arguments', 0);
+
+    // both read before the rewrite, which would collapse `return res.json()` into
+    // `return res.data` and hide that the handler never forwarded the response
+    const returnsResponse = returnsParamUnchanged(j, handlerPath);
+    const reassignsResponse = isResponseParamReassigned(j, handlerPath);
+
+    rewriteThenHandlerResponseAccess(j, handlerPath);
+
+    if (!returnsResponse) break;
+    if (reassignsResponse) break;
   }
 
   const outermostPath = chainLinks[chainLinks.length - 1].callPath;

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -547,6 +547,10 @@ const sendRequestTransformer = (path, j) => {
   for (const link of chainLinks) {
     const [handler] = link.callPath.value.arguments;
 
+    // a `.catch` handler substitutes its own return value for the rest of the chain, so links
+    // past it no longer receive the response we mapped.
+    if (link.methodName === 'catch') break;
+
     const hasFulfilledHandler = link.methodName === 'then' && Boolean(handler) && !isNullLiteral(handler);
 
     if (!hasFulfilledHandler) continue;

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -253,14 +253,11 @@ const makeAwaitable = (j, path) => {
  * that resolve to a different binding — a nested function re-declaring the name —
  * are left alone.
  * @param {Object} j - jscodeshift API
- * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
+ * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument; the
+ *   caller guarantees it is a function expression with an Identifier first param.
  */
 const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
   const handler = handlerPath.value;
-  if (!handler) return;
-  if (handler.type !== 'FunctionExpression' && handler.type !== 'ArrowFunctionExpression') return;
-  if (handler.params[0]?.type !== 'Identifier') return;
-
   const responseVarName = handler.params[0].name;
 
   j(handlerPath).find(j.MemberExpression, {

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -220,14 +220,17 @@ const getPromiseChainLinks = (callPath) => {
  */
 const isPromiseChainHandler = (functionPath) => {
   const parent = functionPath.parent;
-  if (!parent || parent.value.type !== 'CallExpression') return false; // means the function is not a handler
-  if (!parent.value.arguments.includes(functionPath.value)) return false; // means the function is not a handler
+  if (!parent || parent.value.type !== 'CallExpression') return false;
+  if (!parent.value.arguments.includes(functionPath.value)) return false;
 
   const callee = parent.value.callee;
   return callee.type === 'MemberExpression' && PROMISE_CHAIN_METHODS.has(getStaticPropertyName(callee));
 };
 
 /**
+ * Bruno runs scripts in an async closure, so top-level `await` is always legal. Making a
+ * function async is safe only for promise-chain handlers — they already run asynchronously;
+ * for any other function it would change caller semantics.
  * @param {Object} j - jscodeshift API
  * @param {Object} path - Path the await would be emitted at
  * @returns {boolean}
@@ -556,7 +559,8 @@ const sendRequestTransformer = (path, j) => {
     if (!hasFulfilledHandler) continue;
 
     if (handler.type !== 'FunctionExpression' && handler.type !== 'ArrowFunctionExpression') break;
-    if (handler.params[0]?.type !== 'Identifier') break; // if the handler does not have a parameter then break
+    // rewriting response access requires a plain identifier param — destructuring can't be tracked
+    if (handler.params.length === 0 || handler.params[0].type !== 'Identifier') break;
 
     const handlerPath = link.callPath.get('arguments', 0);
 

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -148,6 +148,148 @@ const transformBody = (j, requestOptions) => {
   });
 };
 
+// Postman's response API vs Bruno's axios-shaped response. json()/text() are
+// methods on the Postman response but already-parsed properties on Bruno's.
+const responsePropertyMap = {
+  json: 'data',
+  text: 'data',
+  code: 'status',
+  status: 'statusText'
+};
+
+const PROMISE_CHAIN_METHODS = new Set(['then', 'catch', 'finally']);
+
+/**
+ * Get the statically-known property name of a member expression. A computed
+ * access with a non-literal key (`p[someVar]`) has no static name — even an
+ * Identifier key named `then` is a variable there, not the method.
+ * @param {Object} memberExpr - MemberExpression node
+ * @returns {string|null}
+ */
+const getStaticPropertyName = (memberExpr) => {
+  const property = memberExpr.property;
+
+  if (memberExpr.computed) {
+    return property.type === 'Literal' && typeof property.value === 'string' ? property.value : null;
+  }
+  return property.type === 'Identifier' ? property.name : null;
+};
+
+/**
+ * Collect the `.then`/`.catch`/`.finally` calls chained off the given call,
+ * innermost first.
+ * @param {Object} callPath - Path of the CallExpression the chain hangs off
+ * @returns {Array<{callPath: Object, methodName: string}>}
+ */
+const getPromiseChainLinks = (callPath) => {
+  const links = [];
+  let currentPath = callPath;
+
+  while (true) {
+    const memberPath = currentPath.parent;
+    if (!memberPath || memberPath.value.type !== 'MemberExpression') break;
+    if (memberPath.value.object !== currentPath.value) break;
+
+    const methodName = getStaticPropertyName(memberPath.value);
+    if (!PROMISE_CHAIN_METHODS.has(methodName)) break;
+
+    const chainedCallPath = memberPath.parent;
+    if (!chainedCallPath || chainedCallPath.value.type !== 'CallExpression') break;
+
+    links.push({ callPath: chainedCallPath, methodName });
+    currentPath = chainedCallPath;
+  }
+
+  return links;
+};
+
+/**
+ * Whether a function is a `.then`/`.catch`/`.finally` handler argument. Such a
+ * handler's return value is already promise-wrapped by the chain, so turning it
+ * async is transparent to its caller — unlike an arbitrary callback, where the
+ * caller would start receiving a promise in place of the value it expects.
+ * @param {Object} functionPath - Path of the function to test
+ * @returns {boolean}
+ */
+const isPromiseChainHandler = (functionPath) => {
+  const parent = functionPath.parent;
+  if (!parent || parent.value.type !== 'CallExpression') return false;
+  if (!parent.value.arguments.includes(functionPath.value)) return false;
+
+  const callee = parent.value.callee;
+  return callee.type === 'MemberExpression' && PROMISE_CHAIN_METHODS.has(getStaticPropertyName(callee));
+};
+
+/**
+ * Whether `await` may be emitted at this position, turning the enclosing function
+ * async where that is safe. Bruno evaluates scripts inside an async closure, so
+ * top level is awaitable. Inside a non-async function `await` is a syntax error
+ * that breaks the entire script, so it is emitted there only once the function
+ * has been made async — which is only safe for a promise-chain handler.
+ * @param {Object} j - jscodeshift API
+ * @param {Object} path - Path the await would be emitted at
+ * @returns {boolean}
+ */
+const makeAwaitable = (j, path) => {
+  const enclosingFunction = j(path).closest(j.Function);
+
+  const isTopLevel = enclosingFunction.size() === 0;
+  if (isTopLevel) return true;
+
+  const functionPath = enclosingFunction.get();
+  if (functionPath.value.async === true) return true;
+  if (!isPromiseChainHandler(functionPath)) return false;
+
+  functionPath.value.async = true;
+  return true;
+};
+
+/**
+ * Rewrite Postman response access on a handler's response parameter to its Bruno
+ * equivalent (res.json() -> res.data, res.code -> res.status, ...). References
+ * that resolve to a different binding — a nested function re-declaring the name —
+ * are left alone.
+ * @param {Object} j - jscodeshift API
+ * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
+ */
+const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
+  const handler = handlerPath.value;
+  if (!handler) return;
+  if (handler.type !== 'FunctionExpression' && handler.type !== 'ArrowFunctionExpression') return;
+  if (handler.params[0]?.type !== 'Identifier') return;
+
+  const responseVarName = handler.params[0].name;
+
+  j(handlerPath).find(j.MemberExpression, {
+    object: {
+      type: 'Identifier',
+      name: responseVarName
+    }
+  }).forEach((memberPath) => {
+    const property = memberPath.value.property;
+    if (property.type !== 'Identifier') return;
+
+    const bruProperty = responsePropertyMap[property.name];
+    if (!bruProperty) return;
+
+    // skip references shadowed by a nested re-declaration of the name
+    const declaringScope = memberPath.scope.lookup(responseVarName);
+    if (!declaringScope || declaringScope.node !== handler) return;
+
+    const replacement = j.memberExpression(j.identifier(responseVarName), j.identifier(bruProperty));
+
+    // response.json() collapses to response.data — the call goes away with it.
+    // Only when the member is the callee: in console.log(response.code) the
+    // parent is also a CallExpression, and replacing it would eat the log.
+    const parentPath = memberPath.parent;
+    if (parentPath.value.type === 'CallExpression' && parentPath.value.callee === memberPath.value) {
+      j(parentPath).replaceWith(replacement);
+    } else {
+      j(memberPath).replaceWith(replacement);
+    }
+  });
+};
+
 /**
  * Transform callback function to Bruno format
  * @param {Object} j - jscodeshift API
@@ -170,14 +312,6 @@ const transformCallback = (j, callback) => {
   if (params.length >= 1 && params[0].type === 'Identifier') {
     errorVarName = params[0].name;
   }
-
-  // Define translations for callback response properties
-  const responsePropertyMap = {
-    json: 'data',
-    text: 'data',
-    code: 'status',
-    status: 'statusText'
-  };
 
   // Process the callback body to transform response property references
   j(callbackBody).find(j.MemberExpression, {
@@ -266,7 +400,8 @@ const findAndTransformVariableDeclaration = (j, root, variableName, visited = ne
 };
 
 const sendRequestTransformer = (path, j) => {
-  const callExpr = path.parent.value;
+  const callPath = path.parent;
+  const callExpr = callPath.value;
   if (callExpr.type !== 'CallExpression') return;
 
   // Clone the argument object for modification
@@ -277,7 +412,7 @@ const sendRequestTransformer = (path, j) => {
   const callback = args[1];
 
   // Check if original call was awaited
-  const wasAwaited = path.parent.parent.value.type === 'AwaitExpression';
+  const wasAwaited = callPath.parent.value.type === 'AwaitExpression';
 
   // transform the request config options
   if (requestOptions.type === 'ObjectExpression') {
@@ -296,31 +431,42 @@ const sendRequestTransformer = (path, j) => {
     findAndTransformVariableDeclaration(j, root, variableName);
   }
 
-  // Create the callback block and promise chain if there's a callback
+  let transformedCallback = null;
   if (callback) {
-    const transformedCallback = transformCallback(j, callback);
+    transformedCallback = transformCallback(j, callback);
 
-    // Add async keyword to the callback function
-    if (transformedCallback && (transformedCallback.type === 'FunctionExpression' || transformedCallback.type === 'ArrowFunctionExpression')) {
+    // always async — the body may await a nested bru.sendRequest
+    if (transformedCallback) {
       transformedCallback.async = true;
     }
-
-    // Create expression: await bru.sendRequest(requestConfig, callback);
-    const sendRequestCall = j.callExpression(
-      j.identifier('bru.sendRequest'),
-      transformedCallback ? [requestOptions, transformedCallback] : [requestOptions]
-    );
-
-    return wasAwaited ? sendRequestCall : j.awaitExpression(sendRequestCall);
   }
 
-  // If there's no callback, just transform to await bru.sendRequest
   const sendRequestCall = j.callExpression(
     j.identifier('bru.sendRequest'),
-    [requestOptions]
+    transformedCallback ? [requestOptions, transformedCallback] : [requestOptions]
   );
 
-  return wasAwaited ? sendRequestCall : j.awaitExpression(sendRequestCall);
+  if (wasAwaited) return sendRequestCall;
+
+  const chainLinks = getPromiseChainLinks(callPath);
+
+  if (!chainLinks.length) {
+    return makeAwaitable(j, callPath) ? j.awaitExpression(sendRequestCall) : sendRequestCall;
+  }
+
+  // only the innermost `.then` receives the response — later handlers see what
+  // it returned, and `.catch`/`.finally` handlers an error or nothing
+  const [firstLink] = chainLinks;
+  if (firstLink.methodName === 'then' && firstLink.callPath.value.arguments.length) {
+    rewriteThenHandlerResponseAccess(j, firstLink.callPath.get('arguments', 0));
+  }
+
+  const outermostPath = chainLinks[chainLinks.length - 1].callPath;
+  if (outermostPath.parent.value.type !== 'AwaitExpression' && makeAwaitable(j, outermostPath)) {
+    outermostPath.parentPath.value[outermostPath.name] = j.awaitExpression(outermostPath.value);
+  }
+
+  return sendRequestCall;
 };
 
 export default sendRequestTransformer;

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -180,7 +180,7 @@ const getStaticPropertyName = (memberExpr) => {
  * @param {Object} node - Argument node
  * @returns {boolean}
  */
-const isNullLiteral = (node) =>
+const isNullish = (node) =>
   (node.type === 'Literal' && node.value === null)
   || (node.type === 'Identifier' && node.name === 'undefined');
 
@@ -235,7 +235,7 @@ const isPromiseChainHandler = (functionPath) => {
  * @param {Object} path - Path the await would be emitted at
  * @returns {boolean}
  */
-const makeAwaitable = (j, path) => {
+const ensureAsyncContext = (j, path) => {
   const enclosingFunction = j(path).closest(j.Function);
 
   const isTopLevel = enclosingFunction.size() === 0;
@@ -249,6 +249,19 @@ const makeAwaitable = (j, path) => {
   }
 
   return false;
+};
+
+/**
+ * Whether an identifier reference inside a handler resolves to the handler's own
+ * parameter rather than a nested re-declaration of the same name.
+ * @param {Object} path - Path of the reference
+ * @param {string} name - Parameter name
+ * @param {Object} handler - Handler function node owning the parameter
+ * @returns {boolean}
+ */
+const resolvesToHandlerParam = (path, name, handler) => {
+  const declaringScope = path.scope.lookup(name);
+  return Boolean(declaringScope) && declaringScope.node === handler;
 };
 
 /**
@@ -277,31 +290,21 @@ const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
     if (!bruProperty) return;
 
     // skip references shadowed by a nested re-declaration of the name
-    const declaringScope = memberPath.scope.lookup(responseVarName);
-    if (!declaringScope || declaringScope.node !== handler) return;
+    if (!resolvesToHandlerParam(memberPath, responseVarName, handler)) return;
 
     const replacement = j.memberExpression(j.identifier(responseVarName), j.identifier(bruProperty));
 
-    const parentPath = memberPath.parent;
-    if (parentPath.value.type === 'CallExpression' && parentPath.value.callee === memberPath.value) {
-      j(parentPath).replaceWith(replacement);
+    const parent = memberPath.parent;
+    const isMethodCall = parent.value.type === 'CallExpression' && parent.value.callee === memberPath.value;
+
+    // `json()`/`text()` are methods on the Postman response but plain properties on Bruno's,
+    // so the call has to lose its parentheses: `res.json()` -> `res.data`
+    if (isMethodCall) {
+      j(parent).replaceWith(replacement);
     } else {
       j(memberPath).replaceWith(replacement);
     }
   });
-};
-
-/**
- * Whether an identifier reference inside a handler resolves to the handler's own
- * parameter rather than a nested re-declaration of the same name.
- * @param {Object} path - Path of the reference
- * @param {string} name - Parameter name
- * @param {Object} handler - Handler function node owning the parameter
- * @returns {boolean}
- */
-const resolvesToHandlerParam = (path, name, handler) => {
-  const declaringScope = path.scope.lookup(name);
-  return Boolean(declaringScope) && declaringScope.node === handler;
 };
 
 /**
@@ -541,7 +544,7 @@ const sendRequestTransformer = (path, j) => {
   const chainLinks = getPromiseChainLinks(callPath);
 
   if (!chainLinks.length) {
-    return makeAwaitable(j, callPath) ? j.awaitExpression(sendRequestCall) : sendRequestCall;
+    return ensureAsyncContext(j, callPath) ? j.awaitExpression(sendRequestCall) : sendRequestCall;
   }
 
   for (const link of chainLinks) {
@@ -551,7 +554,7 @@ const sendRequestTransformer = (path, j) => {
     // past it no longer receive the response we mapped.
     if (link.methodName === 'catch') break;
 
-    const hasFulfilledHandler = link.methodName === 'then' && Boolean(handler) && !isNullLiteral(handler);
+    const hasFulfilledHandler = link.methodName === 'then' && Boolean(handler) && !isNullish(handler);
 
     if (!hasFulfilledHandler) continue;
 
@@ -570,7 +573,10 @@ const sendRequestTransformer = (path, j) => {
   }
 
   const outermostPath = chainLinks[chainLinks.length - 1].callPath;
-  if (outermostPath.parent.value.type !== 'AwaitExpression' && makeAwaitable(j, outermostPath)) {
+  const isAlreadyAwaited = outermostPath.parent.value.type === 'AwaitExpression';
+  const shouldAwaitChain = !isAlreadyAwaited && ensureAsyncContext(j, outermostPath);
+
+  if (shouldAwaitChain) {
     outermostPath.parentPath.value[outermostPath.name] = j.awaitExpression(outermostPath.value);
   }
 

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -313,6 +313,30 @@ const resolvesToHandlerParam = (path, name, handler) => {
 };
 
 /**
+ * The return statements belonging to the handler itself. `find` reaches into nested functions too,
+ * so a `return res.data` inside a callback declared in the handler would be mistaken for the
+ * handler's own return; keep only the returns whose nearest enclosing function is the handler.
+ *
+ * @example
+ * sendRequest(req).then((res) => {
+ *   const extract = () => {
+ *     return res.data;      // nested function's return — not the handler's
+ *   };
+ *   console.log(extract());
+ *   return res;             // the handler's actual return
+ * });
+ *
+ * @param {Object} j - jscodeshift API
+ * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
+ * @returns {Object[]} Paths of the handler's own return statements
+ */
+const findOwnReturns = (j, handlerPath) =>
+  j(handlerPath)
+    .find(j.ReturnStatement)
+    .paths()
+    .filter((returnPath) => j(returnPath).closest(j.Function).get().value === handlerPath.value);
+
+/**
  * Whether every value the handler can return is its own response parameter, so the
  * next `.then` in the chain still receives the response. A path that falls through
  * to an implicit undefined does not qualify.
@@ -331,24 +355,18 @@ const returnsParamUnchanged = (j, handlerPath) => {
     return body.type === 'Identifier' && body.name === paramName;
   }
 
-  // if the body is a block statement then check if the last statement isna return statement
-  // and the argument is an identifier and the name is the same as the parameter name
+  // a body that can complete without returning forwards an implicit undefined, so the last
+  // statement must be a return — this also rejects handlers with no return at all, which the
+  // `every` check below would treat as vacuously passing
   const lastStatement = body.body[body.body.length - 1];
   if (!lastStatement || lastStatement.type !== 'ReturnStatement') return false;
 
-  // check that decides whether a .then(handler) is a pass-through (every value it can return is the untouched response param),
-  // so the rewrite can keep flowing down the chain.
-  const ownReturns = j(handlerPath)
-    .find(j.ReturnStatement)
-    .paths()
-    .filter((returnPath) => j(returnPath).closest(j.Function).get().value === handler);
+  const ownReturns = findOwnReturns(j, handlerPath);
 
   return ownReturns.every((returnPath) => {
     const argument = returnPath.value.argument;
-    return argument
-      && argument.type === 'Identifier'
-      && argument.name === paramName
-      && resolvesToHandlerParam(returnPath, paramName, handler);
+    const returnsParamIdentifier = Boolean(argument) && argument.type === 'Identifier' && argument.name === paramName;
+    return returnsParamIdentifier && resolvesToHandlerParam(returnPath, paramName, handler);
   });
 };
 
@@ -363,27 +381,18 @@ const isResponseParamReassigned = (j, handlerPath) => {
   const handler = handlerPath.value;
   const paramName = handler.params[0].name;
 
-  // check if code overwriting the handler's response parameter itself
-  const isRebind = (path, target) =>
+  const isParamReassigned = (path, target) =>
     target.type === 'Identifier'
     && target.name === paramName
     && resolvesToHandlerParam(path, paramName, handler);
 
-  // `res = ...`, `res += ...`, `res ||= ...`
-  const assignedByAssignmentExpression = j(handlerPath)
+  // assignment expression example : `res = ...`, `res += ...`, `res ||= ...`
+  const isParamReassignedByAssignmentExpression = j(handlerPath)
     .find(j.AssignmentExpression)
     .paths()
-    .some((path) => isRebind(path, path.value.left));
+    .some((path) => isParamReassigned(path, path.value.left));
 
-  if (assignedByAssignmentExpression) return true;
-
-  // `res++` / `--res` — a separate node type, with its target under `argument`
-  const assignedByUpdateExpression = j(handlerPath)
-    .find(j.UpdateExpression)
-    .paths()
-    .some((path) => isRebind(path, path.value.argument));
-
-  return assignedByUpdateExpression;
+  return isParamReassignedByAssignmentExpression;
 };
 
 /**
@@ -508,7 +517,7 @@ const sendRequestTransformer = (path, j) => {
   const callback = args[1];
 
   // Check if original call was awaited
-  const wasAwaited = callPath.parent.value.type === 'AwaitExpression';
+  const wasParentAwaited = callPath.parent.value.type === 'AwaitExpression';
 
   // transform the request config options
   if (requestOptions.type === 'ObjectExpression') {
@@ -531,8 +540,8 @@ const sendRequestTransformer = (path, j) => {
   if (callback) {
     transformedCallback = transformCallback(j, callback);
 
-    // always async — the body may await a nested bru.sendRequest
-    if (transformedCallback) {
+    // Add async keyword to the callback function
+    if (transformedCallback && (transformedCallback.type === 'FunctionExpression' || transformedCallback.type === 'ArrowFunctionExpression')) {
       transformedCallback.async = true;
     }
   }
@@ -542,7 +551,9 @@ const sendRequestTransformer = (path, j) => {
     transformedCallback ? [requestOptions, transformedCallback] : [requestOptions]
   );
 
-  if (wasAwaited) return sendRequestCall;
+  // the only shape that does is `(await bru.sendRequest(req)).then(h)`, which calls `.then` on
+  // a plain response object and throws at runtime regardless of what we emit.
+  if (wasParentAwaited) return sendRequestCall;
 
   const chainLinks = getPromiseChainLinks(callPath);
 
@@ -550,13 +561,9 @@ const sendRequestTransformer = (path, j) => {
     return makeAwaitable(j, callPath) ? j.awaitExpression(sendRequestCall) : sendRequestCall;
   }
 
-  // the innermost `.then` receives the response; each later handler does too only
-  // while the one before it forwards its response parameter unchanged. A link with no
-  // fulfilled handler — `.catch`, `.finally`, `.then(null, fn)`, `.then()` — forwards the
-  // response untouched, so the walk continues past it. Its own handler is left alone: it
-  // sees an error or nothing, never the response.
   for (const link of chainLinks) {
     const [handler] = link.callPath.value.arguments;
+
     const hasFulfilledHandler = link.methodName === 'then' && Boolean(handler) && !isNullLiteral(handler);
 
     if (!hasFulfilledHandler) continue;

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -176,6 +176,15 @@ const getStaticPropertyName = (memberExpr) => {
 };
 
 /**
+ * Whether an argument node is an explicit absent value, as in `.then(null, onError)`.
+ * @param {Object} node - Argument node
+ * @returns {boolean}
+ */
+const isNullLiteral = (node) =>
+  (node.type === 'Literal' && node.value === null)
+  || (node.type === 'Identifier' && node.name === 'undefined');
+
+/**
  * Collect the `.then`/`.catch`/`.finally` calls chained off the given call,
  * innermost first.
  * @param {Object} callPath - Path of the CallExpression the chain hangs off
@@ -536,13 +545,16 @@ const sendRequestTransformer = (path, j) => {
   }
 
   // the innermost `.then` receives the response; each later handler does too only
-  // while the one before it forwards its response parameter unchanged. `.catch` and
-  // `.finally` handlers see an error or nothing, so the chain stops being traceable there.
+  // while the one before it forwards its response parameter unchanged. A link with no
+  // fulfilled handler — `.catch`, `.finally`, `.then(null, fn)`, `.then()` — forwards the
+  // response untouched, so the walk continues past it. Its own handler is left alone: it
+  // sees an error or nothing, never the response.
   for (const link of chainLinks) {
-    if (link.methodName !== 'then') break;
-
     const [handler] = link.callPath.value.arguments;
-    if (!handler) break;
+    const hasFulfilledHandler = link.methodName === 'then' && Boolean(handler) && !isNullLiteral(handler);
+
+    if (!hasFulfilledHandler) continue;
+
     if (handler.type !== 'FunctionExpression' && handler.type !== 'ArrowFunctionExpression') break;
     if (handler.params[0]?.type !== 'Identifier') break; // if the handler does not have a parameter then break
 

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -283,11 +283,10 @@ const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
       name: responseVarName
     }
   }).forEach((memberPath) => {
-    const property = memberPath.value.property;
-    if (property.type !== 'Identifier') return;
+    const propertyName = getStaticPropertyName(memberPath.value);
+    if (!Object.hasOwn(responsePropertyMap, propertyName)) return;
 
-    const bruProperty = responsePropertyMap[property.name];
-    if (!bruProperty) return;
+    const bruProperty = responsePropertyMap[propertyName];
 
     // skip references shadowed by a nested re-declaration of the name
     if (!resolvesToHandlerParam(memberPath, responseVarName, handler)) return;

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -228,9 +228,6 @@ const isPromiseChainHandler = (functionPath) => {
 };
 
 /**
- * Whether `await` may be emitted here. Bruno runs scripts in an async closure, so top level is
- * always awaitable. Inside a non-async function `await` is a syntax error that breaks the whole
- * script, so we emit it only after making that function async — safe only for promise-chain handlers.
  * @param {Object} j - jscodeshift API
  * @param {Object} path - Path the await would be emitted at
  * @returns {boolean}
@@ -307,7 +304,7 @@ const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
 };
 
 /**
- * The return statements belonging to the handler itself.
+* The return statements belonging to the handler itself.
 * @example
  * sendRequest(req).then((res) => {
  *   const extract = () => {
@@ -327,7 +324,8 @@ const findOwnReturns = (j, handlerPath) =>
     .filter((returnPath) => j(returnPath).closest(j.Function).get().value === handlerPath.value);
 
 /**
- * Whether every value the handler can return is its own response parameter
+ * Whether the handler forwards its response parameter untouched, so response-shape
+ * rewriting can safely continue on the next `.then` in the chain.
  * @param {Object} j - jscodeshift API
  * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument
  * @returns {boolean}

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -231,11 +231,9 @@ const isPromiseChainHandler = (functionPath) => {
 };
 
 /**
- * Whether `await` may be emitted at this position, turning the enclosing function
- * async where that is safe. Bruno evaluates scripts inside an async closure, so
- * top level is awaitable. Inside a non-async function `await` is a syntax error
- * that breaks the entire script, so it is emitted there only once the function
- * has been made async — which is only safe for a promise-chain handler.
+ * Whether `await` may be emitted here. Bruno runs scripts in an async closure, so top level is
+ * always awaitable. Inside a non-async function `await` is a syntax error that breaks the whole
+ * script, so we emit it only after making that function async — safe only for promise-chain handlers.
  * @param {Object} j - jscodeshift API
  * @param {Object} path - Path the await would be emitted at
  * @returns {boolean}
@@ -571,8 +569,6 @@ const sendRequestTransformer = (path, j) => {
 
     const handlerPath = link.callPath.get('arguments', 0);
 
-    // both read before the rewrite, which would collapse `return res.json()` into
-    // `return res.data` and hide that the handler never forwarded the response
     const returnsResponse = returnsParamUnchanged(j, handlerPath);
     const reassignsResponse = isResponseParamReassigned(j, handlerPath);
 

--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -195,6 +195,7 @@ const getPromiseChainLinks = (callPath) => {
 
     const chainedCallPath = memberPath.parent;
     if (!chainedCallPath || chainedCallPath.value.type !== 'CallExpression') break;
+    if (chainedCallPath.value.callee !== memberPath.value) break;
 
     links.push({ callPath: chainedCallPath, methodName });
     currentPath = chainedCallPath;

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1044,7 +1044,8 @@ await bru.sendRequest({
 
     it('should treat a bracket-notation then as a chain', () => {
       const code = `pm.sendRequest({ url: 'https://echo.usebruno.com' })['then']((res) => res.json());`;
-      expect(translateCode(code)).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' })['then']((res) => res.data);`);
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' })['then']((res) => res.data);`);
     });
 
     it('should not treat a computed variable key as a promise method', () => {

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1104,64 +1104,6 @@ await bru.sendRequest({
       `);
     });
 
-    it('should not rewrite past a then with no fulfilled handler, even though it forwards the response', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then()
-          .then((res) => {
-              console.log(res.code);
-          });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then()
-          .then((res) => {
-              console.log(res.code);
-          });
-      `);
-    });
-
-    it('should not rewrite past a then whose fulfilled handler is null', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then(null, (err) => console.error(err))
-          .then((res) => {
-              console.log(res.code);
-          });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then(null, (err) => console.error(err))
-          .then((res) => {
-              console.log(res.code);
-          });
-      `);
-    });
-
-    it('should not rewrite past a finally, even though it forwards the response', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .finally(() => {
-              console.log('done');
-          })
-          .then((res) => {
-              console.log(res.code);
-          });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .finally(() => {
-              console.log('done');
-          })
-          .then((res) => {
-              console.log(res.code);
-          });
-      `);
-    });
-
     it('should make a non-async then handler async to await a nested sendRequest', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
@@ -1472,7 +1414,7 @@ await bru.sendRequest({
       `);
     });
 
-    it('should stop at a catch even when the preceding then is a pass-through', () => {
+    it('should continue past a catch, which forwards the response when no error occurred', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })
           .then((res) => res)
@@ -1487,8 +1429,76 @@ await bru.sendRequest({
           .then((res) => res)
           .catch(() => null)
           .then((data) => {
-              console.log(data.code);
+              console.log(data.status);
           });
+      `);
+    });
+
+    it('should continue past a finally, which always forwards the response', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).finally(() => {
+            console.log('done');
+        }).then((res) => {
+            console.log(res.json());
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).finally(() => {
+            console.log('done');
+        }).then((res) => {
+            console.log(res.data);
+        });
+      `);
+    });
+
+    it('should continue past a catch placed directly after the request', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).catch((err) => {
+            console.log(err);
+        }).then((res) => {
+            console.log(res.code);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).catch((err) => {
+            console.log(err);
+        }).then((res) => {
+            console.log(res.status);
+        });
+      `);
+    });
+
+    it('should continue past a rejection-only then(null, onRejected)', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).then(null, (err) => {
+            console.log(err);
+        }).then((res) => {
+            console.log(res.json());
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then(null, (err) => {
+            console.log(err);
+        }).then((res) => {
+            console.log(res.data);
+        });
+      `);
+    });
+
+    it('should continue past an empty then()', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).then().then((res) => {
+            console.log(res.json());
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then().then((res) => {
+            console.log(res.data);
+        });
       `);
     });
 

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1048,26 +1048,6 @@ await bru.sendRequest({
       expect(translatedCode).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res.data);`);
     });
 
-    it('should leave bracket-notation response access with a variable key alone', () => {
-      const code = `pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res[method]());`;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res[method]());`);
-    });
-
-    it('should not treat a computed variable key as a promise method', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })[then]((res) => {
-            console.log(res.json());
-        });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        (await bru.sendRequest({ url: 'https://echo.usebruno.com' }))[then]((res) => {
-            console.log(res.json());
-        });
-      `);
-    });
-
     it('should not treat a chain method passed as a value as a chain call', () => {
       const code = `register(pm.sendRequest({ url: 'https://echo.usebruno.com' }).then);`;
       const translatedCode = translateCode(code);

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -922,26 +922,6 @@ await bru.sendRequest({
       `);
     });
 
-    it('should not treat a then after a catch as a second response handler', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then((res) => res.json())
-          .catch(() => null)
-          .then((data) => {
-              console.log(data.status);
-          });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then((res) => res.data)
-          .catch(() => null)
-          .then((data) => {
-              console.log(data.status);
-          });
-      `);
-    });
-
     it('should not rewrite references shadowed by a nested function re-declaring the name', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
@@ -1088,24 +1068,6 @@ await bru.sendRequest({
       `);
     });
 
-    it('should not rewrite a handler receiving the return value of an earlier then', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then(() => ({ code: 1 }))
-          .then((res) => {
-              console.log(res.code);
-          });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then(() => ({ code: 1 }))
-          .then((res) => {
-              console.log(res.code);
-          });
-      `);
-    });
-
     it('should make a non-async then handler async to await a nested sendRequest', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
@@ -1230,24 +1192,6 @@ await bru.sendRequest({
       `);
     });
 
-    it('should rewrite past a pass-through handler whose successor renames the parameter', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then((res) => res)
-          .then((response) => {
-              console.log(response.status);
-          });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then((res) => res)
-          .then((response) => {
-              console.log(response.statusText);
-          });
-      `);
-    });
-
     it('should rewrite a handler that reassigns its parameter but stop after it', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })
@@ -1288,36 +1232,6 @@ await bru.sendRequest({
               console.log(res.status);
               res = 5;
               console.log(res.status);
-          });
-      `);
-    });
-
-    it('should stop after a handler that reassigns its parameter conditionally', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then((res) => {
-              if (x) {
-                  res = res.json();
-              }
-              console.log(res.code);
-              return res;
-          })
-          .then((r) => {
-              console.log(r.code);
-          });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .then((res) => {
-              if (x) {
-                  res = res.data;
-              }
-              console.log(res.status);
-              return res;
-          })
-          .then((r) => {
-              console.log(r.code);
           });
       `);
     });
@@ -1394,9 +1308,10 @@ await bru.sendRequest({
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })
           .then((res) => {
-              if (ok) {
-                  return res;
+              if (!ok) {
+                  return null;
               }
+              return res;
           })
           .then((data) => {
               console.log(data.code);
@@ -1406,9 +1321,10 @@ await bru.sendRequest({
       expect(translatedCode).toBe(`
         await bru.sendRequest({ url: 'https://echo.usebruno.com' })
           .then((res) => {
-              if (ok) {
-                  return res;
+              if (!ok) {
+                  return null;
               }
+              return res;
           })
           .then((data) => {
               console.log(data.code);
@@ -1469,20 +1385,6 @@ await bru.sendRequest({
         }).then((res) => {
             console.log(res.code);
         });
-      `);
-    });
-
-    it('should stop at a catch that returns a substitute response', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://echo.usebruno.com' })
-          .catch(() => ({ code: 599 }))
-          .then((res) => console.log(res.status));
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
-          .catch(() => ({ code: 599 }))
-          .then((res) => console.log(res.status));
       `);
     });
 

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1063,7 +1063,8 @@ await bru.sendRequest({
 
     it('should leave a destructured handler param alone', () => {
       const code = `pm.sendRequest({ url: 'https://echo.usebruno.com' }).then(({ code }) => console.log(code));`;
-      expect(translateCode(code)).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then(({ code }) => console.log(code));`);
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then(({ code }) => console.log(code));`);
     });
 
     it('should translate a nested sendRequest chain inside an async then handler', () => {

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1232,6 +1232,170 @@ await bru.sendRequest({
       `);
     });
 
+    it('should rewrite past a then that returns its response parameter unchanged', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .then((res) => res.json());
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .then((res) => res.data);
+      `);
+    });
+
+    it('should rewrite past a block-bodied then that returns its response parameter', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.code);
+              return res;
+          })
+          .then((r) => r.json());
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.status);
+              return res;
+          })
+          .then((r) => r.data);
+      `);
+    });
+
+    it('should rewrite across several consecutive pass-through handlers', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .then((res) => res)
+          .then((res) => {
+              console.log(res.json());
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .then((res) => res)
+          .then((res) => {
+              console.log(res.data);
+          });
+      `);
+    });
+
+    it('should rewrite past a pass-through handler whose successor renames the parameter', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .then((response) => {
+              console.log(response.status);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .then((response) => {
+              console.log(response.statusText);
+          });
+      `);
+    });
+
+    it('should rewrite a handler that reassigns its parameter but stop after it', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              res = res.json();
+              return res;
+          })
+          .then((r) => {
+              console.log(r.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              res = res.data;
+              return res;
+          })
+          .then((r) => {
+              console.log(r.code);
+          });
+      `);
+    });
+
+    it('should not rewrite past a handler that returns nothing', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.json());
+          })
+          .then((data) => {
+              console.log(data.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.data);
+          })
+          .then((data) => {
+              console.log(data.code);
+          });
+      `);
+    });
+
+    it('should not rewrite past a handler that returns its parameter on only some paths', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              if (ok) {
+                  return res;
+              }
+          })
+          .then((data) => {
+              console.log(data.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              if (ok) {
+                  return res;
+              }
+          })
+          .then((data) => {
+              console.log(data.code);
+          });
+      `);
+    });
+
+    it('should stop at a catch even when the preceding then is a pass-through', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .catch(() => null)
+          .then((data) => {
+              console.log(data.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res)
+          .catch(() => null)
+          .then((data) => {
+              console.log(data.code);
+          });
+      `);
+    });
+
     it('should stop at a zero-arity first handler rather than rewriting a later one', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1328,6 +1328,102 @@ await bru.sendRequest({
       `);
     });
 
+    it('should rewrite response access on both sides of a reassignment in the same handler', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.code);
+              res = 5;
+              console.log(res.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.status);
+              res = 5;
+              console.log(res.status);
+          });
+      `);
+    });
+
+    it('should stop after a handler that reassigns its parameter conditionally', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              if (x) {
+                  res = res.json();
+              }
+              console.log(res.code);
+              return res;
+          })
+          .then((r) => {
+              console.log(r.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              if (x) {
+                  res = res.data;
+              }
+              console.log(res.status);
+              return res;
+          })
+          .then((r) => {
+              console.log(r.code);
+          });
+      `);
+    });
+
+    it('should not rewrite past a handler that returns its parameter through an alias', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              const r = res;
+              return r;
+          })
+          .then((data) => {
+              console.log(data.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              const r = res;
+              return r;
+          })
+          .then((data) => {
+              console.log(data.code);
+          });
+      `);
+    });
+
+    it('should rewrite past a function-expression pass-through handler', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(function (res) {
+              return res;
+          })
+          .then(function (data) {
+              console.log(data.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(function (res) {
+              return res;
+          })
+          .then(function (data) {
+              console.log(data.status);
+          });
+      `);
+    });
+
     it('should not rewrite past a handler that returns nothing', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -803,4 +803,447 @@ describe('Send Request Translation', () => {
       `);
     });
   });
+
+  describe('Promise chains', () => {
+    it('should keep the chain intact and await the outermost call', () => {
+      const code = `
+pm.sendRequest({
+  url: 'https://echo.usebruno.com',
+  method: 'POST',
+  header: {
+    'Content-Type': 'application/json'
+  },
+  body: {
+    mode: 'raw',
+    raw: JSON.stringify({
+      title: 'Bruno'
+    })
+  }
+})
+  .then((res) => {
+    console.log(res.json());
+  })
+  .catch((err) => {
+    console.error(err);
+  });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+await bru.sendRequest({
+  url: 'https://echo.usebruno.com',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  data: JSON.stringify({
+    title: 'Bruno'
+  })
+})
+  .then((res) => {
+    console.log(res.data);
+  })
+  .catch((err) => {
+    console.error(err);
+  });
+      `);
+    });
+
+    it('should transform only the fulfilled handler of then(onFulfilled, onRejected)', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+            console.log(res.json());
+        }, (res) => {
+            console.log(res.json());
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+            console.log(res.data);
+        }, (res) => {
+            console.log(res.json());
+        });
+      `);
+    });
+
+    it('should map code and status inside a then handler', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+            console.log(res.code);
+            console.log(res.status);
+            console.log(res.headers);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+            console.log(res.status);
+            console.log(res.statusText);
+            console.log(res.headers);
+        });
+      `);
+    });
+
+    it('should not await a chain inside a non-async function', () => {
+      const code = `
+        function fetchData() {
+            pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+                console.log(res.json());
+            });
+        }
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        function fetchData() {
+            bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+                console.log(res.data);
+            });
+        }
+      `);
+    });
+
+    it('should rewrite only the first then, since later handlers receive the previous return value', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res.json())
+          .then((data) => {
+              console.log(data.text);
+              console.log(data.status);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res.data)
+          .then((data) => {
+              console.log(data.text);
+              console.log(data.status);
+          });
+      `);
+    });
+
+    it('should not treat a then after a catch as a second response handler', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res.json())
+          .catch(() => null)
+          .then((data) => {
+              console.log(data.status);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => res.data)
+          .catch(() => null)
+          .then((data) => {
+              console.log(data.status);
+          });
+      `);
+    });
+
+    it('should not rewrite references shadowed by a nested function re-declaring the name', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+            console.log(res.json());
+            items.forEach((res) => {
+                console.log(res.json());
+            });
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => {
+            console.log(res.data);
+            items.forEach((res) => {
+                console.log(res.json());
+            });
+        });
+      `);
+    });
+
+    it('should handle a chain ending in finally', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.json());
+          })
+          .catch((err) => {
+              console.error(err);
+          })
+          .finally(() => {
+              console.log('done');
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              console.log(res.data);
+          })
+          .catch((err) => {
+              console.error(err);
+          })
+          .finally(() => {
+              console.log('done');
+          });
+      `);
+    });
+
+    it('should await a chain returned from an async function', () => {
+      const code = `
+        async function fetchData() {
+            return pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res.json());
+        }
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        async function fetchData() {
+            return await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res.data);
+        }
+      `);
+    });
+
+    it('should translate each of several chains in the same script', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
+            console.log(res.json());
+        });
+        pm.sendRequest({ url: 'https://echo.usebruno.com/two' }).then((res) => {
+            console.log(res.code);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
+            console.log(res.data);
+        });
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/two' }).then((res) => {
+            console.log(res.status);
+        });
+      `);
+    });
+
+    it('should not rewrite past a handler referenced by a variable', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(maybeHandler)
+          .then((res) => {
+              console.log(res.json());
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(maybeHandler)
+          .then((res) => {
+              console.log(res.json());
+          });
+      `);
+    });
+
+    it('should treat a bracket-notation then as a chain', () => {
+      const code = `pm.sendRequest({ url: 'https://echo.usebruno.com' })['then']((res) => res.json());`;
+      expect(translateCode(code)).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' })['then']((res) => res.data);`);
+    });
+
+    it('should not treat a computed variable key as a promise method', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })[then]((res) => {
+            console.log(res.json());
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        (await bru.sendRequest({ url: 'https://echo.usebruno.com' }))[then]((res) => {
+            console.log(res.json());
+        });
+      `);
+    });
+
+    it('should leave a destructured handler param alone', () => {
+      const code = `pm.sendRequest({ url: 'https://echo.usebruno.com' }).then(({ code }) => console.log(code));`;
+      expect(translateCode(code)).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then(({ code }) => console.log(code));`);
+    });
+
+    it('should translate a nested sendRequest chain inside an async then handler', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com/users/1' }).then(async (userRes) => {
+            const userId = userRes.json().id;
+            return pm.sendRequest({ url: 'https://echo.usebruno.com/posts' }).then((postsRes) => {
+                console.log(postsRes.json());
+            });
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/users/1' }).then(async (userRes) => {
+            const userId = userRes.data.id;
+            return await bru.sendRequest({ url: 'https://echo.usebruno.com/posts' }).then((postsRes) => {
+                console.log(postsRes.data);
+            });
+        });
+      `);
+    });
+
+    it('should not rewrite a handler receiving the return value of an earlier then', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(() => ({ code: 1 }))
+          .then((res) => {
+              console.log(res.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(() => ({ code: 1 }))
+          .then((res) => {
+              console.log(res.code);
+          });
+      `);
+    });
+
+    it('should not rewrite past a then with no fulfilled handler, even though it forwards the response', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then()
+          .then((res) => {
+              console.log(res.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then()
+          .then((res) => {
+              console.log(res.code);
+          });
+      `);
+    });
+
+    it('should not rewrite past a then whose fulfilled handler is null', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(null, (err) => console.error(err))
+          .then((res) => {
+              console.log(res.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(null, (err) => console.error(err))
+          .then((res) => {
+              console.log(res.code);
+          });
+      `);
+    });
+
+    it('should not rewrite past a finally, even though it forwards the response', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .finally(() => {
+              console.log('done');
+          })
+          .then((res) => {
+              console.log(res.code);
+          });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .finally(() => {
+              console.log('done');
+          })
+          .then((res) => {
+              console.log(res.code);
+          });
+      `);
+    });
+
+    it('should make a non-async then handler async to await a nested sendRequest', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
+            pm.sendRequest({ url: 'https://echo.usebruno.com/two' }).then((inner) => {
+                console.log(inner.json());
+            });
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/one' }).then(async res => {
+            await bru.sendRequest({ url: 'https://echo.usebruno.com/two' }).then((inner) => {
+                console.log(inner.data);
+            });
+        });
+      `);
+    });
+
+    it('should translate a sendRequest chain nested inside a catch handler', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com/one' }).catch((err) => {
+            pm.sendRequest({ url: 'https://echo.usebruno.com/retry' }).then((res) => {
+                console.log(res.code);
+            });
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/one' }).catch(async err => {
+            await bru.sendRequest({ url: 'https://echo.usebruno.com/retry' }).then((res) => {
+                console.log(res.status);
+            });
+        });
+      `);
+    });
+
+    it('should await a nested sendRequest that has no chain of its own', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
+            pm.sendRequest({ url: 'https://echo.usebruno.com/two' });
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/one' }).then(async res => {
+            await bru.sendRequest({ url: 'https://echo.usebruno.com/two' });
+        });
+      `);
+    });
+
+    it('should not await a nested sendRequest inside a plain function declared in a then handler', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
+            function retry() {
+                pm.sendRequest({ url: 'https://echo.usebruno.com/two' }).then((r) => console.log(r.code));
+            }
+            retry();
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com/one' }).then((res) => {
+            function retry() {
+                bru.sendRequest({ url: 'https://echo.usebruno.com/two' }).then((r) => console.log(r.status));
+            }
+            retry();
+        });
+      `);
+    });
+
+    it('should stop at a zero-arity first handler rather than rewriting a later one', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(() => 'done')
+          .then((res) => res.json());
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then(() => 'done')
+          .then((res) => res.json());
+      `);
+    });
+  });
 });

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -902,6 +902,20 @@ await bru.sendRequest({
       `);
     });
 
+    it('should keep a callback passed to a non-promise method synchronous', () => {
+      const code = `
+        setTimeout(function () {
+            pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res.json());
+        }, 0);
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        setTimeout(function () {
+            bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res.data);
+        }, 0);
+      `);
+    });
+
     it('should rewrite only the first then, since later handlers receive the previous return value', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })
@@ -1028,6 +1042,18 @@ await bru.sendRequest({
       expect(translatedCode).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' })['then']((res) => res.data);`);
     });
 
+    it('should rewrite bracket-notation response access with a literal key', () => {
+      const code = `pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res['json']());`;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res.data);`);
+    });
+
+    it('should leave bracket-notation response access with a variable key alone', () => {
+      const code = `pm.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res[method]());`;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then((res) => res[method]());`);
+    });
+
     it('should not treat a computed variable key as a promise method', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })[then]((res) => {
@@ -1040,6 +1066,12 @@ await bru.sendRequest({
             console.log(res.json());
         });
       `);
+    });
+
+    it('should not treat a chain method passed as a value as a chain call', () => {
+      const code = `register(pm.sendRequest({ url: 'https://echo.usebruno.com' }).then);`;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`register((await bru.sendRequest({ url: 'https://echo.usebruno.com' })).then);`);
     });
 
     it('should leave a destructured handler param alone', () => {
@@ -1332,6 +1364,50 @@ await bru.sendRequest({
       `);
     });
 
+    it('should not count a nested function\'s return as the handler\'s own', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              const extract = () => { return res.json(); };
+              console.log(extract());
+              return res;
+          })
+          .then((r) => r.code);
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              const extract = () => { return res.data; };
+              console.log(extract());
+              return res;
+          })
+          .then((r) => r.status);
+      `);
+    });
+
+    it('should rewrite past a handler whose nested function shadows and returns the parameter name', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              const pick = (res) => { return res; };
+              console.log(pick(items));
+              return res;
+          })
+          .then((r) => r.code);
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .then((res) => {
+              const pick = (res) => { return res; };
+              console.log(pick(items));
+              return res;
+          })
+          .then((r) => r.status);
+      `);
+    });
+
     it('should stop at a catch, whose handler can replace the response for the rest of the chain', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })
@@ -1399,6 +1475,24 @@ await bru.sendRequest({
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
         await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then(null, (err) => {
+            console.log(err);
+        }).then((res) => {
+            console.log(res.data);
+        });
+      `);
+    });
+
+    it('should continue past a rejection-only then(undefined, onRejected)', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }).then(undefined, (err) => {
+            console.log(err);
+        }).then((res) => {
+            console.log(res.json());
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }).then(undefined, (err) => {
             console.log(err);
         }).then((res) => {
             console.log(res.data);

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1414,7 +1414,7 @@ await bru.sendRequest({
       `);
     });
 
-    it('should continue past a catch, which forwards the response when no error occurred', () => {
+    it('should stop at a catch, whose handler can replace the response for the rest of the chain', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' })
           .then((res) => res)
@@ -1429,7 +1429,7 @@ await bru.sendRequest({
           .then((res) => res)
           .catch(() => null)
           .then((data) => {
-              console.log(data.status);
+              console.log(data.code);
           });
       `);
     });
@@ -1452,7 +1452,7 @@ await bru.sendRequest({
       `);
     });
 
-    it('should continue past a catch placed directly after the request', () => {
+    it('should stop at a catch placed directly after the request', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' }).catch((err) => {
             console.log(err);
@@ -1465,8 +1465,22 @@ await bru.sendRequest({
         await bru.sendRequest({ url: 'https://echo.usebruno.com' }).catch((err) => {
             console.log(err);
         }).then((res) => {
-            console.log(res.status);
+            console.log(res.code);
         });
+      `);
+    });
+
+    it('should stop at a catch that returns a substitute response', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://echo.usebruno.com' })
+          .catch(() => ({ code: 599 }))
+          .then((res) => console.log(res.status));
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' })
+          .catch(() => ({ code: 599 }))
+          .then((res) => console.log(res.status));
       `);
     });
 


### PR DESCRIPTION
BRU-3117

### Description

Promise chains are now supported while migrating a postman collection scripts. Previously only the callback form and await pm.sendRequest(...) were handled; .then()/.catch()/.finally() chains were left untransformed. The transformer now walks the chain from the sendRequest call outward.

### Problem

When we migrate a Postman script which looks like this pm.sendRequest(config) we check if there is an await that already exists, else we add an await to the script and replace pm.sendRequest -> bru.sendRequest for the migration.
But in our current implementation we are not checking for any chain implementation, if the script has .then .catch .finally handlers which ends up breaking the pm to bru script conversation.

The migration goes like this in the following steps

pm-script --> AST (Abstract syntax tree - using jscodeshift library)
AST --> modifies AST (we modify the AST nodes to convert them to work in bruno)
the problem happens in this step -  modified AST --> converted back to source code during this step since now that we have added await when it is converted back to source code form, it checks precedence. **Since `(.)` binds tighter than `await` it gets converted to**

```
(await bru.sendRequest(config)).then((res) => {
  console.log(res.json());
});
```

### Fix

-  Await the outermost expression, not the inner call. When we do await, await is added to the whole expression statement rather than being nested inside it, so the entire chain resolves before the script continues.
- 
```
// before (broken)
(await sendRequest(options)).then(...);

// after
await sendRequest(options);
```

3. Map the response shape in the .then handler
Postman's pm.sendRequest callback and Bruno's resolved response expose different shapes like this 

Postman | Bruno
-- | --
res.json() / res.text() | res.data
res.code | res.status
res.status | res.statusText

This is handled in the first .then handler where response is consumed 

### Screenshots

| Before | After |
| --- | --- |
| <img width="531" height="510" alt="image" src="https://github.com/user-attachments/assets/a31893b8-c21a-485e-ad50-c34928d9f496" /> | <img width="513" height="496" alt="image" src="https://github.com/user-attachments/assets/24684a0e-6499-43dd-bcce-ccddce519f8b" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved conversion of Postman `pm.sendRequest` promise chains.
  * Supports `.then`, `.catch`, and `.finally`, including nested and multiple chains.
  * Translates response properties, callbacks, request variables, and bracket notation.
  * Preserves behavior in asynchronous contexts, including shadowed and destructured parameters.

* **Bug Fixes**
  * Prevents incorrect or unnecessary `await` insertion.
  * Safely handles unsupported, ambiguous, reassigned, and pass-through callback patterns.
  * Preserves existing asynchronous behavior while avoiding unsafe rewrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->