### PR TITLE
fix(modal): modal overlap with text editor

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmCollectionClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmCollectionClose/index.js
@@ -2,48 +2,51 @@ import React from 'react';
 import { IconAlertTriangle } from '@tabler/icons';
 import Modal from 'components/Modal';
 import Button from 'ui/Button';
+import Portal from 'ui/Portal';
 
 const ConfirmCollectionClose = ({ collection, onCancel, onCloseWithoutSave, onSaveAndClose }) => {
   return (
-    <Modal
-      size="md"
-      title="Unsaved changes"
-      confirmText="Save and Close"
-      cancelText="Close without saving"
-      disableEscapeKey={true}
-      disableCloseOnOutsideClick={true}
-      closeModalFadeTimeout={150}
-      handleCancel={onCancel}
-      onClick={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-      }}
-      hideFooter={true}
-    >
-      <div className="flex items-center font-normal">
-        <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
-        <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
-      </div>
-      <div className="font-normal mt-4">
-        You have unsaved changes in <span className="font-medium">{collection.name}</span> collection settings.
-      </div>
+    <Portal>
+      <Modal
+        size="md"
+        title="Unsaved changes"
+        confirmText="Save and Close"
+        cancelText="Close without saving"
+        disableEscapeKey={true}
+        disableCloseOnOutsideClick={true}
+        closeModalFadeTimeout={150}
+        handleCancel={onCancel}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
+        hideFooter={true}
+      >
+        <div className="flex items-center font-normal">
+          <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
+          <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
+        </div>
+        <div className="font-normal mt-4">
+          You have unsaved changes in <span className="font-medium">{collection.name}</span> collection settings.
+        </div>
 
-      <div className="flex justify-between mt-6">
-        <div>
-          <Button color="danger" onClick={onCloseWithoutSave}>
-            Don't Save
-          </Button>
+        <div className="flex justify-between mt-6">
+          <div>
+            <Button color="danger" onClick={onCloseWithoutSave}>
+              Don't Save
+            </Button>
+          </div>
+          <div className="flex gap-2">
+            <Button color="secondary" variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button onClick={onSaveAndClose}>
+              Save
+            </Button>
+          </div>
         </div>
-        <div className="flex gap-2">
-          <Button color="secondary" variant="ghost" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button onClick={onSaveAndClose}>
-            Save
-          </Button>
-        </div>
-      </div>
-    </Modal>
+      </Modal>
+    </Portal>
   );
 };
 

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmFolderClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmFolderClose/index.js
@@ -2,48 +2,51 @@ import React from 'react';
 import { IconAlertTriangle } from '@tabler/icons';
 import Modal from 'components/Modal';
 import Button from 'ui/Button';
+import Portal from 'ui/Portal';
 
 const ConfirmFolderClose = ({ folder, onCancel, onCloseWithoutSave, onSaveAndClose }) => {
   return (
-    <Modal
-      size="md"
-      title="Unsaved changes"
-      confirmText="Save and Close"
-      cancelText="Close without saving"
-      disableEscapeKey={true}
-      disableCloseOnOutsideClick={true}
-      closeModalFadeTimeout={150}
-      handleCancel={onCancel}
-      onClick={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-      }}
-      hideFooter={true}
-    >
-      <div className="flex items-center font-normal">
-        <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
-        <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
-      </div>
-      <div className="font-normal mt-4">
-        You have unsaved changes in <span className="font-medium">{folder.name}</span> folder settings.
-      </div>
+    <Portal>
+      <Modal
+        size="md"
+        title="Unsaved changes"
+        confirmText="Save and Close"
+        cancelText="Close without saving"
+        disableEscapeKey={true}
+        disableCloseOnOutsideClick={true}
+        closeModalFadeTimeout={150}
+        handleCancel={onCancel}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
+        hideFooter={true}
+      >
+        <div className="flex items-center font-normal">
+          <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
+          <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
+        </div>
+        <div className="font-normal mt-4">
+          You have unsaved changes in <span className="font-medium">{folder.name}</span> folder settings.
+        </div>
 
-      <div className="flex justify-between mt-6">
-        <div>
-          <Button color="danger" onClick={onCloseWithoutSave}>
-            Don't Save
-          </Button>
+        <div className="flex justify-between mt-6">
+          <div>
+            <Button color="danger" onClick={onCloseWithoutSave}>
+              Don't Save
+            </Button>
+          </div>
+          <div className="flex gap-2">
+            <Button color="secondary" variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button onClick={onSaveAndClose}>
+              Save
+            </Button>
+          </div>
         </div>
-        <div className="flex gap-2">
-          <Button color="secondary" variant="ghost" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button onClick={onSaveAndClose}>
-            Save
-          </Button>
-        </div>
-      </div>
-    </Modal>
+      </Modal>
+    </Portal>
   );
 };
 

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
@@ -31,7 +31,7 @@ const ConfirmRequestClose = ({ item, example, onCancel, onCloseWithoutSave, onSa
           <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
         </div>
         <div className="font-normal mt-4">
-          You have unsaved changes in hsh {itemType} <span className="font-medium">{itemName}</span>.
+          You have unsaved changes in {itemType} <span className="font-medium">{itemName}</span>.
         </div>
 
         <div className="flex justify-between mt-6">

--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/ConfirmRequestClose/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { IconAlertTriangle } from '@tabler/icons';
 import Modal from 'components/Modal';
 import Button from 'ui/Button';
+import Portal from 'ui/Portal';
 
 const ConfirmRequestClose = ({ item, example, onCancel, onCloseWithoutSave, onSaveAndClose }) => {
   const isExample = !!example;
@@ -9,43 +10,45 @@ const ConfirmRequestClose = ({ item, example, onCancel, onCloseWithoutSave, onSa
   const itemType = isExample ? 'example' : 'request';
 
   return (
-    <Modal
-      size="md"
-      title="Unsaved changes"
-      confirmText="Save and Close"
-      cancelText="Close without saving"
-      disableEscapeKey={true}
-      disableCloseOnOutsideClick={true}
-      closeModalFadeTimeout={150}
-      handleCancel={onCancel}
-      onClick={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-      }}
-      hideFooter={true}
-    >
-      <div className="flex items-center font-normal">
-        <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
-        <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
-      </div>
-      <div className="font-normal mt-4">
-        You have unsaved changes in {itemType} <span className="font-medium">{itemName}</span>.
-      </div>
+    <Portal>
+      <Modal
+        size="md"
+        title="Unsaved changes"
+        confirmText="Save and Close"
+        cancelText="Close without saving"
+        disableEscapeKey={true}
+        disableCloseOnOutsideClick={true}
+        closeModalFadeTimeout={150}
+        handleCancel={onCancel}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
+        hideFooter={true}
+      >
+        <div className="flex items-center font-normal">
+          <IconAlertTriangle size={32} strokeWidth={1.5} className="text-yellow-600" />
+          <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
+        </div>
+        <div className="font-normal mt-4">
+          You have unsaved changes in hsh {itemType} <span className="font-medium">{itemName}</span>.
+        </div>
 
-      <div className="flex justify-between mt-6">
-        <div>
-          <Button color="danger" onClick={onCloseWithoutSave}>
-            Don't Save
-          </Button>
+        <div className="flex justify-between mt-6">
+          <div>
+            <Button color="danger" onClick={onCloseWithoutSave}>
+              Don't Save
+            </Button>
+          </div>
+          <div className="flex gap-2">
+            <Button color="secondary" variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button onClick={onSaveAndClose}>Save</Button>
+          </div>
         </div>
-        <div className="flex gap-2">
-          <Button color="secondary" variant="ghost" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button onClick={onSaveAndClose}>Save</Button>
-        </div>
-      </div>
-    </Modal>
+      </Modal>
+    </Portal>
   );
 };
 


### PR DESCRIPTION
### Description

BRU-4288

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
The unsaved changes modal of Colelcion, Folder and Request overlaps with doc editor shortcuts icons.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
The modal was rendered inside a nested container, so its z-index: 20 was limited to that container’s stacking context. Because the toolbar belonged to a different stacking context, it appeared above the modal even with a lower z-index.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- Rendered the modals in a portal with root element as document body. which puts the modal at the top-level stacking context
- Used the existinf Portal component from `src/ui`

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="1279" height="245" alt="image" src="https://github.com/user-attachments/assets/5939b6f5-3a04-4344-a146-d6fbda62c8f8" />|  <img width="1292" height="707" alt="image" src="https://github.com/user-attachments/assets/f9d4e229-018a-4c88-b8c6-12308aba24df" />|

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display and layering of confirmation dialogs when closing collections, folders, or requests.
  - Preserved existing unsaved-change warnings, modal controls, and close/cancel actions.
  - Confirmation prompts now appear reliably without altering their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->