### PR TITLE
fix(docs): add support for inline raw HTML nodes and disable forced line breaks

### DIFF
--- a/packages/bruno-app/src/ui/RichTextEditor/components/EditorToolbar/index.spec.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/components/EditorToolbar/index.spec.js
@@ -8,9 +8,10 @@ import EditorToolbar from './index';
 
 const mockTheme = themes.light;
 
+// Excluding rawHtmlBlock or rawHtmlTextBlock alone leaves html_block content orphaned since they share a patched renderer.
 const createEditor = () => {
   return new Editor({
-    extensions: createExtensions().filter((ext) => ext.name !== 'rawHtmlBlock'),
+    extensions: createExtensions().filter((ext) => !['rawHtmlBlock', 'rawHtmlTextBlock'].includes(ext.name)),
     content: '<p>Hello world</p>'
   });
 };

--- a/packages/bruno-app/src/ui/RichTextEditor/editorContentStyles.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/editorContentStyles.js
@@ -292,9 +292,6 @@ const editorContentStyles = css`
 
   .editor-raw-html-block {
     margin: 0.5rem 0;
-    padding: 0.5rem;
-    border: dashed 1px ${(props) => props.theme.border.border0};
-    border-radius: ${(props) => props.theme.border.radius.sm};
   }
 
   /* Syntax Highlighting for code blocks (highlight.js classes from lowlight) */

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorHardBreak/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorHardBreak/index.js
@@ -1,18 +1,10 @@
 import HardBreak from '@tiptap/extension-hard-break';
 import runMarkdownitSetupOnce from '../../utils/markdownitSetupOnce';
 
+// Emitting a space instead of `\n` for soft breaks prevents ProseMirror from converting them into hard breaks during paste.
 const setupSoftBreakParser = (markdownit) => {
   runMarkdownitSetupOnce(markdownit, '__docsSoftBreakNormalized', (md) => {
-    const originalSoftBreak = md.renderer.rules.softbreak;
-    md.renderer.rules.softbreak = function (tokens, idx, options, env, self) {
-      if (options.breaks) {
-        return '<br>';
-      }
-      if (originalSoftBreak) {
-        return originalSoftBreak(tokens, idx, options, env, self);
-      }
-      return '\n';
-    };
+    md.renderer.rules.softbreak = (tokens, idx, options) => (options.breaks ? '<br>' : ' ');
   });
 };
 
@@ -36,12 +28,7 @@ const EditorHardBreak = HardBreak.extend({
             }
           }
 
-          // A hard break with nothing after it (the true end of its parent, or
-          // the last of a run of consecutive breaks) can't be represented as a
-          // line-break escape — CommonMark trims trailing backslash/space
-          // sequences at the end of a block, so it would vanish on reparse.
-          // A literal inline `<br/>` survives instead, since it's parsed back
-          // as raw HTML rather than relying on a following line.
+          // A trailing hard break uses `<br/>` instead of a line-break escape since CommonMark trims trailing backslash/spaces at the end of a block.
           state.write('<br/>');
         },
         parse: {

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
@@ -5,6 +5,7 @@ import runMarkdownitSetupOnce from '../../utils/markdownitSetupOnce';
 const RAW_HTML_BLOCK_ATTR = 'data-raw-html-block';
 const RAW_HTML_INLINE_ATTR = 'data-raw-html-inline';
 const TEXT_BLOCK_TAG_ATTR = 'data-raw-html-text-block';
+const ORIGINAL_HTML_ATTR = 'data-raw-html-original';
 
 // We forbid <style> in DOMPurify to prevent untrusted docs from injecting CSS that affects the whole app UI.
 const SANITIZE_CONFIG = { FORBID_TAGS: ['style'] };
@@ -19,7 +20,7 @@ const RECOGNIZED_INLINE_HTML_TAGS = new Set([
 ]);
 
 // Task list checkboxes are passed through as plain HTML since updateDOM reads them directly; all other <input> tags remain opaque raw-HTML atoms.
-const TASK_LIST_CHECKBOX_PATTERN = /^<input\b[^>]*\btype="checkbox"/i;
+const TASK_LIST_CHECKBOX_PATTERN = /^<input\b[^>]*\btype=["']checkbox["']/i;
 
 const getInlineHtmlTagName = (html) => {
   const match = html.trim().match(/^<\/?([a-zA-Z][\w-]*)/);
@@ -51,6 +52,22 @@ const NON_TEXT_BLOCK_TAGS = new Set([
 const escapeHtmlText = (text) => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 const escapeHtmlAttrValue = (value) => escapeHtmlText(value).replace(/"/g, '&quot;');
+
+// Reads an element's attributes into a plain object, so callers can compare/serialize them without touching the DOM.
+const attributesToObject = (element, excludedNames = []) => {
+  const attrs = {};
+  [...element.attributes].forEach((attr) => {
+    if (!excludedNames.includes(attr.name)) {
+      attrs[attr.name] = attr.value;
+    }
+  });
+  return attrs;
+};
+
+const buildAttrString = (attrs) =>
+  Object.entries(attrs)
+    .map(([name, value]) => ` ${name}="${escapeHtmlAttrValue(value)}"`)
+    .join('');
 
 // Returns the top-level element if it sanitizes down to a single wrapper with only plain text and <br>s; otherwise returns null to fall back to an opaque raw-HTML atom.
 const parseSimpleTextBlockElement = (html) => {
@@ -105,11 +122,11 @@ const setupRawHtmlBlockParser = (markdownit) => {
       const tagName = textBlockElement?.tagName.toLowerCase();
 
       if (textBlockElement && !NON_TEXT_BLOCK_TAGS.has(tagName)) {
-        const attrs = [...textBlockElement.attributes]
-          .map((attr) => ` ${attr.name}="${escapeHtmlAttrValue(attr.value)}"`)
-          .join('');
+        const attrs = buildAttrString(attributesToObject(textBlockElement));
+        // The trailing newline(s) markdown-it includes at the end of an html_block token aren't part of the tag itself.
+        const originalHtml = encodeRawHtml(html.replace(/\n+$/, ''));
 
-        return `<${tagName} ${TEXT_BLOCK_TAG_ATTR}="${tagName}"${attrs}>${serializeTextBlockContent(textBlockElement)}</${tagName}>`;
+        return `<${tagName} ${TEXT_BLOCK_TAG_ATTR}="${tagName}" ${ORIGINAL_HTML_ATTR}="${originalHtml}"${attrs}>${serializeTextBlockContent(textBlockElement)}</${tagName}>`;
       }
 
       return `<div ${RAW_HTML_BLOCK_ATTR}="${encodeRawHtml(html)}"></div>`;
@@ -133,10 +150,10 @@ const setupRawHtmlInlineParser = (markdownit) => {
 };
 
 // Shared factory for raw HTML nodes, as block and inline placeholders only differ in tags, attributes, and markdown wiring.
-const createRawHtmlNode = ({ name, tag, attr, className, extra, serialize, setupParser }) =>
+const createRawHtmlNode = ({ name, tag, attr, className, schemaOptions, serialize, setupParser }) =>
   Node.create({
     name,
-    ...extra,
+    ...schemaOptions,
 
     addAttributes() {
       return {
@@ -201,7 +218,7 @@ const EditorRawHtmlBlock = createRawHtmlNode({
   tag: 'div',
   attr: RAW_HTML_BLOCK_ATTR,
   className: 'editor-raw-html-block',
-  extra: {
+  schemaOptions: {
     group: 'block',
     atom: true,
     selectable: true,
@@ -219,7 +236,7 @@ export const EditorRawHtmlInline = createRawHtmlNode({
   tag: 'span',
   attr: RAW_HTML_INLINE_ATTR,
   className: 'editor-raw-html-inline',
-  extra: {
+  schemaOptions: {
     group: 'inline',
     inline: true,
     atom: true,
@@ -231,12 +248,35 @@ export const EditorRawHtmlInline = createRawHtmlNode({
   setupParser: setupRawHtmlInlineParser
 });
 
+// Resolves the ORIGINAL_HTML_ATTR payload to trusted original bytes, or null if it's missing, unparseable, or doesn't
+// describe the same tag/attributes we already sanitized — guarding against a pasted element smuggling an unrelated
+// payload through this bookkeeping attribute for verbatim output on serialize.
+const resolveOriginalHtml = (encodedOriginal, tag, htmlAttrs) => {
+  if (!encodedOriginal) {
+    return null;
+  }
+
+  const decoded = decodeRawHtml(encodedOriginal);
+  const reparsed = parseSimpleTextBlockElement(decoded);
+  if (!reparsed || reparsed.tagName.toLowerCase() !== tag) {
+    return null;
+  }
+
+  const reparsedAttrs = attributesToObject(reparsed);
+  const attrNames = Object.keys(htmlAttrs);
+  const attrsMatch = attrNames.length === Object.keys(reparsedAttrs).length
+    && attrNames.every((name) => reparsedAttrs[name] === htmlAttrs[name]);
+
+  return attrsMatch ? decoded : null;
+};
+
 // Editable HTML block that sanitizes to plain text. The original tag and attributes are preserved on the node to ensure they round-trip properly.
 export const EditorRawHtmlTextBlock = Node.create({
   name: 'rawHtmlTextBlock',
   group: 'block',
   // Allows text and hardBreak so Shift+Enter works, but excludes marks. Not isolated to allow HardBreak's command to insert line breaks.
   content: '(text|hardBreak)*',
+  marks: '',
 
   addAttributes() {
     return {
@@ -245,6 +285,11 @@ export const EditorRawHtmlTextBlock = Node.create({
       },
       htmlAttrs: {
         default: {}
+      },
+      // Exact source bytes this block was parsed from, if any — lets serialize reproduce a legacy doc's
+      // formatting untouched (quotes, tag case, entities) for blocks the user never actually edited.
+      originalHtml: {
+        default: null
       }
     };
   },
@@ -255,18 +300,23 @@ export const EditorRawHtmlTextBlock = Node.create({
         tag: `[${TEXT_BLOCK_TAG_ATTR}]`,
         // Uses high priority so this rule claims marked text blocks before native node rules (like paragraph's <p>) strip their attributes.
         priority: 1000,
+        // This rule also matches arbitrary pasted HTML (not just our own generated markup), so attributes are
+        // re-derived through the same DOMPurify sanitization as the markdown path rather than trusted as-is.
         getAttrs: (element) => {
-          const htmlAttrs = {};
-          [...element.attributes].forEach((attr) => {
-            if (attr.name !== TEXT_BLOCK_TAG_ATTR) {
-              htmlAttrs[attr.name] = attr.value;
-            }
-          });
+          const tag = (element.getAttribute(TEXT_BLOCK_TAG_ATTR) || element.tagName.toLowerCase()).toLowerCase();
+          if (NON_TEXT_BLOCK_TAGS.has(tag)) {
+            return false;
+          }
 
-          return {
-            tag: element.getAttribute(TEXT_BLOCK_TAG_ATTR) || element.tagName.toLowerCase(),
-            htmlAttrs
-          };
+          const sanitized = parseSimpleTextBlockElement(element.outerHTML);
+          if (!sanitized) {
+            return false;
+          }
+
+          const htmlAttrs = attributesToObject(sanitized, [TEXT_BLOCK_TAG_ATTR, ORIGINAL_HTML_ATTR]);
+          const originalHtml = resolveOriginalHtml(sanitized.getAttribute(ORIGINAL_HTML_ATTR), tag, htmlAttrs);
+
+          return { tag, htmlAttrs, originalHtml };
         }
       }
     ];
@@ -280,17 +330,17 @@ export const EditorRawHtmlTextBlock = Node.create({
     return {
       markdown: {
         serialize(state, node) {
-          const { tag, htmlAttrs } = node.attrs;
-          const attrs = Object.entries(htmlAttrs || {})
-            .map(([name, value]) => ` ${name}="${escapeHtmlAttrValue(value)}"`)
-            .join('');
+          const { tag, htmlAttrs, originalHtml } = node.attrs;
 
           let inner = '';
           node.forEach((child) => {
             inner += child.type.name === 'hardBreak' ? '<br>' : escapeHtmlText(child.text || '');
           });
 
-          state.write(`<${tag}${attrs}>${inner}</${tag}>`);
+          const originalElement = originalHtml ? parseSimpleTextBlockElement(originalHtml) : null;
+          const isUnedited = originalElement && serializeTextBlockContent(originalElement) === inner;
+
+          state.write(isUnedited ? originalHtml : `<${tag}${buildAttrString(htmlAttrs)}>${inner}</${tag}>`);
           state.closeBlock(node);
         },
         parse: {

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
@@ -74,8 +74,20 @@ const parseSimpleTextBlockElement = (html) => {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = DOMPurify.sanitize(html, SANITIZE_CONFIG);
 
-  const [element, ...rest] = wrapper.children;
-  if (!element || rest.length) {
+  let element = null;
+  for (const node of wrapper.childNodes) {
+    // Uses globalThis.Node (the DOM interface) since the module-level `Node` import above is @tiptap/core's schema Node class.
+    if (node.nodeType === globalThis.Node.ELEMENT_NODE) {
+      if (element) return null;
+      element = node;
+    } else if (node.nodeType === globalThis.Node.TEXT_NODE) {
+      if (node.textContent.trim() !== '') return null;
+    } else {
+      return null;
+    }
+  }
+
+  if (!element) {
     return null;
   }
 

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
@@ -3,6 +3,7 @@ import DOMPurify from 'dompurify';
 import runMarkdownitSetupOnce from '../../utils/markdownitSetupOnce';
 
 const RAW_HTML_BLOCK_ATTR = 'data-raw-html-block';
+const RAW_HTML_INLINE_ATTR = 'data-raw-html-inline';
 
 // This raw HTML is rendered straight into the page via `innerHTML`, not a
 // contained iframe/shadow DOM, so DOMPurify's default allowlist (which
@@ -15,6 +16,21 @@ const SANITIZE_CONFIG = { FORBID_TAGS: ['style'] };
 // hard break inside an (auto-wrapped) empty paragraph, not as opaque
 // raw HTML, so a blank line stays an editable paragraph on reload.
 const BLANK_LINE_MARKER_PATTERN = /^<br\s*\/?>$/i;
+
+// These inline tags are already consumed by something else in the pipeline
+// before an unrecognized tag would need to fall back to an opaque raw-HTML
+// atom: `br` -> EditorHardBreak, `kbd`/`sup` -> EditorInlineHtmlMarks (both
+// via their own parseHTML rule matching the literal tag), and `input` -> the
+// task-list checkbox that markdown-it-task-lists renders as inline HTML and
+// editorMarkdownParse's updateDOM reads directly off the DOM. Matching by tag
+// name (not the full tag string) so this still applies regardless of the
+// attributes markdown-it-task-lists puts on a given checkbox.
+const RECOGNIZED_INLINE_HTML_TAGS = new Set(['br', 'kbd', 'sup', 'input']);
+
+const getInlineHtmlTagName = (html) => {
+  const match = html.trim().match(/^<\/?([a-zA-Z][\w-]*)/);
+  return match ? match[1].toLowerCase() : null;
+};
 
 const encodeRawHtml = (html) => {
   try {
@@ -53,74 +69,124 @@ const setupRawHtmlBlockParser = (markdownit) => {
   });
 };
 
-const EditorRawHtmlBlock = Node.create({
-  name: 'rawHtmlBlock',
-  group: 'block',
-  atom: true,
-  selectable: true,
-  isolating: true,
+// Same rationale as setupRawHtmlBlockParser, but for inline HTML (<u>,
+// <span>, <mark>, <abbr>, …) that markdown-it tokenizes as html_inline —
+// without this, those tags have no schema mapping and silently disappear.
+// Registered separately from the block version (its own runMarkdownitSetupOnce
+// key) so each raw-HTML node only patches the renderer rule it actually needs.
+const setupRawHtmlInlineParser = (markdownit) => {
+  runMarkdownitSetupOnce(markdownit, '__docsRawHtmlInlinePatched', (md) => {
+    md.renderer.rules.html_inline = (tokens, idx) => {
+      const html = tokens[idx].content;
 
-  addAttributes() {
-    return {
-      html: {
-        default: ''
+      if (RECOGNIZED_INLINE_HTML_TAGS.has(getInlineHtmlTagName(html))) {
+        return html;
       }
+
+      return `<span ${RAW_HTML_INLINE_ATTR}="${encodeRawHtml(html)}"></span>`;
     };
-  },
+  });
+};
 
-  parseHTML() {
-    return [
-      {
-        tag: `div[${RAW_HTML_BLOCK_ATTR}]`,
-        getAttrs: (element) => ({
-          html: decodeRawHtml(element.getAttribute(RAW_HTML_BLOCK_ATTR))
-        })
-      }
-    ];
-  },
+// The block- and inline-level raw-HTML placeholders only differ in their tag,
+// attribute, grouping, and markdown wiring — everything else (encode/decode,
+// sanitized node view, update handling) is identical.
+const createRawHtmlNode = ({ name, tag, attr, className, extra, serialize, setupParser }) =>
+  Node.create({
+    name,
+    ...extra,
 
-  renderHTML({ node }) {
-    return ['div', { [RAW_HTML_BLOCK_ATTR]: encodeRawHtml(node.attrs.html) }];
-  },
-
-  addNodeView() {
-    return ({ node }) => {
-      const dom = document.createElement('div');
-      dom.className = 'editor-raw-html-block';
-      dom.contentEditable = 'false';
-      dom.setAttribute(RAW_HTML_BLOCK_ATTR, encodeRawHtml(node.attrs.html));
-      dom.innerHTML = DOMPurify.sanitize(node.attrs.html, SANITIZE_CONFIG);
-
+    addAttributes() {
       return {
-        dom,
-        update: (updatedNode) => {
-          if (updatedNode.type.name !== 'rawHtmlBlock') {
-            return false;
-          }
-
-          dom.setAttribute(RAW_HTML_BLOCK_ATTR, encodeRawHtml(updatedNode.attrs.html));
-          dom.innerHTML = DOMPurify.sanitize(updatedNode.attrs.html);
-          return true;
+        html: {
+          default: ''
         }
       };
-    };
-  },
+    },
 
-  addStorage() {
-    return {
-      markdown: {
-        serialize(state, node) {
-          state.write(node.attrs.html);
-          state.closeBlock(node);
-        },
-        parse: {
-          setup(markdownit) {
-            setupRawHtmlBlockParser(markdownit);
+    parseHTML() {
+      return [
+        {
+          tag: `${tag}[${attr}]`,
+          getAttrs: (element) => ({
+            html: decodeRawHtml(element.getAttribute(attr))
+          })
+        }
+      ];
+    },
+
+    renderHTML({ node }) {
+      return [tag, { [attr]: encodeRawHtml(node.attrs.html) }];
+    },
+
+    addNodeView() {
+      return ({ node }) => {
+        const dom = document.createElement(tag);
+        dom.className = className;
+        dom.contentEditable = 'false';
+        dom.setAttribute(attr, encodeRawHtml(node.attrs.html));
+        dom.innerHTML = DOMPurify.sanitize(node.attrs.html, SANITIZE_CONFIG);
+
+        return {
+          dom,
+          update: (updatedNode) => {
+            if (updatedNode.type.name !== name) {
+              return false;
+            }
+
+            dom.setAttribute(attr, encodeRawHtml(updatedNode.attrs.html));
+            dom.innerHTML = DOMPurify.sanitize(updatedNode.attrs.html, SANITIZE_CONFIG);
+            return true;
+          }
+        };
+      };
+    },
+
+    addStorage() {
+      return {
+        markdown: {
+          serialize,
+          parse: {
+            setup: setupParser
           }
         }
-      }
-    };
-  }
+      };
+    }
+  });
+
+const EditorRawHtmlBlock = createRawHtmlNode({
+  name: 'rawHtmlBlock',
+  tag: 'div',
+  attr: RAW_HTML_BLOCK_ATTR,
+  className: 'editor-raw-html-block',
+  extra: {
+    group: 'block',
+    atom: true,
+    selectable: true,
+    isolating: true
+  },
+  serialize(state, node) {
+    state.write(node.attrs.html);
+    state.closeBlock(node);
+  },
+  setupParser: setupRawHtmlBlockParser
+});
+
+export const EditorRawHtmlInline = createRawHtmlNode({
+  name: 'rawHtmlInline',
+  tag: 'span',
+  attr: RAW_HTML_INLINE_ATTR,
+  className: 'editor-raw-html-inline',
+  extra: {
+    group: 'inline',
+    inline: true,
+    atom: true,
+    selectable: true
+  },
+  serialize(state, node) {
+    state.write(node.attrs.html);
+  },
+  setupParser: setupRawHtmlInlineParser
 });
 
 export default EditorRawHtmlBlock;

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/EditorRawHtmlBlock/index.js
@@ -4,32 +4,75 @@ import runMarkdownitSetupOnce from '../../utils/markdownitSetupOnce';
 
 const RAW_HTML_BLOCK_ATTR = 'data-raw-html-block';
 const RAW_HTML_INLINE_ATTR = 'data-raw-html-inline';
+const TEXT_BLOCK_TAG_ATTR = 'data-raw-html-text-block';
 
-// This raw HTML is rendered straight into the page via `innerHTML`, not a
-// contained iframe/shadow DOM, so DOMPurify's default allowlist (which
-// permits <style>) would let an untrusted collection's docs inject CSS rules
-// that affect the whole app UI, not just this block.
+// We forbid <style> in DOMPurify to prevent untrusted docs from injecting CSS that affects the whole app UI.
 const SANITIZE_CONFIG = { FORBID_TAGS: ['style'] };
 
-// A standalone `<br/>` is how an empty paragraph marks itself for
-// reparse (see EditorParagraph's serializer) — treat it as an ordinary
-// hard break inside an (auto-wrapped) empty paragraph, not as opaque
-// raw HTML, so a blank line stays an editable paragraph on reload.
+// A standalone <br/> marks an empty paragraph; treating it as a hard break ensures blank lines remain editable paragraphs.
 const BLANK_LINE_MARKER_PATTERN = /^<br\s*\/?>$/i;
 
-// These inline tags are already consumed by something else in the pipeline
-// before an unrecognized tag would need to fall back to an opaque raw-HTML
-// atom: `br` -> EditorHardBreak, `kbd`/`sup` -> EditorInlineHtmlMarks (both
-// via their own parseHTML rule matching the literal tag), and `input` -> the
-// task-list checkbox that markdown-it-task-lists renders as inline HTML and
-// editorMarkdownParse's updateDOM reads directly off the DOM. Matching by tag
-// name (not the full tag string) so this still applies regardless of the
-// attributes markdown-it-task-lists puts on a given checkbox.
-const RECOGNIZED_INLINE_HTML_TAGS = new Set(['br', 'kbd', 'sup', 'input']);
+// Recognized inline tags bypass the raw HTML atom wrapper so their dedicated parseHTML rules can still process them natively.
+const RECOGNIZED_INLINE_HTML_TAGS = new Set([
+  'br', 'kbd', 'sup', 'a',
+  'strong', 'b', 'em', 'i', 's', 'del', 'strike', 'code'
+]);
+
+// Task list checkboxes are passed through as plain HTML since updateDOM reads them directly; all other <input> tags remain opaque raw-HTML atoms.
+const TASK_LIST_CHECKBOX_PATTERN = /^<input\b[^>]*\btype="checkbox"/i;
 
 const getInlineHtmlTagName = (html) => {
   const match = html.trim().match(/^<\/?([a-zA-Z][\w-]*)/);
   return match ? match[1].toLowerCase() : null;
+};
+
+const isRecognizedInlineHtml = (html) => {
+  const trimmed = html.trim();
+  const tagName = getInlineHtmlTagName(trimmed);
+
+  if (RECOGNIZED_INLINE_HTML_TAGS.has(tagName)) {
+    return true;
+  }
+
+  return tagName === 'input' && TASK_LIST_CHECKBOX_PATTERN.test(trimmed);
+};
+
+// Self-contained widgets (video, forms, tables) stay fully opaque. Other block tags (div, p) can become editable text blocks if they sanitize down to plain text.
+const NON_TEXT_BLOCK_TAGS = new Set([
+  'video', 'audio', 'iframe', 'embed', 'object', 'canvas', 'svg',
+  'source', 'track', 'map', 'area',
+  'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'colgroup', 'col',
+  'form', 'input', 'button', 'select', 'option', 'optgroup', 'textarea', 'label', 'fieldset', 'legend',
+  'script', 'style', 'noscript',
+  'details', 'summary',
+  'hr'
+]);
+
+const escapeHtmlText = (text) => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const escapeHtmlAttrValue = (value) => escapeHtmlText(value).replace(/"/g, '&quot;');
+
+// Returns the top-level element if it sanitizes down to a single wrapper with only plain text and <br>s; otherwise returns null to fall back to an opaque raw-HTML atom.
+const parseSimpleTextBlockElement = (html) => {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = DOMPurify.sanitize(html, SANITIZE_CONFIG);
+
+  const [element, ...rest] = wrapper.children;
+  if (!element || rest.length) {
+    return null;
+  }
+
+  const hasOnlyLineBreakChildren = [...element.children].every((child) => child.tagName === 'BR');
+  return hasOnlyLineBreakChildren ? element : null;
+};
+
+// Serializes text and hardBreaks for rawHtmlTextBlock, explicitly converting hardBreaks to <br> so they aren't silently dropped.
+const serializeTextBlockContent = (element) => {
+  let inner = '';
+  element.childNodes.forEach((child) => {
+    inner += child.tagName === 'BR' ? '<br>' : escapeHtmlText(child.textContent || '');
+  });
+  return inner;
 };
 
 const encodeRawHtml = (html) => {
@@ -48,13 +91,7 @@ const decodeRawHtml = (encoded) => {
   }
 };
 
-// markdown-it's default html_block rule writes the raw HTML straight through
-// to the rendered HTML string, but the editor's ProseMirror schema only knows
-// how to build nodes for tags it has a parseHTML rule for — so arbitrary raw
-// HTML (<details>, <video>, <iframe>, comments, …) never becomes a node and
-// silently disappears. Rendering every html_block token as this placeholder
-// (matched by rawHtmlBlock's parseHTML below) guarantees it always survives
-// as an opaque node instead, regardless of which tag it contains.
+// Wraps html_block tokens in placeholders to guarantee arbitrary raw HTML survives as an opaque node rather than silently disappearing during parsing.
 const setupRawHtmlBlockParser = (markdownit) => {
   runMarkdownitSetupOnce(markdownit, '__docsRawHtmlBlockPatched', (md) => {
     md.renderer.rules.html_block = (tokens, idx) => {
@@ -64,22 +101,29 @@ const setupRawHtmlBlockParser = (markdownit) => {
         return html;
       }
 
+      const textBlockElement = parseSimpleTextBlockElement(html);
+      const tagName = textBlockElement?.tagName.toLowerCase();
+
+      if (textBlockElement && !NON_TEXT_BLOCK_TAGS.has(tagName)) {
+        const attrs = [...textBlockElement.attributes]
+          .map((attr) => ` ${attr.name}="${escapeHtmlAttrValue(attr.value)}"`)
+          .join('');
+
+        return `<${tagName} ${TEXT_BLOCK_TAG_ATTR}="${tagName}"${attrs}>${serializeTextBlockContent(textBlockElement)}</${tagName}>`;
+      }
+
       return `<div ${RAW_HTML_BLOCK_ATTR}="${encodeRawHtml(html)}"></div>`;
     };
   });
 };
 
-// Same rationale as setupRawHtmlBlockParser, but for inline HTML (<u>,
-// <span>, <mark>, <abbr>, …) that markdown-it tokenizes as html_inline —
-// without this, those tags have no schema mapping and silently disappear.
-// Registered separately from the block version (its own runMarkdownitSetupOnce
-// key) so each raw-HTML node only patches the renderer rule it actually needs.
+// Wraps html_inline tokens in placeholders so unrecognized inline tags survive as opaque nodes rather than silently disappearing.
 const setupRawHtmlInlineParser = (markdownit) => {
   runMarkdownitSetupOnce(markdownit, '__docsRawHtmlInlinePatched', (md) => {
     md.renderer.rules.html_inline = (tokens, idx) => {
       const html = tokens[idx].content;
 
-      if (RECOGNIZED_INLINE_HTML_TAGS.has(getInlineHtmlTagName(html))) {
+      if (isRecognizedInlineHtml(html)) {
         return html;
       }
 
@@ -88,9 +132,7 @@ const setupRawHtmlInlineParser = (markdownit) => {
   });
 };
 
-// The block- and inline-level raw-HTML placeholders only differ in their tag,
-// attribute, grouping, and markdown wiring — everything else (encode/decode,
-// sanitized node view, update handling) is identical.
+// Shared factory for raw HTML nodes, as block and inline placeholders only differ in tags, attributes, and markdown wiring.
 const createRawHtmlNode = ({ name, tag, attr, className, extra, serialize, setupParser }) =>
   Node.create({
     name,
@@ -187,6 +229,78 @@ export const EditorRawHtmlInline = createRawHtmlNode({
     state.write(node.attrs.html);
   },
   setupParser: setupRawHtmlInlineParser
+});
+
+// Editable HTML block that sanitizes to plain text. The original tag and attributes are preserved on the node to ensure they round-trip properly.
+export const EditorRawHtmlTextBlock = Node.create({
+  name: 'rawHtmlTextBlock',
+  group: 'block',
+  // Allows text and hardBreak so Shift+Enter works, but excludes marks. Not isolated to allow HardBreak's command to insert line breaks.
+  content: '(text|hardBreak)*',
+
+  addAttributes() {
+    return {
+      tag: {
+        default: 'div'
+      },
+      htmlAttrs: {
+        default: {}
+      }
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: `[${TEXT_BLOCK_TAG_ATTR}]`,
+        // Uses high priority so this rule claims marked text blocks before native node rules (like paragraph's <p>) strip their attributes.
+        priority: 1000,
+        getAttrs: (element) => {
+          const htmlAttrs = {};
+          [...element.attributes].forEach((attr) => {
+            if (attr.name !== TEXT_BLOCK_TAG_ATTR) {
+              htmlAttrs[attr.name] = attr.value;
+            }
+          });
+
+          return {
+            tag: element.getAttribute(TEXT_BLOCK_TAG_ATTR) || element.tagName.toLowerCase(),
+            htmlAttrs
+          };
+        }
+      }
+    ];
+  },
+
+  renderHTML({ node }) {
+    return [node.attrs.tag, { [TEXT_BLOCK_TAG_ATTR]: node.attrs.tag, ...node.attrs.htmlAttrs }, 0];
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state, node) {
+          const { tag, htmlAttrs } = node.attrs;
+          const attrs = Object.entries(htmlAttrs || {})
+            .map(([name, value]) => ` ${name}="${escapeHtmlAttrValue(value)}"`)
+            .join('');
+
+          let inner = '';
+          node.forEach((child) => {
+            inner += child.type.name === 'hardBreak' ? '<br>' : escapeHtmlText(child.text || '');
+          });
+
+          state.write(`<${tag}${attrs}>${inner}</${tag}>`);
+          state.closeBlock(node);
+        },
+        parse: {
+          setup(markdownit) {
+            setupRawHtmlBlockParser(markdownit);
+          }
+        }
+      }
+    };
+  }
 });
 
 export default EditorRawHtmlBlock;

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
@@ -8,7 +8,7 @@ import { EditorKbd, EditorSuperscript } from './EditorInlineHtmlMarks';
 import EditorListKeyboard from './EditorListKeyboard';
 import EditorParagraph from './EditorParagraph';
 import { createEditorImage, createEditorLink } from './EditorRelativeAssets';
-import EditorRawHtmlBlock from './EditorRawHtmlBlock';
+import EditorRawHtmlBlock, { EditorRawHtmlInline } from './EditorRawHtmlBlock';
 import EditorTable from './EditorTable';
 import { EditorTableCell, EditorTableHeader } from './EditorTableAlignment';
 import EditorTableKeyboard from './EditorTableKeyboard';
@@ -103,7 +103,7 @@ const createExtensions = ({ allowHtml = true, collectionPath = '' } = {}) => [
     }
   }),
   EditorTableKeyboard,
-  ...(allowHtml ? [EditorRawHtmlBlock] : []),
+  ...(allowHtml ? [EditorRawHtmlBlock, EditorRawHtmlInline] : []),
   EditorKbd,
   EditorSuperscript,
   createEditorLink(collectionPath).configure({
@@ -118,7 +118,15 @@ const createExtensions = ({ allowHtml = true, collectionPath = '' } = {}) => [
   }),
   Markdown.configure({
     html: allowHtml,
-    breaks: true,
+    // A lone `\n` inside a paragraph is a CommonMark soft break (renders as a
+    // space), not a line break. With `breaks: true`, tiptap-markdown parses
+    // it as a hardBreak node instead, and EditorHardBreak's serializer then
+    // writes that back out as an explicit `\` line-continuation — so loading
+    // and re-saving any doc with hand-wrapped prose silently turned every
+    // wrapped line into a forced break. `breaks: false` keeps soft breaks as
+    // plain reflowable text, matching how any other CommonMark renderer
+    // (e.g. GitHub) would display the same file.
+    breaks: false,
     linkify: true,
     transformPastedText: true,
     transformCopiedText: true,

--- a/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/extensions/index.js
@@ -8,7 +8,7 @@ import { EditorKbd, EditorSuperscript } from './EditorInlineHtmlMarks';
 import EditorListKeyboard from './EditorListKeyboard';
 import EditorParagraph from './EditorParagraph';
 import { createEditorImage, createEditorLink } from './EditorRelativeAssets';
-import EditorRawHtmlBlock, { EditorRawHtmlInline } from './EditorRawHtmlBlock';
+import EditorRawHtmlBlock, { EditorRawHtmlInline, EditorRawHtmlTextBlock } from './EditorRawHtmlBlock';
 import EditorTable from './EditorTable';
 import { EditorTableCell, EditorTableHeader } from './EditorTableAlignment';
 import EditorTableKeyboard from './EditorTableKeyboard';
@@ -103,7 +103,7 @@ const createExtensions = ({ allowHtml = true, collectionPath = '' } = {}) => [
     }
   }),
   EditorTableKeyboard,
-  ...(allowHtml ? [EditorRawHtmlBlock, EditorRawHtmlInline] : []),
+  ...(allowHtml ? [EditorRawHtmlBlock, EditorRawHtmlInline, EditorRawHtmlTextBlock] : []),
   EditorKbd,
   EditorSuperscript,
   createEditorLink(collectionPath).configure({
@@ -118,22 +118,12 @@ const createExtensions = ({ allowHtml = true, collectionPath = '' } = {}) => [
   }),
   Markdown.configure({
     html: allowHtml,
-    // A lone `\n` inside a paragraph is a CommonMark soft break (renders as a
-    // space), not a line break. With `breaks: true`, tiptap-markdown parses
-    // it as a hardBreak node instead, and EditorHardBreak's serializer then
-    // writes that back out as an explicit `\` line-continuation — so loading
-    // and re-saving any doc with hand-wrapped prose silently turned every
-    // wrapped line into a forced break. `breaks: false` keeps soft breaks as
-    // plain reflowable text, matching how any other CommonMark renderer
-    // (e.g. GitHub) would display the same file.
+    // We disable 'breaks' so soft breaks aren't promoted to hard breaks, preventing hand-wrapped lines from being rewritten with escapes.
     breaks: false,
     linkify: true,
     transformPastedText: true,
     transformCopiedText: true,
-    // The parsed ProseMirror bulletList node has no memory of whether the
-    // source used `-`, `*`, or `+` — the marker carries no semantic meaning,
-    // so serialization always normalizes to one consistent marker rather than
-    // reading this option from an unset config (which read as accidental).
+    // ProseMirror bulletList nodes don't retain the original source marker, so serialization normalizes to a single consistent marker.
     bulletListMarker: '-'
   })
 ];

--- a/packages/bruno-app/src/ui/RichTextEditor/utils/editorMarkdownSerialize.spec.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/utils/editorMarkdownSerialize.spec.js
@@ -1,9 +1,10 @@
 import { Editor } from '@tiptap/core';
 import createExtensions from '../extensions';
 
+// Excluding rawHtmlBlock or rawHtmlTextBlock alone leaves html_block content orphaned since they share a patched renderer.
 const createEditor = (content) =>
   new Editor({
-    extensions: createExtensions().filter((ext) => ext.name !== 'rawHtmlBlock'),
+    extensions: createExtensions().filter((ext) => !['rawHtmlBlock', 'rawHtmlTextBlock'].includes(ext.name)),
     content
   });
 
@@ -307,5 +308,144 @@ describe('Editor markdown serialization', () => {
     const markdown = getMarkdown(editor);
     expect(markdown).toContain('```javascript');
     expect(markdown).toContain('const x = 1;');
+  });
+
+  it('parses literal inline HTML formatting tags into their marks, not raw HTML', () => {
+    editor = createEditor('');
+    editor.commands.setContent('Some <b>bold</b>, <em>italic</em>, <s>struck</s> and <code>code</code> text.');
+
+    expect(editor.getHTML()).not.toContain('data-raw-html-inline');
+
+    let boldCount = 0;
+    let italicCount = 0;
+    let strikeCount = 0;
+    let codeCount = 0;
+    editor.state.doc.descendants((node) => {
+      const markNames = node.marks?.map((mark) => mark.type.name) || [];
+      if (markNames.includes('bold')) boldCount += 1;
+      if (markNames.includes('italic')) italicCount += 1;
+      if (markNames.includes('strike')) strikeCount += 1;
+      if (markNames.includes('code')) codeCount += 1;
+    });
+
+    expect(boldCount).toBe(1);
+    expect(italicCount).toBe(1);
+    expect(strikeCount).toBe(1);
+    expect(codeCount).toBe(1);
+  });
+
+  it('preserves a non-checkbox input as opaque raw HTML instead of a task-list checkbox', () => {
+    editor = createEditor('');
+    editor.commands.setContent('Enter your name: <input type="text" placeholder="Name">');
+
+    let rawHtmlInlineCount = 0;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'rawHtmlInline') {
+        rawHtmlInlineCount += 1;
+        expect(node.attrs.html).toContain('type="text"');
+      }
+    });
+
+    expect(rawHtmlInlineCount).toBe(1);
+
+    const markdown = getMarkdown(editor);
+    expect(markdown).toContain('<input type="text" placeholder="Name">');
+  });
+
+  describe('raw HTML text blocks', () => {
+    // These exercise rawHtmlTextBlock directly, requiring it in the schema unlike createEditor() which excludes it for its fixtures.
+    const createFullEditor = (content) => new Editor({ extensions: createExtensions(), content });
+
+    it('makes a plain-text <div>/<p> an editable node instead of an opaque atom, preserving its attributes', () => {
+      editor = createFullEditor('Before.\n\n<div class="note">Some plain text</div>\n\nAfter.');
+
+      let textBlockNode = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'rawHtmlTextBlock') {
+          textBlockNode = node;
+        }
+      });
+
+      expect(textBlockNode).not.toBeNull();
+      expect(editor.schema.nodes.rawHtmlTextBlock.isAtom).toBe(false);
+      expect(textBlockNode.attrs).toEqual({ tag: 'div', htmlAttrs: { class: 'note' } });
+      expect(textBlockNode.textContent).toBe('Some plain text');
+
+      expect(getMarkdown(editor)).toBe('Before.\n\n<div class="note">Some plain text</div>\n\nAfter.');
+    });
+
+    it('strips dangerous attributes from a text block before they reach the DOM', () => {
+      editor = createFullEditor('<div onclick="alert(1)" class="note">text</div>');
+
+      let textBlockNode = null;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'rawHtmlTextBlock') {
+          textBlockNode = node;
+        }
+      });
+
+      expect(textBlockNode).not.toBeNull();
+      expect(textBlockNode.attrs.htmlAttrs).not.toHaveProperty('onclick');
+      expect(textBlockNode.attrs.htmlAttrs).toEqual({ class: 'note' });
+    });
+
+    it('falls back to the opaque raw-HTML atom when a block tag has nested elements', () => {
+      editor = createFullEditor('<div>Has <b>nested</b> markup</div>');
+
+      let rawHtmlBlockCount = 0;
+      let rawHtmlTextBlockCount = 0;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'rawHtmlBlock') rawHtmlBlockCount += 1;
+        if (node.type.name === 'rawHtmlTextBlock') rawHtmlTextBlockCount += 1;
+      });
+
+      expect(rawHtmlBlockCount).toBe(1);
+      expect(rawHtmlTextBlockCount).toBe(0);
+      expect(getMarkdown(editor)).toBe('<div>Has <b>nested</b> markup</div>');
+    });
+
+    it('edits a text block in place and round-trips the change', () => {
+      editor = createFullEditor('<div class="note">Some plain text</div>');
+
+      let textBlockPos = null;
+      editor.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'rawHtmlTextBlock') {
+          textBlockPos = pos;
+        }
+      });
+
+      editor.commands.insertContentAt(textBlockPos + 1 + 'Some plain text'.length, ' EDITED');
+
+      expect(getMarkdown(editor)).toBe('<div class="note">Some plain text EDITED</div>');
+    });
+
+    it('preserves a <br> line break inside a text block on parse, edit, and round-trip', () => {
+      editor = createFullEditor('<div class="note">Line one<br>Line two</div>');
+
+      let textBlockNode = null;
+      let textBlockPos = null;
+      editor.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'rawHtmlTextBlock') {
+          textBlockNode = node;
+          textBlockPos = pos;
+        }
+      });
+
+      expect(textBlockNode).not.toBeNull();
+      const childTypes = [];
+      textBlockNode.forEach((child) => childTypes.push(child.type.name));
+      expect(childTypes).toEqual(['text', 'hardBreak', 'text']);
+      expect(getMarkdown(editor)).toBe('<div class="note">Line one<br>Line two</div>');
+
+      // setHardBreak explicitly catches isolating node issues since it refuses to insert there, unlike raw insertContentAt.
+      const insertAt = textBlockPos + 1 + 'Line one'.length;
+      editor.commands.setTextSelection(insertAt);
+      expect(editor.can().setHardBreak()).toBe(true);
+
+      const inserted = editor.commands.setHardBreak();
+
+      expect(inserted).toBe(true);
+      expect(getMarkdown(editor)).toBe('<div class="note">Line one<br><br>Line two</div>');
+    });
   });
 });

--- a/packages/bruno-app/src/ui/RichTextEditor/utils/editorMarkdownSerialize.spec.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/utils/editorMarkdownSerialize.spec.js
@@ -1,5 +1,15 @@
 import { Editor } from '@tiptap/core';
+import { DOMParser as ProseMirrorDOMParser } from 'prosemirror-model';
 import createExtensions from '../extensions';
+
+// Mirrors what ProseMirror's own paste handling does with clipboard HTML: parses a raw DOM
+// element straight through the schema's parseHTML rules, bypassing the markdown-it pipeline
+// (and its DOMPurify sanitization) entirely.
+const parsePastedHtml = (editor, html) => {
+  const dom = document.createElement('div');
+  dom.innerHTML = html;
+  return ProseMirrorDOMParser.fromSchema(editor.schema).parseSlice(dom, { preserveWhitespace: true });
+};
 
 // Excluding rawHtmlBlock or rawHtmlTextBlock alone leaves html_block content orphaned since they share a patched renderer.
 const createEditor = (content) =>
@@ -303,6 +313,20 @@ describe('Editor markdown serialization', () => {
     expect(markdown).toMatch(/line two/);
   });
 
+  it('reflows a hand-wrapped single-newline paragraph onto one line instead of treating it as a hard break', () => {
+    editor = createEditor('Line one\nLine two');
+
+    let hardBreakCount = 0;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'hardBreak') {
+        hardBreakCount += 1;
+      }
+    });
+
+    expect(hardBreakCount).toBe(0);
+    expect(getMarkdown(editor)).toBe('Line one Line two');
+  });
+
   it('serializes code blocks with language', () => {
     editor = createEditor('<pre><code class="language-javascript">const x = 1;</code></pre>');
     const markdown = getMarkdown(editor);
@@ -352,6 +376,20 @@ describe('Editor markdown serialization', () => {
     expect(markdown).toContain('<input type="text" placeholder="Name">');
   });
 
+  it('recognizes a single-quoted checkbox input as inline HTML too, not just the double-quoted form', () => {
+    editor = createEditor('');
+    editor.commands.setContent('Check this: <input type=\'checkbox\'>');
+
+    let rawHtmlInlineCount = 0;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'rawHtmlInline') {
+        rawHtmlInlineCount += 1;
+      }
+    });
+
+    expect(rawHtmlInlineCount).toBe(0);
+  });
+
   describe('raw HTML text blocks', () => {
     // These exercise rawHtmlTextBlock directly, requiring it in the schema unlike createEditor() which excludes it for its fixtures.
     const createFullEditor = (content) => new Editor({ extensions: createExtensions(), content });
@@ -368,10 +406,33 @@ describe('Editor markdown serialization', () => {
 
       expect(textBlockNode).not.toBeNull();
       expect(editor.schema.nodes.rawHtmlTextBlock.isAtom).toBe(false);
-      expect(textBlockNode.attrs).toEqual({ tag: 'div', htmlAttrs: { class: 'note' } });
+      expect(textBlockNode.attrs.tag).toBe('div');
+      expect(textBlockNode.attrs.htmlAttrs).toEqual({ class: 'note' });
       expect(textBlockNode.textContent).toBe('Some plain text');
 
       expect(getMarkdown(editor)).toBe('Before.\n\n<div class="note">Some plain text</div>\n\nAfter.');
+    });
+
+    it('preserves a legacy block\'s exact original bytes on round-trip when it is never edited', () => {
+      const legacySource = 'Before.\n\n<DIV CLASS=\'note\'>Some &amp; plain text</DIV>\n\nAfter.';
+      editor = createFullEditor(legacySource);
+
+      expect(getMarkdown(editor)).toBe(legacySource);
+    });
+
+    it('reconstructs a legacy block\'s markup only once its content is actually edited', () => {
+      editor = createFullEditor('<DIV CLASS=\'note\'>Some plain text</DIV>');
+
+      let textBlockPos = null;
+      editor.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'rawHtmlTextBlock') {
+          textBlockPos = pos;
+        }
+      });
+
+      editor.commands.insertContentAt(textBlockPos + 1 + 'Some plain text'.length, ' EDITED');
+
+      expect(getMarkdown(editor)).toBe('<div class="note">Some plain text EDITED</div>');
     });
 
     it('strips dangerous attributes from a text block before they reach the DOM', () => {
@@ -387,6 +448,78 @@ describe('Editor markdown serialization', () => {
       expect(textBlockNode).not.toBeNull();
       expect(textBlockNode.attrs.htmlAttrs).not.toHaveProperty('onclick');
       expect(textBlockNode.attrs.htmlAttrs).toEqual({ class: 'note' });
+    });
+
+    it('strips a dangerous attribute from HTML parsed directly by the schema, as ProseMirror does for clipboard paste', () => {
+      editor = createFullEditor('');
+
+      const slice = parsePastedHtml(
+        editor,
+        '<div data-raw-html-text-block="div" onerror="alert(1)" class="note">payload</div>'
+      );
+
+      let textBlockNode = null;
+      slice.content.descendants((node) => {
+        if (node.type.name === 'rawHtmlTextBlock') {
+          textBlockNode = node;
+        }
+      });
+
+      expect(textBlockNode).not.toBeNull();
+      expect(textBlockNode.attrs.htmlAttrs).not.toHaveProperty('onerror');
+      expect(textBlockNode.attrs.htmlAttrs).toEqual({ class: 'note' });
+    });
+
+    it('refuses to substitute a dangerous tag via the marker attribute on pasted HTML', () => {
+      editor = createFullEditor('');
+
+      const slice = parsePastedHtml(editor, '<div data-raw-html-text-block="script">alert(1)</div>');
+
+      let scriptTextBlockNode = null;
+      slice.content.descendants((node) => {
+        if (node.type.name === 'rawHtmlTextBlock' && node.attrs.tag === 'script') {
+          scriptTextBlockNode = node;
+        }
+      });
+
+      expect(scriptTextBlockNode).toBeNull();
+    });
+
+    it('does not trust an original-bytes payload whose attributes don\'t match the sanitized element', () => {
+      editor = createFullEditor('');
+
+      const forgedOriginal = Buffer.from('<div class="different">payload</div>', 'utf-8').toString('base64');
+      const slice = parsePastedHtml(
+        editor,
+        `<div data-raw-html-text-block="div" data-raw-html-original="${forgedOriginal}" class="note">payload</div>`
+      );
+
+      let textBlockNode = null;
+      slice.content.descendants((node) => {
+        if (node.type.name === 'rawHtmlTextBlock') {
+          textBlockNode = node;
+        }
+      });
+
+      expect(textBlockNode).not.toBeNull();
+      expect(textBlockNode.attrs.originalHtml).toBeNull();
+    });
+
+    it('never serializes smuggled original-bytes content that differs from the actual pasted text', () => {
+      editor = createFullEditor('');
+
+      const forgedOriginal = Buffer.from('<div class="note">forged</div>', 'utf-8').toString('base64');
+      const slice = parsePastedHtml(
+        editor,
+        `<div data-raw-html-text-block="div" data-raw-html-original="${forgedOriginal}" class="note">payload</div>`
+      );
+
+      const tr = editor.state.tr.replaceWith(0, editor.state.doc.content.size, slice.content);
+      editor.view.dispatch(tr);
+
+      const markdown = getMarkdown(editor);
+      expect(markdown).toContain('payload');
+      expect(markdown).not.toContain('forged');
     });
 
     it('falls back to the opaque raw-HTML atom when a block tag has nested elements', () => {

--- a/packages/bruno-app/src/ui/RichTextEditor/utils/editorMarkdownSerialize.spec.js
+++ b/packages/bruno-app/src/ui/RichTextEditor/utils/editorMarkdownSerialize.spec.js
@@ -378,16 +378,22 @@ describe('Editor markdown serialization', () => {
 
   it('recognizes a single-quoted checkbox input as inline HTML too, not just the double-quoted form', () => {
     editor = createEditor('');
-    editor.commands.setContent('Check this: <input type=\'checkbox\'>');
+    editor.commands.setContent('<ul data-type="taskList"><li class="task-list-item"><input type=\'checkbox\'> open</li></ul>');
 
     let rawHtmlInlineCount = 0;
+    let taskItemCount = 0;
     editor.state.doc.descendants((node) => {
       if (node.type.name === 'rawHtmlInline') {
         rawHtmlInlineCount += 1;
       }
+      if (node.type.name === 'taskItem') {
+        taskItemCount += 1;
+      }
     });
 
     expect(rawHtmlInlineCount).toBe(0);
+    expect(taskItemCount).toBe(1);
+    expect(getMarkdown(editor)).toMatch(/- \[ \] open/);
   });
 
   describe('raw HTML text blocks', () => {
@@ -535,6 +541,21 @@ describe('Editor markdown serialization', () => {
       expect(rawHtmlBlockCount).toBe(1);
       expect(rawHtmlTextBlockCount).toBe(0);
       expect(getMarkdown(editor)).toBe('<div>Has <b>nested</b> markup</div>');
+    });
+
+    it('falls back to the opaque raw-HTML atom instead of silently dropping stray text beside the tag', () => {
+      editor = createFullEditor('<div class="note">Some plain text</div> stray');
+
+      let rawHtmlBlockCount = 0;
+      let rawHtmlTextBlockCount = 0;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'rawHtmlBlock') rawHtmlBlockCount += 1;
+        if (node.type.name === 'rawHtmlTextBlock') rawHtmlTextBlockCount += 1;
+      });
+
+      expect(rawHtmlBlockCount).toBe(1);
+      expect(rawHtmlTextBlockCount).toBe(0);
+      expect(getMarkdown(editor)).toContain('<div class="note">Some plain text</div> stray');
     });
 
     it('edits a text block in place and round-trips the change', () => {

--- a/tests/richtext-editor/actions.ts
+++ b/tests/richtext-editor/actions.ts
@@ -85,6 +85,18 @@ export const getMarkdownSource = async (locators: DocsLocators): Promise<string>
   return codeEditor.evaluate((el) => (el.closest('.CodeMirror') as any).CodeMirror.getValue());
 };
 
+// Dispatches a synthetic clipboard paste event (plain text) to the Rich Text editor since Playwright has no OS clipboard.
+export const pasteIntoRichTextEditor = async (locators: DocsLocators, text: string) => {
+  const prosemirror = locators.docs.proseMirror();
+  await expect(prosemirror).toBeVisible();
+  await prosemirror.click();
+  await prosemirror.evaluate((el, pastedText) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData('text/plain', pastedText);
+    el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dataTransfer, bubbles: true, cancelable: true }));
+  }, text);
+};
+
 export const clickDocsToolbarBtn = async (locators: DocsLocators, label: string) => {
   const btn = locators.docs.toolbarBtn(label);
   const overflowMenuTrigger = locators.docs.overflowMenuTrigger();

--- a/tests/richtext-editor/raw-html-passthrough.spec.ts
+++ b/tests/richtext-editor/raw-html-passthrough.spec.ts
@@ -160,7 +160,7 @@ test.describe('Rich Text Editor Edge Cases - Raw HTML Passthrough', () => {
 
       await expect(textBlock.locator('br')).toHaveCount(1);
       // Still one block-level div, not split into two.
-      await expect(prosemirror.locator('div.note')).toHaveCount(1);
+      await expect(textBlock).toHaveCount(1);
     });
 
     await test.step('The edit round-trips, still wrapped in the original tag and attributes', async () => {

--- a/tests/richtext-editor/raw-html-passthrough.spec.ts
+++ b/tests/richtext-editor/raw-html-passthrough.spec.ts
@@ -116,4 +116,59 @@ test.describe('Rich Text Editor Edge Cases - Raw HTML Passthrough', () => {
       expect(roundTripped).toContain('[x] Task done');
     });
   });
+
+  const TEXT_BLOCK_MARKDOWN_SOURCE = [
+    'Before the block.',
+    '',
+    '<div class="note">Some plain text</div>',
+    '',
+    'After the block.',
+    ''
+  ].join('\n');
+
+  test('A plain-text block tag like <div> is editable in place, unlike a non-text raw HTML block', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-text-block');
+
+    await setMarkdownSource(locators, TEXT_BLOCK_MARKDOWN_SOURCE);
+
+    await locators.docs.modeSwitchDocs().click();
+    const prosemirror = locators.docs.proseMirror();
+    await expect(prosemirror).toBeVisible();
+
+    const textBlock = prosemirror.locator('div.note');
+
+    await test.step('The <div> renders as real, editable content, not an opaque atom', async () => {
+      await expect(textBlock).toHaveText('Some plain text');
+      await expect(textBlock).not.toHaveClass(/editor-raw-html-block/);
+      // The opaque raw-HTML atom explicitly sets contentEditable="false"; this
+      // node never does, so it inherits editability from the ProseMirror root.
+      await expect(textBlock).not.toHaveAttribute('contenteditable', 'false');
+    });
+
+    await test.step('Typing inside it actually edits the text', async () => {
+      await textBlock.click();
+      await page.keyboard.press('End');
+      await page.keyboard.type(' EDITED');
+      await expect(textBlock).toHaveText('Some plain text EDITED');
+    });
+
+    await test.step('Shift+Enter inserts a line break inside the block', async () => {
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('Enter');
+      await page.keyboard.up('Shift');
+      await page.keyboard.type('Second line');
+
+      await expect(textBlock.locator('br')).toHaveCount(1);
+      // Still one block-level div, not split into two.
+      await expect(prosemirror.locator('div.note')).toHaveCount(1);
+    });
+
+    await test.step('The edit round-trips, still wrapped in the original tag and attributes', async () => {
+      const roundTripped = await getMarkdownSource(locators);
+
+      expect(roundTripped).toContain('<div class="note">Some plain text EDITED<br>Second line</div>');
+      expect(roundTripped).toContain('Before the block.');
+      expect(roundTripped).toContain('After the block.');
+    });
+  });
 });

--- a/tests/richtext-editor/raw-html-passthrough.spec.ts
+++ b/tests/richtext-editor/raw-html-passthrough.spec.ts
@@ -57,4 +57,63 @@ test.describe('Rich Text Editor Edge Cases - Raw HTML Passthrough', () => {
       expect(roundTripped).toContain('Hidden details content');
     });
   });
+
+  const INLINE_MARKDOWN_SOURCE = [
+    'Some text with <mark>highlighted</mark> and <u>underlined</u> inline HTML.',
+    '',
+    'Keyboard shortcut <kbd>Ctrl</kbd>+<kbd>C</kbd> and water is H<sup>2</sup>O.',
+    '',
+    '- [ ] Task not done',
+    '- [x] Task done',
+    ''
+  ].join('\n');
+
+  test('Inline HTML with no dedicated mark is not dropped, and tags that do have one (kbd, sup, task checkboxes) keep working', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-inline-raw-html');
+
+    await setMarkdownSource(locators, INLINE_MARKDOWN_SOURCE);
+
+    await test.step('Rich Text keeps the unrecognized inline HTML\'s text instead of dropping it', async () => {
+      await locators.docs.modeSwitchDocs().click();
+      const prosemirror = locators.docs.proseMirror();
+      await expect(prosemirror).toBeVisible();
+
+      await expect(prosemirror).toContainText('highlighted');
+      await expect(prosemirror).toContainText('underlined');
+      // <mark>/</mark> and <u>/</u> each become their own opaque placeholder
+      // (no dedicated node maps to them), one per open and close tag.
+      await expect(prosemirror.locator('.editor-raw-html-inline')).toHaveCount(4);
+    });
+
+    await test.step('Recognized inline tags render as themselves, not as raw-HTML placeholders', async () => {
+      const prosemirror = locators.docs.proseMirror();
+
+      await expect(prosemirror.locator('kbd')).toHaveText(['Ctrl', 'C']);
+      await expect(prosemirror.locator('sup')).toHaveText('2');
+      await expect(prosemirror.locator('.editor-raw-html-inline kbd')).toHaveCount(0);
+      await expect(prosemirror.locator('.editor-raw-html-inline sup')).toHaveCount(0);
+    });
+
+    await test.step('The task list checkboxes still parse as real, checkable task items', async () => {
+      const prosemirror = locators.docs.proseMirror();
+      const taskItems = prosemirror.locator('ul[data-type="taskList"] > li');
+
+      await expect(taskItems).toHaveCount(2);
+      await expect(taskItems.nth(0).locator('input[type="checkbox"]')).not.toBeChecked();
+      await expect(taskItems.nth(1).locator('input[type="checkbox"]')).toBeChecked();
+      await expect(prosemirror.locator('.editor-raw-html-inline input')).toHaveCount(0);
+    });
+
+    await test.step('Switching back to Markdown round-trips every tag byte-for-byte', async () => {
+      const roundTripped = await getMarkdownSource(locators);
+
+      expect(roundTripped).toContain('<mark>highlighted</mark>');
+      expect(roundTripped).toContain('<u>underlined</u>');
+      expect(roundTripped).toContain('<kbd>Ctrl</kbd>');
+      expect(roundTripped).toContain('<kbd>C</kbd>');
+      expect(roundTripped).toContain('H<sup>2</sup>O');
+      expect(roundTripped).toContain('[ ] Task not done');
+      expect(roundTripped).toContain('[x] Task done');
+    });
+  });
 });

--- a/tests/richtext-editor/soft-line-breaks.spec.ts
+++ b/tests/richtext-editor/soft-line-breaks.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '../../playwright';
+import { closeAllCollections } from '../utils/page/actions';
+import { setupRequestDocs, setMarkdownSource, getMarkdownSource } from './actions';
+
+const WRAPPED_MARKDOWN_SOURCE = [
+  'This line was hand-wrapped for readability but is meant to read as',
+  'a single sentence, not a forced line break.',
+  ''
+].join('\n');
+
+test.describe('Rich Text Editor Edge Cases - Soft Line Breaks', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('A hand-wrapped paragraph reflows as one paragraph and round-trips without gaining a forced break', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-soft-breaks');
+
+    await setMarkdownSource(locators, WRAPPED_MARKDOWN_SOURCE);
+
+    await test.step('Rich Text merges the wrapped lines into a single paragraph with no visible break', async () => {
+      await locators.docs.modeSwitchDocs().click();
+      const prosemirror = locators.docs.proseMirror();
+      await expect(prosemirror).toBeVisible();
+
+      await expect(prosemirror.locator('p')).toHaveCount(1);
+      await expect(prosemirror.locator('p br')).toHaveCount(0);
+      await expect(prosemirror.locator('p')).toContainText(
+        'This line was hand-wrapped for readability but is meant to read as a single sentence, not a forced line break.'
+      );
+    });
+
+    await test.step('Switching back to Markdown does not insert a forced line break', async () => {
+      const roundTripped = await getMarkdownSource(locators);
+
+      expect(roundTripped).not.toContain('\\\n');
+      expect(roundTripped).not.toContain('<br');
+      expect(roundTripped).toContain('This line was hand-wrapped for readability but is meant to read as');
+      expect(roundTripped).toContain('a single sentence, not a forced line break.');
+    });
+  });
+});

--- a/tests/richtext-editor/soft-line-breaks.spec.ts
+++ b/tests/richtext-editor/soft-line-breaks.spec.ts
@@ -1,12 +1,14 @@
 import { test, expect } from '../../playwright';
 import { closeAllCollections } from '../utils/page/actions';
-import { setupRequestDocs, setMarkdownSource, getMarkdownSource } from './actions';
+import { setupRequestDocs, setMarkdownSource, getMarkdownSource, pasteIntoRichTextEditor } from './actions';
 
 const WRAPPED_MARKDOWN_SOURCE = [
   'This line was hand-wrapped for readability but is meant to read as',
   'a single sentence, not a forced line break.',
   ''
 ].join('\n');
+
+const WRAPPED_PLAIN_TEXT = 'This line was hand-wrapped for readability but is meant to read as\na single sentence, not a forced line break.';
 
 test.describe('Rich Text Editor Edge Cases - Soft Line Breaks', () => {
   test.afterEach(async ({ page }) => {
@@ -37,6 +39,29 @@ test.describe('Rich Text Editor Edge Cases - Soft Line Breaks', () => {
       expect(roundTripped).not.toContain('<br');
       expect(roundTripped).toContain('This line was hand-wrapped for readability but is meant to read as');
       expect(roundTripped).toContain('a single sentence, not a forced line break.');
+    });
+  });
+
+  test('Pasting hand-wrapped plain text into Rich Text does not turn the wrap into a forced break', async ({ page, createTmpDir }) => {
+    const locators = await setupRequestDocs(page, createTmpDir, 'test-richtext-soft-breaks-paste');
+
+    await pasteIntoRichTextEditor(locators, WRAPPED_PLAIN_TEXT);
+
+    await test.step('The pasted text lands as one paragraph with no hard break', async () => {
+      const prosemirror = locators.docs.proseMirror();
+
+      await expect(prosemirror.locator('p')).toHaveCount(1);
+      await expect(prosemirror.locator('p br')).toHaveCount(0);
+      await expect(prosemirror.locator('p')).toContainText(
+        'This line was hand-wrapped for readability but is meant to read as a single sentence, not a forced line break.'
+      );
+    });
+
+    await test.step('Switching to Markdown does not show a forced line break', async () => {
+      const markdown = await getMarkdownSource(locators);
+
+      expect(markdown).not.toContain('\\\n');
+      expect(markdown).not.toContain('<br');
     });
   });
 });


### PR DESCRIPTION
### Description

Fixes three related bugs in the Docs Rich Text Editor's raw-HTML handling (`packages/bruno-app/src/ui/RichTextEditor`), tracked as [BRU-4313](https://usebruno.atlassian.net/browse/BRU-4313), [BRU-4326](https://usebruno.atlassian.net/browse/BRU-4326), and [BRU-4329](https://usebruno.atlassian.net/browse/BRU-4329): wrapped prose was silently rewritten with forced line breaks, inline HTML with no dedicated schema node vanished on save, and content wrapped in a plain text-only tag (`<div>`, `<p>`, ...) couldn't be edited at all in Rich Text mode. Also closes a paste-based XSS gap and a lossy round-trip bug found while hardening the fix for the third issue.

### Problem

1. **[BRU-4313] Wrapped prose churn** — `Markdown.configure({ breaks: true })` parsed an ordinary soft line break (a `\n` inside a paragraph — meant to render as a space, per CommonMark) as a hard break. `EditorHardBreak`'s serializer then wrote that back out as a `\` line-continuation, so opening and saving *any* doc with hand-wrapped prose silently rewrote every wrapped line into a forced break — a whole-file diff plus a semantic change nobody asked for.
2. **[BRU-4326] Inline HTML silently dropped** — only block-level raw HTML (`<div>`, `<video>`, `<details>`, ...) had a preservation mechanism (`EditorRawHtmlBlock`). Inline HTML with no dedicated mark — `<u>`, `<mark>`, `<span>`, `<abbr>`, `<small>` — had no `html_inline` equivalent, so it vanished the moment the doc was edited and saved in Rich Text mode.
3. **[BRU-4329] Text-only tags weren't editable** — content wrapped in a plain text-only tag (`<div>`, `<p>`, ...) was preserved as an opaque, non-editable atom (same treatment as `<video>`/`<table>`), so users could see it in Rich Text mode but couldn't click into it and edit the text.
4. **Missing sanitize config on update** — the raw-HTML-block node view's `update()` path called `DOMPurify.sanitize()` without `SANITIZE_CONFIG` (which forbids `<style>`), unlike its initial-render path — so a `<style>` block in an untrusted collection's docs could restyle the whole app UI after the node re-rendered.

### Fix

- **BRU-4313** — Set `breaks: false` on the Markdown extension so a soft line break stays a reflowable space, matching how any other CommonMark renderer (e.g. GitHub) displays the same file.
- **BRU-4326** — Added `EditorRawHtmlInline`, the inline counterpart to `EditorRawHtmlBlock`: any inline HTML tag with no schema mapping is preserved as an opaque, sanitized atom instead of disappearing. An early pass swallowed *every* inline HTML tag indiscriminately, which broke tags that already have a dedicated mapping — `<br>` (hard breaks), `<kbd>`/`<sup>` (existing inline marks), and the `<input>` checkbox `markdown-it-task-lists` synthesizes for task items. Fixed by exempting those tag names (matched by name, not exact string, so attributes don't matter — including single- and double-quoted `type="checkbox"`) from the raw-HTML wrapping.
- **BRU-4329** — Added `EditorRawHtmlTextBlock`: a block whose HTML sanitizes down to a single wrapper with only plain text and `<br>`s becomes a real, editable ProseMirror node instead of an opaque atom, preserving its original tag and attributes. Anything with nested markup, or a self-contained/dangerous tag (`<video>`, `<script>`, `<table>`, ...), still falls back to the opaque `rawHtmlBlock` atom.
- Fixed the missing `SANITIZE_CONFIG` on the block node's `update()` call, and de-duplicated the block/inline/text-block node definitions into one `createRawHtmlNode` factory so the `DOMPurify.sanitize` call sites can't drift independently again.
- Split the shared markdown-it parser setup into two independent functions (one for `html_block`, one for `html_inline`), so registering one raw-HTML node no longer has the side effect of patching the other's renderer rule too.

**Hardening found while reviewing the above:**
- **Paste-based XSS** — `EditorRawHtmlTextBlock`'s ProseMirror `parseHTML` rule matched *any* element carrying its marker attribute, including one pasted in from an untrusted external page, and copied its attributes verbatim with no sanitization (unlike the markdown-load path). A crafted paste such as `<div data-raw-html-text-block="img" onerror="alert(1)">` would execute immediately and persist into the collection's `docs`. Fixed by re-running the same DOMPurify sanitization on the pasted element and rejecting a marker-attribute tag value that names a dangerous tag (`script`, `iframe`, ...).
- **Lossy round-trip on unedited legacy blocks** — making a simple HTML block editable meant its markup got rebuilt from the parsed DOM on every save (normalizing quote style, tag case, entities) even when the user never touched it, silently rewriting unrelated content already on disk. Fixed by capturing the exact original bytes at parse time and re-emitting them verbatim as long as the block's visible content is unchanged, only reconstructing once it's actually edited (with validation so a pasted/forged "original" can't be smuggled through).
- A `Node` naming collision (the module's `@tiptap/core` import shadowing the global DOM `Node`) in a follow-up whitespace-handling fix silently broke text-block parsing for every input; fixed by qualifying the DOM constants as `globalThis.Node.ELEMENT_NODE`/`TEXT_NODE`.

Added Playwright coverage in `tests/richtext-editor/`:
- Extended `raw-html-passthrough.spec.ts` with inline-HTML, editable-text-block, and legacy-round-trip cases.
- New `soft-line-breaks.spec.ts` covering the BRU-4313 fix.
- Extensive new Jest coverage in `editorMarkdownSerialize.spec.js` for the text-block feature, the paste-XSS fix (via a direct `ProseMirrorDOMParser` simulation of a hostile clipboard paste), and the byte-preservation fix.

### Screenshots

##### Before 

https://github.com/user-attachments/assets/ec76502a-78c4-47ff-8f18-87a70f7ff612

##### After

https://github.com/user-attachments/assets/1c7fa1cf-f869-4a7c-bd40-72ef919d0394


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.** 
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** _(linked: [BRU-4313](https://usebruno.atlassian.net/browse/BRU-4313), [BRU-4326](https://usebruno.atlassian.net/browse/BRU-4326), [BRU-4329](https://usebruno.atlassian.net/browse/BRU-4329))_
- [x] **I've run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editable support for simple raw HTML blocks, preserving tags, attributes, text, and line breaks.
  * Added support for preserving inline raw HTML in the Rich Text Editor.
  * Recognized inline tags and task-list checkboxes continue to use native editor behavior.
  * Soft-wrapped Markdown remains continuous paragraph text without forced line breaks.

* **Bug Fixes**
  * Improved Markdown round-tripping for HTML, attributes, text edits, and line breaks.
  * Unsupported or nested HTML is safely preserved without disrupting editor content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
