### PR TITLE
fix(RequestTab): streamline transient request save confirmation logic

### DIFF
--- a/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
+++ b/packages/bruno-app/src/components/RequestTabs/RequestTab/index.js
@@ -586,18 +586,16 @@ const RequestTab = ({ tab, collection, tabIndex, collectionRequestTabs, folderUi
             setShowConfirmClose(false);
           }}
           onSaveAndClose={() => {
-            const useFileSave = collection.fileMode || item.type === 'js';
-            let savePromise;
-
-            if (useFileSave) {
-              savePromise = dispatch(saveFile(item?.draft?.raw ?? item?.raw, item.uid, collection.uid));
-            } else if (isItemTransientRequest(item)) {
+            if (isItemTransientRequest(item)) {
               dispatch(addSaveTransientRequestModal({ item, collection, closeAfterSave: true }));
               setShowConfirmClose(false);
               return;
-            } else {
-              savePromise = dispatch(saveRequest(item.uid, collection.uid));
             }
+
+            const useFileSave = collection.fileMode || item.type === 'js';
+            const savePromise = useFileSave
+              ? dispatch(saveFile(item?.draft?.raw ?? item?.raw, item.uid, collection.uid))
+              : dispatch(saveRequest(item.uid, collection.uid));
 
             savePromise
               .then(() => {

--- a/tests/transient-requests/transient-file-mode-save.spec.ts
+++ b/tests/transient-requests/transient-file-mode-save.spec.ts
@@ -6,6 +6,7 @@ import {
   createCollection,
   createTransientRequest,
   fillRequestUrl,
+  openRequest,
   saveTransientViaModal,
   SEARCH_CONTENT,
   searchInFileMode,
@@ -81,7 +82,9 @@ const defineFileModeSaveSuite = (format: CollectionFormat) => {
       });
 
       await test.step('Saved request keeps the file-mode edit', async () => {
+        // Save & Close dismisses the tab; reopen from the sidebar to verify persisted content.
         await expect(locators.sidebar.request('Saved From Close X')).toBeVisible({ timeout: 10000 });
+        await openRequest(page, collectionName, 'Saved From Close X');
         await expect
           .poll(async () => locators.fileMode.editorContent().textContent(), { timeout: 10000 })
           .toContain(editedUrl);
@@ -106,7 +109,9 @@ const defineFileModeSaveSuite = (format: CollectionFormat) => {
       });
 
       await test.step('Saved request keeps the file-mode edit', async () => {
+        // Save & Close dismisses the tab; reopen from the sidebar to verify persisted content.
         await expect(locators.sidebar.request('Saved From Close Shortcut')).toBeVisible({ timeout: 10000 });
+        await openRequest(page, collectionName, 'Saved From Close Shortcut');
         await expect
           .poll(async () => locators.fileMode.editorContent().textContent(), { timeout: 10000 })
           .toContain(editedUrl);


### PR DESCRIPTION
### Description

Fixes a minor issue that was causing test failures in 4/4 shard

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved request-close handling for transient requests.
* Transient requests now open the appropriate save dialog without triggering an unnecessary save operation.
* Existing save behavior remains unchanged for regular requests, including file-mode and standard request saves.
* Reopened saved requests now correctly retain file-mode edits after using Save & Close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->