### PR TITLE
fix(app): make long script errors scrollable

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/StyledWrapper.js
@@ -60,6 +60,7 @@ const StyledWrapper = styled.div`
 
     &.has-script-error {
       height: auto;
+      overflow-y: auto;
     }
   }
 

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -297,7 +297,10 @@ const ResponsePane = ({ item, collection }) => {
           rightContentExpandedWidth={RIGHT_CONTENT_EXPANDED_WIDTH}
         />
       </div>
-      <section className={`response-pane-content ${hasScriptError && showScriptErrorCard ? 'has-script-error' : ''}`}>
+      <section
+        className={`response-pane-content ${hasScriptError && showScriptErrorCard ? 'has-script-error' : ''}`}
+        data-testid="response-pane-content"
+      >
         {isLoading ? <Overlay item={item} collection={collection} /> : null}
         {hasScriptError && showScriptErrorCard && (
           <ScriptError

--- a/tests/script-errors/fixtures/collections/script-errors-test/long-error-message.bru
+++ b/tests/script-errors/fixtures/collections/script-errors-test/long-error-message.bru
@@ -1,0 +1,20 @@
+meta {
+  name: long-error-message
+  type: http
+  seq: 13
+}
+
+get {
+  url: http://localhost:8081/ping
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  const longMessage = Array.from(
+    { length: 150 },
+    (_, index) => `Script error line ${index + 1}`
+  ).join('\n');
+
+  throw new Error(`${longMessage}\nEND OF LONG SCRIPT ERROR`);
+}

--- a/tests/script-errors/script-errors.spec.ts
+++ b/tests/script-errors/script-errors.spec.ts
@@ -413,5 +413,34 @@ for (const mode of ['safe', 'developer'] as const) {
         await expect(testsTab).toHaveClass(/active/);
       });
     });
+
+    test('18. Long script error message can be scrolled to the end', async ({ pageWithUserData: page }) => {
+      await test.step('Open request and show long script error', async () => {
+        await openRequest(page, 'script-errors-test', 'long-error-message');
+        await sendAndWaitForErrorCard(page);
+      });
+
+      await test.step('Scroll response content to the end of the error', async () => {
+        const scrollContainer = scriptErrorLocators.scrollContainer();
+        const card = scriptErrorLocators.card();
+
+        await expect(card).toBeVisible();
+        await expect(scriptErrorLocators.message(card)).toContainText('END OF LONG SCRIPT ERROR');
+
+        const scrollHeight = await scrollContainer.evaluate((element) => element.scrollHeight);
+        const clientHeight = await scrollContainer.evaluate((element) => element.clientHeight);
+
+        expect(scrollHeight).toBeGreaterThan(clientHeight);
+
+        await scrollContainer.hover();
+        await page.mouse.wheel(0, scrollHeight);
+
+        await expect.poll(async () => {
+          return scrollContainer.evaluate((element) => {
+            return Math.ceil(element.scrollTop + element.clientHeight) >= element.scrollHeight;
+          });
+        }).toBe(true);
+      });
+    });
   });
 }

--- a/tests/script-errors/script-errors.spec.ts
+++ b/tests/script-errors/script-errors.spec.ts
@@ -426,12 +426,13 @@ for (const mode of ['safe', 'developer'] as const) {
 
         await expect(card).toBeVisible();
         await expect(scriptErrorLocators.message(card)).toContainText('END OF LONG SCRIPT ERROR');
+        await expect(scrollContainer).toBeVisible();
+
+        await expect
+          .poll(() => scrollContainer.evaluate((element) => element.scrollHeight > element.clientHeight))
+          .toBe(true);
 
         const scrollHeight = await scrollContainer.evaluate((element) => element.scrollHeight);
-        const clientHeight = await scrollContainer.evaluate((element) => element.clientHeight);
-
-        expect(scrollHeight).toBeGreaterThan(clientHeight);
-
         await scrollContainer.hover();
         await page.mouse.wheel(0, scrollHeight);
 

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -398,6 +398,8 @@ export const buildScriptErrorLocators = (page: Page) => ({
   stackToggle: (card?: Locator) => (card ?? page).getByTestId('script-error-stack-toggle'),
   /** Stack trace content within a card */
   stack: (card?: Locator) => (card ?? page).getByTestId('script-error-stack'),
+  /** Scrollable response content that contains script error cards */
+  scrollContainer: () => page.getByTestId('response-pane-content'),
   /** ScriptErrorIcon (the red alert button shown when card is dismissed) */
   errorIcon: () => page.getByTestId('script-error-icon')
 });


### PR DESCRIPTION
### Description

Makes long Bruno script error messages scrollable within the response pane.

### Problem

Fixes #8967.
Ref: BRU-4289

When a pre-request, post-response, or test script produces an error message taller than the available response area, the script error card extends outside the visible pane. The outer response wrapper clips the overflow, so users cannot scroll to read the complete error.

### Fix

- Enable vertical scrolling on the response content container while a script error card is displayed.
- Keep the existing response-tab scroll container unchanged for normal responses.
- Add a stable test locator for the response content container.
- Add an Electron E2E regression test covering a long script error message and mouse-wheel scrolling.

### Testing

- `npm run lint -- packages/bruno-app/src/components/ResponsePane/index.js packages/bruno-app/src/components/ResponsePane/StyledWrapper.js tests/utils/page/locators.ts tests/script-errors/script-errors.spec.ts` (passes with two pre-existing unused-variable warnings)
- `npm run build:web` (passes)
- `git diff --check` (passes)
- Targeted Electron E2E could not start locally because the Electron executable is missing from the current workspace installation.
- Existing ScriptError Jest tests could not start locally because the native `canvas.node` module is missing.

### Screenshots

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Long pre-request script error messages can now be scrolled vertically in the response pane.
  * Improved visibility of the full error content, including access to the end of lengthy messages.

* **Tests**
  * Added coverage verifying scrolling behavior for extended script error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->