### PR TITLE
fix(environments): keep environment colors when mounting from the file cache

### DIFF
--- a/packages/bruno-app/src/components/ColorBadge/index.js
+++ b/packages/bruno-app/src/components/ColorBadge/index.js
@@ -8,6 +8,7 @@ const ColorBadge = ({ color, size = 10 }) => {
   return (
     <div
       className="flex-shrink-0 rounded-full"
+      data-testid="color-badge"
       style={{
         width: sizeValue,
         height: sizeValue,

--- a/packages/bruno-electron/src/services/mount/tree-builder.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.js
@@ -147,6 +147,7 @@ const buildEnvironmentNode = (collectionPath, relativePath, entry, uidFor) => {
   const absolutePath = path.join(collectionPath, relativePath);
   const data = entry.data || {};
   return {
+    ...data,
     uid: uidFor(absolutePath),
     name: stripExt(basename),
     variables: data.variables || [],

--- a/packages/bruno-electron/src/services/mount/tree-builder.spec.js
+++ b/packages/bruno-electron/src/services/mount/tree-builder.spec.js
@@ -57,6 +57,30 @@ describe('buildTree — app code', () => {
   });
 });
 
+describe('buildTree — environments', () => {
+  const buildSingleEnvironment = (data) =>
+    buildTree(COLLECTION_PATH, new Map([[path.join('environments', 'Local.yml'), { data, raw: '' }]])).environments[0];
+
+  it('carries the color of an environment', () => {
+    const node = buildSingleEnvironment({ name: 'Local', color: '#CE4F3B', variables: [] });
+
+    expect(node.color).toBe('#CE4F3B');
+  });
+
+  it('carries external secrets alongside the variables', () => {
+    const externalSecrets = { type: 'infisical', variables: [{ name: 'token' }] };
+    const node = buildSingleEnvironment({ name: 'Local', variables: [], externalSecrets });
+
+    expect(node.externalSecrets).toEqual(externalSecrets);
+  });
+
+  it('names the environment after its file, not the name stored inside it', () => {
+    const node = buildSingleEnvironment({ name: 'stale', variables: [] });
+
+    expect(node.name).toBe('Local');
+  });
+});
+
 describe('buildTree — uid hydration', () => {
   it('hydrates exactly the request lists this spec covers', () => {
     expect(REQUEST_UID_PATHS.map(([dotPath]) => dotPath).sort()).toEqual(

--- a/tests/environments/color-file-cache/env-color-file-cache.spec.ts
+++ b/tests/environments/color-file-cache/env-color-file-cache.spec.ts
@@ -80,12 +80,10 @@ test.describe('[file-cache on] Environment colors', () => {
   });
 
   test('survive a mount served from the file cache', async () => {
-    const environments = buildCommonLocators(page).environment;
-
-    await page.locator('#sidebar-collection-name').filter({ hasText: COLLECTION_NAME }).click();
+    const locators = buildCommonLocators(page);
+    await locators.sidebar.collection(COLLECTION_NAME).click();
     await openEnvironmentSelector(page);
-
-    const colorBadge = environments.listItem(ENVIRONMENT_NAME).locator('.rounded-full').first();
+    const colorBadge = locators.environment.listOptionBadge(ENVIRONMENT_NAME).first();
     await expect(colorBadge).toHaveCSS('background-color', COLOR_RGB);
   });
 });

--- a/tests/environments/color-file-cache/env-color-file-cache.spec.ts
+++ b/tests/environments/color-file-cache/env-color-file-cache.spec.ts
@@ -1,85 +1,13 @@
-import * as os from 'os';
-import * as path from 'path';
-import * as fs from 'fs';
-import { test, expect, ElectronApplication, Page, waitForReadyPage, closeElectronApp } from '../../../playwright';
+import { test, expect } from '../../../playwright';
 import { buildCommonLocators } from '../../utils/page/locators';
 import { openEnvironmentSelector } from '../../utils/page/environments';
 
 const COLLECTION_NAME = 'Env Color Collection';
 const ENVIRONMENT_NAME = 'Local';
-const COLOR = '#CE4F3B';
 const COLOR_RGB = 'rgb(206, 79, 59)';
 
-interface Fixture {
-  userDataPath: string;
-  collectionPath: string;
-  cleanup: () => Promise<void>;
-}
-
-const buildFixture = async (): Promise<Fixture> => {
-  const userDataPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-env-color-userdata-'));
-  const collectionPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-env-color-collection-'));
-
-  const cleanup = async () => {
-    await Promise.all([
-      fs.promises.rm(userDataPath, { recursive: true, force: true }),
-      fs.promises.rm(collectionPath, { recursive: true, force: true })
-    ]);
-  };
-
-  try {
-    await fs.promises.writeFile(
-      path.join(collectionPath, 'opencollection.yml'),
-      `opencollection: "1.0.0"\ninfo:\n  name: ${COLLECTION_NAME}\n`
-    );
-    await fs.promises.mkdir(path.join(collectionPath, 'environments'));
-    await fs.promises.writeFile(
-      path.join(collectionPath, 'environments', `${ENVIRONMENT_NAME}.yml`),
-      `name: ${ENVIRONMENT_NAME}\ncolor: "${COLOR}"\nvariables:\n  - name: host\n    value: http://localhost:8081\n`
-    );
-
-    const preferences = {
-      lastOpenedCollections: [collectionPath],
-      preferences: {
-        cache: {
-          file: { enabled: true }
-        },
-        onboarding: {
-          hasLaunchedBefore: true,
-          hasSeenWelcomeModal: true
-        }
-      }
-    };
-    await fs.promises.writeFile(path.join(userDataPath, 'preferences.json'), JSON.stringify(preferences, null, 2));
-
-    return { userDataPath, collectionPath, cleanup };
-  } catch (error) {
-    await cleanup();
-    throw error;
-  }
-};
-
 test.describe('[file-cache on] Environment colors', () => {
-  let fixture: Fixture;
-  let app: ElectronApplication;
-  let page: Page;
-
-  test.beforeAll(async ({ launchElectronApp }) => {
-    fixture = await buildFixture();
-    app = await launchElectronApp({ userDataPath: fixture.userDataPath });
-    page = await waitForReadyPage(app);
-  });
-
-  test.afterAll(async () => {
-    if (app) {
-      await closeElectronApp(app);
-    }
-    if (fixture) {
-      await fixture.cleanup();
-    }
-  });
-
-  test('survive a mount served from the file cache', async () => {
+  test('survive a mount served from the file cache', async ({ pageWithUserData: page }) => {
     const locators = buildCommonLocators(page);
     await locators.sidebar.collection(COLLECTION_NAME).click();
     await openEnvironmentSelector(page);

--- a/tests/environments/color-file-cache/env-color-file-cache.spec.ts
+++ b/tests/environments/color-file-cache/env-color-file-cache.spec.ts
@@ -1,0 +1,91 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { test, expect, ElectronApplication, Page, waitForReadyPage, closeElectronApp } from '../../../playwright';
+import { buildCommonLocators } from '../../utils/page/locators';
+import { openEnvironmentSelector } from '../../utils/page/environments';
+
+const COLLECTION_NAME = 'Env Color Collection';
+const ENVIRONMENT_NAME = 'Local';
+const COLOR = '#CE4F3B';
+const COLOR_RGB = 'rgb(206, 79, 59)';
+
+interface Fixture {
+  userDataPath: string;
+  collectionPath: string;
+  cleanup: () => Promise<void>;
+}
+
+const buildFixture = async (): Promise<Fixture> => {
+  const userDataPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-env-color-userdata-'));
+  const collectionPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'bruno-env-color-collection-'));
+
+  const cleanup = async () => {
+    await Promise.all([
+      fs.promises.rm(userDataPath, { recursive: true, force: true }),
+      fs.promises.rm(collectionPath, { recursive: true, force: true })
+    ]);
+  };
+
+  try {
+    await fs.promises.writeFile(
+      path.join(collectionPath, 'opencollection.yml'),
+      `opencollection: "1.0.0"\ninfo:\n  name: ${COLLECTION_NAME}\n`
+    );
+    await fs.promises.mkdir(path.join(collectionPath, 'environments'));
+    await fs.promises.writeFile(
+      path.join(collectionPath, 'environments', `${ENVIRONMENT_NAME}.yml`),
+      `name: ${ENVIRONMENT_NAME}\ncolor: "${COLOR}"\nvariables:\n  - name: host\n    value: http://localhost:8081\n`
+    );
+
+    const preferences = {
+      lastOpenedCollections: [collectionPath],
+      preferences: {
+        cache: {
+          file: { enabled: true }
+        },
+        onboarding: {
+          hasLaunchedBefore: true,
+          hasSeenWelcomeModal: true
+        }
+      }
+    };
+    await fs.promises.writeFile(path.join(userDataPath, 'preferences.json'), JSON.stringify(preferences, null, 2));
+
+    return { userDataPath, collectionPath, cleanup };
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+};
+
+test.describe('[file-cache on] Environment colors', () => {
+  let fixture: Fixture;
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async ({ launchElectronApp }) => {
+    fixture = await buildFixture();
+    app = await launchElectronApp({ userDataPath: fixture.userDataPath });
+    page = await waitForReadyPage(app);
+  });
+
+  test.afterAll(async () => {
+    if (app) {
+      await closeElectronApp(app);
+    }
+    if (fixture) {
+      await fixture.cleanup();
+    }
+  });
+
+  test('survive a mount served from the file cache', async () => {
+    const environments = buildCommonLocators(page).environment;
+
+    await page.locator('#sidebar-collection-name').filter({ hasText: COLLECTION_NAME }).click();
+    await openEnvironmentSelector(page);
+
+    const colorBadge = environments.listItem(ENVIRONMENT_NAME).locator('.rounded-full').first();
+    await expect(colorBadge).toHaveCSS('background-color', COLOR_RGB);
+  });
+});

--- a/tests/environments/color-file-cache/fixtures/collection/environments/Local.yml
+++ b/tests/environments/color-file-cache/fixtures/collection/environments/Local.yml
@@ -1,0 +1,5 @@
+name: Local
+color: "#CE4F3B"
+variables:
+  - name: host
+    value: http://localhost:8081

--- a/tests/environments/color-file-cache/fixtures/collection/opencollection.yml
+++ b/tests/environments/color-file-cache/fixtures/collection/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: Env Color Collection

--- a/tests/environments/color-file-cache/init-user-data/preferences.json
+++ b/tests/environments/color-file-cache/init-user-data/preferences.json
@@ -1,0 +1,13 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": [
+    "{{collectionPath}}"
+  ],
+  "preferences": {
+    "cache": {
+      "file": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -8,7 +8,11 @@ export const buildEnvironmentLocators = (page: Page) => ({
   envOption: (name: string) =>
     page.getByTestId('env-list-item').filter({ has: page.getByText(name, { exact: true }) }),
   listOption: (name: string) => page.locator('.environment-list .dropdown-item', { hasText: name }),
-  listOptionBadge: (name: string) => page.locator('.environment-list .dropdown-item', { hasText: name }).getByTestId('color-badge'),
+  listOptionBadge: (name: string) =>
+    page
+      .locator('.environment-list .dropdown-item')
+      .filter({ has: page.getByText(name, { exact: true }) })
+      .getByTestId('color-badge'),
   currentEnvironment: () => page.locator('.current-environment'),
   configureButton: () => page.locator('#configure-env'),
   saveButton: () => page.getByTestId('save-env'),

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -8,6 +8,7 @@ export const buildEnvironmentLocators = (page: Page) => ({
   envOption: (name: string) =>
     page.getByTestId('env-list-item').filter({ has: page.getByText(name, { exact: true }) }),
   listOption: (name: string) => page.locator('.environment-list .dropdown-item', { hasText: name }),
+  listOptionBadge: (name: string) => page.locator('.environment-list .dropdown-item', { hasText: name }).getByTestId('color-badge'),
   currentEnvironment: () => page.locator('.current-environment'),
   configureButton: () => page.locator('#configure-env'),
   saveButton: () => page.getByTestId('save-env'),


### PR DESCRIPTION
### Problem

With the file cache enabled, an environment's color is gone the next time the collection mounts. The mount v2 tree builder rebuilds every environment from `uid`, `name` and `variables` alone, so the `color` (and `externalSecrets`) parsed from the file never reach the renderer. Colors look fine while you are editing because the watcher change event carries the whole environment.

### Fix

Carry the parsed environment onto the tree node and override only the fields derived from the file path.

Unit tests cover the color and external secrets; an e2e asserts the color badge after a mount served from the cache — without the fix the badge renders transparent.

Ticket: BRU-4287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Environment colors now remain visible when collections are loaded from the file cache.
* Environment names are consistently derived from their filenames.
* Additional environment settings, including external secrets, are preserved when environments are loaded.

## Tests
* Added coverage for environment properties, color persistence, and file-cached collections.
* Added test support for verifying environment color badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->