### PR TITLE
fix(collections): stop a transient request from adding a phantom folder to the tree

### DIFF
--- a/packages/bruno-app/src/utils/common/platform.js
+++ b/packages/bruno-app/src/utils/common/platform.js
@@ -16,7 +16,11 @@ export const resolveRequestFilename = (name, extension = 'bru') => {
 
 export const getSubdirectoriesFromRoot = (rootPath, pathname) => {
   const relativePath = path.relative(rootPath, pathname);
-  return relativePath ? relativePath.split(path.sep) : [];
+  if (!relativePath || path.isAbsolute(relativePath)) {
+    return [];
+  }
+  const segments = relativePath.split(path.sep);
+  return segments[0] === '..' ? [] : segments;
 };
 
 export const isWindowsOS = () => {

--- a/packages/bruno-app/src/utils/common/platform.spec.js
+++ b/packages/bruno-app/src/utils/common/platform.spec.js
@@ -1,0 +1,31 @@
+jest.mock('platform', () => ({
+  os: {
+    family: 'Unix'
+  }
+}));
+
+import { getSubdirectoriesFromRoot } from './platform';
+
+describe('getSubdirectoriesFromRoot', () => {
+  it('lists the directories between the root and a nested path', () => {
+    expect(getSubdirectoriesFromRoot('/collections/my-collection', '/collections/my-collection/api/v2')).toEqual([
+      'api',
+      'v2'
+    ]);
+  });
+
+  it('returns nothing for the root itself', () => {
+    expect(getSubdirectoriesFromRoot('/collections/my-collection', '/collections/my-collection')).toEqual([]);
+  });
+
+  it('returns nothing for a path outside the root', () => {
+    expect(getSubdirectoriesFromRoot('/collections/my-collection', '/tmp/transient/bruno-a1b2')).toEqual([]);
+    expect(getSubdirectoriesFromRoot('/collections/my-collection', '/collections')).toEqual([]);
+  });
+
+  it('keeps a directory whose name merely starts with dots', () => {
+    expect(getSubdirectoriesFromRoot('/collections/my-collection', '/collections/my-collection/..hidden')).toEqual([
+      '..hidden'
+    ]);
+  });
+});

--- a/packages/bruno-app/src/utils/common/platform.windows.spec.js
+++ b/packages/bruno-app/src/utils/common/platform.windows.spec.js
@@ -1,0 +1,24 @@
+jest.mock('platform', () => ({
+  os: {
+    family: 'Windows'
+  }
+}));
+
+import { getSubdirectoriesFromRoot } from './platform';
+
+describe('getSubdirectoriesFromRoot - Windows Platform', () => {
+  it('lists the directories between the root and a nested path', () => {
+    expect(getSubdirectoriesFromRoot('C:\\collections\\my-collection', 'C:\\collections\\my-collection\\api\\v2')).toEqual([
+      'api',
+      'v2'
+    ]);
+  });
+
+  it('returns nothing for a path outside the root', () => {
+    expect(getSubdirectoriesFromRoot('C:\\collections\\my-collection', 'C:\\collections')).toEqual([]);
+  });
+
+  it('returns nothing for a path on another drive', () => {
+    expect(getSubdirectoriesFromRoot('C:\\collections\\my-collection', 'D:\\Temp\\transient\\bruno-a1b2')).toEqual([]);
+  });
+});

--- a/tests/transient-requests/delete-with-transient-open.spec.ts
+++ b/tests/transient-requests/delete-with-transient-open.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect, ConsoleMessage } from '../../playwright';
+import {
+  closeAllCollections,
+  createCollection,
+  createRequest,
+  createTransientRequest,
+  deleteRequest,
+  fillRequestUrl
+} from '../utils/page';
+import { buildCommonLocators } from '../utils/page/locators';
+
+const COLLECTION_NAME = 'delete-with-transient';
+
+// A transient request is stored outside the collection directory. Deriving its folders from the
+// collection root used to add a `..` folder to the tree, which every later delete then asked the
+// main process to resequence — and it rejects paths outside the collection.
+test.describe('Deleting items while a transient request is open', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('deletes a request without an error toast', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+
+    await createCollection(page, COLLECTION_NAME, await createTmpDir('delete-with-transient'));
+    await createTransientRequest(page, { requestType: 'HTTP' });
+    await fillRequestUrl(page, 'http://localhost:8081/ping');
+    await createRequest(page, 'plain-req', COLLECTION_NAME, { url: '/ping', method: 'GET' });
+
+    // deleteRequest already asserts that the request does not exist in the sidebar
+    // not sure if we need more assertion here.
+    await deleteRequest(page, 'plain-req', COLLECTION_NAME);
+  });
+});


### PR DESCRIPTION
### Problem

With a transient request open, deleting a request, JS file or folder shows `Path: … should be inside a collection`, and it repeats on every delete.

A transient request's file lives in the app's temp directory, outside the collection, so `getSubdirectoriesFromRoot` returns `../../…` for it and the tree reducer builds those `..` segments as folders. The collection ends up with a hidden folder named `..` whose pathname is the collection's *parent*. Deleting a root item resequences its siblings — that phantom among them — and the main process rightly refuses to write outside the collection.

The validation added in #8274 is not the bug: before it, the same resequence silently wrote a `folder.yml` above the collection root.

### Fix

`getSubdirectoriesFromRoot` now returns no subdirectories when the path is outside the root, so a transient request attaches at the collection root — where the file-cache mount already puts it.

Covered by unit tests for the helper and an e2e that deletes a request while a transient request is open.

Ticket: BRU-4286


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling to prevent directories outside the selected root from appearing as subdirectories.
  * Fixed deletion behavior when a transient request is open, preventing erroneous path-validation alerts and console errors.

* **Tests**
  * Added coverage for nested, root, external, dot-prefixed, and cross-drive directories.
  * Added end-to-end coverage for deleting requests while transient requests are open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->