### PR TITLE
Fix:openapi sync update

### DIFF
--- a/packages/bruno-common/src/index.ts
+++ b/packages/bruno-common/src/index.ts
@@ -3,6 +3,7 @@ export { default as interpolate, interpolateObject } from './interpolate';
 export { percentageToZoomLevel } from './zoom';
 export { default as isRequestTagsIncluded } from './tags';
 export { transformExampleStatusInCollection } from './example-status';
+export { normalizeOpenApiSyncConfigs } from './openapi-sync';
 
 export { buildHar } from './generate-code/har';
 export type {

--- a/packages/bruno-common/src/openapi-sync/index.spec.ts
+++ b/packages/bruno-common/src/openapi-sync/index.spec.ts
@@ -54,6 +54,44 @@ describe('normalizeOpenApiSyncConfigs', () => {
     ]);
   });
 
+  it('drops entries without a usable sourceUrl', () => {
+    expect(normalizeOpenApiSyncConfigs([
+      {},
+      [],
+      { sourceUrl: '' },
+      { sourceUrl: 42 },
+      { sourceUrl: null },
+      { groupBy: 'tags', autoCheck: true }
+    ])).toEqual([]);
+  });
+
+  it('does not let a malformed entry shadow the valid one behind it', () => {
+    expect(normalizeOpenApiSyncConfigs([
+      {},
+      { sourceUrl: 'https://example.com/openapi.json', groupBy: 'path' }
+    ])).toEqual([
+      {
+        sourceUrl: 'https://example.com/openapi.json',
+        groupBy: 'path',
+        autoCheck: true,
+        autoCheckInterval: 5
+      }
+    ]);
+  });
+
+  it('keeps the entry but drops an unsupported groupBy', () => {
+    const [config] = normalizeOpenApiSyncConfigs([
+      { sourceUrl: 'https://example.com/openapi.json', groupBy: 'tag' }
+    ]);
+
+    expect(config).toEqual({
+      sourceUrl: 'https://example.com/openapi.json',
+      autoCheck: true,
+      autoCheckInterval: 5
+    });
+    expect('groupBy' in config).toBe(false);
+  });
+
   it('returns an empty list for anything that is not an array of entries', () => {
     expect(normalizeOpenApiSyncConfigs(undefined)).toEqual([]);
     expect(normalizeOpenApiSyncConfigs(null)).toEqual([]);

--- a/packages/bruno-common/src/openapi-sync/index.spec.ts
+++ b/packages/bruno-common/src/openapi-sync/index.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from '@jest/globals';
+import { normalizeOpenApiSyncConfigs } from './index';
+
+describe('normalizeOpenApiSyncConfigs', () => {
+  it('keeps the sync metadata and fills in the auto-check defaults', () => {
+    expect(normalizeOpenApiSyncConfigs([
+      { sourceUrl: 'https://example.com/openapi.json', groupBy: 'tags' }
+    ])).toEqual([
+      {
+        sourceUrl: 'https://example.com/openapi.json',
+        groupBy: 'tags',
+        autoCheck: true,
+        autoCheckInterval: 5
+      }
+    ]);
+  });
+
+  it('preserves explicitly configured auto-check settings', () => {
+    expect(normalizeOpenApiSyncConfigs([
+      {
+        sourceUrl: 'https://example.com/openapi.json',
+        groupBy: 'path',
+        lastSyncDate: '2026-08-13T10:00:00.000Z',
+        specHash: 'd41d8cd98f00b204e9800998ecf8427e',
+        autoCheck: false,
+        autoCheckInterval: 30
+      }
+    ])).toEqual([
+      {
+        sourceUrl: 'https://example.com/openapi.json',
+        groupBy: 'path',
+        lastSyncDate: '2026-08-13T10:00:00.000Z',
+        specHash: 'd41d8cd98f00b204e9800998ecf8427e',
+        autoCheck: false,
+        autoCheckInterval: 30
+      }
+    ]);
+  });
+
+  it('drops malformed entries and keeps the usable ones', () => {
+    expect(normalizeOpenApiSyncConfigs([
+      null,
+      undefined,
+      'https://example.com/openapi.json',
+      42,
+      { sourceUrl: 'https://example.com/openapi.json', groupBy: 'tags' }
+    ])).toEqual([
+      {
+        sourceUrl: 'https://example.com/openapi.json',
+        groupBy: 'tags',
+        autoCheck: true,
+        autoCheckInterval: 5
+      }
+    ]);
+  });
+
+  it('returns an empty list for anything that is not an array of entries', () => {
+    expect(normalizeOpenApiSyncConfigs(undefined)).toEqual([]);
+    expect(normalizeOpenApiSyncConfigs(null)).toEqual([]);
+    expect(normalizeOpenApiSyncConfigs([])).toEqual([]);
+    expect(normalizeOpenApiSyncConfigs([null, undefined])).toEqual([]);
+    expect(normalizeOpenApiSyncConfigs({ sourceUrl: 'https://example.com/openapi.json' })).toEqual([]);
+  });
+});

--- a/packages/bruno-common/src/openapi-sync/index.ts
+++ b/packages/bruno-common/src/openapi-sync/index.ts
@@ -1,0 +1,25 @@
+interface OpenApiSyncConfig {
+  sourceUrl: string;
+  groupBy?: 'tags' | 'path';
+  lastSyncDate?: string;
+  specHash?: string;
+  autoCheck: boolean;
+  autoCheckInterval: number;
+}
+
+export const normalizeOpenApiSyncConfigs = (entries: unknown): OpenApiSyncConfig[] => {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry !== null && typeof entry === 'object')
+    .map((entry) => ({
+      sourceUrl: entry.sourceUrl,
+      groupBy: entry.groupBy,
+      ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
+      ...(entry.specHash && { specHash: entry.specHash }),
+      autoCheck: entry.autoCheck !== false,
+      autoCheckInterval: entry.autoCheckInterval || 5
+    }));
+};

--- a/packages/bruno-common/src/openapi-sync/index.ts
+++ b/packages/bruno-common/src/openapi-sync/index.ts
@@ -7,19 +7,25 @@ interface OpenApiSyncConfig {
   autoCheckInterval: number;
 }
 
+const SUPPORTED_GROUP_BY = ['tags', 'path'];
+
+const isUsableEntry = (entry: any): boolean =>
+  entry !== null
+  && typeof entry === 'object'
+  && typeof entry.sourceUrl === 'string'
+  && entry.sourceUrl !== '';
+
 export const normalizeOpenApiSyncConfigs = (entries: unknown): OpenApiSyncConfig[] => {
   if (!Array.isArray(entries)) {
     return [];
   }
 
-  return entries
-    .filter((entry) => entry !== null && typeof entry === 'object')
-    .map((entry) => ({
-      sourceUrl: entry.sourceUrl,
-      groupBy: entry.groupBy,
-      ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
-      ...(entry.specHash && { specHash: entry.specHash }),
-      autoCheck: entry.autoCheck !== false,
-      autoCheckInterval: entry.autoCheckInterval || 5
-    }));
+  return entries.filter(isUsableEntry).map((entry) => ({
+    sourceUrl: entry.sourceUrl,
+    ...(SUPPORTED_GROUP_BY.includes(entry.groupBy) && { groupBy: entry.groupBy }),
+    ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
+    ...(entry.specHash && { specHash: entry.specHash }),
+    autoCheck: entry.autoCheck !== false,
+    autoCheckInterval: entry.autoCheckInterval || 5
+  }));
 };

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -193,8 +193,11 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
     brunoExtension.scripts = { flow: scriptFlow };
   }
   const openApiExtensions = brunoConfig?.openapi;
-  if (Array.isArray(openApiExtensions) && openApiExtensions.length > 0) {
-    brunoExtension.openapi = openApiExtensions.map((entry: any) => ({
+  const openApiEntries = Array.isArray(openApiExtensions)
+    ? openApiExtensions.filter((entry: any) => entry !== null && typeof entry === 'object')
+    : [];
+  if (openApiEntries.length > 0) {
+    brunoExtension.openapi = openApiEntries.map((entry: any) => ({
       sourceUrl: entry.sourceUrl,
       groupBy: entry.groupBy,
       ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -167,6 +167,7 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
     ignore?: string[];
     presets?: BrunoPresets;
     scripts?: { flow?: 'sandwich' | 'sequential' };
+    openapi?:BrunoConfig['openapi'];
   } = {};
 
   if (brunoConfig?.ignore?.length) {
@@ -190,6 +191,17 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
   const scriptFlow = brunoConfig?.scripts?.flow;
   if (scriptFlow === 'sandwich' || scriptFlow === 'sequential') {
     brunoExtension.scripts = { flow: scriptFlow };
+  }
+  const openApiExtensions = brunoConfig?.openapi;
+  if (Array.isArray(openApiExtensions) && openApiExtensions.length > 0) {
+    brunoExtension.openapi = openApiExtensions.map((entry: any) => ({
+      sourceUrl: entry.sourceUrl,
+      groupBy: entry.groupBy,
+      ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
+      ...(entry.specHash && { specHash: entry.specHash }),
+      autoCheck: entry.autoCheck !== false,
+      autoCheckInterval: entry.autoCheckInterval || 5
+    }));
   }
 
   if (Object.keys(brunoExtension).length > 0) {

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -1,3 +1,4 @@
+import { normalizeOpenApiSyncConfigs } from "@usebruno/common";
 import { toOpenCollectionActions, toOpenCollectionAuth, toOpenCollectionHeaders, toOpenCollectionScripts, toOpenCollectionVariables } from "./common";
 import { toOpenCollectionEnvironments } from "./environment";
 import { toOpenCollectionFolder } from "./folder";
@@ -192,19 +193,10 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
   if (scriptFlow === 'sandwich' || scriptFlow === 'sequential') {
     brunoExtension.scripts = { flow: scriptFlow };
   }
-  const openApiExtensions = brunoConfig?.openapi;
-  const openApiEntries = Array.isArray(openApiExtensions)
-    ? openApiExtensions.filter((entry: any) => entry !== null && typeof entry === 'object')
-    : [];
+
+  const openApiEntries = normalizeOpenApiSyncConfigs(brunoConfig?.openapi);
   if (openApiEntries.length > 0) {
-    brunoExtension.openapi = openApiEntries.map((entry: any) => ({
-      sourceUrl: entry.sourceUrl,
-      groupBy: entry.groupBy,
-      ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
-      ...(entry.specHash && { specHash: entry.specHash }),
-      autoCheck: entry.autoCheck !== false,
-      autoCheckInterval: entry.autoCheckInterval || 5
-    }));
+    brunoExtension.openapi = openApiEntries;
   }
 
   if (Object.keys(brunoExtension).length > 0) {

--- a/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
+++ b/packages/bruno-converters/src/opencollection/bruno-to-opencollection.ts
@@ -167,7 +167,7 @@ export const brunoToOpenCollection = (collection: BrunoCollection): OpenCollecti
     ignore?: string[];
     presets?: BrunoPresets;
     scripts?: { flow?: 'sandwich' | 'sequential' };
-    openapi?:BrunoConfig['openapi'];
+    openapi?: BrunoConfig['openapi'];
   } = {};
 
   if (brunoConfig?.ignore?.length) {

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -56,6 +56,7 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
       autoCheckInterval: entry.autoCheckInterval || 5
     }));
   }
+  
   const config = oc.config;
   if (!config) {
     return brunoConfig;

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -1,4 +1,5 @@
 import { OpenCollection } from "@opencollection/types";
+import { normalizeOpenApiSyncConfigs } from "@usebruno/common";
 import { BrunoCollection, BrunoCollectionRoot, BrunoConfig, BrunoPresets, PemCertificate, Pkcs12Certificate } from "./types";
 import { fromOpenCollectionActions, fromOpenCollectionAuth, fromOpenCollectionHeaders, fromOpenCollectionScripts, fromOpenCollectionVariables } from "./common";
 import { uuid } from "../common";
@@ -45,21 +46,12 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
   if (scriptFlow === 'sandwich' || scriptFlow === 'sequential') {
     brunoConfig.scripts = { flow: scriptFlow };
   }
-  const openApiExtensions = brunoExtension?.openapi;
-  const openApiEntries = Array.isArray(openApiExtensions)
-    ? openApiExtensions.filter((entry: any) => entry !== null && typeof entry === 'object')
-    : [];
+
+  const openApiEntries = normalizeOpenApiSyncConfigs(brunoExtension?.openapi);
   if (openApiEntries.length > 0) {
-    brunoConfig.openapi = openApiEntries.map((entry: any) => ({
-      sourceUrl: entry.sourceUrl,
-      groupBy: entry.groupBy,
-      ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
-      ...(entry.specHash && { specHash: entry.specHash }),
-      autoCheck: entry.autoCheck !== false,
-      autoCheckInterval: entry.autoCheckInterval || 5
-    }));
+    brunoConfig.openapi = openApiEntries;
   }
-  
+
   const config = oc.config;
   if (!config) {
     return brunoConfig;

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -46,8 +46,11 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
     brunoConfig.scripts = { flow: scriptFlow };
   }
   const openApiExtensions = brunoExtension?.openapi;
-  if (Array.isArray(openApiExtensions) && openApiExtensions.length > 0) {
-    brunoConfig.openapi = openApiExtensions.map((entry: any) => ({
+  const openApiEntries = Array.isArray(openApiExtensions)
+    ? openApiExtensions.filter((entry: any) => entry !== null && typeof entry === 'object')
+    : [];
+  if (openApiEntries.length > 0) {
+    brunoConfig.openapi = openApiEntries.map((entry: any) => ({
       sourceUrl: entry.sourceUrl,
       groupBy: entry.groupBy,
       ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),

--- a/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
+++ b/packages/bruno-converters/src/opencollection/opencollection-to-bruno.ts
@@ -11,6 +11,7 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
     ignore?: string[];
     presets?: BrunoPresets;
     scripts?: { flow?: unknown };
+    openapi?: BrunoConfig['openapi'];
   } | undefined;
 
   const ignoreList = brunoExtension && Array.isArray(brunoExtension.ignore)
@@ -44,7 +45,17 @@ const fromOpenCollectionConfig = (oc: OpenCollection): BrunoConfig => {
   if (scriptFlow === 'sandwich' || scriptFlow === 'sequential') {
     brunoConfig.scripts = { flow: scriptFlow };
   }
-
+  const openApiExtensions = brunoExtension?.openapi;
+  if (Array.isArray(openApiExtensions) && openApiExtensions.length > 0) {
+    brunoConfig.openapi = openApiExtensions.map((entry: any) => ({
+      sourceUrl: entry.sourceUrl,
+      groupBy: entry.groupBy,
+      ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
+      ...(entry.specHash && { specHash: entry.specHash }),
+      autoCheck: entry.autoCheck !== false,
+      autoCheckInterval: entry.autoCheckInterval || 5
+    }));
+  }
   const config = oc.config;
   if (!config) {
     return brunoConfig;

--- a/packages/bruno-converters/tests/opencollection/openapi-sync.spec.js
+++ b/packages/bruno-converters/tests/opencollection/openapi-sync.spec.js
@@ -28,6 +28,15 @@ describe('brunoToOpenCollection (export): openapi sync config', () => {
     expect(withEmptyList.extensions?.bruno?.openapi).toBeUndefined();
   });
 
+  it('skips malformed entries and keeps the usable ones', () => {
+    const oc = brunoToOpenCollection({
+      name: 'Petstore',
+      brunoConfig: { openapi: [null, 'https://example.com/openapi.json', syncConfig] },
+      items: []
+    });
+    expect(oc.extensions.bruno.openapi).toEqual([syncConfig]);
+  });
+
   it('omits sync metadata that is absent and defaults the auto-check fields', () => {
     const oc = brunoToOpenCollection({
       name: 'Petstore',
@@ -60,6 +69,15 @@ describe('openCollectionToBruno (import): openapi sync config', () => {
         autoCheckInterval: 5
       }
     ]);
+  });
+
+  it('skips malformed entries and keeps the usable ones', () => {
+    const { brunoConfig } = openCollectionToBruno({
+      opencollection: '1.0.0',
+      info: { name: 'Petstore' },
+      extensions: { bruno: { openapi: [null, 'https://example.com/openapi.json', syncConfig] } }
+    });
+    expect(brunoConfig.openapi).toEqual([syncConfig]);
   });
 
   it('leaves the collection unlinked when the file carries no sync config', () => {

--- a/packages/bruno-converters/tests/opencollection/openapi-sync.spec.js
+++ b/packages/bruno-converters/tests/opencollection/openapi-sync.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from '@jest/globals';
+import { brunoToOpenCollection } from '../../src/opencollection/bruno-to-opencollection';
+import { openCollectionToBruno } from '../../src/opencollection/opencollection-to-bruno';
+
+const syncConfig = {
+  sourceUrl: 'https://petstore3.swagger.io/api/v3/openapi.json',
+  groupBy: 'tags',
+  lastSyncDate: '2026-08-13T10:00:00.000Z',
+  specHash: 'd41d8cd98f00b204e9800998ecf8427e',
+  autoCheck: false,
+  autoCheckInterval: 15
+};
+
+describe('brunoToOpenCollection (export): openapi sync config', () => {
+  it('writes the sync config under extensions.bruno.openapi', () => {
+    const oc = brunoToOpenCollection({
+      name: 'Petstore',
+      brunoConfig: { openapi: [syncConfig] },
+      items: []
+    });
+    expect(oc.extensions?.bruno?.openapi).toEqual([syncConfig]);
+  });
+
+  it('writes nothing when the collection has no sync config', () => {
+    const withoutKey = brunoToOpenCollection({ name: 'API', brunoConfig: {}, items: [] });
+    const withEmptyList = brunoToOpenCollection({ name: 'API', brunoConfig: { openapi: [] }, items: [] });
+    expect(withoutKey.extensions?.bruno?.openapi).toBeUndefined();
+    expect(withEmptyList.extensions?.bruno?.openapi).toBeUndefined();
+  });
+
+  it('omits sync metadata that is absent and defaults the auto-check fields', () => {
+    const oc = brunoToOpenCollection({
+      name: 'Petstore',
+      brunoConfig: { openapi: [{ sourceUrl: 'https://example.com/openapi.json', groupBy: 'path' }] },
+      items: []
+    });
+    expect(oc.extensions.bruno.openapi).toEqual([
+      {
+        sourceUrl: 'https://example.com/openapi.json',
+        groupBy: 'path',
+        autoCheck: true,
+        autoCheckInterval: 5
+      }
+    ]);
+  });
+});
+
+describe('openCollectionToBruno (import): openapi sync config', () => {
+  it('reads the sync config back, defaulting the auto-check fields', () => {
+    const { brunoConfig } = openCollectionToBruno({
+      opencollection: '1.0.0',
+      info: { name: 'Petstore' },
+      extensions: { bruno: { openapi: [{ sourceUrl: 'https://example.com/openapi.json', groupBy: 'tags' }] } }
+    });
+    expect(brunoConfig.openapi).toEqual([
+      {
+        sourceUrl: 'https://example.com/openapi.json',
+        groupBy: 'tags',
+        autoCheck: true,
+        autoCheckInterval: 5
+      }
+    ]);
+  });
+
+  it('leaves the collection unlinked when the file carries no sync config', () => {
+    const { brunoConfig } = openCollectionToBruno({
+      opencollection: '1.0.0',
+      info: { name: 'API' }
+    });
+    expect(brunoConfig.openapi).toBeUndefined();
+  });
+});
+
+describe('openapi sync config: export then import keeps it the same', () => {
+  it('preserves the sync config across a round trip', () => {
+    const oc = brunoToOpenCollection({
+      name: 'Petstore',
+      brunoConfig: { openapi: [syncConfig] },
+      items: []
+    });
+    const { brunoConfig } = openCollectionToBruno(oc);
+    expect(brunoConfig.openapi).toEqual([syncConfig]);
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/parseCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseCollection.ts
@@ -1,5 +1,6 @@
 import type { OpenCollection } from '@opencollection/types';
 import type { FolderRoot } from '@usebruno/schema-types/collection/folder';
+import { normalizeOpenApiSyncConfigs } from '@usebruno/common';
 import { parseYml } from './utils';
 import { toBrunoAuth } from './common/auth';
 import { toBrunoHttpHeaders } from './common/headers';
@@ -70,15 +71,10 @@ const parseCollection = (ymlString: string): ParsedCollection => {
         flow: brunoExtensions.scripts.flow
       };
     }
-    if (Array.isArray(brunoExtensions?.openapi) && brunoExtensions.openapi.length > 0) {
-      brunoConfig.openapi = brunoExtensions.openapi.map((entry: any) => ({
-        sourceUrl: entry.sourceUrl,
-        groupBy: entry.groupBy,
-        ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
-        ...(entry.specHash && { specHash: entry.specHash }),
-        autoCheck: entry.autoCheck !== false,
-        autoCheckInterval: entry.autoCheckInterval || 5
-      }));
+
+    const openApiEntries = normalizeOpenApiSyncConfigs(brunoExtensions?.openapi);
+    if (openApiEntries.length > 0) {
+      brunoConfig.openapi = openApiEntries;
     }
 
     // protobuf

--- a/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyCollection.ts
@@ -5,6 +5,7 @@ import type { ClientCertificate, PemCertificate, Pkcs12Certificate } from '@open
 import type { Variable } from '@opencollection/types/common/variables';
 import type { Action } from '@opencollection/types/common/actions';
 import type { Scripts } from '@opencollection/types/common/scripts';
+import { normalizeOpenApiSyncConfigs } from '@usebruno/common';
 import { stringifyYml } from './utils';
 import { toOpenCollectionAuth } from './common/auth';
 import { toOpenCollectionHttpHeaders } from './common/headers';
@@ -280,18 +281,12 @@ const stringifyCollection = (collectionRoot: any, brunoConfig: any): string => {
     }
 
     // bruno-specific extensions
-    if (Array.isArray(brunoConfig.openapi) && brunoConfig.openapi.length > 0) {
+    const openApiEntries = normalizeOpenApiSyncConfigs(brunoConfig.openapi);
+    if (openApiEntries.length > 0) {
       if (!oc.extensions.bruno) {
         oc.extensions.bruno = {};
       }
-      (oc.extensions.bruno as any).openapi = brunoConfig.openapi.map((entry: any) => ({
-        sourceUrl: entry.sourceUrl,
-        groupBy: entry.groupBy,
-        ...(entry.lastSyncDate && { lastSyncDate: entry.lastSyncDate }),
-        ...(entry.specHash && { specHash: entry.specHash }),
-        autoCheck: entry.autoCheck !== false,
-        autoCheckInterval: entry.autoCheckInterval || 5
-      }));
+      (oc.extensions.bruno as any).openapi = openApiEntries;
     }
 
     return stringifyYml(oc);


### PR DESCRIPTION
### Description

REF: BRU-4012

When you export a collection as a single OpenCollection YAML, the OpenAPI sync settings were being dropped. This adds them to the export and reads them back on import, so a shared collection stays linked to its spec.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

If a collection is linked to an OpenAPI spec, Bruno stores that link in the collection's config (the spec URL, whether folders are grouped by tags or paths, the auto-check setting and interval, and when it last synced).Saving to disk keeps all of this,it's written into opencollection.yml under extensions.bruno.openapi and read straight back. But the single-file export takes a different route through @usebruno/converters, and that route never knew about the field. brunoToOpenCollection builds extensions.bruno from a fixed list  ignore, presets, and script flow so the OpenAPI config was skipped. openCollectionToBruno had the same blind spot and ignored the block even when it was present in the file.
The result: export a linked collection as a .yml, send it to someone, and they get all the requests but no link to the spec. They'd have to set up sync again by hand.

<!-- What issue does this PR solve? Link the related issue if one exists. -->

### Fix
1) YAML export now includes extensions.bruno.openapi when an OpenAPI sync configuration exists.
2)YAML import restores the OpenAPI sync configuration 
3)Collections without an OpenAPI configuration continue to export exactly as before, with no empty extensions.bruno.openapi field

<!-- How does this PR fix the problem? Briefly describe your approach. -->

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserved OpenAPI synchronization settings when converting between Bruno and OpenCollection formats.
  - Retained synchronization metadata, automatic check preferences, check intervals, and supported grouping options.
  - Applied default automatic checking with a five-minute interval when unspecified.
  - Safely ignored invalid, incomplete, unsupported, or empty synchronization entries.

- **Bug Fixes**
  - Improved consistency of OpenAPI synchronization settings when reading and writing collection files.

- **Tests**
  - Added coverage for imports, exports, defaults, invalid entries, missing settings, and round-trip preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->