### PR TITLE
fix (sqlite): updated the createDatabase method to handle failures

### DIFF
--- a/packages/bruno-sqlite/scripts/verify-migrations.ts
+++ b/packages/bruno-sqlite/scripts/verify-migrations.ts
@@ -1,6 +1,6 @@
 import { DB } from '../src/node/db';
-import type { Migration } from '../src/shared/types';
-import { loadMigrations } from './lib/sources';
+import type { Migration, StatementDef } from '../src/shared/types';
+import { loadMigrations, loadStatements } from './lib/sources';
 import { vacuumIntoStatement } from './lib/sql';
 import { DatabaseSync } from 'node:sqlite';
 import os from 'node:os';
@@ -13,18 +13,22 @@ const main = () => {
   if (!path.isAbsolute(dbPath)) throw new Error('non absolute DB_PATH. provide an absolute path');
 
   let migrations: Migration[];
+  let statements: StatementDef[];
   try {
     migrations = loadMigrations();
+    statements = loadStatements();
   } catch (err) {
-    console.error(`Failed to load migrations: ${(err as Error).message}`);
+    console.error(`Failed to load migrations and statements: ${(err as Error).message}`);
     process.exitCode = 1;
     return;
   }
 
-  if (migrations.length === 0) {
-    console.log('No migrations to verify.');
+  if (migrations.length === 0 && statements.length === 0) {
+    console.log('No migrations or statements to verify.');
     return;
   }
+
+  const unpreparable: { name: string; message: string }[] = [];
   let dbHandle, backupHandle, tempDir;
   try {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-sqlite-backup-'));
@@ -32,6 +36,17 @@ const main = () => {
     dbHandle = new DatabaseSync(dbPath);
     dbHandle.exec(vacuumIntoStatement(backupPath));
     backupHandle = new DB(backupPath, migrations);
+
+    const migratedDb = backupHandle._db;
+    if (migratedDb === undefined) throw new Error('the migrated database is not open.');
+
+    for (const statement of statements) {
+      try {
+        migratedDb.prepare(statement.sql);
+      } catch (err) {
+        unpreparable.push({ name: statement.name, message: (err as Error).message });
+      }
+    }
   } catch (err) {
     console.error(`Migration verification failed: ${(err as Error).stack}`);
     process.exitCode = 1;
@@ -42,7 +57,18 @@ const main = () => {
     if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
   }
 
-  console.log(`Verified ${migrations.length} migration(s): all statements applied cleanly.`);
+  if (unpreparable.length > 0) {
+    console.error(
+      `Statement verification failed: ${unpreparable.length} of ${statements.length} statement(s) cannot be prepared against the migrated schema.`
+    );
+    for (const failure of unpreparable) console.error(`  ${failure.name}: ${failure.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Verified ${migrations.length} migration(s) and ${statements.length} statement(s): all applied cleanly.`
+  );
 };
 
 main();

--- a/packages/bruno-sqlite/src/node/db.ts
+++ b/packages/bruno-sqlite/src/node/db.ts
@@ -4,6 +4,24 @@ import type { Migration } from '../shared/types';
 
 export type DatabaseOptions = DatabaseSyncOptions;
 
+const MIGRATION_ERROR = Symbol.for('@usebruno/sqlite:migration-error');
+
+export class DatabaseMigrationError extends Error {
+  readonly [MIGRATION_ERROR] = true;
+  readonly path: string;
+  readonly cause: unknown;
+
+  constructor(path: string, cause: unknown) {
+    super(`failed to migrate the database at "${path}": ${(cause as Error)?.message ?? cause}`);
+    this.name = 'DatabaseMigrationError';
+    this.path = path;
+    this.cause = cause;
+  }
+}
+
+export const isDatabaseMigrationError = (err: unknown): err is DatabaseMigrationError =>
+  typeof err === 'object' && err !== null && MIGRATION_ERROR in err;
+
 export class DB {
   _db: DatabaseSync | undefined = undefined;
   _migrations_table: string = `CREATE TABLE IF NOT EXISTS _migrations (
@@ -17,13 +35,19 @@ export class DB {
   )`;
 
   constructor(path: string, migrations: Migration[], options: DatabaseOptions = {}) {
-    this._db = new DatabaseSync(path, options);
+    try {
+      this._db = new DatabaseSync(path, options);
+    } catch (err) {
+      this._db = undefined;
+      throw err;
+    }
+
     try {
       this._runMigrations(migrations);
     } catch (err) {
       this._db.close();
       this._db = undefined;
-      throw err;
+      throw new DatabaseMigrationError(path, err);
     }
   }
 

--- a/packages/bruno-sqlite/src/node/index.ts
+++ b/packages/bruno-sqlite/src/node/index.ts
@@ -1,10 +1,10 @@
-import { DB } from './db';
-import type { DatabaseOptions } from './db';
-import { Statements } from './statements';
-import type { OnMutation } from './statements';
+import { existsSync, mkdirSync, renameSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { DB, DatabaseOptions, isDatabaseMigrationError } from './db';
+import { Statements, OnMutation } from './statements';
 import { migrations } from '../generated/node/migrations';
 
-export { DB } from './db';
+export { DB, DatabaseMigrationError, isDatabaseMigrationError } from './db';
 export type { DatabaseOptions } from './db';
 export { Statements } from './statements';
 export type { OnMutation } from './statements';
@@ -18,12 +18,64 @@ export type CreateDatabaseOptions = DatabaseOptions & {
   onMutation?: OnMutation;
 };
 
-export const createDatabase = (path: string, options: CreateDatabaseOptions = {}) => {
-  const { onMutation, ...dbOptions } = options;
-  const db = new DB(path, migrations, dbOptions);
-  if (db._db === undefined) {
-    throw new Error('Failed to open the database.');
+const IN_MEMORY_PATH = ':memory:';
+
+const BACKUP_DIRECTORY = 'sqlite-backup';
+
+const DATABASE_FILE_SUFFIXES = ['', '-journal', '-wal', '-shm'];
+
+const backupDatabase = (path: string): string => {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(dirname(path), BACKUP_DIRECTORY, `${timestamp}-${basename(path)}`);
+
+  mkdirSync(dirname(backupPath), { recursive: true });
+  for (const suffix of DATABASE_FILE_SUFFIXES) {
+    if (existsSync(path + suffix)) renameSync(path + suffix, backupPath + suffix);
   }
-  const statements = new Statements(db._db, onMutation);
-  return { db, statements };
+
+  return backupPath;
+};
+
+const open = (target: string, options: CreateDatabaseOptions) => {
+  const { onMutation, ...dbOptions } = options;
+  const db = new DB(target, migrations, dbOptions);
+  try {
+    return { db, statements: new Statements(db._db!, onMutation) };
+  } catch (err) {
+    db.close();
+    throw err;
+  }
+};
+
+const openInMemory = (options: CreateDatabaseOptions) => {
+  try {
+    return open(IN_MEMORY_PATH, options);
+  } catch (err) {
+    console.error('failed to open in-memory database: ', err);
+    return { db: undefined, statements: undefined };
+  }
+};
+
+const rebuildFromBackup = (path: string, options: CreateDatabaseOptions, cause: unknown) => {
+  try {
+    const backupPath = backupDatabase(path);
+    console.warn(`failed to migrate the database, moved it to "${backupPath}" and started a new one: `, cause);
+    return open(path, options);
+  } catch (err) {
+    console.error('failed to rebuild the database after a failed migration: ', err);
+    return openInMemory(options);
+  }
+};
+
+export const createDatabase = (path: string, options: CreateDatabaseOptions = {}): {
+  db: DB | undefined;
+  statements: Statements | undefined;
+} => {
+  try {
+    return open(path, options);
+  } catch (err) {
+    if (isDatabaseMigrationError(err) && path !== IN_MEMORY_PATH) return rebuildFromBackup(path, options, err);
+    console.warn('failed to open the database file, falling back to an in-memory database: ', err);
+    return openInMemory(options);
+  }
 };

--- a/packages/bruno-sqlite/src/node/index.ts
+++ b/packages/bruno-sqlite/src/node/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, renameSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, rmSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { DB, DatabaseOptions, isDatabaseMigrationError } from './db';
 import { Statements, OnMutation } from './statements';
@@ -24,16 +24,12 @@ const BACKUP_DIRECTORY = 'sqlite-backup';
 
 const DATABASE_FILE_SUFFIXES = ['', '-journal', '-wal', '-shm'];
 
-const backupDatabase = (path: string): string => {
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const backupPath = join(dirname(path), BACKUP_DIRECTORY, `${timestamp}-${basename(path)}`);
-
-  mkdirSync(dirname(backupPath), { recursive: true });
+// TODO (chirag): This has to do a proper backup and create a new one. This requires a thorough
+// refinement to handle permission errors and such. Right now, just falling back to deleting the old DB and creating a new one
+const deleteDbFiles = (path: string): void => {
   for (const suffix of DATABASE_FILE_SUFFIXES) {
-    if (existsSync(path + suffix)) renameSync(path + suffix, backupPath + suffix);
+    rmSync(path + suffix, { force: true, maxRetries: 3 });
   }
-
-  return backupPath;
 };
 
 const open = (target: string, options: CreateDatabaseOptions) => {
@@ -56,10 +52,10 @@ const openInMemory = (options: CreateDatabaseOptions) => {
   }
 };
 
-const rebuildFromBackup = (path: string, options: CreateDatabaseOptions, cause: unknown) => {
+const rebuildFromBackup = (cause: unknown, path: string, options: CreateDatabaseOptions) => {
   try {
-    const backupPath = backupDatabase(path);
-    console.warn(`failed to migrate the database, moved it to "${backupPath}" and started a new one: `, cause);
+    deleteDbFiles(path);
+    console.warn(`failed to migrate the database, writing a new one: `, cause);
     return open(path, options);
   } catch (err) {
     console.error('failed to rebuild the database after a failed migration: ', err);
@@ -74,7 +70,7 @@ export const createDatabase = (path: string, options: CreateDatabaseOptions = {}
   try {
     return open(path, options);
   } catch (err) {
-    if (isDatabaseMigrationError(err) && path !== IN_MEMORY_PATH) return rebuildFromBackup(path, options, err);
+    if (isDatabaseMigrationError(err) && path !== IN_MEMORY_PATH) return rebuildFromBackup(err, path, options);
     console.warn('failed to open the database file, falling back to an in-memory database: ', err);
     return openInMemory(options);
   }

--- a/packages/bruno-sqlite/src/node/statements.ts
+++ b/packages/bruno-sqlite/src/node/statements.ts
@@ -14,15 +14,22 @@ export class Statements {
     this._onMutation = onMutation;
     for (const def of statementDefs) {
       this._defs.set(def.name, def);
-      this._prepared.set(def.name, db.prepare(def.sql));
+      try {
+        this._prepared.set(def.name, db.prepare(def.sql));
+      } catch (err) {
+        console.error(`failed to prepare the statement "${def.name}": `, err);
+      }
     }
   }
 
   execute(name: string, params: SQLiteParams = {}): unknown {
-    const stmt = this._prepared.get(name);
     const def = this._defs.get(name);
-    if (stmt === undefined || def === undefined) {
+    if (def === undefined) {
       throw new Error(`Unknown statement: "${name}"`);
+    }
+    const stmt = this._prepared.get(name);
+    if (stmt === undefined) {
+      throw new Error(`Statement "${name}" could not be prepared against this database`);
     }
     const args = params as Record<string, SupportedValueType>;
     switch (def.type) {

--- a/packages/bruno-sqlite/tests/node/create-database.spec.ts
+++ b/packages/bruno-sqlite/tests/node/create-database.spec.ts
@@ -1,0 +1,101 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const brokenMigrations = {
+  migrations: [
+    {
+      sequence: 1,
+      name: 'broken',
+      up: 'NOT VALID SQL',
+      down: 'DROP TABLE broken'
+    }
+  ]
+};
+
+describe('createDatabase', () => {
+  let dir: string;
+  let dbPath: string;
+  let warn: jest.SpyInstance;
+  let error: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    dir = mkdtempSync(join(tmpdir(), 'bruno-sqlite-'));
+    dbPath = join(dir, 'bruno.db');
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    error.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const backups = (): string[] => {
+    const backupDir = join(dir, 'sqlite-backup');
+    return existsSync(backupDir) ? readdirSync(backupDir) : [];
+  };
+
+  it('opens the database file when it is accessible', () => {
+    const { createDatabase } = require('../../src/node/index');
+    const { db, statements } = createDatabase(dbPath);
+
+    expect(db).toBeDefined();
+    expect(statements).toBeDefined();
+    expect(backups()).toEqual([]);
+    db.close();
+  });
+
+  it('falls back to an in-memory database when the file cannot be opened', () => {
+    const { createDatabase } = require('../../src/node/index');
+
+    const { db, statements } = createDatabase(join(dir, 'missing-dir', 'bruno.db'));
+
+    expect(db).toBeDefined();
+    expect(statements).toBeDefined();
+    expect(warn).toHaveBeenCalled();
+    db.close();
+  });
+
+  it('backs up an unusable database file and rebuilds it', () => {
+    writeFileSync(dbPath, 'this is not a sqlite database');
+    const { createDatabase } = require('../../src/node/index');
+
+    const { db, statements } = createDatabase(dbPath);
+
+    expect(db).toBeDefined();
+    expect(statements).toBeDefined();
+    expect(backups()).toHaveLength(1);
+    expect(existsSync(dbPath)).toBe(true);
+    expect(db._db.prepare('SELECT name FROM _migrations').all()).toEqual([]);
+    db.close();
+  });
+
+  it('opens the file database even when a statement cannot be prepared', () => {
+    jest.doMock('../../src/generated/node/statements', () => ({
+      statements: [{ name: 'broken', sql: 'NOT VALID SQL', type: 'one', tables: [] }]
+    }));
+    const { createDatabase } = require('../../src/node/index');
+
+    const { db, statements } = createDatabase(dbPath);
+
+    expect(db).toBeDefined();
+    expect(statements).toBeDefined();
+    expect(backups()).toEqual([]);
+    db.close();
+  });
+
+  it('backs up only once when the migrations themselves are broken', () => {
+    jest.doMock('../../src/generated/node/migrations', () => brokenMigrations);
+    const { createDatabase } = require('../../src/node/index');
+
+    const { db, statements } = createDatabase(dbPath);
+
+    expect(db).toBeUndefined();
+    expect(statements).toBeUndefined();
+    expect(backups()).toHaveLength(1);
+    expect(error).toHaveBeenCalled();
+  });
+});

--- a/packages/bruno-sqlite/tests/node/statements.spec.ts
+++ b/packages/bruno-sqlite/tests/node/statements.spec.ts
@@ -6,7 +6,8 @@ const defs: StatementDef[] = [
   { name: 'insertWithId', type: 'exec', sql: 'INSERT INTO items(id, name) VALUES (:id, :name)', tables: ['items'] },
   { name: 'getItem', type: 'one', sql: 'SELECT * FROM items WHERE id = :id', tables: ['items'] },
   { name: 'allItems', type: 'many', sql: 'SELECT * FROM items', tables: ['items'] },
-  { name: 'invalid', type: 'invalid_type' as StatementType, sql: 'SELECT * FROM items', tables: ['items'] }
+  { name: 'invalid', type: 'invalid_type' as StatementType, sql: 'SELECT * FROM items', tables: ['items'] },
+  { name: 'unpreparable', type: 'one', sql: 'SELECT * FROM missing_table', tables: ['missing_table'] }
 ];
 
 jest.doMock('../../src/generated/node/statements', () => ({ statements: defs }));
@@ -18,6 +19,16 @@ const newStatements = (onMutation?: (event: unknown) => void) => {
   db.exec('CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)');
   return new Statements(db, onMutation);
 };
+
+let error: jest.SpyInstance;
+
+beforeEach(() => {
+  error = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  error.mockRestore();
+});
 
 describe('Statements.execute mutation signalling', () => {
   it('notifies with the statement name and tables after a successful write', () => {
@@ -75,5 +86,31 @@ describe('Statements.execute mutation signalling', () => {
     const statements = newStatements(onMutation);
     expect(() => statements.execute('invalid', {})).toThrow('unknown definition type: invalid_type');
     expect(onMutation).not.toHaveBeenCalled();
+  });
+});
+
+describe('Statements preparation', () => {
+  it('discards only the statement that cannot be prepared', () => {
+    const statements = newStatements();
+
+    expect(statements._prepared.has('unpreparable')).toBe(false);
+    expect(statements._prepared.size).toBe(defs.length - 1);
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the healthy statements usable', () => {
+    const statements = newStatements();
+
+    statements.execute('insertItem', { name: 'alpha' });
+
+    expect(statements.execute('allItems', {})).toEqual([{ id: 1, name: 'alpha' }]);
+  });
+
+  it('throws a distinct error when executing a discarded statement', () => {
+    const statements = newStatements();
+
+    expect(() => statements.execute('unpreparable', {})).toThrow(
+      'Statement "unpreparable" could not be prepared against this database'
+    );
   });
 });


### PR DESCRIPTION
Earlier the app would fail to open if the OS denied access to the DB file. The first fix here was to fall back to an in-memory DB whenever setup failed, but that turned out to be too blunt. A bad migration or a corrupt file would get quietly papered over with a throwaway DB, and the user would carry on with a store that disappears on quit.

So instead of one catch-all fallback, we now look at what actually broke:

- **The file cannot be opened** (permissions, missing folder): in-memory fallback, same as before. The app starts, just without persistence.
- **The file opens but the migrations fail**: the file is the problem, not us. This happens with a corrupt DB, one written by a newer version of Bruno, or a `down` that no longer applies. We move it into `sqlite-backup/` with a timestamp on it, then create a fresh file and migrate that instead.
- **The rebuild fails too**: our own migrations are broken, so renaming the file a second time will not help anyone. We log it and fall back to in-memory.
- **A single statement will not prepare**: drop only that statement, instead of letting it take the whole store down with it.

A few notes on the details:

- Nothing in this DB is authored by the user, it is all derived state, so rebuilding it is safe. We keep the old file rather than deleting it, so we can still look at it if someone reports something odd.
- The journal and WAL are moved along with the DB file, because sqlite pairs those to a DB by filename and a leftover one would otherwise get replayed into the fresh file.
- Migration errors are tagged with a `Symbol.for` brand rather than checked with `instanceof`. We ship separate CJS and ESM bundles and each inlines its own copy of the class, so `instanceof` can come back false for what is clearly the same error. Moving the user's file aside is the destructive branch, so it only runs on a positive match, and anything we cannot classify goes to the in-memory fallback instead of renaming data.
- Executing a dropped statement now tells you it could not be prepared, instead of the old and fairly confusing "Unknown statement".
- `npm run migration:verify` now prepares every generated statement against the migrated schema and lists all of the failures in one run, so a statement pointing at a column that no migration creates fails there rather than at runtime.

Ticket: BRU-4300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup reliability by safely handling initialization and migration failures.
  * Added automatic in-memory fallback when a database file cannot be opened or recovered.
  * Preserved failed database files through backup before migration recovery.
  * Prevented cleanup errors when database setup is incomplete.
  * Improved error messages for unavailable or invalid SQL statements.
  * Allowed valid statements to remain usable when another statement fails to prepare.
  * Added clearer warnings and error reporting when database creation or migrations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
