### PR TITLE
fix(modal): remove collection modal overlap with search container

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollection/index.js
@@ -8,6 +8,7 @@ import { findCollectionByUid, flattenItems, isItemARequest, hasRequestChanges } 
 import filter from 'lodash/filter';
 import ConfirmCollectionCloseDrafts from './ConfirmCollectionCloseDrafts';
 import StyledWrapper from './StyledWrapper';
+import Portal from 'ui/Portal';
 
 const RemoveCollection = ({ onClose, collectionUid }) => {
   const dispatch = useDispatch();
@@ -46,23 +47,25 @@ const RemoveCollection = ({ onClose, collectionUid }) => {
   // Otherwise, show the standard remove confirmation modal
   return (
     <StyledWrapper>
-      <Modal
-        size="sm"
-        title="Remove Collection"
-        confirmText="Remove"
-        confirmButtonColor="danger"
-        handleConfirm={onConfirm}
-        handleCancel={onClose}
-      >
-        <p className="mb-4">Are you sure you want to close following collection in Bruno?</p>
-        <div className="collection-info-card">
-          <div className="collection-name">{collection.name}</div>
-          <div className="collection-path">{collection.pathname}</div>
-        </div>
-        <p className="mt-4 text-muted text-sm">
-          It will still be available in the filesystem at the above location and can be re-opened later.
-        </p>
-      </Modal>
+      <Portal>
+        <Modal
+          size="sm"
+          title="Remove Collection"
+          confirmText="Remove"
+          confirmButtonColor="danger"
+          handleConfirm={onConfirm}
+          handleCancel={onClose}
+        >
+          <p className="mb-4">Are you sure you want to close following collection in Bruno?</p>
+          <div className="collection-info-card">
+            <div className="collection-name">{collection.name}</div>
+            <div className="collection-path">{collection.pathname}</div>
+          </div>
+          <p className="mt-4 text-muted text-sm">
+            It will still be available in the filesystem at the above location and can be re-opened later.
+          </p>
+        </Modal>
+      </Portal>
     </StyledWrapper>
   );
 };


### PR DESCRIPTION
### Description

BRU-4301

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
The remove collection modal of overlaps with doc editor search.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
The modal was rendered inside a nested container, so its z-index: 20 was limited to that container’s stacking context. Because the toolbar belonged to a different stacking context, it appeared above the modal even with a lower z-index.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- Rendered the modals in a portal with root element as document body. which puts the modal at the top-level stacking context
- Used the existing Portal component from `src/ui`

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection-removal modal rendering to ensure it displays correctly above other interface elements.
  * Preserved the modal’s existing content and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->