### PR TITLE
fix (request): Requests showing example count

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.js
@@ -99,13 +99,6 @@ const Wrapper = styled.div`
       overflow: hidden;
     }
 
-    .example-count-badge {
-      font-size: 10px;
-      font-weight: 500;
-      color: ${(props) => props.theme.colors.text.muted};
-      flex-shrink: 0;
-    }
-
     /* Single source of truth for hover/focus states: background and menu icon visibility */
     &:hover,
     &.item-hovered,

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -763,11 +763,6 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
               <span className="item-name" title={item.name}>
                 {item.name}
               </span>
-              {hasExamples && (
-                <sup className="ml-1 example-count-badge" title={`${item.examples.length} example${item.examples.length > 1 ? 's' : ''}`} data-testid="example-count-badge">
-                  {item.examples.length}
-                </sup>
-              )}
             </div>
           </div>
           <div className="pr-2">


### PR DESCRIPTION
### Description

The request on the sidebar shows the number of examples within it. 

### Problem
JIRA: BRU-4303

There was a change made during mock servers to keep a count of the examples. What was done earlier to see of there examples count can be listed, wasn't removed. 

### Fix

Removed the code that showed the count and the CSS class. 

### Screenshots

*Before*

<img width="502" height="418" alt="image" src="https://github.com/user-attachments/assets/0809695a-26b6-442e-a4e0-e36bb0a1db08" />

*After*

<img width="218" height="427" alt="image" src="https://github.com/user-attachments/assets/dcfdc8f6-ba10-4bfd-ae43-eb114c722d29" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the response example count badge displayed beside collection item names.
  * Updated collection item styling to reflect the simplified appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->