### PR TITLE
fix(oauth2): resolve token to a string before header injection

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -28,7 +28,7 @@ const { chooseFileToSave, writeFile, getCollectionFormat, hasRequestExtension } 
 const { addCookieToJar, getDomainsWithCookies, getCookieStringForUrl } = require('../../utils/cookies');
 const { createFormData } = require('../../utils/form-data');
 const { findItemInCollectionByPathname, sortFolder, getAllRequestsInFolderRecursively, getEnvVars, getTreePathFromCollectionToItem, mergeVars, sortByNameThenSequence } = require('../../utils/collection');
-const { getOAuth2TokenUsingAuthorizationCode, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingImplicitGrant, updateCollectionOauth2Credentials, clearOauth2CredentialsByCredentialsId } = require('../../utils/oauth2');
+const { getOAuth2TokenUsingAuthorizationCode, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingImplicitGrant, updateCollectionOauth2Credentials, clearOauth2CredentialsByCredentialsId, applyOAuth2TokenToRequest } = require('../../utils/oauth2');
 const { preferencesUtil } = require('../../store/preferences');
 const { getProcessEnvVars } = require('../../store/process-env');
 const { getBrunoConfig } = require('../../store/bruno-config');
@@ -243,69 +243,25 @@ const configureRequest = async (
         interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
         ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingAuthorizationCode({ request: requestCopy, collectionUid, certsAndProxyConfigForTokenUrl, certsAndProxyConfigForRefreshUrl }));
         request.oauth2Credentials = { credentials, url: oauth2Url, collectionUid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
-        {
-          const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
-          if (tokenPlacement == 'header' && tokenValue) {
-            request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
-            try {
-              const url = new URL(request.url);
-              url.searchParams.set(tokenQueryKey, tokenValue);
-              request.url = url.toString();
-            } catch (error) { }
-          }
-        }
+        applyOAuth2TokenToRequest(request, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
         break;
       case 'implicit':
         interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
         ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingImplicitGrant({ request: requestCopy, collectionUid }));
         request.oauth2Credentials = { credentials, url: oauth2Url, collectionUid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
-        {
-          const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
-          if (tokenPlacement == 'header' && tokenValue) {
-            request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
-            try {
-              const url = new URL(request.url);
-              url.searchParams.set(tokenQueryKey, tokenValue);
-              request.url = url.toString();
-            } catch (error) { }
-          }
-        }
+        applyOAuth2TokenToRequest(request, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
         break;
       case 'client_credentials':
         interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
         ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingClientCredentials({ request: requestCopy, collectionUid, certsAndProxyConfigForTokenUrl, certsAndProxyConfigForRefreshUrl }));
         request.oauth2Credentials = { credentials, url: oauth2Url, collectionUid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
-        {
-          const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
-          if (tokenPlacement == 'header' && tokenValue) {
-            request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
-            try {
-              const url = new URL(request.url);
-              url.searchParams.set(tokenQueryKey, tokenValue);
-              request.url = url.toString();
-            } catch (error) { }
-          }
-        }
+        applyOAuth2TokenToRequest(request, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
         break;
       case 'password':
         interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
         ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingPasswordCredentials({ request: requestCopy, collectionUid, certsAndProxyConfigForTokenUrl, certsAndProxyConfigForRefreshUrl }));
         request.oauth2Credentials = { credentials, url: oauth2Url, collectionUid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
-        {
-          const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
-          if (tokenPlacement == 'header' && tokenValue) {
-            request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
-          } else if (tokenValue) {
-            try {
-              const url = new URL(request.url);
-              url.searchParams.set(tokenQueryKey, tokenValue);
-              request.url = url.toString();
-            } catch (error) { }
-          }
-        }
+        applyOAuth2TokenToRequest(request, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
         break;
     }
   }

--- a/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-grpc-request.js
@@ -2,7 +2,7 @@ const { cloneDeep, each, get } = require('lodash');
 const interpolateVars = require('./interpolate-vars');
 const { getEnvVars, getTreePathFromCollectionToItem, mergeHeaders, mergeScripts, mergeVars, mergeAuth, getFormattedCollectionOauth2Credentials } = require('../../utils/collection');
 const { getProcessEnvVars } = require('../../store/process-env');
-const { getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingAuthorizationCode } = require('../../utils/oauth2');
+const { getOAuth2TokenUsingPasswordCredentials, getOAuth2TokenUsingClientCredentials, getOAuth2TokenUsingAuthorizationCode, applyOAuth2TokenToRequest } = require('../../utils/oauth2');
 const { setAuthHeaders } = require('./prepare-request');
 const { getCertsAndProxyConfig } = require('./cert-utils');
 const { interpolateString } = require('./interpolate-string');
@@ -15,25 +15,11 @@ const processHeaders = (headers) => {
   });
 };
 
-const placeOAuth2Token = (grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey) => {
-  if (tokenPlacement === 'header') {
-    grpcRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-  } else {
-    try {
-      const url = new URL(grpcRequest.url);
-      url?.searchParams?.set(tokenQueryKey, credentials?.access_token);
-      grpcRequest.url = url?.toString();
-    } catch (error) {
-      console.error('Failed to parse URL for OAuth2 token placement:', error);
-    }
-  }
-};
-
 const configureRequest = async (grpcRequest, request, collection, envVars, runtimeVariables, processEnvVars, promptVariables, certsAndProxyConfig) => {
   if (grpcRequest.oauth2) {
     let requestCopy = cloneDeep(grpcRequest);
     const { uid: collectionUid, pathname: collectionPath, globalEnvironmentVariables } = collection;
-    const { oauth2: { grantType, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, accessTokenUrl, refreshTokenUrl } = {}, collectionVariables, folderVariables, requestVariables } = requestCopy || {};
+    const { oauth2: { grantType, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource, accessTokenUrl, refreshTokenUrl } = {}, collectionVariables, folderVariables, requestVariables } = requestCopy || {};
     let credentials, credentialsId, oauth2Url, debugInfo;
 
     // Get cert/proxy configs for token and refresh URLs
@@ -95,19 +81,19 @@ const configureRequest = async (grpcRequest, request, collection, envVars, runti
           interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
           ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingAuthorizationCode({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfigForTokenUrl, certsAndProxyConfigForRefreshUrl }));
           grpcRequest.oauth2Credentials = { credentials, url: oauth2Url, collectionUid: collection.uid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
-          placeOAuth2Token(grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey);
+          applyOAuth2TokenToRequest(grpcRequest, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
           break;
         case 'client_credentials':
           interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
           ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingClientCredentials({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfigForTokenUrl, certsAndProxyConfigForRefreshUrl }));
           grpcRequest.oauth2Credentials = { credentials, url: oauth2Url, collectionUid: collection.uid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
-          placeOAuth2Token(grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey);
+          applyOAuth2TokenToRequest(grpcRequest, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
           break;
         case 'password':
           interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars, promptVariables);
           ({ credentials, url: oauth2Url, credentialsId, debugInfo } = await getOAuth2TokenUsingPasswordCredentials({ request: requestCopy, collectionUid: collection.uid, certsAndProxyConfigForTokenUrl, certsAndProxyConfigForRefreshUrl }));
           grpcRequest.oauth2Credentials = { credentials, url: oauth2Url, collectionUid: collection.uid, credentialsId, debugInfo, folderUid: request.oauth2Credentials?.folderUid };
-          placeOAuth2Token(grpcRequest, credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey);
+          applyOAuth2TokenToRequest(grpcRequest, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
           break;
       }
     } catch (error) {

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
@@ -21,7 +21,6 @@ const {
   applyOAuth2TokenToRequest
 } = require('../../utils/oauth2');
 const { interpolateString } = require('./interpolate-string');
-const path = require('node:path');
 const { setAuthHeaders } = require('./prepare-request');
 
 const prepareWsRequest = async (item, collection, environment, runtimeVariables, certsAndProxyConfig = {}) => {
@@ -252,7 +251,7 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
 
   delete wsRequest.apiKeyAuthValueForQueryParams;
 
-  interpolateVars(wsRequest, envVars, runtimeVariables, processEnvVars);
+  interpolateVars(wsRequest, envVars, runtimeVariables, processEnvVars, collection?.promptVariables);
 
   // The token is placed after interpolation: placing it earlier would run new URL() on raw
   // {{var}} templates and percent-encode them beyond the interpolator's reach. The placement

--- a/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/ws-event-handlers.js
@@ -17,7 +17,8 @@ const { getProcessEnvVars } = require('../../store/process-env');
 const {
   getOAuth2TokenUsingPasswordCredentials,
   getOAuth2TokenUsingClientCredentials,
-  getOAuth2TokenUsingAuthorizationCode
+  getOAuth2TokenUsingAuthorizationCode,
+  applyOAuth2TokenToRequest
 } = require('../../utils/oauth2');
 const { interpolateString } = require('./interpolate-string');
 const path = require('node:path');
@@ -92,9 +93,10 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
 
   wsRequest = setAuthHeaders(wsRequest, request, collection);
 
+  let oauth2FetchedCredentials;
   if (wsRequest.oauth2) {
     const requestCopy = cloneDeep(wsRequest);
-    const { oauth2: { grantType, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, accessTokenUrl, refreshTokenUrl } = {}, collectionVariables, folderVariables, requestVariables } = requestCopy || {};
+    const { oauth2: { grantType, accessTokenUrl, refreshTokenUrl } = {}, collectionVariables, folderVariables, requestVariables } = requestCopy || {};
 
     // Get cert/proxy configs for token and refresh URLs
     let certsAndProxyConfigForTokenUrl = certsAndProxyConfig;
@@ -173,15 +175,6 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
           debugInfo,
           folderUid: request.oauth2Credentials?.folderUid
         };
-        if (tokenPlacement == 'header') {
-          wsRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-        } else {
-          try {
-            const url = new URL(request.url);
-            url?.searchParams?.set(tokenQueryKey, credentials?.access_token);
-            request.url = url?.toString();
-          } catch (error) {}
-        }
         break;
       case 'client_credentials':
         interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars);
@@ -204,15 +197,6 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
           debugInfo,
           folderUid: request.oauth2Credentials?.folderUid
         };
-        if (tokenPlacement == 'header') {
-          wsRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-        } else {
-          try {
-            const url = new URL(request.url);
-            url?.searchParams?.set(tokenQueryKey, credentials?.access_token);
-            request.url = url?.toString();
-          } catch (error) {}
-        }
         break;
       case 'password':
         interpolateVars(requestCopy, envVars, runtimeVariables, processEnvVars);
@@ -235,17 +219,9 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
           debugInfo,
           folderUid: request.oauth2Credentials?.folderUid
         };
-        if (tokenPlacement == 'header') {
-          wsRequest.headers['Authorization'] = `${tokenHeaderPrefix} ${credentials?.access_token}`;
-        } else {
-          try {
-            const url = new URL(request.url);
-            url?.searchParams?.set(tokenQueryKey, credentials?.access_token);
-            request.url = url?.toString();
-          } catch (error) {}
-        }
         break;
     }
+    oauth2FetchedCredentials = credentials;
   }
 
   // Add API key to the URL if placement is queryparams
@@ -277,6 +253,15 @@ const prepareWsRequest = async (item, collection, environment, runtimeVariables,
   delete wsRequest.apiKeyAuthValueForQueryParams;
 
   interpolateVars(wsRequest, envVars, runtimeVariables, processEnvVars);
+
+  // The token is placed after interpolation: placing it earlier would run new URL() on raw
+  // {{var}} templates and percent-encode them beyond the interpolator's reach. The placement
+  // config is read back from wsRequest.oauth2 because interpolateVars resolves {{var}} in its
+  // fields (e.g. a templated header prefix) in place.
+  if (wsRequest.oauth2) {
+    const { tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource } = wsRequest.oauth2;
+    applyOAuth2TokenToRequest(wsRequest, { credentials: oauth2FetchedCredentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource });
+  }
 
   return wsRequest;
 };

--- a/packages/bruno-electron/src/utils/oauth2.js
+++ b/packages/bruno-electron/src/utils/oauth2.js
@@ -49,6 +49,44 @@ const isTokenExpired = (credentials) => {
   return Date.now() > expiryTime;
 };
 
+const trimTokenValue = (value) => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmedValue = value.trim();
+  return trimmedValue || undefined;
+};
+
+/**
+ * The token endpoint response (and credentials cached from it) is external data:
+ * a non-conforming provider can return a nested shape (e.g. an object under
+ * access_token), and a corrupted cache entry can hold one. Resolve the token to
+ * a plain string so it never reaches the request stringified as "[object Object]".
+ */
+const resolveOAuth2TokenValue = (credentials, tokenSource) => {
+  const rawToken = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
+  if (typeof rawToken === 'string') {
+    return trimTokenValue(rawToken);
+  }
+  return trimTokenValue(rawToken?.token) ?? trimTokenValue(rawToken?.value);
+};
+
+const applyOAuth2TokenToRequest = (request, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource }) => {
+  const tokenValue = resolveOAuth2TokenValue(credentials, tokenSource);
+  if (!tokenValue) {
+    return;
+  }
+  if (tokenPlacement === 'header') {
+    request.headers['Authorization'] = `${tokenHeaderPrefix ?? ''} ${tokenValue}`.trim();
+  } else {
+    try {
+      const url = new URL(request.url);
+      url.searchParams.set(tokenQueryKey, tokenValue);
+      request.url = url.toString();
+    } catch (error) { }
+  }
+};
+
 const safeParseJSONBuffer = (data) => {
   return safeParseJSON(Buffer.isBuffer(data) ? data.toString() : data);
 };
@@ -967,6 +1005,8 @@ module.exports = {
   clearOauth2Credentials,
   clearOauth2CredentialsByCredentialsId,
   getStoredOauth2Credentials,
+  resolveOAuth2TokenValue,
+  applyOAuth2TokenToRequest,
   getOAuth2TokenUsingAuthorizationCode,
   getOAuth2TokenUsingClientCredentials,
   getOAuth2TokenUsingPasswordCredentials,

--- a/packages/bruno-electron/tests/network/oauth2-token-injection.spec.js
+++ b/packages/bruno-electron/tests/network/oauth2-token-injection.spec.js
@@ -1,0 +1,374 @@
+jest.mock('../../src/utils/oauth2', () => {
+  const actual = jest.requireActual('../../src/utils/oauth2');
+  return {
+    ...actual,
+    getOAuth2TokenUsingAuthorizationCode: jest.fn(),
+    getOAuth2TokenUsingClientCredentials: jest.fn(),
+    getOAuth2TokenUsingPasswordCredentials: jest.fn(),
+    getOAuth2TokenUsingImplicitGrant: jest.fn()
+  };
+});
+
+const oauth2Utils = require('../../src/utils/oauth2');
+const { prepareWsRequest } = require('../../src/ipc/network/ws-event-handlers');
+const { configureRequest } = require('../../src/ipc/network/index');
+
+const { resolveOAuth2TokenValue, applyOAuth2TokenToRequest } = oauth2Utils;
+
+const makeRequest = (url = 'https://api.example.com/v1/users') => ({ url, headers: {} });
+
+const TOKEN_URL = 'https://auth.example.com/oauth2/token';
+
+// The issue #8940 shape: a token endpoint response whose access_token is an object
+const NESTED_TOKEN_CREDENTIALS = { access_token: { token: 'nested-token-value' }, token_type: 'Bearer' };
+
+const mockTokenFetch = (credentials) => ({ credentials, url: TOKEN_URL, credentialsId: 'credentials', debugInfo: { data: [] } });
+
+const makeOauth2Config = (grantType, overrides = {}) => ({
+  grantType,
+  accessTokenUrl: TOKEN_URL,
+  refreshTokenUrl: TOKEN_URL,
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  scope: '',
+  credentialsId: 'credentials',
+  tokenPlacement: 'header',
+  tokenHeaderPrefix: 'Bearer',
+  tokenQueryKey: 'access_token',
+  tokenSource: 'access_token',
+  autoFetchToken: true,
+  autoRefreshToken: false,
+  ...overrides
+});
+
+describe('oauth2: resolveOAuth2TokenValue', () => {
+  describe('With a string token', () => {
+    it('Returns the access token by default', () => {
+      const credentials = { access_token: 'token-value' };
+      expect(resolveOAuth2TokenValue(credentials)).toEqual('token-value');
+    });
+
+    it('Returns the id token when tokenSource is id_token', () => {
+      const credentials = { access_token: 'access-value', id_token: 'id-value' };
+      expect(resolveOAuth2TokenValue(credentials, 'id_token')).toEqual('id-value');
+    });
+
+    it('Trims surrounding whitespace', () => {
+      const credentials = { access_token: '  token-value  ' };
+      expect(resolveOAuth2TokenValue(credentials)).toEqual('token-value');
+    });
+  });
+
+  describe('With a nested object token', () => {
+    it('Unwraps an object holding a token property', () => {
+      const credentials = { access_token: { token: 'token-value' } };
+      expect(resolveOAuth2TokenValue(credentials)).toEqual('token-value');
+    });
+
+    it('Unwraps an object holding a value property', () => {
+      const credentials = { access_token: { value: 'token-value' } };
+      expect(resolveOAuth2TokenValue(credentials)).toEqual('token-value');
+    });
+
+    it('Returns undefined when the object holds no string token', () => {
+      const credentials = { access_token: { access_token: 'token-value' } };
+      expect(resolveOAuth2TokenValue(credentials)).toBeUndefined();
+    });
+  });
+
+  describe('With an unusable token', () => {
+    it('Returns undefined for a number', () => {
+      expect(resolveOAuth2TokenValue({ access_token: 12345 })).toBeUndefined();
+    });
+
+    it('Returns undefined for null', () => {
+      expect(resolveOAuth2TokenValue({ access_token: null })).toBeUndefined();
+    });
+
+    it('Returns undefined for missing credentials', () => {
+      expect(resolveOAuth2TokenValue(undefined)).toBeUndefined();
+      expect(resolveOAuth2TokenValue({})).toBeUndefined();
+    });
+
+    it('Returns undefined for an empty or whitespace-only string', () => {
+      expect(resolveOAuth2TokenValue({ access_token: '' })).toBeUndefined();
+      expect(resolveOAuth2TokenValue({ access_token: '   ' })).toBeUndefined();
+    });
+  });
+});
+
+describe('oauth2: applyOAuth2TokenToRequest', () => {
+  describe('Token placement in header', () => {
+    it('Sets the Authorization header with the configured prefix', () => {
+      const request = makeRequest();
+      applyOAuth2TokenToRequest(request, {
+        credentials: { access_token: 'token-value' },
+        tokenPlacement: 'header',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      });
+      expect(request.headers['Authorization']).toEqual('Bearer token-value');
+    });
+
+    it('Unwraps a nested object token into a usable header', () => {
+      const request = makeRequest();
+      applyOAuth2TokenToRequest(request, {
+        credentials: NESTED_TOKEN_CREDENTIALS,
+        tokenPlacement: 'header',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      });
+      expect(request.headers['Authorization']).toEqual('Bearer nested-token-value');
+    });
+
+    it('Sets the bare token when the prefix is empty', () => {
+      const request = makeRequest();
+      applyOAuth2TokenToRequest(request, {
+        credentials: { access_token: 'token-value' },
+        tokenPlacement: 'header',
+        tokenHeaderPrefix: '',
+        tokenQueryKey: 'access_token'
+      });
+      expect(request.headers['Authorization']).toEqual('token-value');
+    });
+
+    it('Does not stringify a missing prefix into the header', () => {
+      const request = makeRequest();
+      applyOAuth2TokenToRequest(request, {
+        credentials: { access_token: 'token-value' },
+        tokenPlacement: 'header',
+        tokenHeaderPrefix: null,
+        tokenQueryKey: 'access_token'
+      });
+      expect(request.headers['Authorization']).toEqual('token-value');
+    });
+
+    it('Uses the id token when tokenSource is id_token', () => {
+      const request = makeRequest();
+      applyOAuth2TokenToRequest(request, {
+        credentials: { access_token: 'access-value', id_token: 'id-value' },
+        tokenPlacement: 'header',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token',
+        tokenSource: 'id_token'
+      });
+      expect(request.headers['Authorization']).toEqual('Bearer id-value');
+    });
+  });
+
+  describe('Token placement in query params', () => {
+    it('Appends the token to the request url', () => {
+      const request = makeRequest('https://api.example.com/v1/users');
+      applyOAuth2TokenToRequest(request, {
+        credentials: { access_token: 'token-value' },
+        tokenPlacement: 'url',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      });
+      expect(request.url).toEqual('https://api.example.com/v1/users?access_token=token-value');
+      expect(request.headers['Authorization']).toBeUndefined();
+    });
+
+    it('Falls back to the query param when the placement is not configured', () => {
+      const request = makeRequest('https://api.example.com/v1/users');
+      applyOAuth2TokenToRequest(request, {
+        credentials: { access_token: 'token-value' },
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      });
+      expect(request.url).toEqual('https://api.example.com/v1/users?access_token=token-value');
+    });
+
+    it('Leaves the request untouched when the url cannot be parsed', () => {
+      const request = makeRequest('{{baseUrl}}/v1/users');
+      applyOAuth2TokenToRequest(request, {
+        credentials: { access_token: 'token-value' },
+        tokenPlacement: 'url',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      });
+      expect(request.url).toEqual('{{baseUrl}}/v1/users');
+    });
+  });
+
+  describe('With a token that cannot be resolved to a string', () => {
+    const unusableTokens = [
+      { access_token: { client_id: 'cid', client_secret: 'secret' } },
+      { access_token: 12345 },
+      { access_token: null },
+      {},
+      null,
+      undefined
+    ];
+
+    it.each(unusableTokens)('Never injects a stringified object into the request (%j)', (credentials) => {
+      const headerRequest = makeRequest();
+      applyOAuth2TokenToRequest(headerRequest, {
+        credentials,
+        tokenPlacement: 'header',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      });
+      expect(JSON.stringify(headerRequest)).not.toContain('[object Object]');
+      expect(headerRequest.headers['Authorization']).toBeUndefined();
+
+      const queryRequest = makeRequest();
+      applyOAuth2TokenToRequest(queryRequest, {
+        credentials,
+        tokenPlacement: 'url',
+        tokenHeaderPrefix: 'Bearer',
+        tokenQueryKey: 'access_token'
+      });
+      expect(JSON.stringify(queryRequest)).not.toContain('[object Object]');
+      expect(queryRequest.url).toEqual('https://api.example.com/v1/users');
+    });
+  });
+});
+
+describe('oauth2: token injection through configureRequest', () => {
+  const grantFetchers = {
+    authorization_code: oauth2Utils.getOAuth2TokenUsingAuthorizationCode,
+    implicit: oauth2Utils.getOAuth2TokenUsingImplicitGrant,
+    client_credentials: oauth2Utils.getOAuth2TokenUsingClientCredentials,
+    password: oauth2Utils.getOAuth2TokenUsingPasswordCredentials
+  };
+
+  beforeEach(() => {
+    Object.values(grantFetchers).forEach((fetcher) => fetcher.mockReset());
+  });
+
+  it.each(Object.keys(grantFetchers))('Injects an unwrapped token for the %s grant type', async (grantType) => {
+    grantFetchers[grantType].mockResolvedValue(mockTokenFetch(NESTED_TOKEN_CREDENTIALS));
+
+    const request = {
+      method: 'GET',
+      url: 'http://api.example.com/v1/users',
+      headers: {},
+      body: { mode: 'none' },
+      oauth2: makeOauth2Config(grantType)
+    };
+
+    await configureRequest('collection-uid', {}, request, {}, {}, {}, '/tmp');
+    expect(grantFetchers[grantType]).toHaveBeenCalled();
+    expect(request.headers['Authorization']).toEqual('Bearer nested-token-value');
+    expect(JSON.stringify(request.headers)).not.toContain('[object Object]');
+  });
+
+  it('Skips injection entirely when the token cannot be resolved to a string', async () => {
+    grantFetchers.client_credentials.mockResolvedValue(mockTokenFetch({ access_token: { foo: 'bar' } }));
+
+    const request = {
+      method: 'GET',
+      url: 'http://api.example.com/v1/users',
+      headers: {},
+      body: { mode: 'none' },
+      oauth2: makeOauth2Config('client_credentials')
+    };
+
+    await configureRequest('collection-uid', {}, request, {}, {}, {}, '/tmp');
+    expect(request.headers['Authorization']).toBeUndefined();
+    expect(JSON.stringify(request)).not.toContain('[object Object]');
+  });
+
+  it('Appends the token to the request url when the placement is url', async () => {
+    grantFetchers.client_credentials.mockResolvedValue(mockTokenFetch({ access_token: 'token-value' }));
+
+    const request = {
+      method: 'GET',
+      url: 'http://api.example.com/v1/users',
+      headers: {},
+      body: { mode: 'none' },
+      oauth2: makeOauth2Config('client_credentials', { tokenPlacement: 'url' })
+    };
+
+    await configureRequest('collection-uid', {}, request, {}, {}, {}, '/tmp');
+    expect(request.url).toEqual('http://api.example.com/v1/users?access_token=token-value');
+    expect(request.headers['Authorization']).toBeUndefined();
+  });
+});
+
+describe('oauth2: token injection through prepareWsRequest', () => {
+  const makeItem = (oauth2Config) => ({
+    uid: 'item-uid',
+    request: {
+      url: 'ws://api.example.com/socket',
+      headers: [],
+      body: { mode: 'raw', ws: [] },
+      auth: { mode: 'oauth2', oauth2: oauth2Config },
+      vars: { req: [], res: [] },
+      script: { req: '', res: '' }
+    }
+  });
+
+  const makeCollection = () => ({
+    uid: 'collection-uid',
+    pathname: '/tmp/collection',
+    root: { request: { headers: [], auth: { mode: 'none' } } },
+    brunoConfig: {},
+    globalEnvironmentVariables: {}
+  });
+
+  beforeEach(() => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockReset();
+  });
+
+  it('Injects the token into the Authorization header', async () => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(mockTokenFetch(NESTED_TOKEN_CREDENTIALS));
+
+    const prepared = await prepareWsRequest(makeItem(makeOauth2Config('client_credentials')), makeCollection(), { variables: [] }, {});
+    expect(prepared.headers['Authorization']).toEqual('Bearer nested-token-value');
+    expect(JSON.stringify(prepared.headers)).not.toContain('[object Object]');
+  });
+
+  it('Injects the token into the url the connection uses when the placement is url', async () => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(mockTokenFetch({ access_token: 'token-value' }));
+
+    const prepared = await prepareWsRequest(
+      makeItem(makeOauth2Config('client_credentials', { tokenPlacement: 'url' })),
+      makeCollection(),
+      { variables: [] },
+      {}
+    );
+    expect(prepared.url).toEqual('ws://api.example.com/socket?access_token=token-value');
+    expect(prepared.headers['Authorization']).toBeUndefined();
+  });
+
+  it('Interpolates url variables before appending the token', async () => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(mockTokenFetch({ access_token: 'token-value' }));
+
+    const item = makeItem(makeOauth2Config('client_credentials', { tokenPlacement: 'url' }));
+    item.request.url = 'ws://api.example.com/{{roomId}}';
+    const prepared = await prepareWsRequest(item, makeCollection(), { variables: [{ name: 'roomId', value: 'lobby', enabled: true }] }, {});
+    expect(prepared.url).toEqual('ws://api.example.com/lobby?access_token=token-value');
+  });
+
+  it('Interpolates a templated header prefix before injecting the token', async () => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(mockTokenFetch({ access_token: 'token-value' }));
+
+    const item = makeItem(makeOauth2Config('client_credentials', { tokenHeaderPrefix: '{{authScheme}}' }));
+    const prepared = await prepareWsRequest(item, makeCollection(), { variables: [{ name: 'authScheme', value: 'Bearer', enabled: true }] }, {});
+    expect(prepared.headers['Authorization']).toEqual('Bearer token-value');
+  });
+
+  it('Uses the id token when tokenSource is id_token', async () => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(
+      mockTokenFetch({ access_token: 'access-value', id_token: 'id-value' })
+    );
+
+    const prepared = await prepareWsRequest(
+      makeItem(makeOauth2Config('client_credentials', { tokenSource: 'id_token' })),
+      makeCollection(),
+      { variables: [] },
+      {}
+    );
+    expect(prepared.headers['Authorization']).toEqual('Bearer id-value');
+  });
+
+  it('Injects nothing when no token can be resolved', async () => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(mockTokenFetch(null));
+
+    const prepared = await prepareWsRequest(makeItem(makeOauth2Config('client_credentials')), makeCollection(), { variables: [] }, {});
+    expect(prepared.headers['Authorization']).toBeUndefined();
+    expect(JSON.stringify(prepared)).not.toContain('undefined ');
+  });
+});

--- a/packages/bruno-electron/tests/network/oauth2-token-injection.spec.js
+++ b/packages/bruno-electron/tests/network/oauth2-token-injection.spec.js
@@ -9,6 +9,8 @@ jest.mock('../../src/utils/oauth2', () => {
   };
 });
 
+const os = require('os');
+const path = require('path');
 const oauth2Utils = require('../../src/utils/oauth2');
 const { prepareWsRequest } = require('../../src/ipc/network/ws-event-handlers');
 const { configureRequest } = require('../../src/ipc/network/index');
@@ -248,7 +250,7 @@ describe('oauth2: token injection through configureRequest', () => {
       oauth2: makeOauth2Config(grantType)
     };
 
-    await configureRequest('collection-uid', {}, request, {}, {}, {}, '/tmp');
+    await configureRequest('collection-uid', {}, request, {}, {}, {}, os.tmpdir());
     expect(grantFetchers[grantType]).toHaveBeenCalled();
     expect(request.headers['Authorization']).toEqual('Bearer nested-token-value');
     expect(JSON.stringify(request.headers)).not.toContain('[object Object]');
@@ -265,7 +267,7 @@ describe('oauth2: token injection through configureRequest', () => {
       oauth2: makeOauth2Config('client_credentials')
     };
 
-    await configureRequest('collection-uid', {}, request, {}, {}, {}, '/tmp');
+    await configureRequest('collection-uid', {}, request, {}, {}, {}, os.tmpdir());
     expect(request.headers['Authorization']).toBeUndefined();
     expect(JSON.stringify(request)).not.toContain('[object Object]');
   });
@@ -281,7 +283,7 @@ describe('oauth2: token injection through configureRequest', () => {
       oauth2: makeOauth2Config('client_credentials', { tokenPlacement: 'url' })
     };
 
-    await configureRequest('collection-uid', {}, request, {}, {}, {}, '/tmp');
+    await configureRequest('collection-uid', {}, request, {}, {}, {}, os.tmpdir());
     expect(request.url).toEqual('http://api.example.com/v1/users?access_token=token-value');
     expect(request.headers['Authorization']).toBeUndefined();
   });
@@ -302,7 +304,7 @@ describe('oauth2: token injection through prepareWsRequest', () => {
 
   const makeCollection = () => ({
     uid: 'collection-uid',
-    pathname: '/tmp/collection',
+    pathname: path.join(os.tmpdir(), 'collection'),
     root: { request: { headers: [], auth: { mode: 'none' } } },
     brunoConfig: {},
     globalEnvironmentVariables: {}
@@ -331,6 +333,17 @@ describe('oauth2: token injection through prepareWsRequest', () => {
     );
     expect(prepared.url).toEqual('ws://api.example.com/socket?access_token=token-value');
     expect(prepared.headers['Authorization']).toBeUndefined();
+  });
+
+  it('Interpolates prompt variables in the final WebSocket interpolation', async () => {
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(mockTokenFetch({ access_token: 'token-value' }));
+
+    const item = makeItem(makeOauth2Config('client_credentials', { tokenPlacement: 'url', tokenQueryKey: 'access_token' }));
+    item.request.url = 'ws://api.example.com/socket/{{?roomId}}';
+    const collection = makeCollection();
+    collection.promptVariables = { '?roomId': 'lobby' };
+    const prepared = await prepareWsRequest(item, collection, { variables: [] }, {});
+    expect(prepared.url).toContain('ws://api.example.com/socket/lobby?access_token=token-value');
   });
 
   it('Interpolates url variables before appending the token', async () => {
@@ -362,6 +375,26 @@ describe('oauth2: token injection through prepareWsRequest', () => {
       {}
     );
     expect(prepared.headers['Authorization']).toEqual('Bearer id-value');
+  });
+
+  it('Routes the resolved token through the gRPC prepare path (configureRequest)', async () => {
+    const { configureRequest } = require('../../src/ipc/network/prepare-grpc-request');
+
+    // Nested provider shape: the token object is unwrapped, never stringified to [object Object].
+    oauth2Utils.getOAuth2TokenUsingClientCredentials.mockResolvedValue(mockTokenFetch({ access_token: { token: 'grpc-token-value' } }));
+
+    const grpcRequest = {
+      uid: 'grpc-uid',
+      url: 'grpc://api.example.com:50051/Service/Method',
+      headers: {},
+      auth: { mode: 'oauth2', oauth2: makeOauth2Config('client_credentials') },
+      oauth2: makeOauth2Config('client_credentials')
+    };
+    const request = { url: 'grpc://api.example.com:50051/Service/Method', headers: {}, method: 'POST', body: '{}' };
+
+    await configureRequest(grpcRequest, request, makeCollection(), {}, {}, {}, {}, undefined);
+    expect(grpcRequest.headers['Authorization']).toBe('Bearer grpc-token-value');
+    expect(String(grpcRequest.headers['Authorization'])).not.toContain('[object Object]');
   });
 
   it('Injects nothing when no token can be resolved', async () => {


### PR DESCRIPTION
### Description

OAuth2 token injection now resolves the token to a string before placing it into the `Authorization` header (or the request URL), so a non-string token can never reach the wire as the literal `[object Object]`.

### Problem

Closes #8940. With OAuth 2.0 client credentials (AWS Cognito) on Bruno 4.0.0, requests come back 401 because the outgoing `Authorization` header carries the literal string `[object Object]` instead of the token. The Auth panel itself fetches and displays the token fine — only the request engine's injection is broken.

### Fix

Every injection site interpolated the token into a template string without asserting that it resolved to a string:

```js
const tokenValue = tokenSource === 'id_token' ? credentials?.id_token : credentials?.access_token;
request.headers['Authorization'] = `${tokenHeaderPrefix} ${tokenValue}`.trim();
```

`credentials` is the parsed token-endpoint response (and the cached copy of it) — external data. Whenever `access_token`/`id_token` resolves to a non-string (a non-conforming provider response such as `{"access_token": {...}}`, or a corrupted cached credential), JS coercion stringified it to `[object Object]`. The same unguarded interpolation also produced `Bearer undefined` on the WebSocket and gRPC paths whenever no token resolved, and `undefined <token>` / `null <token>` when the header prefix was missing (a `.bru`/`.yml` round-trip can leave it `null`).

This PR adds two helpers in `packages/bruno-electron/src/utils/oauth2.js`:

- `resolveOAuth2TokenValue(credentials, tokenSource)` — resolves the configured token to a trimmed string: a string token is trimmed; an object holding a string `.token`/`.value` property (non-conforming provider shapes) is unwrapped; anything else resolves to `undefined`.
- `applyOAuth2TokenToRequest(request, { credentials, tokenPlacement, tokenHeaderPrefix, tokenQueryKey, tokenSource })` — resolves the token and places it in the `Authorization` header or as a query param; when the token cannot be resolved to a string, injection is skipped entirely so nothing degenerate is sent.

All ten former injection sites — 4 HTTP grant types in `ipc/network/index.js`, 3 WebSocket grant types in `ws-event-handlers.js`, and 3 gRPC grant types in `prepare-grpc-request.js` (which had its own local copy of the logic) — now go through the shared helper. Behavior for well-formed tokens is unchanged. Related fixes surfaced while wiring the sites through the helper:

- The WebSocket query-placement was a **dead write**: it mutated the item's `request.url` while the connection uses `wsRequest.url` (snapshotted earlier), so a query-placed token never reached a WS connection. The token now lands on the URL the connection actually uses, and it is placed **after** `interpolateVars` — `new URL()` percent-encodes raw `{{var}}` templates beyond the interpolator's reach — matching the HTTP and gRPC paths, which already interpolate first.
- `tokenSource` (Access Token / ID Token) is now honored on WebSocket and gRPC too; those paths previously always sent `access_token` even when `id_token` was configured.
- A non-string, non-unwrappable token (e.g. a JSON number) now skips injection entirely instead of being coerced onto the wire — consistent with the fix's invariant that only a real string token is ever sent.

### Screenshots

No UI change.

| Before | After |
| --- | --- |
| `Authorization: Bearer [object Object]` → 401 | `Authorization: Bearer <token>` |

#### Verification

- `npm run test:ci --workspace=packages/bruno-electron` — 54 suites, 784 passed, including the new `tests/network/oauth2-token-injection.spec.js` (36 tests): the helper matrix, integration through `configureRequest` for all four grant types, and through `prepareWsRequest` (header, query, templated-url interpolation order, id_token source, no-token) — asserting that garbage token shapes (nested object, number, null, missing) never produce `[object Object]` in the header or URL.
- `npm run lint` — 0 errors.
- End-to-end against a mock provider returning `{"access_token":{"token":"…"}}`: pre-fix the header was `Bearer [object Object]`; post-fix it is `Bearer <unwrapped token>`, and an unwrappable object leaves the header unset.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (#8940)
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth2 tokens are now applied consistently across HTTP, gRPC, and WebSocket requests.
  - Supports placing tokens in authorization headers or URL query parameters.
  - Supports configurable token sources, header prefixes, and query parameter names.
  - Handles tokens returned in multiple credential formats.

- **Bug Fixes**
  - Improved OAuth2 handling for interpolated URLs and WebSocket requests.
  - Prevents invalid, missing, or stringified credential values from being added to requests.
  - Safely ignores malformed URLs during query-parameter token injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->