### PR TITLE
tests(cli): read the json report even if its one run or an array

### DIFF
--- a/packages/bruno-cli/tests/integration/run-sent-headers.spec.js
+++ b/packages/bruno-cli/tests/integration/run-sent-headers.spec.js
@@ -10,6 +10,16 @@ const writeFixtureFile = (filePath, content) => {
   fs.writeFileSync(filePath, content);
 };
 
+/** The json reporter writes either a single `{ summary, results }` or an array holding one of
+ *  those per iteration. On the array form `report.results` is undefined, so reaching straight
+ *  for `report.results[0]` throws instead of failing an assertion. Pick the run first. */
+const readReportedHeaders = (dir) => {
+  const report = JSON.parse(fs.readFileSync(path.join(dir, 'report.json'), 'utf8'));
+  const run = Array.isArray(report) ? report[0] : report;
+
+  return run.results[0].request.headers;
+};
+
 /**
  * The transport headers (Host, Connection, Accept-Encoding, ...) only exist once the request is
  * on the wire, so nothing that runs before the axios interceptors can know about them.
@@ -79,11 +89,7 @@ ${extra}`;
     const { code } = await runCli(['run', 'req.bru', '--noproxy', '--reporter-json', 'report.json'], tmpDir);
     expect(code).toBe(0);
 
-    /** The json reporter writes either a single `{ summary, results }` or an array holding one of
-     *  those per iteration. On the array form `report.results` is undefined, so reaching straight
-     *  for `report.results[0]` throws instead of failing an assertion. Pick the run first. */
-    const report = JSON.parse(fs.readFileSync(path.join(tmpDir, 'report.json'), 'utf8'));
-    const sent = (Array.isArray(report) ? report[0] : report).results[0].request.headers;
+    const sent = readReportedHeaders(tmpDir);
     const reported = Object.keys(sent).map((name) => name.toLowerCase());
 
     expect(Object.keys(receivedHeaders).filter((name) => !reported.includes(name))).toEqual([]);
@@ -104,9 +110,7 @@ ${extra}`;
     const { code } = await runCli(['run', 'req.bru', '--noproxy', '--reporter-json', 'report.json'], tmpDir);
     expect(code).toBe(0);
 
-    /** Array form holds one run per iteration, see the first test. */
-    const report = JSON.parse(fs.readFileSync(path.join(tmpDir, 'report.json'), 'utf8'));
-    const sent = (Array.isArray(report) ? report[0] : report).results[0].request.headers;
+    const sent = readReportedHeaders(tmpDir);
 
     expect(sent['user-agent']).toBe('mine/1.0');
     expect(sent['User-Agent']).toBeUndefined();

--- a/packages/bruno-cli/tests/integration/run-sent-headers.spec.js
+++ b/packages/bruno-cli/tests/integration/run-sent-headers.spec.js
@@ -12,8 +12,11 @@ const writeFixtureFile = (filePath, content) => {
 
 /**
  * The transport headers (Host, Connection, Accept-Encoding, ...) only exist once the request is
- * on the wire, so nothing upstream of the axios interceptors can report them. These cover the
- * whole path: interceptor -> request.headers -> json reporter, and the same set inside a
+ * on the wire, so nothing that runs before the axios interceptors can know about them.
+ *
+ * These cover the whole path end to end: the response interceptor reads them back off the
+ * ClientRequest, the runner folds them into `request.headers`, and from there they have to reach
+ * both the json reporter and `req.getHeaders()` inside a post-response script.
  */
 describe('CLI run — headers the request actually sent', () => {
   let server;
@@ -76,11 +79,15 @@ ${extra}`;
     const { code } = await runCli(['run', 'req.bru', '--noproxy', '--reporter-json', 'report.json'], tmpDir);
     expect(code).toBe(0);
 
+    /** The json reporter writes either a single `{ summary, results }` or an array holding one of
+     *  those per iteration. On the array form `report.results` is undefined, so reaching straight
+     *  for `report.results[0]` throws instead of failing an assertion. Pick the run first. */
     const report = JSON.parse(fs.readFileSync(path.join(tmpDir, 'report.json'), 'utf8'));
-    const reported = Object.keys(report.results[0].request.headers).map((name) => name.toLowerCase());
+    const sent = (Array.isArray(report) ? report[0] : report).results[0].request.headers;
+    const reported = Object.keys(sent).map((name) => name.toLowerCase());
 
     expect(Object.keys(receivedHeaders).filter((name) => !reported.includes(name))).toEqual([]);
-    expect(report.results[0].request.headers).toMatchObject({
+    expect(sent).toMatchObject({
       'Host': `127.0.0.1:${port}`,
       'Connection': 'keep-alive',
       'Accept-Encoding': 'gzip, compress, deflate, br',
@@ -97,15 +104,19 @@ ${extra}`;
     const { code } = await runCli(['run', 'req.bru', '--noproxy', '--reporter-json', 'report.json'], tmpDir);
     expect(code).toBe(0);
 
+    /** Array form holds one run per iteration, see the first test. */
     const report = JSON.parse(fs.readFileSync(path.join(tmpDir, 'report.json'), 'utf8'));
+    const sent = (Array.isArray(report) ? report[0] : report).results[0].request.headers;
 
-    expect(report.results[0].request.headers['user-agent']).toBe('mine/1.0');
-    expect(report.results[0].request.headers['User-Agent']).toBeUndefined();
+    expect(sent['user-agent']).toBe('mine/1.0');
+    expect(sent['User-Agent']).toBeUndefined();
   });
 
   it('hands the same set to a post-response script', async () => {
     stageCollection(
-      // A bru block keyword only parses at column 0, so this stays flush left
+      /** A bru block keyword only parses at column 0. Indented, the whole file fails to parse,
+       *  the script never runs, and the run still exits 0, so the only symptom is the stdout match
+       *  below coming back null. */
       httpRequest(`
 script:post-response {
   console.log('SENT_HEADERS ' + JSON.stringify(Object.keys(req.getHeaders()).sort()));


### PR DESCRIPTION
### Description

Related - BRU-3731

`run-sent-headers.spec.js` reads the json report the CLI writes, and it assumes that report is always a single object. That holds in this repo but not everywhere the same spec runs, so two of its three tests failed on an identical file.

### Problem

The json reporter has two output shapes: `{ summary, results }` a single run `[{ iterationIndex, summary, results }]` one entry per iteration

The spec only handled the first, reaching straight for `report.results[0]`. On the array form `report.results` is undefined, so the next `[0]` throws a TypeError rather than failing an assertion, which reads like a broken test instead of a shape mismatch.

### Fix

Pick the run before indexing into it, so either shape works: `const run = Array.isArray(report) ? report[0] : report`

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON reports containing either a single run or multiple runs.
  * Updated header reporting checks for more reliable results.
  * Clarified behavior related to transport headers and report parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->