### PR TITLE
fix(response): elapsed time resets issue while streaming

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
@@ -3,33 +3,21 @@ import StyledWrapper from './StyledWrapper';
 
 const TICK_INTERVAL = 100;
 
-const isValidStartTime = (startTime) => Number.isFinite(startTime);
-
-const getElapsedTime = (startTime, startMillis) => (
-  isValidStartTime(startTime)
-    ? Math.max(0, Date.now() - startTime)
-    : startMillis
-);
-
-const ResponseStopWatch = ({ startTime, startMillis = 0 }) => {
-  const [milliseconds, setMilliseconds] = useState(() => getElapsedTime(startTime, startMillis));
+const ResponseStopWatch = ({ startTimestamp }) => {
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
-    setMilliseconds(getElapsedTime(startTime, startMillis));
-
-    const timerId = setInterval(() => {
-      setMilliseconds((currentMilliseconds) => (
-        isValidStartTime(startTime)
-          ? Math.max(0, Date.now() - startTime)
-          : currentMilliseconds + TICK_INTERVAL
-      ));
+    const timerID = setInterval(() => {
+      setNow(Date.now());
     }, TICK_INTERVAL);
+    return () => {
+      clearInterval(timerID);
+    };
+  }, []);
 
-    return () => clearInterval(timerId);
-  }, [startTime, startMillis]);
-
-  const secondsFormatted = `${(milliseconds / 1000).toFixed(1)}s`;
-  const width = secondsFormatted.length * 0.4;
+  const elapsedMillis = startTimestamp ? Math.max(0, now - startTimestamp) : 0;
+  const secondsFormatted = `${(elapsedMillis / 1000).toFixed(1)}s`;
+  const width = secondsFormatted.length * 0.4; // Calculate width manually to stop parent layout from "flickering" by changing width too fast
 
   return (
     <StyledWrapper className="ml-2" style={{ width: `${width}rem` }}>

--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
@@ -15,7 +15,11 @@ const ResponseStopWatch = ({ startTimestamp }) => {
     };
   }, []);
 
-  const elapsedMillis = startTimestamp ? Math.max(0, now - startTimestamp) : 0;
+  const isValidTimeStamp = (timestamp) => {
+    return Number.isInteger(timestamp) && timestamp > 0 && timestamp <= now;
+  };
+
+  const elapsedMillis = isValidTimeStamp(startTimestamp, now) ? Math.max(0, now - startTimestamp) : 0;
   const secondsFormatted = `${(elapsedMillis / 1000).toFixed(1)}s`;
   const width = secondsFormatted.length * 0.4; // Calculate width manually to stop parent layout from "flickering" by changing width too fast
 

--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
@@ -15,13 +15,11 @@ const ResponseStopWatch = ({ startTimestamp }) => {
     };
   }, []);
 
-  const isValidTimeStamp = (timestamp) => {
-    return Number.isInteger(timestamp) && timestamp > 0 && timestamp <= now;
-  };
+  const isValidTimestamp = Number.isFinite(startTimestamp) && startTimestamp > 0;
 
-  const elapsedMillis = isValidTimeStamp(startTimestamp, now) ? Math.max(0, now - startTimestamp) : 0;
+  const elapsedMillis = isValidTimestamp(startTimestamp) ? Math.max(0, now - startTimestamp) : 0;
   const secondsFormatted = `${(elapsedMillis / 1000).toFixed(1)}s`;
-  const width = secondsFormatted.length * 0.4; // Calculate width manually to stop parent layout from "flickering" by changing width too fast
+  const width = secondsFormatted.length * 0.4;
 
   return (
     <StyledWrapper className="ml-2" style={{ width: `${width}rem` }} data-testid="response-elapsed-time">

--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
@@ -20,7 +20,7 @@ const ResponseStopWatch = ({ startTimestamp }) => {
   const width = secondsFormatted.length * 0.4; // Calculate width manually to stop parent layout from "flickering" by changing width too fast
 
   return (
-    <StyledWrapper className="ml-2" style={{ width: `${width}rem` }}>
+    <StyledWrapper className="ml-2" style={{ width: `${width}rem` }} data-testid="response-elapsed-time">
       {secondsFormatted}
     </StyledWrapper>
   );

--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.js
@@ -17,7 +17,7 @@ const ResponseStopWatch = ({ startTimestamp }) => {
 
   const isValidTimestamp = Number.isFinite(startTimestamp) && startTimestamp > 0;
 
-  const elapsedMillis = isValidTimestamp(startTimestamp) ? Math.max(0, now - startTimestamp) : 0;
+  const elapsedMillis = isValidTimestamp ? Math.max(0, now - startTimestamp) : 0;
   const secondsFormatted = `${(elapsedMillis / 1000).toFixed(1)}s`;
   const width = secondsFormatted.length * 0.4;
 

--- a/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseStopWatch/index.spec.js
@@ -25,9 +25,8 @@ describe('ResponseStopWatch', () => {
   });
 
   it('derives elapsed time from the request start timestamp', () => {
-    const startTime = Date.now() - 1500;
-
-    renderStopWatch({ startTime, startMillis: 200 });
+    const startTimestamp = Date.now() - 1500;
+    renderStopWatch({ startTimestamp });
 
     expect(screen.getByText('1.5s')).toBeInTheDocument();
 
@@ -39,8 +38,8 @@ describe('ResponseStopWatch', () => {
   });
 
   it('preserves elapsed time after unmounting and remounting', () => {
-    const startTime = Date.now() - 1000;
-    const firstRender = renderStopWatch({ startTime, startMillis: 100 });
+    const startTimestamp = Date.now() - 1000;
+    const firstRender = renderStopWatch({ startTimestamp });
 
     expect(screen.getByText('1.0s')).toBeInTheDocument();
     firstRender.unmount();
@@ -49,38 +48,38 @@ describe('ResponseStopWatch', () => {
       jest.advanceTimersByTime(2000);
     });
 
-    renderStopWatch({ startTime, startMillis: 100 });
+    renderStopWatch({ startTimestamp });
 
     expect(screen.getByText('3.0s')).toBeInTheDocument();
   });
 
-  it('continues from the supplied duration when start time is unavailable', () => {
-    renderStopWatch({ startMillis: 400 });
+  it('shows zero while the request start timestamp is unavailable', () => {
+    renderStopWatch({});
 
-    expect(screen.getByText('0.4s')).toBeInTheDocument();
+    expect(screen.getByText('0.0s')).toBeInTheDocument();
 
     act(() => {
       jest.advanceTimersByTime(300);
     });
 
-    expect(screen.getByText('0.7s')).toBeInTheDocument();
+    expect(screen.getByText('0.0s')).toBeInTheDocument();
   });
 
   it('does not display a negative duration for a future start timestamp', () => {
-    renderStopWatch({ startTime: Date.now() + 1000, startMillis: 400 });
+    renderStopWatch({ startTimestamp: Date.now() + 1000 });
 
     expect(screen.getByText('0.0s')).toBeInTheDocument();
   });
 
   it('uses a request start timestamp received after the initial render', () => {
-    const { rerender } = renderStopWatch({ startMillis: 200 });
+    const { rerender } = renderStopWatch({});
 
-    expect(screen.getByText('0.2s')).toBeInTheDocument();
+    expect(screen.getByText('0.0s')).toBeInTheDocument();
 
-    const startTime = Date.now() - 1500;
+    const startTimestamp = Date.now() - 1500;
     rerender(
       <ThemeProvider theme={theme}>
-        <ResponseStopWatch startTime={startTime} startMillis={200} />
+        <ResponseStopWatch startTimestamp={startTimestamp} />
       </ThemeProvider>
     );
 

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -262,7 +262,7 @@ const ResponsePane = ({ item, collection }) => {
       <div className="flex items-center response-pane-status">
         <StatusCode status={response.status} isStreaming={item.response?.stream?.running} />
         {item.response?.stream?.running
-          ? <ResponseStopWatch startTime={item.requestSent?.timestamp} />
+          ? <ResponseStopWatch startTimestamp={item.requestSent?.timestamp} />
           : <ResponseTime duration={response.duration} />}
         <ResponseSize size={responseSize} />
       </div>

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -262,12 +262,7 @@ const ResponsePane = ({ item, collection }) => {
       <div className="flex items-center response-pane-status">
         <StatusCode status={response.status} isStreaming={item.response?.stream?.running} />
         {item.response?.stream?.running
-          ? (
-              <ResponseStopWatch
-                startTime={item.requestSent?.timestamp}
-                startMillis={response.duration}
-              />
-            )
+          ? <ResponseStopWatch startTime={item.requestSent?.timestamp} />
           : <ResponseTime duration={response.duration} />}
         <ResponseSize size={responseSize} />
       </div>

--- a/tests/sse/fixtures/collection/opencollection.yml
+++ b/tests/sse/fixtures/collection/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: sse-test

--- a/tests/sse/fixtures/collection/ping-request.bru
+++ b/tests/sse/fixtures/collection/ping-request.bru
@@ -1,0 +1,11 @@
+meta {
+  name: ping-request
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:8081/ping
+  body: none
+  auth: none
+}

--- a/tests/sse/fixtures/collection/ping-request.yml
+++ b/tests/sse/fixtures/collection/ping-request.yml
@@ -1,11 +1,10 @@
-meta {
+info:
   name: ping-request
   type: http
   seq: 2
-}
 
-get {
+http:
+  method: GET
   url: http://localhost:8081/ping
-  body: none
-  auth: none
-}
+  body:
+    type: none

--- a/tests/sse/fixtures/collection/sse-stream-request.yml
+++ b/tests/sse/fixtures/collection/sse-stream-request.yml
@@ -1,11 +1,10 @@
-meta {
+info:
   name: sse-stream-request
   type: http
   seq: 1
-}
 
-get {
+http:
+  method: GET
   url: http://localhost:8081/api/sse/stream
-  body: none
-  auth: none
-}
+  body:
+    type: none

--- a/tests/sse/streaming-elapsed-time.spec.ts
+++ b/tests/sse/streaming-elapsed-time.spec.ts
@@ -28,7 +28,7 @@ test.describe('SSE Elapsed Time', () => {
       await switchToOpenTab(page, 'sse-stream-request');
     });
 
-    await test.step('The elapsed time covers the time spent away', async () => {
+    await test.step('The elapsed time is not reset after switching back to the stream', async () => {
       await expect(locators.response.elapsedTime()).toBeVisible();
       expect(await elapsedSeconds(page)).toBeGreaterThanOrEqual(elapsedBefore);
     });

--- a/tests/sse/streaming-elapsed-time.spec.ts
+++ b/tests/sse/streaming-elapsed-time.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, Page } from '../../playwright';
+import { openRequest, sendRequest, switchToOpenTab } from '../utils/page';
+import { buildCommonLocators } from '../utils/page/locators';
+
+const elapsedSeconds = async (page: Page) => {
+  const text = await buildCommonLocators(page).response.elapsedTime().innerText();
+  return parseFloat(text.replace('s', ''));
+};
+
+test.describe('SSE Elapsed Time', () => {
+  test('preserves elapsed time when navigating away from and back to a running stream', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+    let elapsedBefore = 0;
+
+    await openRequest(page, 'sse-test', 'sse-stream-request');
+    await sendRequest(page);
+
+    await test.step('The counter runs while the stream is open', async () => {
+      await expect.poll(() => elapsedSeconds(page), { timeout: 10000 }).toBeGreaterThan(3);
+      elapsedBefore = await elapsedSeconds(page);
+    });
+
+    await test.step('Switch to another request, stay there a second, then come back', async () => {
+      await openRequest(page, 'sse-test', 'ping-request');
+      await expect(locators.response.elapsedTime()).toBeHidden();
+      await switchToOpenTab(page, 'sse-stream-request');
+    });
+
+    await test.step('The elapsed time covers the time spent away', async () => {
+      await expect(locators.response.elapsedTime()).toBeVisible();
+      expect(await elapsedSeconds(page)).toBeGreaterThanOrEqual(elapsedBefore);
+    });
+  });
+});

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -208,6 +208,7 @@ export const buildCommonLocators = (page: Page) => ({
   },
   response: {
     statusCode: () => page.getByTestId('response-status-code'),
+    elapsedTime: () => page.getByTestId('response-elapsed-time'),
     // Rendered by every response pane (http, grpc, ws) only while a response exists, so its
     // absence doubles as the "response is cleared" signal.
     clearButton: () => page.getByTestId('response-clear-btn'),


### PR DESCRIPTION
BRU-4095

### Description

Fixes an issue where the elapsed-time counter reset to zero when navigating away from and then back to an active streaming request

### Problem

Previously, we relied on `response.duration`, which only reflects the actual duration after the request or stream finishes. While streaming, it still contains the previous value. On top of that, the stopwatch tracked elapsed time in component state, so navigating between tabs unmounted the response pane and caused the counter to reset.

### Fix

Now, we calculate elapsed time from `item.requestSent.timestamp` and the current time. This makes the counter derived from the actual request start time, so it stays accurate even after the component remounts. Future timestamps are also clamped to zero to prevent negative elapsed times.


### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/40221756-55b5-44a1-b781-fff9ec42755e" controls></video> | <video src="https://github.com/user-attachments/assets/6e03b6b7-1108-49e0-b97a-68448e4586bc" controls></video> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
