### PR TITLE
feat(transient-requests): open links as transient requests anywhere in app

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -15,6 +15,7 @@ import { JSHINT } from 'jshint';
 import stripJsonComments from 'strip-json-comments';
 import { getAllVariables } from 'utils/collections';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
+import { resolveLinkClickHandler } from 'utils/codemirror/linkClickHandler';
 import { setupLintErrorTooltip } from 'utils/codemirror/lint-errors';
 import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
 import CodeMirrorSearch from 'components/CodeMirrorSearch/index';
@@ -261,7 +262,9 @@ class CodeEditor extends React.Component {
       );
 
       setupLinkAware(editor, {
-        onLinkClick: typeof this.props.onLinkClick === 'function' ? this.handleLinkClick : undefined
+        onLinkClick: (typeof this.props.onLinkClick === 'function' || resolveLinkClickHandler(this.props.item, this.props.collection))
+          ? this.handleLinkClick
+          : undefined
       });
 
       // Setup lint error tooltip on line number hover
@@ -470,7 +473,10 @@ class CodeEditor extends React.Component {
   };
 
   handleLinkClick = (url) => {
-    this.props.onLinkClick?.(url);
+    const onLinkClick = typeof this.props.onLinkClick === 'function'
+      ? this.props.onLinkClick
+      : resolveLinkClickHandler(this.props.item, this.props.collection);
+    onLinkClick?.(url);
   };
 }
 

--- a/packages/bruno-app/src/components/CreateTransientRequest/index.js
+++ b/packages/bruno-app/src/components/CreateTransientRequest/index.js
@@ -6,8 +6,7 @@ import { newHttpRequest, newGrpcRequest, newWsRequest } from 'providers/ReduxSto
 import { sanitizeName } from 'utils/common/regex';
 import toast from 'react-hot-toast';
 import { useDispatch, useSelector } from 'react-redux';
-import { flattenItems, isItemARequest, isItemTransientRequest } from 'utils/collections';
-import filter from 'lodash/filter';
+import { generateTransientRequestName } from 'utils/collections';
 import { get } from 'lodash';
 import { formatIpcError } from 'utils/common/error';
 
@@ -16,38 +15,6 @@ const REQUEST_TYPE = {
   GRAPHQL: 'graphql',
   GRPC: 'grpc',
   WEBSOCKET: 'websocket'
-};
-
-/**
- * Generate a request name for transient requests in the pattern "Untitled {Count}"
- * @param {Object} collection - The collection object
- * @returns {string} A request name like "Untitled 1", "Untitled 2", etc.
- */
-const generateTransientRequestName = (collection) => {
-  if (!collection || !collection.items) {
-    return 'Untitled 1';
-  }
-  const allItems = flattenItems(collection.items);
-  const transientRequests = filter(allItems, (item) => {
-    return isItemTransientRequest(item);
-  });
-
-  // Find the highest "Untitled X" number among transient requests
-  let maxNumber = 0;
-  transientRequests.forEach((item) => {
-    const match = item.name?.match(/^Untitled (\d+)$/);
-    if (match) {
-      const number = parseInt(match[1], 10);
-      if (number > maxNumber) {
-        maxNumber = number;
-      }
-    }
-  });
-
-  // Increment from the highest number found, or start at 1 if none found
-  const count = maxNumber + 1;
-
-  return `Untitled ${count}`;
 };
 
 const CreateTransientRequest = ({ collectionUid }) => {

--- a/packages/bruno-app/src/components/Documentation/index.js
+++ b/packages/bruno-app/src/components/Documentation/index.js
@@ -56,6 +56,7 @@ const Documentation = ({ item, collection }) => {
       {isEditing ? (
         <CodeEditor
           collection={collection}
+          item={item}
           theme={displayedTheme}
           font={get(preferences, 'font.codeFont', 'default')}
           fontSize={get(preferences, 'font.codeFontSize')}

--- a/packages/bruno-app/src/components/MultiLineEditor/index.js
+++ b/packages/bruno-app/src/components/MultiLineEditor/index.js
@@ -6,6 +6,7 @@ import { setupAutoComplete } from 'utils/codemirror/autocomplete';
 import { MaskedEditor } from 'utils/common/masked-editor';
 import StyledWrapper from './StyledWrapper';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
+import { resolveLinkClickHandler } from 'utils/codemirror/linkClickHandler';
 import { IconEye, IconEyeOff } from '@tabler/icons';
 
 const CodeMirror = require('codemirror');
@@ -80,7 +81,9 @@ class MultiLineEditor extends Component {
       autoCompleteOptions
     );
 
-    setupLinkAware(this.editor);
+    setupLinkAware(this.editor, {
+      onLinkClick: resolveLinkClickHandler(this.props.item, this.props.collection)
+    });
 
     // Add mousetrap calss so Mousetrap captures shortcuts even when Codemirror is focused
     const cmInput = this.editor.getInputField();

--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -198,6 +198,7 @@ const GraphQLRequestPane = ({ item, collection, onSchemaLoad, toggleDocs, handle
             <div className="flex-1 min-h-0">
               <QueryEditor
                 ref={queryEditorRef}
+                item={item}
                 collection={collection}
                 theme={displayedTheme}
                 schema={schema}

--- a/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLVariables/index.js
@@ -28,6 +28,7 @@ const GraphQLVariables = ({ variables, item, collection }) => {
   return (
     <CodeEditor
       collection={collection}
+      item={item}
       value={variables || ''}
       theme={displayedTheme}
       font={get(preferences, 'font.codeFont', 'default')}

--- a/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
@@ -204,6 +204,7 @@ const SingleGrpcMessage = ({ message, item, collection, index, methodType, handl
         <CodeEditor
           ref={editorRef}
           collection={collection}
+          item={item}
           theme={displayedTheme}
           font={get(preferences, 'font.codeFont', 'default')}
           fontSize={get(preferences, 'font.codeFontSize')}

--- a/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcQueryUrl/index.js
@@ -313,6 +313,7 @@ const GrpcQueryUrl = ({ item, collection, handleRun }) => {
           collection={collection}
           highlightPathParams={true}
           item={item}
+          disableLinkAwareClick={true}
         />
 
       </div>

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -16,6 +16,7 @@ import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
 import onHasCompletion from './onHasCompletion';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
+import { resolveLinkClickHandler } from 'utils/codemirror/linkClickHandler';
 import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
 
 const CodeMirror = require('codemirror');
@@ -149,7 +150,9 @@ export default class QueryEditor extends React.Component {
     }
     this.addOverlay();
 
-    setupLinkAware(editor);
+    setupLinkAware(editor, {
+      onLinkClick: resolveLinkClickHandler(this.props.item, this.props.collection)
+    });
     this.cleanupResizeRefresh = setupCodeMirrorResizeRefresh(editor, this._node);
 
     // Add mousetrap class so Mousetrap captures shortcuts even when CodeMirror is focused

--- a/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryUrl/index.js
@@ -412,6 +412,7 @@ const QueryUrl = ({ item, collection, handleRun }) => {
             highlightPathParams={true}
             item={item}
             showNewlineArrow={true}
+            disableLinkAwareClick={true}
           />
           <div className="flex items-center h-full mx-2 gap-3" id="request-actions">
             <div

--- a/packages/bruno-app/src/components/RequestPane/Script/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Script/index.js
@@ -107,6 +107,7 @@ const Script = ({ item, collection }) => {
           <CodeEditor
             ref={preRequestEditorRef}
             collection={collection}
+            item={item}
             docKey="script:pre-request"
             value={requestScript || ''}
             theme={displayedTheme}
@@ -126,6 +127,7 @@ const Script = ({ item, collection }) => {
           <CodeEditor
             ref={postResponseEditorRef}
             collection={collection}
+            item={item}
             docKey="script:post-response"
             value={responseScript || ''}
             theme={displayedTheme}

--- a/packages/bruno-app/src/components/RequestPane/Tests/index.js
+++ b/packages/bruno-app/src/components/RequestPane/Tests/index.js
@@ -34,6 +34,7 @@ const Tests = ({ item, collection }) => {
       <CodeEditor
         ref={testsEditorRef}
         collection={collection}
+        item={item}
         docKey="tests"
         value={tests || ''}
         theme={displayedTheme}

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -168,6 +168,7 @@ export const SingleWSMessage = ({
       <div className="editor-container">
         <CodeEditor
           collection={collection}
+          item={item}
           theme={displayedTheme}
           font={get(preferences, 'font.codeFont', 'default')}
           fontSize={get(preferences, 'font.codeFontSize')}

--- a/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsQueryUrl/index.js
@@ -138,6 +138,7 @@ const WsQueryUrl = ({ item, collection, handleRun }) => {
             onRun={handleRun}
             collection={collection}
             item={item}
+            disableLinkAwareClick={true}
           />
           <div className="flex items-center h-full cursor-pointer gap-3 mx-3">
             <div

--- a/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcQueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcQueryResult/index.js
@@ -54,6 +54,7 @@ const GrpcQueryResult = ({ item, collection }) => {
             <div className="h-full" data-testid="grpc-single-response">
               <CodeEditor
                 collection={collection}
+                item={item}
                 font={get(preferences, 'font.codeFont', 'default')}
                 fontSize={get(preferences, 'font.codeFontSize')}
                 theme={displayedTheme}
@@ -94,6 +95,7 @@ const GrpcQueryResult = ({ item, collection }) => {
                       <div className="message-content">
                         <CodeEditor
                           collection={collection}
+                          item={item}
                           font={get(preferences, 'font.codeFont', 'default')}
                           fontSize={get(preferences, 'font.codeFontSize')}
                           theme={displayedTheme}

--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/QueryResultPreview/index.js
@@ -1,8 +1,8 @@
-import React, { useCallback, useState, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import CodeEditor from 'components/CodeEditor/index';
 import { get } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
-import { newHttpRequest, sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { usePersistedState } from 'hooks/usePersistedState';
 import { Document, Page } from 'react-pdf';
 import 'pdfjs-dist/build/pdf.worker';
@@ -15,49 +15,7 @@ import TextPreview from './TextPreview';
 import HtmlPreview from './HtmlPreview';
 import VideoPreview from './VideoPreview';
 import JsonPreview from './JsonPreview';
-import { sanitizeName } from 'utils/common/regex';
-import { flattenItems, isItemARequest } from 'utils/collections';
-import toast from 'react-hot-toast';
-import { formatIpcError } from 'utils/common/error';
-
-const LINKED_REQUEST_FALLBACK_NAME = 'Linked Request';
-
-const getRequestNameFromUrl = (url) => {
-  try {
-    const { hostname, pathname } = new URL(url);
-    const pathSegment = pathname.split('/').filter(Boolean).pop();
-    return decodeURIComponent(pathSegment || hostname || LINKED_REQUEST_FALLBACK_NAME) || LINKED_REQUEST_FALLBACK_NAME;
-  } catch (e) {
-    return LINKED_REQUEST_FALLBACK_NAME;
-  }
-};
-
-const getUniqueLinkedRequestFilename = (collection, requestName) => {
-  const baseFilename = sanitizeName(requestName) || LINKED_REQUEST_FALLBACK_NAME;
-  const existingFilenames = new Set(
-    flattenItems(collection?.items || [])
-      .filter(isItemARequest)
-      .map((requestItem) => String(requestItem.filename || '').replace(/\.(bru|ya?ml)$/i, '').trim())
-  );
-
-  if (!existingFilenames.has(baseFilename)) {
-    return baseFilename;
-  }
-
-  let suffix = 2;
-  while (existingFilenames.has(`${baseFilename} (${suffix})`)) {
-    suffix += 1;
-  }
-  return `${baseFilename} (${suffix})`;
-};
-
-const isPutObjectPresignedUrl = (url) => {
-  try {
-    return new URL(url).searchParams.get('x-id')?.toLowerCase() === 'putobject';
-  } catch (e) {
-    return false;
-  }
-};
+import { resolveLinkClickHandler } from 'utils/codemirror/linkClickHandler';
 
 const QueryResultPreview = ({
   selectedTab,
@@ -93,34 +51,8 @@ const QueryResultPreview = ({
 
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
 
-  const handleResponseLinkClick = useCallback((url) => {
-    if (!url || !collection?.uid) {
-      return;
-    }
-
-    const requestName = getRequestNameFromUrl(url);
-    const isPutObject = isPutObjectPresignedUrl(url);
-
-    dispatch(
-      newHttpRequest({
-        requestName,
-        filename: getUniqueLinkedRequestFilename(collection, requestName),
-        requestType: 'http-request',
-        requestUrl: url,
-        requestMethod: isPutObject ? 'PUT' : 'GET',
-        collectionUid: collection.uid,
-        itemUid: null,
-        isTransient: true,
-        auth: {
-          mode: 'none'
-        },
-        settings: {
-          encodeUrl: false
-        },
-        ...(isPutObject ? { requestPaneTab: 'body' } : {})
-      })
-    ).catch((err) => toast.error(formatIpcError(err) || 'An error occurred while adding the request'));
-  }, [collection, dispatch]);
+  // Same type as the request this response belongs to (HTTP -> HTTP, GraphQL -> GraphQL).
+  const handleResponseLinkClick = resolveLinkClickHandler(item, collection);
 
   if (selectedTab === 'editor') {
     return (

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
@@ -59,7 +59,7 @@ const TypeIcon = ({ type }) => {
   }[type];
 };
 
-const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
+const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => {
   const [showHex, setShowHex] = useState(false);
   const preferences = useSelector((state) => state.app.preferences);
   const { displayedTheme } = useTheme();
@@ -166,6 +166,8 @@ const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
               enableLineWrapping={showHex ? false : true}
               font={preferences.codeFont || 'default'}
               value={showHex ? contentHexdump : parsedContent.content}
+              item={item}
+              collection={collection}
             />
           </div>
         </>
@@ -174,7 +176,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle }) => {
   );
 });
 
-const WSMessagesList = ({ messages = [] }) => {
+const WSMessagesList = ({ messages = [], item, collection }) => {
   const virtuosoRef = useRef(null);
   const [scrollerElement, setScrollerElement] = useState(null);
   const [openMessages, setOpenMessages] = useState(new Set());
@@ -230,8 +232,8 @@ const WSMessagesList = ({ messages = [] }) => {
 
   const renderItem = useCallback((_, msg) => {
     const isOpen = openMessages.has(msg.timestamp);
-    return <WSMessageItem message={msg} isOpen={isOpen} onToggle={handleMessageToggle} />;
-  }, [openMessages, handleMessageToggle]);
+    return <WSMessageItem message={msg} isOpen={isOpen} onToggle={handleMessageToggle} item={item} collection={collection} />;
+  }, [openMessages, handleMessageToggle, item, collection]);
 
   const computeItemKey = useCallback((_, msg) => {
     return msg.seq ?? msg.timestamp;

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/index.js
@@ -16,8 +16,8 @@ import ResponsiveTabs from 'ui/ResponsiveTabs';
 import WSMessagesList from './WSMessagesList';
 import WSResponseHeaders from './WSResponseHeaders';
 
-const WSResult = ({ response }) => {
-  return <WSMessagesList messages={response.responses || []} />;
+const WSResult = ({ response, item, collection }) => {
+  return <WSMessagesList messages={response.responses || []} item={item} collection={collection} />;
 };
 
 const WSResponsePane = ({ item, collection }) => {
@@ -66,7 +66,7 @@ const WSResponsePane = ({ item, collection }) => {
   const getTabPanel = (tab) => {
     switch (tab) {
       case 'response': {
-        return <WSResult response={response} />;
+        return <WSResult response={response} item={item} collection={collection} />;
       }
       case 'headers': {
         return <WSResponseHeaders response={response} />;

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -155,7 +155,7 @@ const ResponsePane = ({ item, collection }) => {
       case 'response': {
         const isStream = item.response?.stream ?? false;
         if (isStream) {
-          return <WSMessagesList order={-1} messages={item.response.data} />;
+          return <WSMessagesList order={-1} messages={item.response.data} item={item} collection={collection} />;
         }
         return (
           <QueryResult

--- a/packages/bruno-app/src/components/SingleLineEditor/index.js
+++ b/packages/bruno-app/src/components/SingleLineEditor/index.js
@@ -1,12 +1,13 @@
-import React, { Component } from 'react';
+import { IconEye, IconEyeOff } from '@tabler/icons';
 import isEqual from 'lodash/isEqual';
+import React, { Component } from 'react';
+import { setupAutoComplete } from 'utils/codemirror/autocomplete';
+import { setupLinkAware } from 'utils/codemirror/linkAware';
+import { resolveLinkClickHandler } from 'utils/codemirror/linkClickHandler';
 import { getAllVariables } from 'utils/collections';
 import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
 import { MaskedEditor } from 'utils/common/masked-editor';
-import { setupAutoComplete } from 'utils/codemirror/autocomplete';
 import StyledWrapper from './StyledWrapper';
-import { IconEye, IconEyeOff } from '@tabler/icons';
-import { setupLinkAware } from 'utils/codemirror/linkAware';
 
 const CodeMirror = require('codemirror');
 
@@ -91,6 +92,18 @@ class SingleLineEditor extends Component {
       autoCompleteOptions
     );
 
+    /*
+     * Must run before setValue() below, or it misses the 'change' event setValue() fires
+     * and never marks the link. disableLinkAwareClick opts a field out of the "open as new
+     * request" click (e.g. the URL bar) - it still marks URLs and Cmd/Ctrl+Click still opens
+     * them externally, matching Bruno's pre-existing URL bar behaviour.
+     */
+    setupLinkAware(this.editor, {
+      onLinkClick: this.props.disableLinkAwareClick
+        ? undefined
+        : resolveLinkClickHandler(this.props.item, this.props.collection)
+    });
+
     this.editor.setValue(String(this.props.value ?? ''));
     this.editor.on('change', this._onEdit);
     this.editor.on('paste', this._onPaste);
@@ -103,7 +116,6 @@ class SingleLineEditor extends Component {
     if (this.props.showNewlineArrow) {
       this._updateNewlineMarkers();
     }
-    setupLinkAware(this.editor);
 
     // Add mousetrap class so Mousetrap captures shortcuts even when CodeMirror is focused
     const cmInput = this.editor.getInputField();

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -22,7 +22,9 @@ import {
   getAllVariables,
   transformRequestToSaveToFilesystem,
   transformCollectionRootToSave,
-  flattenItems
+  flattenItems,
+  generateTransientRequestName,
+  isPutObjectPresignedUrl
 } from 'utils/collections';
 import { uuid, waitForNextTick } from 'utils/common';
 import { cancelNetworkRequest, connectWS, sendGrpcRequest, sendNetworkRequest, sendWsRequest } from 'utils/network/index';
@@ -1711,6 +1713,63 @@ export const newWsRequest = (params) => (dispatch, getState) => {
         .catch(reject);
     }
   });
+};
+
+/**
+ * Opens a URL clicked inside a CodeMirror editor (see utils/codemirror/linkAware.js) as a new
+ * transient request in the same collection. `requestType` is decided by the caller - either the
+ * type of the request tab the link was clicked from, or the collection's presets when clicked
+ * from collection/folder settings.
+ */
+export const openLinkedRequest = ({ url, collectionUid, requestType }) => (dispatch, getState) => {
+  const state = getState();
+  const collection = findCollectionByUid(state.collections.collections, collectionUid);
+  if (!collection || !url) {
+    return Promise.reject(new Error('Collection not found'));
+  }
+
+  const requestName = generateTransientRequestName(collection);
+  const filename = sanitizeName(requestName);
+
+  if (requestType === 'grpc-request') {
+    return dispatch(
+      newGrpcRequest({ requestName, filename, requestUrl: url, collectionUid, itemUid: null, isTransient: true })
+    );
+  }
+
+  if (requestType === 'ws-request') {
+    return dispatch(
+      newWsRequest({
+        requestName,
+        requestMethod: 'ws',
+        filename,
+        requestUrl: url,
+        collectionUid,
+        itemUid: null,
+        isTransient: true
+      })
+    );
+  }
+
+  const isGraphqlRequest = requestType === 'graphql-request';
+  const isPutObject = !isGraphqlRequest && isPutObjectPresignedUrl(url);
+
+  return dispatch(
+    newHttpRequest({
+      requestName,
+      filename,
+      requestType, // 'http-request' | 'graphql-request'
+      requestUrl: url,
+      requestMethod: isGraphqlRequest ? 'POST' : (isPutObject ? 'PUT' : 'GET'),
+      collectionUid,
+      itemUid: null,
+      isTransient: true,
+      auth: { mode: 'none' },
+      settings: { encodeUrl: false },
+      ...(isGraphqlRequest ? { body: { mode: 'graphql', graphql: { query: '', variables: '' } } } : {}),
+      ...(isPutObject ? { requestPaneTab: 'body' } : {})
+    })
+  );
 };
 
 export const loadGrpcMethodsFromReflection = (item, collectionUid, url) => async (dispatch, getState) => {

--- a/packages/bruno-app/src/utils/codemirror/linkAware.js
+++ b/packages/bruno-app/src/utils/codemirror/linkAware.js
@@ -190,7 +190,9 @@ function updateCmdCtrlClass(event, editorWrapper, cmdCtrlClass, isCmdOrCtrlPress
 }
 
 /**
- * Handles click events on links to open them externally or through a custom handler
+ * Handles click events on links to open them externally or through a custom handler.
+ * When a custom handler is registered, a plain click uses it (e.g. open as a new request)
+ * while Cmd/Ctrl+click still falls back to opening the link externally.
  * @param {Event} event - The click event
  * @param {string} linkClass - CSS class name for links
  * @param {Function} isCmdOrCtrlPressed - Function to check if Cmd/Ctrl is pressed
@@ -200,14 +202,15 @@ function handleClick(event, linkClass, isCmdOrCtrlPressed, onLinkClick) {
   if (!event.target.classList.contains(linkClass)) return;
 
   const shouldUseCustomHandler = typeof onLinkClick === 'function';
-  if (!shouldUseCustomHandler && !isCmdOrCtrlPressed(event)) return;
+  const modifierPressed = isCmdOrCtrlPressed(event);
+  if (!shouldUseCustomHandler && !modifierPressed) return;
 
   event.preventDefault();
   event.stopPropagation();
   const url = event.target.getAttribute('data-url');
   if (!url) return;
 
-  if (shouldUseCustomHandler) {
+  if (shouldUseCustomHandler && !modifierPressed) {
     onLinkClick(url);
   } else {
     window?.ipcRenderer?.openExternal(url);
@@ -234,7 +237,7 @@ function setupLinkAware(editor, options = {}) {
   const linkHoverClass = 'hovered-link';
   const onLinkClick = options?.onLinkClick;
   const linkHint = typeof onLinkClick === 'function'
-    ? 'Click to open link as request'
+    ? (isMacOS() ? 'Click to open as request · Cmd+Click to open externally' : 'Click to open as request · Ctrl+Click to open externally')
     : isMacOS() ? 'Hold Cmd and click to open link' : 'Hold Ctrl and click to open link';
 
   // Helper function to check if Cmd/Ctrl is pressed

--- a/packages/bruno-app/src/utils/codemirror/linkClickHandler.js
+++ b/packages/bruno-app/src/utils/codemirror/linkClickHandler.js
@@ -1,0 +1,29 @@
+import { store } from 'providers/ReduxStore';
+import { openLinkedRequest } from 'providers/ReduxStore/slices/collections/actions';
+import toast from 'react-hot-toast';
+import { getRequestTypeFromCollectionPresets } from 'utils/collections';
+import { formatIpcError } from 'utils/common/error';
+
+const REQUEST_ITEM_TYPES = ['http-request', 'graphql-request', 'grpc-request', 'ws-request'];
+
+/**
+ * Handles clicking a URL inside a CodeMirror editor - opens it as a new transient
+ * request. If we're inside a request tab, the new request matches that request's
+ * type; otherwise (e.g. collection/folder settings) we fall back to the collection's
+ * Presets type. Returns undefined with no collection, so Cmd/Ctrl+Click still opens
+ * the link externally as usual.
+ */
+export function resolveLinkClickHandler(item, collection) {
+  if (!collection?.uid) {
+    return undefined;
+  }
+
+  const requestType = REQUEST_ITEM_TYPES.includes(item?.type)
+    ? item.type
+    : getRequestTypeFromCollectionPresets(collection);
+
+  return (url) => {
+    store.dispatch(openLinkedRequest({ url, collectionUid: collection.uid, requestType }))
+      .catch((err) => toast.error(formatIpcError(err) || 'An error occurred while adding the request'));
+  };
+}

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1772,6 +1772,71 @@ export const isItemTransientRequest = (item) => {
 };
 
 /**
+ * Generate a request name for transient requests in the pattern "Untitled {Count}"
+ * @param {Object} collection - The collection object
+ * @returns {string} A request name like "Untitled 1", "Untitled 2", etc.
+ */
+export const generateTransientRequestName = (collection) => {
+  if (!collection || !collection.items) {
+    return 'Untitled 1';
+  }
+  const allItems = flattenItems(collection.items);
+  const transientRequests = filter(allItems, (item) => {
+    return isItemTransientRequest(item);
+  });
+
+  // Find the highest "Untitled X" number among transient requests
+  let maxNumber = 0;
+  transientRequests.forEach((item) => {
+    const match = item.name?.match(/^Untitled (\d+)$/);
+    if (match) {
+      const number = parseInt(match[1], 10);
+      if (number > maxNumber) {
+        maxNumber = number;
+      }
+    }
+  });
+
+  // Increment from the highest number found, or start at 1 if none found
+  const count = maxNumber + 1;
+
+  return `Untitled ${count}`;
+};
+
+/**
+ * Maps a collection's "Presets" request type (used to default new requests created from
+ * the sidebar) to the request item type used elsewhere in the app.
+ * @param {Object} collection - The collection object
+ * @returns {string} One of 'http-request' | 'graphql-request' | 'grpc-request' | 'ws-request'
+ */
+export const getRequestTypeFromCollectionPresets = (collection) => {
+  const presets = collection?.draft?.brunoConfig?.presets ?? collection?.brunoConfig?.presets;
+
+  switch (presets?.requestType) {
+    case 'graphql':
+      return 'graphql-request';
+    case 'grpc':
+      return 'grpc-request';
+    case 'ws':
+      return 'ws-request';
+    default:
+      return 'http-request';
+  }
+};
+
+/**
+ * S3 (and compatible) presigned "PutObject" URLs are meant to be uploaded to, not fetched.
+ * A request linked from such a URL should default to PUT instead of GET.
+ */
+export const isPutObjectPresignedUrl = (url) => {
+  try {
+    return new URL(url).searchParams.get('x-id')?.toLowerCase() === 'putobject';
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
  * Recursively filter out transient items from a collection's items array.
  * Used for collection runner, exports, and other operations that shouldn't include transient requests.
  * @param {Array} items - The items array to filter

--- a/tests/codemirror-linkaware/collection.spec.ts
+++ b/tests/codemirror-linkaware/collection.spec.ts
@@ -1,0 +1,81 @@
+import { Page, test } from '../../playwright';
+import { buildCommonLocators, closeAllCollections, closeAllTabs, LINK_AWARE_COLLECTION_NAME as COLLECTION_NAME, expectLinkOpensRequest, openCollectionFromDialog, openRequest } from '../utils/page';
+
+const settings = (page: Page) => page.locator('.collection-settings-content');
+const url = (path: string) => `http://link-aware.test/${path}`;
+
+const openCollectionSettingsTab = async (page: Page, key: string) => {
+  const locators = buildCommonLocators(page);
+  await locators.sidebar.collection(COLLECTION_NAME).hover();
+  await locators.actions.collectionActions(COLLECTION_NAME).click();
+  await locators.dropdown.item('Settings').click();
+  await locators.paneTabs.collectionSettingsTab(key).click();
+};
+
+test.describe('CodeMirror link-aware — Collection settings', () => {
+  test.beforeEach(async ({ page, electronApp, collectionFixturePath }) => {
+    await openCollectionFromDialog(page, electronApp, collectionFixturePath!);
+    // Opening a request first is the concrete "collection fully loaded" signal (same
+    // watcher scan that parses collection.bru's headers/auth/vars/script/tests) —
+    // otherwise Settings can race ahead of collection.root being populated.
+    await openRequest(page, COLLECTION_NAME, 'http-request');
+    await closeAllTabs(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('Vars: plain click creates a transient request', async ({ page }) => {
+    await openCollectionSettingsTab(page, 'vars');
+    const cm = buildCommonLocators(page).codeMirror.valueCellAt(settings(page));
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('collection-vars') });
+  });
+
+  test('Pre-Request-Script: plain click creates a transient request', async ({ page }) => {
+    const locators = buildCommonLocators(page);
+    await openCollectionSettingsTab(page, 'script');
+    await locators.paneTabs.tabTrigger('pre-request').click();
+    const cm = locators.codeMirror.byTestId('collection-pre-request-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('collection-script') });
+  });
+
+  test('Post-Response-Script: plain click creates a transient request', async ({ page }) => {
+    const locators = buildCommonLocators(page);
+    await openCollectionSettingsTab(page, 'script');
+    await locators.paneTabs.tabTrigger('post-response').click();
+    const cm = locators.codeMirror.byTestId('collection-post-response-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('collection-script') });
+  });
+
+  test('Tests: plain click creates a transient request', async ({ page }) => {
+    await openCollectionSettingsTab(page, 'tests');
+    const cm = buildCommonLocators(page).codeMirror.within(settings(page));
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('collection-tests') });
+  });
+
+  const presets: Array<{ radio: string; type: 'http' | 'graphql' | 'grpc' | 'ws' }> = [
+    { radio: 'http', type: 'http' },
+    { radio: 'graphql', type: 'graphql' },
+    { radio: 'grpc', type: 'grpc' },
+    { radio: 'ws', type: 'ws' }
+  ];
+
+  for (const { radio, type } of presets) {
+    test(`Presets = ${radio}: Vars link resolves to a transient ${type} request`, async ({ page }) => {
+      await openCollectionSettingsTab(page, 'presets');
+      await page.locator(`#${radio}`).check();
+      await openCollectionSettingsTab(page, 'vars');
+      const cm = buildCommonLocators(page).codeMirror.valueCellAt(settings(page));
+      await expectLinkOpensRequest(page, cm, { type, url: url('collection-vars') });
+    });
+  }
+
+  test('Presets never configured: Vars link defaults to a transient HTTP request', async ({ page }) => {
+    // Fixture's bruno.json already sets presets.requestType to "http" — this is the default
+    // path (getRequestTypeFromCollectionPresets() falls back to 'http-request' either way).
+    await openCollectionSettingsTab(page, 'vars');
+    const cm = buildCommonLocators(page).codeMirror.valueCellAt(settings(page));
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('collection-vars') });
+  });
+});

--- a/tests/codemirror-linkaware/fixtures/collection/bruno.json
+++ b/tests/codemirror-linkaware/fixtures/collection/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "codemirror-linkaware",
+  "type": "collection",
+  "presets": {
+    "requestType": "http",
+    "requestUrl": ""
+  }
+}

--- a/tests/codemirror-linkaware/fixtures/collection/collection.bru
+++ b/tests/codemirror-linkaware/fixtures/collection/collection.bru
@@ -1,0 +1,16 @@
+vars:pre-request {
+  linkVar: http://link-aware.test/collection-vars
+}
+
+
+script:pre-request {
+  // http://link-aware.test/collection-script
+}
+
+script:post-response {
+  // http://link-aware.test/collection-script
+}
+
+tests {
+  // http://link-aware.test/collection-tests
+}

--- a/tests/codemirror-linkaware/fixtures/collection/folder-fixture/folder.bru
+++ b/tests/codemirror-linkaware/fixtures/collection/folder-fixture/folder.bru
@@ -1,0 +1,24 @@
+meta {
+  name: folder-fixture
+  seq: 1
+}
+
+vars:pre-request {
+  linkVar: http://link-aware.test/folder-vars
+}
+
+script:pre-request {
+  // http://link-aware.test/folder-script
+}
+
+script:post-response {
+  // http://link-aware.test/folder-script
+}
+
+tests {
+  // http://link-aware.test/folder-tests
+}
+
+docs {
+  See http://link-aware.test/folder-docs for details.
+}

--- a/tests/codemirror-linkaware/fixtures/collection/graphql-request.bru
+++ b/tests/codemirror-linkaware/fixtures/collection/graphql-request.bru
@@ -1,0 +1,47 @@
+meta {
+  name: graphql-request
+  type: graphql
+  seq: 2
+}
+
+post {
+  url: http://link-aware.test/graphql-url
+  body: graphql
+}
+
+body:graphql {
+  # http://link-aware.test/graphql-query
+  query {
+    ping
+  }
+}
+
+body:graphql:vars {
+  {
+    "link": "http://link-aware.test/graphql-variables"
+  }
+}
+
+vars:pre-request {
+  linkVar: http://link-aware.test/graphql-vars
+}
+
+script:pre-request {
+  // http://link-aware.test/graphql-script
+}
+
+script:post-response {
+  // http://link-aware.test/graphql-script
+}
+
+assert {
+  res.status: eq http://link-aware.test/graphql-assert
+}
+
+tests {
+  // http://link-aware.test/graphql-tests
+}
+
+docs {
+  See http://link-aware.test/graphql-docs for details.
+}

--- a/tests/codemirror-linkaware/fixtures/collection/grpc-request.bru
+++ b/tests/codemirror-linkaware/fixtures/collection/grpc-request.bru
@@ -1,0 +1,25 @@
+meta {
+  name: grpc-request
+  type: grpc
+  seq: 3
+}
+
+grpc {
+  url: http://link-aware.test/grpc-url
+  method: /hello.HelloService/SayHello
+  body: grpc
+  methodType: unary
+}
+
+body:grpc {
+  name: message 1
+  content: '''
+    {
+      "link": "http://link-aware.test/grpc-body"
+    }
+  '''
+}
+
+docs {
+  See http://link-aware.test/grpc-docs for details.
+}

--- a/tests/codemirror-linkaware/fixtures/collection/http-request.bru
+++ b/tests/codemirror-linkaware/fixtures/collection/http-request.bru
@@ -1,0 +1,45 @@
+meta {
+  name: http-request
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://testbench-sanity.usebruno.com/api/echo/json
+  body: json
+  auth: none
+}
+
+params:query {
+  q: http://link-aware.test/http-params
+}
+
+body:json {
+  {
+    "link": "http://link-aware.test/http-body"
+  }
+}
+
+vars:pre-request {
+  linkVar: http://link-aware.test/http-vars
+}
+
+assert {
+  res.status: eq http://link-aware.test/http-assert
+}
+
+script:pre-request {
+  // http://link-aware.test/http-script
+}
+
+script:post-response {
+  // http://link-aware.test/http-script
+}
+
+tests {
+  // http://link-aware.test/http-tests
+}
+
+docs {
+  See http://link-aware.test/http-docs for details.
+}

--- a/tests/codemirror-linkaware/fixtures/collection/ws-request.bru
+++ b/tests/codemirror-linkaware/fixtures/collection/ws-request.bru
@@ -1,0 +1,22 @@
+meta {
+  name: ws-request
+  type: ws
+  seq: 4
+}
+
+ws {
+  url: ws://link-aware.test/ws-url
+}
+
+body:ws {
+  name: message 1
+  content: '''
+    {
+      "link": "http://link-aware.test/ws-body"
+    }
+  '''
+}
+
+docs {
+  See http://link-aware.test/ws-docs for details.
+}

--- a/tests/codemirror-linkaware/folder.spec.ts
+++ b/tests/codemirror-linkaware/folder.spec.ts
@@ -1,0 +1,58 @@
+import { Page, test } from '../../playwright';
+import { buildCommonLocators, closeAllCollections, LINK_AWARE_COLLECTION_NAME as COLLECTION_NAME, expectLinkOpensRequest, openCollectionFromDialog, openfolder, selectfolderPaneTab } from '../utils/page';
+
+const FOLDER_NAME = 'folder-fixture';
+const settings = (page: Page) => page.locator('.folder-settings-content');
+const url = (path: string) => `http://link-aware.test/${path}`;
+
+test.describe('CodeMirror link-aware - Folder settings', () => {
+  test.beforeEach(async ({ page, electronApp, collectionFixturePath }) => {
+    await openCollectionFromDialog(page, electronApp, collectionFixturePath!);
+    await openfolder(page, COLLECTION_NAME, FOLDER_NAME, { persist: true });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('Vars: plain click creates a transient request', async ({ page }) => {
+    await selectfolderPaneTab(page, 'vars');
+    const cm = buildCommonLocators(page).codeMirror.valueCellAt(settings(page));
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('folder-vars') });
+  });
+
+  test('Pre-Request-Script: plain click creates a transient request', async ({ page }) => {
+    await selectfolderPaneTab(page, 'script');
+    const locators = buildCommonLocators(page);
+    await locators.paneTabs.tabTrigger('pre-request').click();
+    const cm = locators.codeMirror.byTestId('folder-pre-request-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('folder-script') });
+  });
+
+  test('Post-Response-Script: plain click creates a transient request', async ({ page }) => {
+    await selectfolderPaneTab(page, 'script');
+    const locators = buildCommonLocators(page);
+    await locators.paneTabs.tabTrigger('post-response').click();
+    const cm = locators.codeMirror.byTestId('folder-post-response-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('folder-script') });
+  });
+
+  test('Tests: plain click creates a transient request', async ({ page }) => {
+    await selectfolderPaneTab(page, 'test');
+    const cm = buildCommonLocators(page).codeMirror.within(settings(page));
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('folder-tests') });
+  });
+
+  test('Docs: plain click creates a transient request', async ({ page }) => {
+    await selectfolderPaneTab(page, 'docs');
+    const locators = buildCommonLocators(page);
+    await locators.docs.editToggle(settings(page)).click();
+    await expectLinkOpensRequest(page, locators.codeMirror.within(settings(page)), { type: 'http', url: url('folder-docs') });
+  });
+
+  test('Folder Settings use the parent collections Presets (HTTP), not a folder-local default', async ({ page }) => {
+    await selectfolderPaneTab(page, 'vars');
+    const cm = buildCommonLocators(page).codeMirror.valueCellAt(settings(page));
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('folder-vars') });
+  });
+});

--- a/tests/codemirror-linkaware/request-graphql.spec.ts
+++ b/tests/codemirror-linkaware/request-graphql.spec.ts
@@ -1,0 +1,74 @@
+import { expect, Page, test } from '../../playwright';
+import { buildCommonLocators, closeAllCollections, LINK_AWARE_COLLECTION_NAME as COLLECTION_NAME, expectLinkOpensExternally, expectLinkOpensRequest, openCollectionFromDialog, openRequest, selectRequestPaneTab, selectScriptSubTab } from '../utils/page';
+
+const pane = (page: Page) => page.locator('[data-testid="request-pane"]');
+const url = (path: string) => `http://link-aware.test/${path}`;
+
+const openVariablesPanel = async (page: Page) => {
+  await page.getByText('Variables', { exact: true }).click();
+};
+
+test.describe('CodeMirror link-aware - GraphQL request tab', () => {
+  test.beforeEach(async ({ page, electronApp, collectionFixturePath }) => {
+    await openCollectionFromDialog(page, electronApp, collectionFixturePath!);
+    await openRequest(page, COLLECTION_NAME, 'graphql-request');
+    await selectRequestPaneTab(page, 'Query');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('URL Bar: plain click does not open a request; Cmd/Ctrl+Click opens it externally', async ({ page }) => {
+    const cm = buildCommonLocators(page).request.urlInput();
+    const link = cm.locator('.CodeMirror-link').first();
+    await expect(link).toBeVisible();
+
+    await link.click();
+    await expect(cm).toContainClass('CodeMirror-focused');
+
+    await expectLinkOpensExternally(page, cm);
+  });
+
+  test('Query editor: plain click opens a transient GraphQL request', async ({ page }) => {
+    const cm = buildCommonLocators(page).codeMirror.within(pane(page));
+    await expectLinkOpensRequest(page, cm, { type: 'graphql', url: url('graphql-query') });
+  });
+
+  test('Variables: plain click opens a transient GraphQL request', async ({ page }) => {
+    await openVariablesPanel(page);
+    const cm = pane(page).locator('.CodeMirror').last();
+    await expectLinkOpensRequest(page, cm, { type: 'graphql', url: url('graphql-variables') });
+  });
+
+  test('Vars: plain click opens a transient GraphQL request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Vars');
+    const cm = buildCommonLocators(page).codeMirror.valueCellAt(pane(page));
+    await expectLinkOpensRequest(page, cm, { type: 'graphql', url: url('graphql-vars') });
+  });
+
+  test('Pre-Request-Script: plain click opens a transient GraphQL request', async ({ page }) => {
+    await selectScriptSubTab(page, 'pre-request');
+    const cm = buildCommonLocators(page).codeMirror.byTestId('pre-request-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'graphql', url: url('graphql-script') });
+  });
+
+  test('Post-Response-Script: plain click opens a transient GraphQL request', async ({ page }) => {
+    await selectScriptSubTab(page, 'post-response');
+    const cm = buildCommonLocators(page).codeMirror.byTestId('post-response-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'graphql', url: url('graphql-script') });
+  });
+
+  test('Tests: plain click opens a transient GraphQL request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Tests');
+    const cm = buildCommonLocators(page).codeMirror.byTestId('test-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'graphql', url: url('graphql-tests') });
+  });
+
+  test('Docs: plain click opens a transient GraphQL request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Docs');
+    const locators = buildCommonLocators(page);
+    await locators.docs.editToggle(pane(page)).click();
+    await expectLinkOpensRequest(page, locators.codeMirror.within(pane(page)), { type: 'graphql', url: url('graphql-docs') });
+  });
+});

--- a/tests/codemirror-linkaware/request-grpc.spec.ts
+++ b/tests/codemirror-linkaware/request-grpc.spec.ts
@@ -1,0 +1,40 @@
+import { expect, Page, test } from '../../playwright';
+import { buildCommonLocators, buildGrpcCommonLocators, closeAllCollections, LINK_AWARE_COLLECTION_NAME as COLLECTION_NAME, expectLinkOpensExternally, expectLinkOpensRequest, openCollectionFromDialog, openRequest, selectRequestPaneTab } from '../utils/page';
+
+const pane = (page: Page) => page.locator('[data-testid="request-pane"]');
+const url = (path: string) => `http://link-aware.test/${path}`;
+
+test.describe('CodeMirror link-aware - gRPC request tab', () => {
+  test.beforeEach(async ({ page, electronApp, collectionFixturePath }) => {
+    await openCollectionFromDialog(page, electronApp, collectionFixturePath!);
+    await openRequest(page, COLLECTION_NAME, 'grpc-request');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('URL Bar: plain click does not open a request; Cmd/Ctrl+Click opens it externally', async ({ page }) => {
+    const cm = buildGrpcCommonLocators(page).request.queryUrlContainer().locator('.CodeMirror');
+    const link = cm.locator('.CodeMirror-link').first();
+    await expect(link).toBeVisible();
+
+    await link.click();
+    await expect(cm).toContainClass('CodeMirror-focused');
+
+    await expectLinkOpensExternally(page, cm);
+  });
+
+  test('Body / Messages: plain click opens a transient gRPC request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Message');
+    const cm = buildGrpcCommonLocators(page).request.messagesContainer().locator('.CodeMirror').first();
+    await expectLinkOpensRequest(page, cm, { type: 'grpc', url: url('grpc-body') });
+  });
+
+  test('Docs: plain click opens a transient gRPC request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Docs');
+    const locators = buildCommonLocators(page);
+    await locators.docs.editToggle(pane(page)).click();
+    await expectLinkOpensRequest(page, locators.codeMirror.within(pane(page)), { type: 'grpc', url: url('grpc-docs') });
+  });
+});

--- a/tests/codemirror-linkaware/request-http.spec.ts
+++ b/tests/codemirror-linkaware/request-http.spec.ts
@@ -1,0 +1,98 @@
+import { expect, Page, test } from '../../playwright';
+import { buildCommonLocators, closeAllCollections, LINK_AWARE_COLLECTION_NAME as COLLECTION_NAME, expectLinkOpensExternally, expectLinkOpensRequest, expectNoLink, openCollectionFromDialog, openRequest, selectRequestPaneTab, selectScriptSubTab, setCodeMirrorValue as setCmValue } from '../utils/page';
+
+const pane = (page: Page) => page.locator('[data-testid="request-pane"]');
+const url = (path: string) => `http://link-aware.test/${path}`;
+const varsCm = (page: Page) => buildCommonLocators(page).codeMirror.valueCellAt(pane(page));
+
+test.describe('CodeMirror link-aware - HTTP request tab', () => {
+  test.beforeEach(async ({ page, electronApp, collectionFixturePath }) => {
+    await openCollectionFromDialog(page, electronApp, collectionFixturePath!);
+    await openRequest(page, COLLECTION_NAME, 'http-request');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('URL Bar: plain click does not open a request; Cmd/Ctrl+Click opens it externally', async ({ page }) => {
+    const cm = buildCommonLocators(page).request.urlInput();
+    const link = cm.locator('.CodeMirror-link').first();
+    await expect(link).toBeVisible();
+
+    await link.click();
+    await expect(cm).toContainClass('CodeMirror-focused');
+
+    await expectLinkOpensExternally(page, cm);
+  });
+
+  test('Params: plain click opens a transient HTTP request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Params');
+    const cm = buildCommonLocators(page).codeMirror.valueCellAt(pane(page));
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('http-params') });
+  });
+
+  test('Body: plain click opens a transient HTTP request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Body');
+    const cm = buildCommonLocators(page).request.bodyEditor().locator('.CodeMirror');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('http-body') });
+  });
+
+  test('Vars: plain click opens a transient HTTP request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Vars');
+    await expectLinkOpensRequest(page, varsCm(page), { type: 'http', url: url('http-vars') });
+  });
+
+  test('Pre-Request-Script: plain click opens a transient HTTP request', async ({ page }) => {
+    await selectScriptSubTab(page, 'pre-request');
+    const cm = buildCommonLocators(page).codeMirror.byTestId('pre-request-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('http-script') });
+  });
+
+  test('Post-Response-Script: plain click opens a transient HTTP request', async ({ page }) => {
+    await selectScriptSubTab(page, 'post-response');
+    const cm = buildCommonLocators(page).codeMirror.byTestId('post-response-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('http-script') });
+  });
+
+  test('Tests: plain click opens a transient HTTP request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Tests');
+    const cm = buildCommonLocators(page).codeMirror.byTestId('test-script-editor');
+    await expectLinkOpensRequest(page, cm, { type: 'http', url: url('http-tests') });
+  });
+
+  test('Docs: plain click opens a transient HTTP request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Docs');
+    const locators = buildCommonLocators(page);
+    await locators.docs.editToggle(pane(page)).click();
+    await expectLinkOpensRequest(page, locators.codeMirror.within(pane(page)), { type: 'http', url: url('http-docs') });
+  });
+
+  test('Vars: repeated clicks generate unique "Untitled N" names', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Vars');
+    await expectLinkOpensRequest(page, varsCm(page), { type: 'http', url: url('http-vars') });
+    const firstName = await page.locator('.request-tab.active .tab-name').innerText();
+
+    await openRequest(page, COLLECTION_NAME, 'http-request');
+    await selectRequestPaneTab(page, 'Vars');
+    await expectLinkOpensRequest(page, varsCm(page), { type: 'http', url: url('http-vars') });
+    const secondName = await page.locator('.request-tab.active .tab-name').innerText();
+
+    expect(secondName).not.toBe(firstName);
+  });
+
+  test('Params: {{variable}}-interpolated URL is not treated as a link', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Params');
+    const cm = buildCommonLocators(page).codeMirror.valueCellAt(pane(page), 1); // second (auto-added empty) params row
+    await setCmValue(cm, url('{{shouldNotLink}}'));
+    await expectNoLink(cm);
+  });
+
+  test('Vars: transient request opens as a new tab in the same collection', async ({ page }) => {
+    await openRequest(page, COLLECTION_NAME, 'http-request', { persist: true });
+
+    await selectRequestPaneTab(page, 'Vars');
+    await expectLinkOpensRequest(page, varsCm(page), { type: 'http', url: url('http-vars') });
+    await expect(page.locator('.request-tab')).toHaveCount(2);
+  });
+});

--- a/tests/codemirror-linkaware/request-ws.spec.ts
+++ b/tests/codemirror-linkaware/request-ws.spec.ts
@@ -1,0 +1,33 @@
+import { Page, test } from '../../playwright';
+import { buildCommonLocators, closeAllCollections, LINK_AWARE_COLLECTION_NAME as COLLECTION_NAME, expectLinkOpensRequest, expectNoLink, openCollectionFromDialog, openRequest, selectRequestPaneTab } from '../utils/page';
+
+const pane = (page: Page) => page.locator('[data-testid="request-pane"]');
+const url = (path: string) => `http://link-aware.test/${path}`;
+
+test.describe('CodeMirror link-aware - WebSocket request tab', () => {
+  test.beforeEach(async ({ page, electronApp, collectionFixturePath }) => {
+    await openCollectionFromDialog(page, electronApp, collectionFixturePath!);
+    await openRequest(page, COLLECTION_NAME, 'ws-request');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('URL Bar: a ws:// URL is not treated as a link', async ({ page }) => {
+    await expectNoLink(page.locator('.input-container .CodeMirror').first());
+  });
+
+  test('Messages: plain click opens a transient WS request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Message');
+    const cm = buildCommonLocators(page).codeMirror.within(pane(page));
+    await expectLinkOpensRequest(page, cm, { type: 'ws', url: url('ws-body') });
+  });
+
+  test('Docs: plain click opens a transient WS request', async ({ page }) => {
+    await selectRequestPaneTab(page, 'Docs');
+    const locators = buildCommonLocators(page);
+    await locators.docs.editToggle(pane(page)).click();
+    await expectLinkOpensRequest(page, locators.codeMirror.within(pane(page)), { type: 'ws', url: url('ws-docs') });
+  });
+});

--- a/tests/codemirror-linkaware/response.spec.ts
+++ b/tests/codemirror-linkaware/response.spec.ts
@@ -1,0 +1,63 @@
+import { expect, Page, test } from '../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  createRequest,
+  expectLinkOpensRequest,
+  expectTransientRequestOpened,
+  openRequest,
+  selectRequestBodyMode,
+  sendRequestAndWaitForResponse,
+  setCodeMirrorValue as setCmValue,
+  switchResponseFormat,
+  switchToPreviewTab
+} from '../utils/page';
+
+const ECHO_URL = 'http://localhost:8081/api/echo/json';
+const responsePane = (page: Page) => page.locator('[data-testid="response-pane"]');
+const requestPane = (page: Page) => page.locator('[data-testid="request-pane"]');
+// HttpMethodSelector lives in the query-url-wrapper, a sibling of [data-testid="request-pane"], not inside it.
+const queryUrlWrapper = (page: Page) => page.locator('.query-url-wrapper');
+
+test.describe('CodeMirror link-aware - Response pane (HTTP/GraphQL, pre-existing PR #8189)', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('Body - JSON preview tree: clicking a URL value opens it as a transient request', async ({ page, createTmpDir }) => {
+    const REMOTE_ECHO_URL = 'https://testbench-sanity.usebruno.com/api/echo/json';
+
+    await createCollection(page, 'response-json-preview', await createTmpDir('response-json-preview'));
+    await createRequest(page, 'echo', 'response-json-preview', { url: REMOTE_ECHO_URL, method: 'POST' });
+    await openRequest(page, 'response-json-preview', 'echo');
+
+    await selectRequestBodyMode(page, 'JSON');
+    await setCmValue(buildCommonLocators(page).codeMirror.within(page.locator('.request-pane')), '{ "link": "http://link-aware.test/http-body" }');
+    await sendRequestAndWaitForResponse(page);
+
+    await switchResponseFormat(page, 'JSON');
+    await switchToPreviewTab(page);
+
+    const value = responsePane(page).locator('.variable-value').filter({ hasText: 'link-aware.test/http-body' });
+    await expect(value).toBeVisible();
+    await value.click();
+    await expectTransientRequestOpened(page, { type: 'http', url: 'http://link-aware.test/http-body' });
+  });
+
+  test('presigned "PutObject" URL defaults the new request to PUT and opens on the Body tab', async ({ page, createTmpDir }) => {
+    const presignedUrl = 'https://bucket.s3.amazonaws.com/key?x-id=PutObject';
+    await createCollection(page, 'response-presigned', await createTmpDir('response-presigned'));
+    await createRequest(page, 'echo', 'response-presigned', { url: ECHO_URL, method: 'POST' });
+    await openRequest(page, 'response-presigned', 'echo');
+
+    await selectRequestBodyMode(page, 'JSON');
+    await setCmValue(buildCommonLocators(page).codeMirror.within(page.locator('.request-pane')), `{ "link": "${presignedUrl}" }`);
+    await sendRequestAndWaitForResponse(page);
+
+    await expectLinkOpensRequest(page, buildCommonLocators(page).codeMirror.within(responsePane(page)), { type: 'http', url: presignedUrl });
+
+    await expect(queryUrlWrapper(page).getByTestId('method-selector')).toHaveText('PUT');
+    await expect(requestPane(page).locator('.tabs').getByRole('tab', { name: 'Body' })).toContainClass('active');
+  });
+});

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1,7 +1,7 @@
-import { test, expect, Page, ElectronApplication, waitForReadyPage as waitForReadyPageImpl } from '../../../playwright';
+import { test, expect, Page, Locator, ElectronApplication, waitForReadyPage as waitForReadyPageImpl } from '../../../playwright';
 import process from 'node:process';
 import * as path from 'path';
-import { buildCommonLocators, buildScriptErrorLocators } from './locators';
+import { buildCommonLocators, buildGrpcCommonLocators, buildScriptErrorLocators } from './locators';
 
 type SandboxMode = 'safe' | 'developer';
 
@@ -89,6 +89,28 @@ const openCollection = async (page, collectionName: string) => {
 };
 
 /**
+ * Open a collection living at an arbitrary filesystem path via the native "Open Collection"
+ * flow — mocks `dialog.showOpenDialog` to return `collectionPath` directly (no real file
+ * picker), then drives the "+" menu's "Open collection" item. Useful for loading a committed
+ * fixture collection copied to a tmp dir (e.g. via the `collectionFixturePath` fixture).
+ * @param page - The page object
+ * @param electronApp - The Electron application object
+ * @param collectionPath - Absolute path to the collection folder to open
+ * @returns void
+ */
+const openCollectionFromDialog = async (page: Page, electronApp: ElectronApplication, collectionPath: string) => {
+  await test.step(`Open collection from dialog at "${collectionPath}"`, async () => {
+    await electronApp.evaluate(({ dialog }, dir) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [dir] });
+    }, collectionPath);
+
+    const locators = buildCommonLocators(page);
+    await locators.plusMenu.button().click();
+    await locators.plusMenu.openCollection().click();
+  });
+};
+
+/**
  * Create a collection
  * @param page - The page object
  * @param collectionName - The name of the collection to create
@@ -104,8 +126,9 @@ const createCollection = async (
   format?: 'bru' | 'yml'
 ) => {
   await test.step(`Create collection "${collectionName}"`, async () => {
-    await page.getByTestId('collections-header-add-menu').click();
-    await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Create collection' }).click();
+    const locators = buildCommonLocators(page);
+    await locators.plusMenu.button().click();
+    await locators.plusMenu.createCollection().click();
 
     // Wait for inline creator to appear, then click the cog button to open advanced modal
     const inlineCreator = page.locator('.inline-collection-creator');
@@ -464,8 +487,8 @@ const importCollection = async (
   await test.step(`Import collection from "${filePath}"`, async () => {
     const locators = buildCommonLocators(page);
 
-    await page.getByTestId('collections-header-add-menu').click();
-    await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Import collection' }).click();
+    await locators.plusMenu.button().click();
+    await locators.plusMenu.importCollection().click();
 
     // Wait for import modal
     const importModal = page.getByRole('dialog');
@@ -1623,6 +1646,84 @@ const openExampleFromSidebar = async (page: Page, requestName: string, exampleNa
   await exampleRow.click();
 };
 
+// --- CodeMirror link-aware assertions (open-as-transient-request feature) -------------------
+
+type LinkAwareRequestType = 'http' | 'graphql' | 'grpc' | 'ws';
+
+// Name of the committed fixture collection under tests/codeeditor-state/codemirror/fixtures.
+const LINK_AWARE_COLLECTION_NAME = 'codemirror-linkaware';
+
+// Cmd on macOS, Ctrl elsewhere — matches isCmdOrCtrlPressed() in linkAware.js.
+const LINK_CLICK_MODIFIER: 'Meta' | 'Control' = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+const LINK_AWARE_METHOD_LABEL: Record<LinkAwareRequestType, string | null> = {
+  http: null, // HTTP shows the verb (GET/POST/...), not a fixed label
+  graphql: 'GQL',
+  grpc: 'gRPC',
+  ws: 'WS'
+};
+
+const setCodeMirrorValue = async (cm: Locator, value: string) => {
+  await cm.evaluate((el: any, v: string) => el.CodeMirror?.setValue(v), value);
+};
+
+const linkAwareUrlBarCm = (page: Page, type: LinkAwareRequestType): Locator =>
+  type === 'grpc'
+    ? buildGrpcCommonLocators(page).request.queryUrlContainer().locator('.CodeMirror')
+    : buildCommonLocators(page).request.urlInput();
+
+/** Asserts the currently active tab is a freshly-created transient request of the given type. */
+const expectTransientRequestOpened = async (page: Page, opts: { type: LinkAwareRequestType; url?: string }) => {
+  const tab = page.locator('.request-tab.active');
+  await expect(tab).toContainText('Untitled', { timeout: 10000 });
+
+  const expectedLabel = LINK_AWARE_METHOD_LABEL[opts.type];
+  if (expectedLabel) {
+    await expect(tab.locator('.tab-method')).toHaveText(expectedLabel, { timeout: 5000 });
+  } else {
+    await expect(tab.locator('.tab-method')).not.toHaveText('', { timeout: 5000 });
+  }
+
+  if (opts.url && opts.type !== 'ws') {
+    await expect.poll(
+      () => linkAwareUrlBarCm(page, opts.type).evaluate((el: any) => el.CodeMirror?.getValue() ?? ''),
+      { timeout: 5000 }
+    ).toBe(opts.url);
+  }
+};
+
+/** Plain click on the marked link — asserts a new transient request of `type` opens with `url`. */
+const expectLinkOpensRequest = async (page: Page, cm: Locator, opts: { type: LinkAwareRequestType; url: string }) => {
+  const link = cm.locator('.CodeMirror-link').first();
+  await expect(link).toBeVisible({ timeout: 10000 });
+  await link.click();
+  await expectTransientRequestOpened(page, opts);
+};
+
+/** Modifier+click on the marked link — must fall back to "open externally", no new tab. */
+const expectLinkOpensExternally = async (page: Page, cm: Locator) => {
+  const link = cm.locator('.CodeMirror-link').first();
+  await expect(link).toBeVisible({ timeout: 10000 });
+  const tabCountBefore = await page.locator('.request-tab').count();
+  await link.click({ modifiers: [LINK_CLICK_MODIFIER] });
+  await page.waitForTimeout(300); // no new-tab locator to await — asserting absence of change
+  await expect(page.locator('.request-tab')).toHaveCount(tabCountBefore);
+};
+
+/**
+ * A URL-looking value must behave as plain text (e.g. `{{var}}`-interpolated, `ws://`, or a
+ * field with link-awareness disabled): clicking it — with or without the open-externally
+ * modifier — must be handled as a normal text click (CodeMirror focuses and places the
+ * cursor), never intercepted to open a transient request.
+ */
+const expectNoLink = async (cm: Locator) => {
+  await cm.click();
+  await expect(cm).toContainClass('CodeMirror-focused');
+
+  await cm.click({ modifiers: [LINK_CLICK_MODIFIER] });
+  await expect(cm).toContainClass('CodeMirror-focused');
+};
+
 type DialogOptions = {
   showOpenDialog: () => Promise<{ canceled: boolean; filePaths: string[] }>;
 };
@@ -1645,6 +1746,7 @@ export {
   dismissImportIssuesToasts,
   closeAllCollections,
   openCollection,
+  openCollectionFromDialog,
   createCollection,
   createRequest,
   createUntitledRequest,
@@ -1698,11 +1800,19 @@ export {
   sendAndWaitForErrorCard,
   sendAndWaitForResponse,
   selectAuthMode,
+  fieldEditor,
   typeIntoField,
   readField,
   createExampleFromSidebar,
   openExampleFromSidebar,
-  openWorkspaceFromDialog
+  openWorkspaceFromDialog,
+  setCodeMirrorValue,
+  expectTransientRequestOpened,
+  expectLinkOpensRequest,
+  expectLinkOpensExternally,
+  expectNoLink,
+  LINK_AWARE_COLLECTION_NAME,
+  LINK_CLICK_MODIFIER
 };
 
-export type { SandboxMode, EnvironmentType, EnvironmentVariable, ImportCollectionOptions, CreateRequestOptions, CreateUntitledRequestOptions, CreateTransientRequestOptions, AssertionInput };
+export type { SandboxMode, EnvironmentType, EnvironmentVariable, ImportCollectionOptions, CreateRequestOptions, CreateUntitledRequestOptions, CreateTransientRequestOptions, AssertionInput, LinkAwareRequestType };

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -75,7 +75,15 @@ export const buildCommonLocators = (page: Page) => ({
     envNameInput: () => page.locator('input[name="name"]')
   },
   codeMirror: {
-    byTestId: (testId: string) => page.getByTestId(testId).locator('.CodeMirror').first()
+    byTestId: (testId: string) => page.getByTestId(testId).locator('.CodeMirror').first(),
+    within: (scope: Locator) => scope.locator('.CodeMirror').first(),
+    /** Nth row's value-column editor in an EditableTable (Headers / Params / Vars / Assertions). */
+    valueCellAt: (scope: Locator, rowIndex: number = 0) =>
+      scope.locator('table tbody tr').nth(rowIndex).getByTestId('column-value').locator('.CodeMirror')
+  },
+  docs: {
+    /** Docs tabs default to preview mode — this toggles into edit mode. */
+    editToggle: (scope: Locator) => scope.locator('.editing-mode')
   },
   request: {
     urlInput: () => page.locator('#request-url .CodeMirror'),
@@ -118,6 +126,7 @@ export const buildCommonLocators = (page: Page) => ({
   },
   plusMenu: {
     button: () => page.getByTestId('collections-header-add-menu'),
+    openCollection: () => page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Open collection' }),
     createCollection: () => page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Create collection' }),
     importCollection: () => page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Import collection' })
   },


### PR DESCRIPTION
### Description

BRU-2070

This PR extends #8189 (which only let you open response URLs as new HTTP requests) into a general "click any link, open it as a request" feature that works everywhere Bruno renders a clickable URL inside a CodeMirror editor - request tabs (HTTP, GraphQL, gRPC, WS), the response pane, and Collection/Folder settings.

Clicking a link now opens it as a new **transient** request in the same collection, matching context:
- From inside an open request tab -> same type as that request (HTTP -> HTTP, GraphQL -> GraphQL, gRPC -> gRPC, WS -> WS).
- From Collection/Folder settings (no request in scope) -> the type configured in the collection's **Presets** settings.

Cmd/Ctrl+click still opens the link externally, exactly as before, everywhere.

### Problem

The feature only existed in one place (the HTTP/GraphQL response body) and always created an HTTP request there regardless of the actual request type. Everywhere else- request tabs, gRPC/WS, collection settings - clicking a link did nothing.

### Fix

Added a shared resolver + thunk that picks the right request type (from the current item, or the collection's Presets) and opens a transient request accordingly, wired into the four core CodeMirror editor components so it reaches every field automatically. Fixed a few components that weren't passing the current request through to their editor, which was silently defaulting new requests to HTTP. Added e2e test coverage across request tabs, settings, and the response pane.

Headers are intentionally excluded - header values never render as clickable links.

### Screenshots

https://github.com/user-attachments/assets/4b44a67f-9d35-44e9-a81d-e9a9b6f46a2d

| Before | After |
| --- | --- |
| | |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
