### PR TITLE
fix(mock-server): try on mock server would fail a rule with body in it

### DIFF
--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -106,8 +106,6 @@ const setJsonPathValue = (target, jsonPath, value) => {
   current[segments[segments.length - 1]] = value;
 };
 
-const REGEX_CLASS_SAMPLES = { d: '1', w: 'a', s: ' ' };
-
 // Expand common tokens into a literal the matcher will accept.
 // Unrecognized patterns fall through to the raw value in demoValueForMatches.
 const buildRegexSample = (pattern) => String(pattern)
@@ -172,6 +170,9 @@ export const buildDemoRequestFromRules = (request, rules) => {
     const bodyObject = {};
     bodyConditions.forEach((condition) => setJsonPathValue(bodyObject, condition.key, demoValueForCondition(condition)));
     body = { mode: 'json', content: JSON.stringify(bodyObject, null, 2) };
+    if (body?.mode === 'json' && body?.content) {
+      body.json = JSON.parse(body.content);
+    }
   }
 
   return {

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -220,13 +220,13 @@ export const buildMockServerTryRequest = ({
   const body = request?.body;
   let requestBody = null;
 
-  if (body?.mode === 'json' && body.content) {
-    requestBody = body.content;
+  if (body?.mode === 'json' && body.json) {
+    requestBody = body.json;
     if (!headers['Content-Type'] && !headers['content-type']) {
       headers['Content-Type'] = 'application/json';
     }
-  } else if (body?.mode === 'text' && body.content) {
-    requestBody = body.content;
+  } else if (body?.mode === 'text' && body.text) {
+    requestBody = body.text;
     if (!headers['Content-Type'] && !headers['content-type']) {
       headers['Content-Type'] = 'text/plain';
     }


### PR DESCRIPTION
### Description

The 'Try' option in the mock server would show No mock response found if there was a response with a rule with body and some key equating to a value. 

### Problem
JIRA_ BRU-4306
If the body was json, the request body would go as body.content rather than body.json, this would not have the rules parse the body and therefore the key was never found. 

### Fix

Added a simple fix where if the body is json, then we pass requestBody.json for the rules to parse the body for the key. 


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mock server requests now correctly process JSON and text request bodies, improving request simulation accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->