### PR TITLE
fix(docs): hide popper reference elements when hidden to prevent interaction

### DIFF
--- a/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
@@ -30,6 +30,17 @@ const Wrapper = styled.div`
     }
   }
 
+  &[data-reference-hidden],
+  &[data-popper-reference-hidden] {
+    visibility: hidden;
+    pointer-events: none;
+
+    &, * {
+      visibility: hidden !important;
+      transition: none !important;
+    }
+  }
+
   .label-item {
     display: flex;
     align-items: center;

--- a/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Dropdown/StyledWrapper.js
@@ -32,9 +32,6 @@ const Wrapper = styled.div`
 
   &[data-reference-hidden],
   &[data-popper-reference-hidden] {
-    visibility: hidden;
-    pointer-events: none;
-
     &, * {
       visibility: hidden !important;
       transition: none !important;


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Fixes language selector dropdown overflow issue on scrolling

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->

Popover element scrolls along with the trigger irrespective of its visibility on the page.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

The fix, now blocks the view whenever the dropdown trigger goes out of the view

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

###### Before
https://github.com/user-attachments/assets/87387674-6cf4-4e5d-8cac-06cba708f762
###### After
https://github.com/user-attachments/assets/9e14797a-dc00-4864-b97b-915a6002640b

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown behavior when its reference element is hidden.
  * Hidden dropdowns are now invisible, non-interactive, and avoid unnecessary transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->