### PR TITLE
feat(bruno-js): expose __dirname and __filename to node-vm scripts

### DIFF
--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -224,18 +224,21 @@ const mergeVars = (collection, request, requestTreePath) => {
 /**
  * Wraps a script in an IIFE closure to isolate its scope
  * @param {string} script - The script code to wrap
+ * @param {{ dirname: string, filename: string } | null} paths - Absolute paths bound to __dirname / __filename
  * @returns {string} The wrapped script
  */
-const wrapScriptInClosure = (script) => {
+const wrapScriptInClosure = (script, paths = null) => {
   if (!script || script.trim() === '') {
     return '';
   }
   // Wrap script in async IIFE to create isolated scope
   // This prevents variable re-declaration errors and allows early returns
   // to only affect the current script segment
-  return `await (async () => {
+  const dirnameParam = paths?.dirname != null ? JSON.stringify(paths.dirname) : '__dirname';
+  const filenameParam = paths?.filename != null ? JSON.stringify(paths.filename) : '__filename';
+  return `await (async (__dirname, __filename) => {
 ${script}
-})();`;
+})(${dirnameParam}, ${filenameParam});`;
 };
 
 /**
@@ -250,8 +253,16 @@ ${script}
  * @param {number} requestIndex - Index in scripts of the request-level segment.
  * @returns {{ code: string, metadata: { requestStartLine: number, requestEndLine: number } | null }}
  */
-const wrapAndJoinScripts = (scripts, requestIndex, segmentSources = null) => {
-  const wrapped = scripts.map((s) => wrapScriptInClosure(s));
+const wrapAndJoinScripts = (scripts, requestIndex, segmentSources = null, requestSegmentSource = null) => {
+  const buildPaths = (i) => {
+    const filePath = i === requestIndex
+      ? requestSegmentSource?.filePath
+      : segmentSources?.[i]?.filePath;
+    if (!filePath) return null;
+    return { dirname: path.dirname(filePath), filename: filePath };
+  };
+
+  const wrapped = scripts.map((s, i) => wrapScriptInClosure(s, buildPaths(i)));
   const code = wrapped.filter(Boolean).join('\n\n');
 
   let offset = 0;
@@ -302,6 +313,10 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
     displayPath: config.collectionFile
   };
 
+  const requestItem = requestTreePath?.[requestTreePath.length - 1];
+  const requestPathname = request?.pathname || requestItem?.pathname;
+  const requestSegmentSource = requestPathname ? { filePath: requestPathname } : null;
+
   let combinedPreReqScript = [];
   let combinedPreReqSources = [];
   let combinedPostResScript = [];
@@ -347,7 +362,7 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
     request?.script?.req || ''
   ];
   const preReqSources = [collectionSource, ...combinedPreReqSources, null];
-  const preReq = wrapAndJoinScripts(preReqScripts, preReqScripts.length - 1, preReqSources);
+  const preReq = wrapAndJoinScripts(preReqScripts, preReqScripts.length - 1, preReqSources, requestSegmentSource);
   request.script.req = preReq.code;
   request.script.reqMetadata = preReq.metadata;
 
@@ -359,7 +374,7 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
       request?.script?.res || ''
     ];
     const postResSources = [collectionSource, ...combinedPostResSources, null];
-    const postRes = wrapAndJoinScripts(postResScripts, postResScripts.length - 1, postResSources);
+    const postRes = wrapAndJoinScripts(postResScripts, postResScripts.length - 1, postResSources, requestSegmentSource);
     request.script.res = postRes.code;
     request.script.resMetadata = postRes.metadata;
   } else {
@@ -370,7 +385,7 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
       collectionPostResScript
     ];
     const postResSources = [null, ...[...combinedPostResSources].reverse(), collectionSource];
-    const postRes = wrapAndJoinScripts(postResScripts, 0, postResSources);
+    const postRes = wrapAndJoinScripts(postResScripts, 0, postResSources, requestSegmentSource);
     request.script.res = postRes.code;
     request.script.resMetadata = postRes.metadata;
   }
@@ -383,7 +398,7 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
       request?.tests || ''
     ];
     const testSources = [collectionSource, ...combinedTestsSources, null];
-    const tests = wrapAndJoinScripts(testScripts, testScripts.length - 1, testSources);
+    const tests = wrapAndJoinScripts(testScripts, testScripts.length - 1, testSources, requestSegmentSource);
     request.tests = tests.code;
     request.testsMetadata = tests.metadata;
   } else {
@@ -394,7 +409,7 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
       collectionTests
     ];
     const testSources = [null, ...[...combinedTestsSources].reverse(), collectionSource];
-    const tests = wrapAndJoinScripts(testScripts, 0, testSources);
+    const tests = wrapAndJoinScripts(testScripts, 0, testSources, requestSegmentSource);
     request.tests = tests.code;
     request.testsMetadata = tests.metadata;
   }
@@ -713,6 +728,7 @@ module.exports = {
   mergeHeaders,
   mergeVars,
   mergeScripts,
+  wrapAndJoinScripts,
   findItemInCollection,
   getTreePathFromCollectionToItem,
   createCollectionFromBrunoObject,

--- a/packages/bruno-cli/tests/integration/dirname-per-script-segment/dirname-per-script-segment.spec.js
+++ b/packages/bruno-cli/tests/integration/dirname-per-script-segment/dirname-per-script-segment.spec.js
@@ -1,0 +1,65 @@
+const { describe, it, expect, beforeAll, afterAll, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { runCli } = require('../helpers/run-cli');
+const { createCollectionFixture } = require('../helpers/collection-fixture');
+
+const FIXTURE_DIR = path.join(__dirname, 'fixtures', 'dirname-filename-cli');
+
+describe('CLI run — __dirname/__filename are bound per script segment (node-vm)', () => {
+  let server;
+  let baseUrl;
+  let workDir;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  afterEach(() => {
+    if (workDir) {
+      fs.rmSync(workDir, { recursive: true, force: true });
+      workDir = null;
+    }
+  });
+
+  it('collection, folder, and request scripts each see their own __dirname/__filename', async () => {
+    workDir = createCollectionFixture(FIXTURE_DIR);
+    const result = await runCli(
+      [
+        'run', 'subfolder/dirname-request.yml',
+        '--env', 'Test',
+        '--env-var', `host=${baseUrl}`,
+        '--sandbox', 'developer',
+        '--noproxy'
+      ],
+      workDir
+    );
+
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+
+    const subfolderPath = path.join(workDir, 'subfolder');
+    const envContent = fs.readFileSync(path.join(workDir, 'environments', 'Test.yml'), 'utf8');
+    expect(envContent).toContain(`value: ${subfolderPath}\n`);
+    expect(envContent).toContain(`value: ${path.join(subfolderPath, 'folder.yml')}\n`);
+    expect(envContent).toContain(`value: ${path.join(subfolderPath, 'dirname-request.yml')}\n`);
+
+    const collectionContent = fs.readFileSync(path.join(workDir, 'opencollection.yml'), 'utf8');
+    expect(collectionContent).toContain(`value: ${workDir}\n`);
+    expect(collectionContent).toContain(`value: ${path.join(workDir, 'opencollection.yml')}\n`);
+  }, 60_000);
+});

--- a/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/environments/Test.yml
+++ b/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/environments/Test.yml
@@ -1,0 +1,5 @@
+name: Test
+
+variables:
+  - name: host
+    value: http://127.0.0.1

--- a/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/opencollection.yml
+++ b/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/opencollection.yml
@@ -1,0 +1,13 @@
+opencollection: "1.0.0"
+
+info:
+  name: dirname-filename-cli
+
+request:
+  scripts:
+    - type: before-request
+      code: |-
+        bru.setCollectionVar("collectionDir", __dirname);
+        bru.setCollectionVar("collectionFile", __filename);
+
+bundled: false

--- a/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/subfolder/data.json
+++ b/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/subfolder/data.json
@@ -1,0 +1,3 @@
+{
+  "greeting": "hello"
+}

--- a/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/subfolder/dirname-request.yml
+++ b/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/subfolder/dirname-request.yml
@@ -1,0 +1,40 @@
+info:
+  name: dirname-request
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: '{{host}}/ping'
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const fs = require('fs');
+        const path = require('path');
+        bru.setEnvVar("requestDir", __dirname);
+        bru.setEnvVar("requestFile", __filename);
+        const raw = fs.readFileSync(path.join(__dirname, 'data.json'), 'utf-8');
+        bru.setVar("readData", JSON.parse(raw).greeting);
+    - type: tests
+      code: |-
+        test("collection __dirname differs from folder __dirname", function() {
+          expect(bru.getCollectionVar("collectionDir")).to.not.equal(bru.getEnvVar("folderDir"));
+        });
+
+        test("folder and request live in the same directory", function() {
+          expect(bru.getEnvVar("folderDir")).to.equal(bru.getEnvVar("requestDir"));
+        });
+
+        test("collection __filename ends with opencollection.yml", function() {
+          expect(bru.getCollectionVar("collectionFile").endsWith("opencollection.yml")).to.equal(true);
+        });
+
+        test("request __filename ends with dirname-request.yml", function() {
+          expect(bru.getEnvVar("requestFile").endsWith("dirname-request.yml")).to.equal(true);
+        });
+
+        test("reads data.json relative to __dirname", function() {
+          expect(bru.getVar("readData")).to.equal("hello");
+        });

--- a/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/subfolder/folder.yml
+++ b/packages/bruno-cli/tests/integration/dirname-per-script-segment/fixtures/dirname-filename-cli/subfolder/folder.yml
@@ -1,0 +1,10 @@
+info:
+  name: subfolder
+  type: folder
+
+request:
+  scripts:
+    - type: before-request
+      code: |-
+        bru.setEnvVar("folderDir", __dirname);
+        bru.setEnvVar("folderFile", __filename);

--- a/packages/bruno-cli/tests/integration/helpers/collection-fixture.js
+++ b/packages/bruno-cli/tests/integration/helpers/collection-fixture.js
@@ -6,7 +6,11 @@ const path = require('path');
 // back into the repo, and returns its path; the caller removes it. Fixtures hold
 // real {{var}} references, so a run supplies their values with --env-var.
 const createCollectionFixture = (from) => {
-  const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), `bruno-${path.basename(from)}-`));
+  // realpathSync: macOS os.tmpdir() is a symlink; the sandbox resolves __dirname
+  // via the realpath, so callers asserting on persisted path values need the same.
+  const targetDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), `bruno-${path.basename(from)}-`))
+  );
   fs.cpSync(from, targetDir, { recursive: true });
   return targetDir;
 };

--- a/packages/bruno-cli/tests/utils/collection/wrap-and-join-scripts.spec.js
+++ b/packages/bruno-cli/tests/utils/collection/wrap-and-join-scripts.spec.js
@@ -1,0 +1,49 @@
+const path = require('node:path');
+const { describe, test, expect } = require('@jest/globals');
+const { wrapAndJoinScripts } = require('../../../src/utils/collection');
+
+describe('CLI wrapAndJoinScripts — hierarchical __dirname/__filename', () => {
+  const colDir = path.resolve('/col');
+  const collectionFile = path.join(colDir, 'collection.bru');
+  const subDir = path.join(colDir, 'sub');
+  const folderFile = path.join(subDir, 'folder.bru');
+  const requestFile = path.join(subDir, 'req.bru');
+
+  test('binds per-segment __dirname/__filename via IIFE args when filePath is provided', () => {
+    const sources = [
+      { filePath: collectionFile, displayPath: 'collection.bru' },
+      { filePath: folderFile, displayPath: path.join('sub', 'folder.bru') },
+      null
+    ];
+    const requestSegmentSource = { filePath: requestFile };
+    const result = wrapAndJoinScripts(
+      ['let a = 1;', 'let b = 2;', 'let c = 3;'],
+      2,
+      sources,
+      requestSegmentSource
+    );
+
+    expect(result.code).toContain('async (__dirname, __filename) => {');
+    expect(result.code).toContain(`)(${JSON.stringify(colDir)}, ${JSON.stringify(collectionFile)});`);
+    expect(result.code).toContain(`)(${JSON.stringify(subDir)}, ${JSON.stringify(folderFile)});`);
+    expect(result.code).toContain(`)(${JSON.stringify(subDir)}, ${JSON.stringify(requestFile)});`);
+  });
+
+  test('preserves line counts when injecting IIFE args (opener stays on one line)', () => {
+    const withPaths = wrapAndJoinScripts(
+      ['let x = 1;', '', 'let y = 2;'],
+      2,
+      [{ filePath: collectionFile, displayPath: 'collection.bru' }, null, null],
+      { filePath: requestFile }
+    );
+    const withoutPaths = wrapAndJoinScripts(['let x = 1;', '', 'let y = 2;'], 2);
+    expect(withPaths.metadata.requestStartLine).toBe(withoutPaths.metadata.requestStartLine);
+    expect(withPaths.metadata.requestEndLine).toBe(withoutPaths.metadata.requestEndLine);
+  });
+
+  test('falls back to sandbox __dirname/__filename identifiers when no filePath is provided', () => {
+    const result = wrapAndJoinScripts(['', '', 'console.log("hi");'], 2);
+    expect(result.code).toContain('async (__dirname, __filename) => {');
+    expect(result.code).toContain(')(__dirname, __filename);');
+  });
+});

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -165,7 +165,7 @@ const mergeVars = (collection, request, requestTreePath = []) => {
 
 // __bruSetScope must stay on the IIFE opener line so wrapAndJoinScripts' line
 // counts (and stack-trace mapping) are unaffected.
-const wrapScriptInClosure = (script, scopeInfo = null) => {
+const wrapScriptInClosure = (script, scopeInfo = null, paths = null) => {
   if (!script || script.trim() === '') {
     return '';
   }
@@ -176,9 +176,12 @@ const wrapScriptInClosure = (script, scopeInfo = null) => {
   const scopeSetter = scopeInfo
     ? ` __bruSetScope(${JSON.stringify(scopeInfo)});`
     : '';
-  return `await (async () => {${scopeSetter}
+  // Shadow sandbox globals so each segment sees its own source-file dir.
+  const dirnameParam = paths?.dirname != null ? JSON.stringify(paths.dirname) : '__dirname';
+  const filenameParam = paths?.filename != null ? JSON.stringify(paths.filename) : '__filename';
+  return `await (async (__dirname, __filename) => {${scopeSetter}
 ${script}
-})();`;
+})(${dirnameParam}, ${filenameParam});`;
 };
 
 /**
@@ -234,7 +237,15 @@ const wrapAndJoinScripts = (scripts, requestIndex, segmentSources = null, reques
     return { type: seg.type, sourceFile: seg.displayPath };
   };
 
-  const wrapped = scripts.map((s, i) => wrapScriptInClosure(s, buildScopeInfo(i)));
+  const buildPaths = (i) => {
+    const filePath = i === requestIndex
+      ? requestSegmentSource?.filePath
+      : segmentSources?.[i]?.filePath;
+    if (!filePath) return null;
+    return { dirname: path.dirname(filePath), filename: filePath };
+  };
+
+  const wrapped = scripts.map((s, i) => wrapScriptInClosure(s, buildScopeInfo(i), buildPaths(i)));
   const code = wrapped.filter(Boolean).join('\n\n');
 
   let offset = 0;
@@ -289,7 +300,10 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
   const requestItem = requestTreePath?.[requestTreePath.length - 1];
   const requestPathname = request?.pathname || requestItem?.pathname;
   const requestSegmentSource = requestPathname && collection?.pathname
-    ? { displayPath: posixifyPath(path.relative(collection.pathname, requestPathname)) }
+    ? {
+        displayPath: posixifyPath(path.relative(collection.pathname, requestPathname)),
+        filePath: requestPathname
+      }
     : null;
 
   const withContent = (source, script) =>

--- a/packages/bruno-electron/tests/utils/collection.spec.js
+++ b/packages/bruno-electron/tests/utils/collection.spec.js
@@ -1,4 +1,7 @@
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { runScriptInNodeVm } = require('@usebruno/js');
 const { parseBruFileMeta, wrapAndJoinScripts, mergeScripts } = require('../../src/utils/collection');
 
 describe('parseBruFileMeta', () => {
@@ -306,7 +309,7 @@ describe('wrapAndJoinScripts', () => {
 
   test('tracks correct request line range with collection script before it', () => {
     const result = wrapAndJoinScripts(['let x = 1;', '', 'let y = 2;'], 2);
-    // Collection script: 3 lines (await (async () => {\nlet x = 1;\n})();)
+    // Collection script: 3 lines (IIFE opener + body + closer — args stay on the opener)
     // Empty gap: 1 line (blank line separator)
     // Request script starts at line 5
     expect(result.metadata.requestStartLine).toBe(5);
@@ -353,6 +356,53 @@ describe('wrapAndJoinScripts', () => {
     expect(result.metadata.segments[0].displayPath).toBe('collection.bru');
     expect(result.metadata.segments[1].displayPath).toBe('sub/folder.bru');
     expect(result.metadata.requestStartLine).toBeGreaterThan(result.metadata.segments[1].endLine);
+  });
+
+  test('binds per-segment __dirname/__filename via IIFE args when filePath is provided', () => {
+    const colDir = path.resolve('/col');
+    const collectionFile = path.join(colDir, 'collection.bru');
+    const subDir = path.join(colDir, 'sub');
+    const folderFile = path.join(subDir, 'folder.bru');
+    const requestFile = path.join(subDir, 'req.bru');
+    const sources = [
+      { filePath: collectionFile, displayPath: 'collection.bru' },
+      { filePath: folderFile, displayPath: path.join('sub', 'folder.bru') },
+      null
+    ];
+    const requestSegmentSource = { filePath: requestFile, displayPath: path.join('sub', 'req.bru') };
+    const result = wrapAndJoinScripts(
+      ['let a = 1;', 'let b = 2;', 'let c = 3;'],
+      2,
+      sources,
+      requestSegmentSource
+    );
+
+    expect(result.code).toContain('async (__dirname, __filename) => {');
+    expect(result.code).toContain(`)(${JSON.stringify(colDir)}, ${JSON.stringify(collectionFile)});`);
+    expect(result.code).toContain(`)(${JSON.stringify(subDir)}, ${JSON.stringify(folderFile)});`);
+    expect(result.code).toContain(`)(${JSON.stringify(subDir)}, ${JSON.stringify(requestFile)});`);
+  });
+
+  test('preserves line counts when injecting IIFE args (opener stays on one line)', () => {
+    const colDir = path.resolve('/col');
+    const collectionFile = path.join(colDir, 'collection.bru');
+    const requestFile = path.join(colDir, 'sub', 'req.bru');
+    const withPaths = wrapAndJoinScripts(
+      ['let x = 1;', '', 'let y = 2;'],
+      2,
+      [{ filePath: collectionFile, displayPath: 'collection.bru' }, null, null],
+      { filePath: requestFile, displayPath: path.join('sub', 'req.bru') }
+    );
+    const withoutPaths = wrapAndJoinScripts(['let x = 1;', '', 'let y = 2;'], 2);
+    // Stack-trace mapping depends on line ranges staying stable.
+    expect(withPaths.metadata.requestStartLine).toBe(withoutPaths.metadata.requestStartLine);
+    expect(withPaths.metadata.requestEndLine).toBe(withoutPaths.metadata.requestEndLine);
+  });
+
+  test('falls back to __dirname/__filename identifiers when no filePath is provided', () => {
+    const result = wrapAndJoinScripts(['', '', 'console.log("hi");'], 2);
+    expect(result.code).toContain('async (__dirname, __filename) => {');
+    expect(result.code).toContain(')(__dirname, __filename);');
   });
 });
 
@@ -541,5 +591,186 @@ describe('mergeScripts metadata', () => {
     mergeScripts(collection, request, [request], 'non-sequential');
 
     expect(request.script.resMetadata.requestScriptContent).toBe('let req = 2;');
+  });
+
+  test('injects hierarchical __dirname/__filename per script segment', () => {
+    const collection = makeCollection({ preReq: 'let col = 1;' });
+    const folder = makeFolder('subfolder', { preReq: 'let fold = 2;' });
+    const request = { ...makeRequest({ preReq: 'let req = 3;' }), pathname: '/test/collection/subfolder/req.bru' };
+    mergeScripts(collection, request, [folder, request], 'sequential');
+
+    const code = request.script.req;
+    const collectionDir = path.join('/test/collection');
+    const collectionFile = path.join('/test/collection', 'collection.bru');
+    const folderDir = path.join('/test/collection/subfolder');
+    const folderFile = path.join('/test/collection/subfolder', 'folder.bru');
+    const requestDir = path.join('/test/collection/subfolder');
+    const requestFile = '/test/collection/subfolder/req.bru';
+
+    expect(code).toContain(`)(${JSON.stringify(collectionDir)}, ${JSON.stringify(collectionFile)});`);
+    expect(code).toContain(`)(${JSON.stringify(folderDir)}, ${JSON.stringify(folderFile)});`);
+    expect(code).toContain(`)(${JSON.stringify(requestDir)}, ${JSON.stringify(requestFile)});`);
+  });
+
+  test('falls back to sandbox __dirname/__filename when request has no pathname', () => {
+    const collection = makeCollection();
+    const request = makeRequest({ preReq: 'let req = 1;' });
+    mergeScripts(collection, request, [request], 'sequential');
+
+    expect(request.script.req).toContain(')(__dirname, __filename);');
+  });
+});
+
+describe('mergeScripts → runScriptInNodeVm (integration)', () => {
+  const setVar = (name) => `bru.setVar('${name}_dir', __dirname); bru.setVar('${name}_file', __filename);`;
+
+  const makeCollection = (scripts = {}, pathname = '/test/collection') => ({
+    pathname,
+    format: 'bru',
+    root: {
+      request: {
+        script: {
+          req: scripts.preReq || '',
+          res: scripts.postRes || ''
+        },
+        tests: scripts.tests || ''
+      }
+    }
+  });
+
+  const makeFolder = (name, scripts = {}, parentPath = '/test/collection') => ({
+    type: 'folder',
+    pathname: path.join(parentPath, name),
+    root: {
+      request: {
+        script: {
+          req: scripts.preReq || '',
+          res: scripts.postRes || ''
+        },
+        tests: scripts.tests || ''
+      }
+    }
+  });
+
+  const makeRequest = (scripts = {}, pathname) => ({
+    ...(pathname !== undefined ? { pathname } : {}),
+    script: {
+      req: scripts.preReq || '',
+      res: scripts.postRes || ''
+    },
+    tests: scripts.tests || ''
+  });
+
+  const run = async (mergedScript, collectionPath, scriptPath) => {
+    const bru = { setVar: jest.fn() };
+    // wrapScriptInClosure injects __bruSetScope({...}) calls at the top of each
+    // segment IIFE when segmentSources is provided. In production the electron
+    // ScriptRuntime supplies this via createScopeSetter(bru); here it's a no-op
+    // since these tests don't assert on segment-scope side effects.
+    const context = { bru, console, __bruSetScope: jest.fn() };
+    await runScriptInNodeVm({
+      script: mergedScript,
+      context,
+      collectionPath,
+      scriptingConfig: {},
+      scriptPath
+    });
+    return bru;
+  };
+
+  test('collection, folder, and request pre-request scripts each see their own __dirname/__filename', async () => {
+    const collectionPath = '/test/collection';
+    const folderPath = path.join(collectionPath, 'subfolder');
+    const requestPath = path.join(folderPath, 'req.bru');
+
+    const collection = makeCollection({ preReq: setVar('col') }, collectionPath);
+    const folder = makeFolder('subfolder', { preReq: setVar('folder') }, collectionPath);
+    const request = makeRequest({ preReq: setVar('req') }, requestPath);
+
+    mergeScripts(collection, request, [folder, request], 'sequential');
+    const bru = await run(request.script.req, collectionPath, requestPath);
+
+    expect(bru.setVar).toHaveBeenCalledWith('col_dir', collectionPath);
+    expect(bru.setVar).toHaveBeenCalledWith('col_file', path.join(collectionPath, 'collection.bru'));
+    expect(bru.setVar).toHaveBeenCalledWith('folder_dir', folderPath);
+    expect(bru.setVar).toHaveBeenCalledWith('folder_file', path.join(folderPath, 'folder.bru'));
+    expect(bru.setVar).toHaveBeenCalledWith('req_dir', folderPath);
+    expect(bru.setVar).toHaveBeenCalledWith('req_file', requestPath);
+  });
+
+  test('request script can read a file relative to __dirname', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-dirname-'));
+    try {
+      const folderPath = path.join(tmpRoot, 'subfolder');
+      fs.mkdirSync(folderPath);
+      const requestPath = path.join(folderPath, 'read.bru');
+      fs.writeFileSync(path.join(folderPath, 'data.json'), '{"hello":"world"}');
+
+      const script = `
+        const fs = require('fs');
+        const path = require('path');
+        const contents = fs.readFileSync(path.join(__dirname, 'data.json'), 'utf-8');
+        bru.setVar('data', contents);
+      `;
+
+      const collection = makeCollection({}, tmpRoot);
+      const folder = makeFolder('subfolder', {}, tmpRoot);
+      const request = makeRequest({ preReq: script }, requestPath);
+
+      mergeScripts(collection, request, [folder, request], 'sequential');
+      const bru = await run(request.script.req, tmpRoot, requestPath);
+
+      expect(bru.setVar).toHaveBeenCalledWith('data', '{"hello":"world"}');
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back to collection dir when request has no pathname', async () => {
+    const collectionPath = '/test/collection';
+    const collection = makeCollection({}, collectionPath);
+    const request = makeRequest({ preReq: setVar('req') });
+
+    mergeScripts(collection, request, [request], 'sequential');
+    expect(request.script.req).toContain(')(__dirname, __filename);');
+
+    const bru = await run(request.script.req, collectionPath, undefined);
+
+    expect(bru.setVar).toHaveBeenCalledWith('req_dir', collectionPath);
+    expect(bru.setVar).toHaveBeenCalledWith('req_file', path.join(collectionPath, 'script.js'));
+  });
+
+  test('post-response and tests scripts also receive per-segment __dirname/__filename', async () => {
+    const collectionPath = '/test/collection';
+    const folderPath = path.join(collectionPath, 'subfolder');
+    const requestPath = path.join(folderPath, 'req.bru');
+
+    const collection = makeCollection(
+      { postRes: setVar('col_post'), tests: setVar('col_test') },
+      collectionPath
+    );
+    const folder = makeFolder(
+      'subfolder',
+      { postRes: setVar('folder_post'), tests: setVar('folder_test') },
+      collectionPath
+    );
+    const request = makeRequest(
+      { postRes: setVar('req_post'), tests: setVar('req_test') },
+      requestPath
+    );
+
+    mergeScripts(collection, request, [folder, request], 'sequential');
+
+    const postBru = await run(request.script.res, collectionPath, requestPath);
+    expect(postBru.setVar).toHaveBeenCalledWith('col_post_dir', collectionPath);
+    expect(postBru.setVar).toHaveBeenCalledWith('folder_post_dir', folderPath);
+    expect(postBru.setVar).toHaveBeenCalledWith('req_post_dir', folderPath);
+    expect(postBru.setVar).toHaveBeenCalledWith('req_post_file', requestPath);
+
+    const testsBru = await run(request.tests, collectionPath, requestPath);
+    expect(testsBru.setVar).toHaveBeenCalledWith('col_test_dir', collectionPath);
+    expect(testsBru.setVar).toHaveBeenCalledWith('folder_test_dir', folderPath);
+    expect(testsBru.setVar).toHaveBeenCalledWith('req_test_dir', folderPath);
+    expect(testsBru.setVar).toHaveBeenCalledWith('req_test_file', requestPath);
   });
 });

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -68,6 +68,14 @@ async function runScriptInNodeVm({
 
     const vmFilename = resolveVmFilename(scriptPath, collectionPath);
 
+    // Expose Node's CommonJS module globals to the top-level user script,
+    // mirroring what cjs-loader already provides to require()d modules. This
+    // lets scripts resolve files relative to their .bru request file /
+    // collection directory, e.g.
+    // fs.readFileSync(path.join(__dirname, './template.hbs')).
+    scriptContext.__filename = vmFilename;
+    scriptContext.__dirname = path.dirname(vmFilename);
+
     // Execute the script in the isolated context
     const wrappedScript = wrapScriptInClosure(script, SANDBOX.NODEVM);
     let compiledScript;

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -1475,4 +1475,64 @@ describe('node-vm sandbox', () => {
       expect(context.bru.setVar).toHaveBeenCalledWith('result', 'a,b');
     });
   });
+
+  describe('__dirname / __filename globals', () => {
+    it('should expose __dirname and __filename to the top-level script', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `
+        bru.setVar('dirname', __dirname);
+        bru.setVar('filename', __filename);
+      `;
+
+      const scriptPath = path.join(collectionPath, 'requests', 'get-users.bru');
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {}, scriptPath });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('filename', scriptPath);
+      expect(context.bru.setVar).toHaveBeenCalledWith('dirname', path.dirname(scriptPath));
+    });
+
+    it('should fall back to the collection directory when scriptPath is not provided', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `
+        bru.setVar('dirname', __dirname);
+        bru.setVar('filename', __filename);
+      `;
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('filename', path.join(collectionPath, 'script.js'));
+      expect(context.bru.setVar).toHaveBeenCalledWith('dirname', collectionPath);
+    });
+
+    it('should let a script read a file relative to __dirname', async () => {
+      fs.writeFileSync(path.join(collectionPath, 'template.hbs'), 'Hello {{name}}');
+
+      const context = {
+        bru: { setVar: jest.fn() },
+        console: console
+      };
+
+      const script = `
+        const fs = require('fs');
+        const path = require('path');
+        const template = fs.readFileSync(path.join(__dirname, './template.hbs'), 'utf-8');
+        bru.setVar('template', template);
+      `;
+
+      const scriptPath = path.join(collectionPath, 'read-template.bru');
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {}, scriptPath });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('template', 'Hello {{name}}');
+    });
+  });
 });

--- a/tests/scripting/bru-api/dirname-per-script-segment/dirname-per-script-segment.spec.ts
+++ b/tests/scripting/bru-api/dirname-per-script-segment/dirname-per-script-segment.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '../../../../playwright';
+import fs from 'fs';
+import path from 'path';
+import { openCollection, selectEnvironment } from '../../../utils/page';
+import { runCollection, validateRunnerResults } from '../../../utils/page/runner';
+
+const PERSISTENCE_TIMEOUT = 10000;
+
+test.describe('__dirname / __filename in node-vm scripts (developer mode)', () => {
+  test('binds per-segment paths for collection, folder, and request scripts', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    await openCollection(page, 'dirname-filename-test');
+    await selectEnvironment(page, 'Test');
+    await runCollection(page, 'dirname-filename-test');
+
+    await validateRunnerResults(page, {
+      totalRequests: 1,
+      passed: 6,
+      failed: 0
+    });
+
+    await test.step('opencollection.yml persists a collection __filename ending in opencollection.yml', async () => {
+      const collectionYmlPath = path.join(
+        collectionFixturePath!,
+        'dirname-filename-test',
+        'opencollection.yml'
+      );
+      await expect
+        .poll(
+          () => {
+            const content = fs.readFileSync(collectionYmlPath, 'utf8');
+            return /name:\s*collectionFile[\s\S]+?value:.*opencollection\.yml/.test(content);
+          },
+          { timeout: PERSISTENCE_TIMEOUT }
+        )
+        .toBe(true);
+    });
+
+    await test.step('environments/Test.yml persists a request __filename ending in dirname-request.yml', async () => {
+      const envFilePath = path.join(
+        collectionFixturePath!,
+        'dirname-filename-test',
+        'environments',
+        'Test.yml'
+      );
+      await expect
+        .poll(
+          () => {
+            const content = fs.readFileSync(envFilePath, 'utf8');
+            return /name:\s*requestFile[\s\S]+?value:.*dirname-request\.yml/.test(content);
+          },
+          { timeout: PERSISTENCE_TIMEOUT }
+        )
+        .toBe(true);
+    });
+  });
+});

--- a/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/bruno.json
+++ b/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "dirname-filename-test",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/environments/Test.yml
+++ b/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/environments/Test.yml
@@ -1,0 +1,5 @@
+name: Test
+
+variables:
+  - name: host
+    value: https://testbench-sanity.usebruno.com

--- a/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/opencollection.yml
+++ b/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/opencollection.yml
@@ -1,0 +1,13 @@
+opencollection: "1.0.0"
+
+info:
+  name: dirname-filename-test
+
+request:
+  scripts:
+    - type: before-request
+      code: |-
+        bru.setCollectionVar("collectionDir", __dirname);
+        bru.setCollectionVar("collectionFile", __filename);
+
+bundled: false

--- a/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/subfolder/data.json
+++ b/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/subfolder/data.json
@@ -1,0 +1,3 @@
+{
+  "greeting": "hello"
+}

--- a/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/subfolder/dirname-request.yml
+++ b/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/subfolder/dirname-request.yml
@@ -1,0 +1,44 @@
+info:
+  name: dirname-request
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: '{{host}}/ping'
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const fs = require('fs');
+        const path = require('path');
+        bru.setEnvVar("requestDir", __dirname);
+        bru.setEnvVar("requestFile", __filename);
+        const raw = fs.readFileSync(path.join(__dirname, 'data.json'), 'utf-8');
+        bru.setVar("readData", JSON.parse(raw).greeting);
+    - type: tests
+      code: |-
+        test("collection __dirname differs from folder __dirname", function() {
+          expect(bru.getCollectionVar("collectionDir")).to.not.equal(bru.getEnvVar("folderDir"));
+        });
+
+        test("folder and request live in the same directory", function() {
+          expect(bru.getEnvVar("folderDir")).to.equal(bru.getEnvVar("requestDir"));
+        });
+
+        test("collection __filename ends with opencollection.yml", function() {
+          expect(bru.getCollectionVar("collectionFile").endsWith("opencollection.yml")).to.equal(true);
+        });
+
+        test("folder __filename ends with folder.yml", function() {
+          expect(bru.getEnvVar("folderFile").endsWith("folder.yml")).to.equal(true);
+        });
+
+        test("request __filename ends with dirname-request.yml", function() {
+          expect(bru.getEnvVar("requestFile").endsWith("dirname-request.yml")).to.equal(true);
+        });
+
+        test("reads data.json relative to __dirname", function() {
+          expect(bru.getVar("readData")).to.equal("hello");
+        });

--- a/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/subfolder/folder.yml
+++ b/tests/scripting/bru-api/dirname-per-script-segment/fixtures/collections/dirname-filename-test/subfolder/folder.yml
@@ -1,0 +1,10 @@
+info:
+  name: subfolder
+  type: folder
+
+request:
+  scripts:
+    - type: before-request
+      code: |-
+        bru.setEnvVar("folderDir", __dirname);
+        bru.setEnvVar("folderFile", __filename);

--- a/tests/scripting/bru-api/dirname-per-script-segment/init-user-data/collection-security.json
+++ b/tests/scripting/bru-api/dirname-per-script-segment/init-user-data/collection-security.json
@@ -1,0 +1,10 @@
+{
+  "collections": [
+    {
+      "path": "{{collectionPath}}/dirname-filename-test",
+      "securityConfig": {
+        "jsSandboxMode": "developer"
+      }
+    }
+  ]
+}

--- a/tests/scripting/bru-api/dirname-per-script-segment/init-user-data/preferences.json
+++ b/tests/scripting/bru-api/dirname-per-script-segment/init-user-data/preferences.json
@@ -1,0 +1,5 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/dirname-filename-test"
+  ]
+}


### PR DESCRIPTION
Different approach #8486

### Description

Exposes CommonJS `__dirname` and `__filename` to scripts running in the developer (`node-vm`) sandbox, and binds them per script segment so collection / folder / request scripts each see their own source file.

### Problem

Scripts in the node-vm sandbox threw `ReferenceError: __dirname is not defined`:

```js
fs.readFileSync(path.join(__dirname, 'data.json'));
```

Node's cjs-loader already provided these globals to `require()`d modules, but the top-level user script never received them.

### Fix

- Inject `__dirname` / `__filename` into the node-vm script context via `resolveVmFilename(scriptPath, collectionPath)`.
- In `wrapAndJoinScripts`, wrap each script segment as `(async (__dirname, __filename) => { ... })(<segmentDir>, <segmentFile>)` so each segment sees its own source location.

### Behavior by script context

| Script segment                                | `__dirname`      | `__filename`                    |
| --------------------------------------------- | ---------------- | ------------------------------- |
| Collection pre-request / tests                | collection dir   | `<collection>/collection.bru`   |
| Folder pre-request / tests                    | folder dir       | `<folder>/folder.bru`           |
| Request pre-request / post-response / tests   | request dir      | `<request>.bru`                 |
| No script path (fallback)                     | collection dir   | `<collection>/script.js`        |

Yml collections use `opencollection.yml` / `folder.yml` / `<name>.yml` in place of the `.bru` filenames.

**Scope:** developer sandbox only. The safe (QuickJS) sandbox intentionally restricts filesystem access, so `__dirname` there has no filesystem use case and is left unchanged.

Closes #8390

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** (n/a — no UI change)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scripts can now access accurate `__dirname` and `__filename` values for their collection, folder, and request locations.
  - Scripts can load nearby files using relative paths, improving support for local fixtures and resources.
  - Behavior is supported consistently across the CLI, desktop app, and JavaScript sandbox.

- **Bug Fixes**
  - Corrected script path resolution across pre-request, post-response, and test scripts, including fallback behavior when paths are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->