### PR TITLE
feat: make URLs clickable in console

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -135,26 +135,32 @@ const getBrunoTypeMetadata = (obj) => {
 const renderTextWithLinks = (text) => {
   if (typeof text !== 'string') return text;
 
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  const urlRegex = /(https?:\/\/[^\s"'()]*[^\s"'().,;!?])/g;
+  if (!text.match(urlRegex)) return text;
+
   const parts = text.split(urlRegex);
 
-  return parts.map((part, index) => {
-    if (part.match(urlRegex)) {
-      return (
-        <a
-          key={index}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-link"
-          style={{ textDecoration: 'underline', color: 'inherit' }}
-        >
-          {part}
-        </a>
-      );
-    }
-    return part;
-  });
+  return (
+    <React.Fragment>
+      {parts.map((part, index) => {
+        if (part.match(urlRegex)) {
+          return (
+            <a
+              key={index}
+              href={part}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-link"
+              style={{ textDecoration: 'underline', color: 'inherit' }}
+            >
+              {part}
+            </a>
+          );
+        }
+        return part;
+      })}
+    </React.Fragment>
+  );
 };
 
 const LogMessage = ({ message, args }) => {

--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -132,6 +132,31 @@ const getBrunoTypeMetadata = (obj) => {
   return {};
 };
 
+const renderTextWithLinks = (text) => {
+  if (typeof text !== 'string') return text;
+
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  const parts = text.split(urlRegex);
+
+  return parts.map((part, index) => {
+    if (part.match(urlRegex)) {
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-link"
+          style={{ textDecoration: 'underline', color: 'inherit' }}
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+};
+
 const LogMessage = ({ message, args }) => {
   const { displayedTheme } = useTheme();
 
@@ -172,10 +197,10 @@ const LogMessage = ({ message, args }) => {
             </div>
           );
         }
-        return String(arg);
+        return renderTextWithLinks(String(arg));
       });
     }
-    return msg;
+    return renderTextWithLinks(msg);
   };
 
   const formattedMessage = formatMessage(message, args);


### PR DESCRIPTION
Ref: BRU-3466

### Description
This PR introduces a small but impactful quality-of-life improvement to the DevTools Console. By implementing a URL detection regex (`/(https?:\/\/[^\s]+)/g`), we parse the string output of logs and map detected URLs directly into standard `<a>` tags with `target="_blank"`. This enables developers to simply click on links rendered in the console directly, avoiding the need to manually highlight and copy-paste them into a browser.

### Problem
Currently, when a URL is logged in the console via scripts (e.g. `console.log("https://usebruno.com")`), it renders as plain text. This is frustrating for users who want to quickly open a logged URL, as they have to manually select, copy, and paste it. 
Fixes #6275 

### Fix
This PR fixes the problem by adding a `renderTextWithLinks` helper function in the `Console` component (`packages/bruno-app/src/components/Devtools/Console/index.js`). Before a string log is rendered by `LogMessage`, the helper function splits the text by a URL regex pattern and wraps matched segments in clickable anchor tags. 

### Screenshot with the fix
<img width="3420" height="2166" alt="Screenshot 2026-08-18 at 3 17 31 PM" src="https://github.com/user-attachments/assets/f5d4fed0-35c5-4bc6-a401-effb2961c43e" />

#### Contribution Checklist:
- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console output now automatically detects HTTP(S) URLs and displays them as underlined links.
  * Links open securely in an external browser, making referenced resources easier to access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->