### PR TITLE
fix(test): removed the backup assertion

### DIFF
--- a/packages/bruno-sqlite/tests/node/create-database.spec.ts
+++ b/packages/bruno-sqlite/tests/node/create-database.spec.ts
@@ -33,18 +33,12 @@ describe('createDatabase', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  const backups = (): string[] => {
-    const backupDir = join(dir, 'sqlite-backup');
-    return existsSync(backupDir) ? readdirSync(backupDir) : [];
-  };
-
   it('opens the database file when it is accessible', () => {
     const { createDatabase } = require('../../src/node/index');
     const { db, statements } = createDatabase(dbPath);
 
     expect(db).toBeDefined();
     expect(statements).toBeDefined();
-    expect(backups()).toEqual([]);
     db.close();
   });
 
@@ -67,7 +61,6 @@ describe('createDatabase', () => {
 
     expect(db).toBeDefined();
     expect(statements).toBeDefined();
-    expect(backups()).toHaveLength(1);
     expect(existsSync(dbPath)).toBe(true);
     expect(db._db.prepare('SELECT name FROM _migrations').all()).toEqual([]);
     db.close();
@@ -83,7 +76,6 @@ describe('createDatabase', () => {
 
     expect(db).toBeDefined();
     expect(statements).toBeDefined();
-    expect(backups()).toEqual([]);
     db.close();
   });
 
@@ -95,7 +87,6 @@ describe('createDatabase', () => {
 
     expect(db).toBeUndefined();
     expect(statements).toBeUndefined();
-    expect(backups()).toHaveLength(1);
     expect(error).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Description
Removed the backup assertions in the tests since they are no longer needed and the tests expected it. It was a miss from the previous PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined database creation test coverage by removing obsolete backup-directory checks.
  * Continued validating successful database opening, rebuild behavior, statement preparation failures, migration state, rebuilt files, and reported errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->