### PR TITLE
fix(query): prevent TypeError when traversing objects with null values

### DIFF
--- a/packages/bruno-query/src/index.ts
+++ b/packages/bruno-query/src/index.ts
@@ -26,7 +26,7 @@ function normalize(value: any) {
  * Once a value is found will not recurse further into that value.
  */
 function getValue(source: any, prop: string, deep = false): any {
-  if (typeof source !== 'object') return;
+  if (!source || typeof source !== 'object') return;
 
   let value;
 
@@ -37,7 +37,7 @@ function getValue(source: any, prop: string, deep = false): any {
     if (deep) {
       value = [value];
       for (const [key, item] of Object.entries(source)) {
-        if (key !== prop && typeof item === 'object') {
+        if (key !== prop && item && typeof item === 'object') {
           value.push(getValue(source[key], prop, deep));
         }
       }

--- a/packages/bruno-query/tests/index.spec.ts
+++ b/packages/bruno-query/tests/index.spec.ts
@@ -57,4 +57,33 @@ describe('get', () => {
   ])('%s should be %j for %s', (expr, result, filter) => {
     expect(get(data, expr, filter)).toEqual(result);
   });
+
+  // null and undefined handling in deep and direct navigation
+  const dataWithNulls = {
+    user: {
+      id: 101,
+      deletedAt: null,
+      profile: null,
+      address: {
+        city: 'bangalore'
+      }
+    },
+    items: [
+      { id: 1, extra: null },
+      null,
+      { id: 2 }
+    ]
+  };
+
+  it.each([
+    ['..city', ['bangalore']],
+    ['..id', [101, 1, 2]],
+    ['..deletedAt', undefined],
+    ['user.profile', null],
+    ['user.profile.nested', null],
+    ['items.id', [1, 2]]
+  ])('with null values: %s should be %j', (expr, result) => {
+    expect(get(dataWithNulls, expr)).toEqual(result);
+  });
 });
+


### PR DESCRIPTION
### Description

This PR fixes a bug in `@usebruno/query` where executing property queries (specifically deep navigation via `..` or scripting with `res('..field')`) on objects or arrays containing `null` values throws a runtime `TypeError: Cannot read properties of null (reading '<prop>')`.

### Problem

In JavaScript, `typeof null === 'object'`. In `packages/bruno-query/src/index.ts`, `getValue()` used `if (typeof source !== 'object') return;` as a guard, which does not filter out `null`. 

When traversing nested structures containing `null` properties (e.g. `{ user: { id: 1, deletedAt: null, address: { city: 'bangalore' } } }` or arrays with null values):
1. `Object.entries(source)` passes `null` properties into `getValue(source[key], prop, deep)` because `typeof item === 'object'` evaluates to `true` for `null`.
2. Inside `getValue`, `null` passes the initial guard and proceeds to `source[prop]` (`null[prop]`), throwing an unhandled `TypeError`.

### Fix

1. Strengthened the guard in `getValue()` to `if (!source || typeof source !== 'object') return;` so `null` values return immediately rather than attempting property access.
2. Added a truthiness check (`if (key !== prop && item && typeof item === 'object')`) in the deep recursive traversal loop to safely skip `null` properties.
3. Added unit regression tests in `packages/bruno-query/tests/index.spec.ts` testing deep and direct traversal over objects/arrays containing `null` values.

### Screenshots

N/A (Backend utility package change; all 26 unit tests in `@usebruno/query` and 453 tests in `@usebruno/common` pass).

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested value retrieval when data contains `null`, `undefined`, or other non-object values.
  * Prevented errors when navigating arrays with null elements or missing nested properties.
  * Preserved expected results for direct and deep searches.

* **Tests**
  * Added coverage for null-valued fields, missing properties, nested data, and array entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->