### PR TITLE
feat: support .yaml files

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ScriptError/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ScriptError/index.js
@@ -8,6 +8,7 @@ import { normalizePath } from 'utils/common/path';
 import { addTab, updateRequestPaneTab, updateScriptPaneTab, setFocusErrorLine } from 'providers/ReduxStore/slices/tabs';
 import { updateSettingsSelectedTab, updatedFolderSettingsSelectedTab } from 'providers/ReduxStore/slices/collections';
 import StyledWrapper from './StyledWrapper';
+import { isCollectionRootBasename, isFolderRootBasename } from '@usebruno/common';
 
 /**
  * Determines the source of a script error (request, folder, or collection)
@@ -39,8 +40,10 @@ const getErrorSourceInfo = (filePath, item, collection, getTreePath) => {
   // logic and regexes expect forward slashes.
   const normalizedPath = normalizePath(filePath);
 
-  const isFolderFile = /(?:^|\/)folder\.(?:bru|yml)$/.test(normalizedPath);
-  const isCollectionFile = normalizedPath === 'collection.bru' || /^opencollection\.yml$/.test(normalizedPath);
+  const basename = normalizedPath.split('/').pop();
+  const isFolderFile = isFolderRootBasename(basename);
+  // A collection root only counts at the collection root, never nested in a folder.
+  const isCollectionFile = !normalizedPath.includes('/') && isCollectionRootBasename(basename);
 
   // Folder level (check before collection to avoid folder.yml matching as collection)
   if (isFolderFile) {

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons';
-import { getLayoutConfig } from '@usebruno/common';
+import { getLayoutConfig, isFolderRootBasename } from '@usebruno/common';
 import Method from './Common/Method/index';
 import Status from './Common/Status/index';
 import { RelativeTime } from './Common/Time/index';
@@ -18,8 +18,10 @@ import { getBadge } from '../entryMeta';
 
 const findFolderByScopeFile = (collection, sourceFile) => {
   if (!collection?.pathname || !sourceFile) return null;
-  const dir = sourceFile.replace(/\/folder\.(?:bru|yml)$/, '');
-  if (!dir || dir === sourceFile) return null;
+  const segments = sourceFile.split('/');
+  if (!isFolderRootBasename(segments[segments.length - 1])) return null;
+  const dir = segments.slice(0, -1).join('/');
+  if (!dir) return null;
   return flattenItems(collection.items || []).find(
     (i) => i.type === 'folder' && getRelativePath(collection.pathname, i.pathname) === dir
   ) || null;

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons';
+import { getLayoutConfig } from '@usebruno/common';
 import Method from './Common/Method/index';
 import Status from './Common/Status/index';
 import { RelativeTime } from './Common/Time/index';
@@ -79,7 +80,7 @@ const TimelineItem = ({
 
   const isMainOrOauth = !source || source === 'main' || isOauth2;
   const scopeType = scope?.type || (isMainOrOauth ? null : 'request');
-  const requestExt = collection?.format === 'yml' ? '.yml' : '.bru';
+  const requestExt = getLayoutConfig(collection?.format).ext;
   const scopeFile = scope?.sourceFile
     || (scopeType === 'request' ? (item?.filename || (item?.name ? `${item.name}${requestExt}` : null)) : null);
   const sourceFile = isMainOrOauth ? null : scopeFile;

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons';
-import { getLayoutConfig, isFolderRootBasename } from '@usebruno/common';
+import { getLayoutConfig } from '@usebruno/common';
 import Method from './Common/Method/index';
 import Status from './Common/Status/index';
 import { RelativeTime } from './Common/Time/index';
@@ -10,22 +10,10 @@ import Request from './Request/index';
 import Response from './Response/index';
 import StyledWrapper from './StyledWrapper';
 import { usePersistedState } from 'hooks/usePersistedState/index';
-import { flattenItems } from 'utils/collections/index';
-import { getRelativePath } from 'utils/common/path';
+import { findFolderByScopeFile } from 'utils/collections/index';
 import { addTab, updateRequestPaneTab, updateScriptPaneTab } from 'providers/ReduxStore/slices/tabs';
 import { updateSettingsSelectedTab, updatedFolderSettingsSelectedTab } from 'providers/ReduxStore/slices/collections';
 import { getBadge } from '../entryMeta';
-
-const findFolderByScopeFile = (collection, sourceFile) => {
-  if (!collection?.pathname || !sourceFile) return null;
-  const segments = sourceFile.split('/');
-  if (!isFolderRootBasename(segments[segments.length - 1])) return null;
-  const dir = segments.slice(0, -1).join('/');
-  if (!dir) return null;
-  return flattenItems(collection.items || []).find(
-    (i) => i.type === 'folder' && getRelativePath(collection.pathname, i.pathname) === dir
-  ) || null;
-};
 
 const TimelineItem = ({
   timestamp,

--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/CreateApiSpec/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/CreateApiSpec/index.js
@@ -12,6 +12,7 @@ import { exportApiSpec } from 'utils/exporters/openapi-spec';
 import { each } from 'lodash';
 import { showApiSpecPage } from 'providers/ReduxStore/slices/app';
 import { validateName, validateNameError } from 'utils/common/regex';
+import { stripRequestExtension } from '@usebruno/common';
 
 export const getEnvironmentVariablesKeyValuePairs = (envVariables) => {
   let variables = {};
@@ -87,7 +88,7 @@ const CreateApiSpec = ({ onClose }) => {
         }
         // Convert envVariables (keyed by filename) to environments array for multi-server export
         const environmentsList = Object.entries(envVariables || {}).map(([envFile, vars]) => ({
-          name: envFile.replace(/\.(bru|yml)$/, ''),
+          name: stripRequestExtension(envFile),
           variables: vars
         }));
         // Create API spec yaml

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ChangeCollectionVersion/index.js
@@ -5,6 +5,7 @@ import { IconArrowRight, IconAlertTriangle } from '@tabler/icons';
 import Modal from 'components/Modal';
 import Portal from 'components/Portal';
 import { findCollectionByUid, getCollectionVersion, isOpenCollectionFormat } from 'utils/collections/index';
+import { getLayoutConfig } from '@usebruno/common';
 import { saveCollectionVersion } from 'providers/ReduxStore/slices/collections/actions';
 import StyledWrapper, { ModalTitle } from './StyledWrapper';
 
@@ -29,7 +30,7 @@ const ChangeCollectionVersion = ({ collectionUid, onClose }) => {
   const currentVersion = getCollectionVersion(collection);
   const isYml = isOpenCollectionFormat(collection);
   const targetKey = isYml ? 'info.version' : 'collectionVersion';
-  const targetFile = isYml ? 'opencollection.yml' : 'bruno.json';
+  const targetFile = isYml ? getLayoutConfig(collection?.format, 'yml').collectionFile : 'bruno.json';
   const [newVersion, setNewVersion] = useState('');
   const [isSaving, setIsSaving] = useState(false);
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/IgnoreCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/IgnoreCollectionItem/index.js
@@ -2,14 +2,16 @@ import React from 'react';
 import Modal from 'components/Modal';
 import { useSelector, useDispatch } from 'react-redux';
 import { ignoreFolder, closeTabs } from 'providers/ReduxStore/slices/collections/actions';
-import { recursivelyGetAllItemUids } from 'utils/collections';
+import { recursivelyGetAllItemUids, isOpenCollectionFormat } from 'utils/collections';
 import toast from 'react-hot-toast';
+import { getLayoutConfig, isOpenCollectionLayout } from '@usebruno/common';
 
 const IgnoreCollectionItem = ({ onClose, item, collectionUid }) => {
   const dispatch = useDispatch();
   const collection = useSelector((state) => state.collections.collections?.find((c) => c.uid === collectionUid));
-  const isYamlCollection = collection?.format === 'yml' || Boolean(collection?.brunoConfig?.opencollection);
-  const configFileName = isYamlCollection ? 'opencollection.yml' : 'bruno.json';
+  const isYamlCollection = isOpenCollectionLayout(collection?.format) || isOpenCollectionFormat(collection);
+  // Name the file the ignore list actually lands in — a `.yaml` collection has no `opencollection.yml`.
+  const configFileName = isYamlCollection ? getLayoutConfig(collection?.format, 'yml').collectionFile : 'bruno.json';
 
   const onConfirm = () => {
     dispatch(ignoreFolder(item.uid, collectionUid))

--- a/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/OpenCollection/index.js
@@ -77,7 +77,7 @@ const OpenCollectionModal = ({ onClose }) => {
           } else if (skippedItems.length) {
             toast.error(`No Bruno collections found. ${skippedItems.length} skipped, config could not be read`);
           } else {
-            toast.error('No Bruno collections found. Couldn\'t find a bruno.json or opencollection.yml');
+            toast.error('No Bruno collections found. Couldn\'t find a bruno.json or opencollection file');
           }
           onClose();
           return;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/collection-format.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/collection-format.spec.js
@@ -35,6 +35,45 @@ describe('collection format derivation from disk config', () => {
     expect(state.collections[0].format).toBe('bru');
   });
 
+  it('brunoConfigUpdateEvent adopts the yaml layout the main process detected', () => {
+    // `opencollection` alone can't distinguish `.yml` from `.yaml`; the renderer must take the
+    // detected layout, because it decides the extension of every file it asks main to create.
+    const state = reducer(
+      makeState('bru'),
+      brunoConfigUpdateEvent({
+        collectionUid: COLLECTION_UID,
+        brunoConfig: { opencollection: '1.0.0', name: 'demo', format: 'yaml' }
+      })
+    );
+
+    expect(state.collections[0].format).toBe('yaml');
+  });
+
+  it('brunoConfigUpdateEvent follows the detected layout back to yml', () => {
+    // A `.yaml` root renamed to `.yml` on disk must not leave a stale `yaml` format behind.
+    const state = reducer(
+      makeState('yml'),
+      brunoConfigUpdateEvent({
+        collectionUid: COLLECTION_UID,
+        brunoConfig: { opencollection: '1.0.0', name: 'demo', format: 'yml' }
+      })
+    );
+
+    expect(state.collections[0].format).toBe('yml');
+  });
+
+  it('collectionLoadedFromTree adopts the detected yaml layout', () => {
+    const state = reducer(
+      makeState('bru'),
+      collectionLoadedFromTree({
+        collectionUid: COLLECTION_UID,
+        tree: { items: [], brunoConfig: { opencollection: '1.0.0', name: 'demo', format: 'yaml' } }
+      })
+    );
+
+    expect(state.collections[0].format).toBe('yaml');
+  });
+
   it('collectionLoadedFromTree derives format from the tree brunoConfig', () => {
     const state = reducer(
       makeState('bru'),

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -60,8 +60,16 @@ const FILE_DERIVED_FOLDER_FIELDS = [
 // Derive from the config on disk only — never keep a previous collection.format.
 // After a migrate-to-yml followed by a git revert to bru, a stale 'yml' would hide
 // the "Convert to YML" action forever.
+//
+// `brunoConfig.format` is the layout the main process detected on disk (`bru`/`yml`/`yaml`) and
+// is re-stamped on every read, so it stays disk-truthy. Prefer it: `opencollection` alone cannot
+// distinguish `.yml` from `.yaml`, and this value decides the extension of every file the
+// renderer asks the main process to create.
 const deriveCollectionFormat = (brunoConfig) => {
-  return brunoConfig?.opencollection ? 'yml' : brunoConfig?.format || 'bru';
+  if (brunoConfig?.format) {
+    return brunoConfig.format;
+  }
+  return brunoConfig?.opencollection ? 'yml' : 'bru';
 };
 
 const mergeTreeItems = (existingItems, newItems) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -3,6 +3,7 @@ import filter from 'lodash/filter';
 import find from 'lodash/find';
 import last from 'lodash/last';
 import { uuid } from 'utils/common';
+import { isOpenCollectionLayout } from '@usebruno/common';
 import { isActiveTab as checkIsActiveTab, deserializeTab } from 'utils/snapshot';
 
 // todo: errors should be tracked in each slice and displayed as toasts
@@ -562,7 +563,7 @@ export const tabsSlice = createSlice({
       }
 
       // Drop request tabs remapped by bru↔yml migrate that no longer match collection format
-      const staleExt = collection.format === 'yml' ? /\.bru$/i : /\.ya?ml$/i;
+      const staleExt = isOpenCollectionLayout(collection.format) ? /\.bru$/i : /\.ya?ml$/i;
 
       (snapshotTabs || []).forEach((snapshotTab) => {
         if (typeof snapshotTab.pathname === 'string' && staleExt.test(snapshotTab.pathname)) {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1,8 +1,8 @@
 import { cloneDeep, isEqual, sortBy, filter, map, isString, findIndex, find, each, get } from 'lodash';
 import { uuid } from 'utils/common';
 import { sortByNameThenSequence } from 'utils/common/index';
-import path, { normalizePath } from 'utils/common/path';
-import { isRequestTagsIncluded } from '@usebruno/common';
+import path, { getRelativePath, normalizePath } from 'utils/common/path';
+import { isFolderRootBasename, isRequestTagsIncluded } from '@usebruno/common';
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
@@ -92,6 +92,24 @@ export const findCollectionByItemUid = (collections, itemUid) => {
 
 export const findItemByPathname = (items = [], pathname) => {
   return find(items, (i) => i.pathname === pathname);
+};
+
+/**
+ * Resolve the folder whose root file a script scope points at, e.g. `users/folder.yaml`.
+ * Returns null when `sourceFile` is not a folder root or names no folder.
+ */
+export const findFolderByScopeFile = (collection, sourceFile) => {
+  if (!collection?.pathname || !sourceFile) return null;
+  // The scope's source file arrives posixified from the main process, but normalize anyway so a
+  // Windows-separated path can't smuggle the whole path in as the basename. `getRelativePath`
+  // posixifies the side it derives, so both sides of the comparison agree.
+  const segments = normalizePath(sourceFile).split('/');
+  if (!isFolderRootBasename(segments[segments.length - 1])) return null;
+  const dir = segments.slice(0, -1).join('/');
+  if (!dir) return null;
+  return flattenItems(collection.items || []).find(
+    (i) => i.type === 'folder' && getRelativePath(collection.pathname, i.pathname) === dir
+  ) || null;
 };
 
 export const findItemInCollectionByPathname = (collection, pathname) => {

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
+import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts, findFolderByScopeFile } from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -130,5 +130,42 @@ describe('getCollectionItemCounts', () => {
   it('returns zero counts for empty or missing items', () => {
     expect(getCollectionItemCounts([])).toEqual({ folderCount: 0, requestCount: 0 });
     expect(getCollectionItemCounts(undefined)).toEqual({ folderCount: 0, requestCount: 0 });
+  });
+});
+
+describe('findFolderByScopeFile', () => {
+  const collection = {
+    pathname: '/coll',
+    items: [
+      { type: 'folder', name: 'users', pathname: '/coll/users', items: [] },
+      { type: 'folder', name: 'admin', pathname: '/coll/admin/nested', items: [] },
+      { type: 'http-request', name: 'ping', pathname: '/coll/ping.yaml' }
+    ]
+  };
+
+  it.each(['folder.bru', 'folder.yml', 'folder.yaml'])('resolves a %s scope to its folder', (folderFile) => {
+    // A `.yaml` folder root must resolve too, or its timeline link is silently disabled.
+    expect(findFolderByScopeFile(collection, `users/${folderFile}`)?.pathname).toBe('/coll/users');
+  });
+
+  it('resolves a Windows-separated scope path', () => {
+    // The main process posixifies this today, but the consumer must not depend on that — an
+    // unnormalized separator would make the whole path look like the basename.
+    expect(findFolderByScopeFile(collection, 'admin\\nested\\folder.yaml')?.pathname).toBe('/coll/admin/nested');
+  });
+
+  it('returns null when the scope file is not a folder root', () => {
+    expect(findFolderByScopeFile(collection, 'users/get-users.yaml')).toBe(null);
+    expect(findFolderByScopeFile(collection, 'opencollection.yaml')).toBe(null);
+  });
+
+  it('returns null for a folder root at the collection root, which names no folder', () => {
+    expect(findFolderByScopeFile(collection, 'folder.yaml')).toBe(null);
+  });
+
+  it('returns null for missing inputs and unknown folders', () => {
+    expect(findFolderByScopeFile(null, 'users/folder.yml')).toBe(null);
+    expect(findFolderByScopeFile(collection, null)).toBe(null);
+    expect(findFolderByScopeFile(collection, 'nope/folder.yml')).toBe(null);
   });
 });

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,4 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
+import path from 'path';
 import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts, findFolderByScopeFile } from './index';
 
 describe('mergeHeaders', () => {
@@ -134,24 +135,29 @@ describe('getCollectionItemCounts', () => {
 });
 
 describe('findFolderByScopeFile', () => {
+  const collectionPath = path.resolve('coll');
   const collection = {
-    pathname: '/coll',
+    pathname: collectionPath,
     items: [
-      { type: 'folder', name: 'users', pathname: '/coll/users', items: [] },
-      { type: 'folder', name: 'admin', pathname: '/coll/admin/nested', items: [] },
-      { type: 'http-request', name: 'ping', pathname: '/coll/ping.yaml' }
+      { type: 'folder', name: 'users', pathname: path.join(collectionPath, 'users'), items: [] },
+      { type: 'folder', name: 'admin', pathname: path.join(collectionPath, 'admin', 'nested'), items: [] },
+      { type: 'http-request', name: 'ping', pathname: path.join(collectionPath, 'ping.yaml') }
     ]
   };
 
   it.each(['folder.bru', 'folder.yml', 'folder.yaml'])('resolves a %s scope to its folder', (folderFile) => {
     // A `.yaml` folder root must resolve too, or its timeline link is silently disabled.
-    expect(findFolderByScopeFile(collection, `users/${folderFile}`)?.pathname).toBe('/coll/users');
+    expect(findFolderByScopeFile(collection, path.posix.join('users', folderFile))?.pathname).toBe(
+      path.join(collectionPath, 'users')
+    );
   });
 
   it('resolves a Windows-separated scope path', () => {
     // The main process posixifies this today, but the consumer must not depend on that — an
     // unnormalized separator would make the whole path look like the basename.
-    expect(findFolderByScopeFile(collection, 'admin\\nested\\folder.yaml')?.pathname).toBe('/coll/admin/nested');
+    expect(findFolderByScopeFile(collection, path.win32.join('admin', 'nested', 'folder.yaml'))?.pathname).toBe(
+      path.join(collectionPath, 'admin', 'nested')
+    );
   });
 
   it('returns null when the scope file is not a folder root', () => {

--- a/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
+++ b/packages/bruno-app/src/utils/exporters/openapi-spec.spec.js
@@ -6,8 +6,10 @@ jest.mock('nanoid', () => ({
   ...jest.requireActual('nanoid')
 }));
 
-// Mock @usebruno/common to provide a working interpolate function
+// Override only `interpolate` with a test double; everything else must stay real, otherwise
+// converters that reach for other exports (e.g. isOpenCollectionLayout) get undefined.
 jest.mock('@usebruno/common', () => ({
+  ...jest.requireActual('@usebruno/common'),
   interpolate: (str, vars) => {
     if (!str || typeof str !== 'string') return str;
     let result = str;

--- a/packages/bruno-app/src/utils/snapshot/index.js
+++ b/packages/bruno-app/src/utils/snapshot/index.js
@@ -1,6 +1,7 @@
 import { findItemInCollection, findItemInCollectionByPathname } from 'utils/collections';
 import path, { normalizePath } from 'utils/common/path';
 import { uuid } from 'utils/common';
+import { getLayoutConfig } from '@usebruno/common';
 
 const normalizeTabType = (type) => {
   if (type === 'mock-server-dashboard' || type === 'mocker') {
@@ -384,8 +385,8 @@ export const getCollectionEnvironmentPath = (collection, environment, defaultVal
     return environment.name || defaultValue;
   }
 
-  const extension = collection.format === 'yml' ? 'yml' : 'bru';
-  return normalizePath(path.join(collection.pathname, 'environments', `${environment.name}.${extension}`));
+  const { ext } = getLayoutConfig(collection.format);
+  return normalizePath(path.join(collection.pathname, 'environments', `${environment.name}${ext}`));
 };
 
 export const findCollectionEnvironmentFromSnapshot = (collection, snapshotData = {}) => {

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -4,18 +4,18 @@ const path = require('path');
 const yaml = require('js-yaml');
 const { forOwn, cloneDeep } = require('lodash');
 const { getRunnerSummary } = require('@usebruno/common/runner');
-const { exists, stripExtension, isSafeFileName } = require('../utils/filesystem');
+const { exists, stripExtension, isSafeFileName, resolveYamlPath } = require('../utils/filesystem');
+const { COLLECTION_LAYOUTS, isRequestTagsIncluded, isYamlFilename } = require('@usebruno/common');
 const { runSingleRequest } = require('../runner/run-single-request');
 const { getEnvVars } = require('../utils/bru');
 const { parseEnvironmentJson } = require('../utils/environment');
-const { isRequestTagsIncluded } = require('@usebruno/common');
 const makeJUnitOutput = require('../reporters/junit');
 const makeHtmlOutput = require('../reporters/html');
 const { getOptions } = require('../utils/bru');
 const { parseDotEnv, parseEnvironment } = require('@usebruno/filestore');
 const constants = require('../constants');
 const Table = require('cli-table3');
-const { findItemInCollection, createCollectionJsonFromPathname, getCallStack, FORMAT_CONFIG } = require('../utils/collection');
+const { findItemInCollection, createCollectionJsonFromPathname, getCallStack } = require('../utils/collection');
 const { hasExecutableTestInScript } = require('../utils/request');
 const { createSkippedFileResults } = require('../utils/run');
 const { sanitizeResultsForReporter } = require('../utils/sanitize-results');
@@ -382,9 +382,8 @@ const handler = async function (argv) {
     const globalEnvVarOverrides = new Map();
 
     const resolveEnvFileFormat = (filePath) => {
-      const ext = path.extname(filePath).toLowerCase();
-      if (ext === '.json') return 'json';
-      if (ext === '.yml') return 'yml';
+      if (path.extname(filePath).toLowerCase() === '.json') return 'json';
+      if (isYamlFilename(filePath)) return 'yml';
       return 'bru';
     };
 
@@ -401,11 +400,11 @@ const handler = async function (argv) {
         const rawName = normalizedEnv?.name;
         const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
         result.__name__ = trimmedName || path.basename(filePath, '.json');
-      } else if (fileExt === '.yml') {
+      } else if (isYamlFilename(filePath)) {
         const content = fs.readFileSync(filePath, 'utf8');
         const envJson = parseEnvironment(content, { format: 'yml' });
         result = getEnvVars(envJson);
-        result.__name__ = nameOverride || path.basename(filePath, '.yml');
+        result.__name__ = nameOverride || path.basename(filePath, fileExt);
       } else {
         const content = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
         const envJson = parseEnvironment(content, { format: 'bru' });
@@ -445,7 +444,7 @@ const handler = async function (argv) {
           chalk.yellow(`Ignoring invalid default environment name: `) + chalk.dim(defaultEnvironment)
         );
       } else {
-        const envExt = FORMAT_CONFIG[collection.format].ext;
+        const envExt = COLLECTION_LAYOUTS[collection.format].ext;
         const defaultEnvFilePath = path.join(collectionPath, 'environments', `${defaultEnvironment}${envExt}`);
         if (await exists(defaultEnvFilePath)) {
           try {
@@ -468,7 +467,7 @@ const handler = async function (argv) {
 
     // Load --env and merge (collection env takes precedence)
     if (env) {
-      const envExt = FORMAT_CONFIG[collection.format].ext;
+      const envExt = COLLECTION_LAYOUTS[collection.format].ext;
       const collectionEnvFilePath = path.join(collectionPath, 'environments', `${env}${envExt}`);
       if (!(await exists(collectionEnvFilePath))) {
         console.error(chalk.red(`Environment file not found: `) + chalk.dim(`environments/${env}${envExt}`));
@@ -488,8 +487,7 @@ const handler = async function (argv) {
       const findWorkspacePath = (startPath) => {
         let currentPath = startPath;
         while (currentPath !== path.dirname(currentPath)) {
-          const workspaceYmlPath = path.join(currentPath, 'workspace.yml');
-          if (fs.existsSync(workspaceYmlPath)) {
+          if (resolveYamlPath(currentPath, 'workspace')) {
             return currentPath;
           }
           currentPath = path.dirname(currentPath);
@@ -512,23 +510,21 @@ const handler = async function (argv) {
         process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
       }
 
-      const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
-      const workspaceYmlExists = await exists(workspaceYmlPath);
-      if (!workspaceYmlExists) {
-        console.error(chalk.red(`Invalid workspace: workspace.yml not found in `) + chalk.dim(workspacePath));
+      if (!resolveYamlPath(workspacePath, 'workspace')) {
+        console.error(chalk.red(`Invalid workspace: workspace.yml (or workspace.yaml) not found in `) + chalk.dim(workspacePath));
         process.exit(constants.EXIT_STATUS.ERROR_WORKSPACE_NOT_FOUND);
       }
 
-      const globalEnvFilePath = path.join(workspacePath, 'environments', `${globalEnv}.yml`);
-      const globalEnvFileExists = await exists(globalEnvFilePath);
-      if (!globalEnvFileExists) {
-        console.error(chalk.red(`Global environment not found: `) + chalk.dim(`environments/${globalEnv}.yml`));
+      const globalEnvFilePath = resolveYamlPath(path.join(workspacePath, 'environments'), globalEnv);
+      if (!globalEnvFilePath) {
+        console.error(chalk.red(`Global environment not found: `) + chalk.dim(`environments/${globalEnv}.yml (or .yaml)`));
         console.error(chalk.dim(`Workspace: ${workspacePath}`));
         process.exit(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_NOT_FOUND);
       }
 
       try {
         const globalEnvContent = fs.readFileSync(globalEnvFilePath, 'utf8');
+        // Both extensions hold the same OpenCollection YAML, so the serializer is `yml` either way.
         const globalEnvJson = parseEnvironment(globalEnvContent, { format: 'yml' });
         globalEnvVars = getEnvVars(globalEnvJson);
         globalEnvVars.__name__ = globalEnv;
@@ -709,8 +705,7 @@ const handler = async function (argv) {
 
     const runtime = getJsSandboxRuntime(sandbox);
 
-    const collectionRootFile = collection.format === 'yml' ? 'opencollection.yml' : 'collection.bru';
-    const collectionRootPath = path.join(collectionPath, collectionRootFile);
+    const collectionRootPath = path.join(collectionPath, COLLECTION_LAYOUTS[collection.format].collectionFile);
     const persistPaths = {
       envFile: envFileDescriptor,
       globalEnvFile: globalEnvFileDescriptor,
@@ -729,7 +724,7 @@ const handler = async function (argv) {
     }
 
     const runSingleRequestByPathname = async (relativeItemPathname) => {
-      const ext = FORMAT_CONFIG[collection.format].ext;
+      const ext = COLLECTION_LAYOUTS[collection.format].ext;
       return new Promise(async (resolve, reject) => {
         let itemPathname = path.join(collectionPath, relativeItemPathname);
         if (itemPathname && !itemPathname?.endsWith(ext)) {

--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -6,27 +6,23 @@ const { sanitizeName } = require('./filesystem');
 const { parseRequest, parseCollection, parseFolder, stringifyCollection, stringifyFolder, stringifyEnvironment, stringifyRequest, DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
 const constants = require('../constants');
 const chalk = require('chalk');
+const { COLLECTION_LAYOUTS, COLLECTION_LAYOUT_ORDER, isOpenCollectionLayout } = require('@usebruno/common');
 
-const FORMAT_CONFIG = {
-  yml: { ext: '.yml', collectionFile: 'opencollection.yml', folderFile: 'folder.yml' },
-  bru: { ext: '.bru', collectionFile: 'collection.bru', folderFile: 'folder.bru' }
-};
 const REQUEST_ITEM_TYPES = ['http-request', 'graphql-request'];
 
-const getCollectionFormat = (collectionPath) => {
-  if (fs.existsSync(path.join(collectionPath, 'opencollection.yml'))) return 'yml';
-  if (fs.existsSync(path.join(collectionPath, 'bruno.json'))) return 'bru';
-  return null;
-};
+const getCollectionFormat = (collectionPath) => COLLECTION_LAYOUT_ORDER.find(
+  (layout) => fs.existsSync(path.join(collectionPath, COLLECTION_LAYOUTS[layout].marker))
+) || null;
 
 const getCollectionConfig = (collectionPath, format) => {
-  if (format === 'yml') {
-    const content = fs.readFileSync(path.join(collectionPath, 'opencollection.yml'), 'utf8');
-    const parsed = parseCollection(content, { format: 'yml' });
+  const { collectionFile } = COLLECTION_LAYOUTS[format];
+  if (isOpenCollectionLayout(format)) {
+    const content = fs.readFileSync(path.join(collectionPath, collectionFile), 'utf8');
+    const parsed = parseCollection(content, { format });
     return { brunoConfig: parsed.brunoConfig, collectionRoot: parsed.collectionRoot || {} };
   }
   const brunoConfig = JSON.parse(fs.readFileSync(path.join(collectionPath, 'bruno.json'), 'utf8'));
-  const collectionBruPath = path.join(collectionPath, 'collection.bru');
+  const collectionBruPath = path.join(collectionPath, collectionFile);
   const collectionRoot = fs.existsSync(collectionBruPath)
     ? parseCollection(fs.readFileSync(collectionBruPath, 'utf8'), { format: 'bru' })
     : {};
@@ -34,7 +30,8 @@ const getCollectionConfig = (collectionPath, format) => {
 };
 
 const getFolderRoot = (dir, format) => {
-  const folderPath = path.join(dir, FORMAT_CONFIG[format].folderFile);
+  const { folderFile } = COLLECTION_LAYOUTS[format];
+  const folderPath = path.join(dir, folderFile);
   if (!fs.existsSync(folderPath)) return null;
   return parseFolder(fs.readFileSync(folderPath, 'utf8'), { format });
 };
@@ -47,7 +44,7 @@ const createCollectionJsonFromPathname = (collectionPath) => {
   }
 
   const { brunoConfig, collectionRoot } = getCollectionConfig(collectionPath, format);
-  const { ext, collectionFile, folderFile } = FORMAT_CONFIG[format];
+  const { ext, collectionFile, folderFile } = COLLECTION_LAYOUTS[format];
   const environmentsPath = path.join(collectionPath, 'environments');
 
   const traverse = (currentPath) => {
@@ -296,7 +293,7 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
 
   // Build source file info for error trace mapping
   const format = collection.format || 'bru';
-  const config = FORMAT_CONFIG[format];
+  const config = COLLECTION_LAYOUTS[format];
   const collectionSource = {
     filePath: path.join(collection.pathname, config.collectionFile),
     displayPath: config.collectionFile
@@ -540,6 +537,7 @@ const safeWriteFileSync = (filePath, content) => {
  */
 const createCollectionFromBrunoObject = async (collection, dirPath, options = {}) => {
   const { format = DEFAULT_COLLECTION_FORMAT } = options;
+  const { ext, collectionFile } = COLLECTION_LAYOUTS[format];
   // Create brunoConfig for yml format
   const brunoConfig = {
     version: '1',
@@ -548,14 +546,12 @@ const createCollectionFromBrunoObject = async (collection, dirPath, options = {}
     ignore: ['node_modules', '.git']
   };
 
-  if (format === 'yml') {
+  if (isOpenCollectionLayout(format)) {
     brunoConfig.opencollection = '1.0.0';
   }
 
-  const collectionContent = await stringifyCollection(collection.root || {}, brunoConfig, {
-    format
-  });
-  const collectionRootFilePath = format == 'bru' ? path.join(dirPath, 'collection.bru') : path.join(dirPath, 'opencollection.yml');
+  const collectionContent = await stringifyCollection(collection.root || {}, brunoConfig, { format });
+  const collectionRootFilePath = path.join(dirPath, collectionFile);
 
   if (format === 'bru') {
     fs.writeFileSync(
@@ -575,7 +571,7 @@ const createCollectionFromBrunoObject = async (collection, dirPath, options = {}
 
     for (const env of collection.environments) {
       const content = stringifyEnvironment(env, { format });
-      const filename = format === 'bru' ? sanitizeName(`${env.name}.bru`) : sanitizeName(`${env.name}.yml`);
+      const filename = sanitizeName(`${env.name}${ext}`);
       fs.writeFileSync(path.join(envDirPath, filename), content);
     }
   }
@@ -592,10 +588,11 @@ const createCollectionFromBrunoObject = async (collection, dirPath, options = {}
  * @param {Array} items - Collection items
  * @param {string} currentPath - Current directory path
  * @param {object} [options] - Current directory path
- * @param {"bru"|"yml"} options.format - Current directory path
+ * @param {"bru"|"yml"|"yaml"} options.format - On-disk layout of the collection being written
  */
 const processCollectionItems = async (items = [], currentPath, options = {}) => {
   const { format = DEFAULT_COLLECTION_FORMAT } = options;
+  const { ext, folderFile } = COLLECTION_LAYOUTS[format];
   for (const item of items) {
     if (item.type === 'folder') {
       // Create folder
@@ -603,10 +600,9 @@ const processCollectionItems = async (items = [], currentPath, options = {}) => 
       const folderPath = path.join(currentPath, sanitizedFolderName);
       fs.mkdirSync(folderPath, { recursive: true });
 
-      // Create folder.yml file if root exists
+      // Create folder root file if root exists
       if (item?.root?.meta?.name) {
-        const folderFileName = format === 'bru' ? 'folder.bru' : 'folder.yml';
-        const folderFilePath = path.join(folderPath, folderFileName);
+        const folderFilePath = path.join(folderPath, folderFile);
         if (item.seq) {
           item.root.meta.seq = item.seq;
         }
@@ -620,17 +616,9 @@ const processCollectionItems = async (items = [], currentPath, options = {}) => 
       }
     } else if (REQUEST_ITEM_TYPES.includes(item.type)) {
       // Create request file
-      let sanitizedFilename;
-      if (format == 'yml') {
-        sanitizedFilename = sanitizeName(item?.filename || `${item.name}.yml`);
-        if (!sanitizedFilename.endsWith('.yml')) {
-          sanitizedFilename += '.yml';
-        }
-      } else {
-        sanitizedFilename = sanitizeName(item?.filename || `${item.name}.bru`);
-        if (!sanitizedFilename.endsWith('.bru')) {
-          sanitizedFilename += '.bru';
-        }
+      let sanitizedFilename = sanitizeName(item?.filename || `${item.name}${ext}`);
+      if (!sanitizedFilename.endsWith(ext)) {
+        sanitizedFilename += ext;
       }
 
       // Convert to YML format
@@ -656,7 +644,6 @@ const processCollectionItems = async (items = [], currentPath, options = {}) => 
         examples: item.examples || []
       };
 
-      // Convert to YML format and write to file
       const content = stringifyRequest(itemJson, { format });
       safeWriteFileSync(path.join(currentPath, sanitizedFilename), content);
     } else {
@@ -707,7 +694,6 @@ const sortByNameThenSequence = (items) => {
 };
 
 module.exports = {
-  FORMAT_CONFIG,
   getCollectionFormat,
   createCollectionJsonFromPathname,
   mergeHeaders,

--- a/packages/bruno-cli/src/utils/collection.js
+++ b/packages/bruno-cli/src/utils/collection.js
@@ -6,7 +6,12 @@ const { sanitizeName } = require('./filesystem');
 const { parseRequest, parseCollection, parseFolder, stringifyCollection, stringifyFolder, stringifyEnvironment, stringifyRequest, DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
 const constants = require('../constants');
 const chalk = require('chalk');
-const { COLLECTION_LAYOUTS, COLLECTION_LAYOUT_ORDER, isOpenCollectionLayout } = require('@usebruno/common');
+const {
+  COLLECTION_LAYOUTS,
+  COLLECTION_LAYOUT_ORDER,
+  isOpenCollectionLayout,
+  stripRequestExtension
+} = require('@usebruno/common');
 
 const REQUEST_ITEM_TYPES = ['http-request', 'graphql-request'];
 
@@ -615,11 +620,9 @@ const processCollectionItems = async (items = [], currentPath, options = {}) => 
         await processCollectionItems(item.items, folderPath, options);
       }
     } else if (REQUEST_ITEM_TYPES.includes(item.type)) {
-      // Create request file
-      let sanitizedFilename = sanitizeName(item?.filename || `${item.name}${ext}`);
-      if (!sanitizedFilename.endsWith(ext)) {
-        sanitizedFilename += ext;
-      }
+      // Create request file. Strip any recognized request extension first, so an item carrying
+      // `users.yml` or `request.YAML` lands as `users.yaml` rather than `users.yml.yaml`.
+      const sanitizedFilename = `${sanitizeName(stripRequestExtension(item?.filename || item.name))}${ext}`;
 
       // Convert to YML format
       const itemJson = {

--- a/packages/bruno-cli/src/utils/filesystem.js
+++ b/packages/bruno-cli/src/utils/filesystem.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
+const { YAML_EXTENSIONS } = require('@usebruno/common');
 const fsPromises = require('fs/promises');
 
 const exists = async (p) => {
@@ -103,6 +104,24 @@ const stripExtension = (filename = '') => {
   return filename.replace(/\.[^/.]+$/, '');
 };
 
+/**
+ * Resolve a YAML file that may carry either supported extension. `.yml` is tried first, so a
+ * Bruno-written file always wins when both are present.
+ *
+ * @param {string} dir - Directory to look in.
+ * @param {string} basename - File name without extension (e.g. `workspace`, or an environment name).
+ * @returns {string|null} Absolute path of the first candidate that exists, or null if neither does.
+ */
+const resolveYamlPath = (dir, basename) => {
+  for (const extension of YAML_EXTENSIONS) {
+    const candidate = path.join(dir, `${basename}${extension}`);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+};
+
 const getSubDirectories = (dir) => {
   try {
     const files = fs.readdirSync(dir);
@@ -202,6 +221,7 @@ module.exports = {
   searchForFiles,
   searchForBruFiles,
   stripExtension,
+  resolveYamlPath,
   getSubDirectories,
   sanitizeName,
   validateName,

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -332,9 +332,9 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
  * Mutate the in-memory collection root and write it out. The mutation matters:
  * subsequent requests in the same iteration read `collection.root` and must see the updated vars.
  *
- * @param {{ root?: object, format: 'bru' | 'yml', brunoConfig?: object }} collection - Loaded collection; mutated in place.
+ * @param {{ root?: object, format: 'bru' | 'yml' | 'yaml', brunoConfig?: object }} collection - Loaded collection; mutated in place.
  * @param {Object<string, any>} scriptCollVars - Flat map of collection vars the script declared.
- * @param {string} collectionRootPath - Absolute path to the collection root file (`collection.bru` / `opencollection.yml`).
+ * @param {string} collectionRootPath - Absolute path to the collection root file (`collection.bru` / `opencollection.yml` / `opencollection.yaml`).
  * @returns {void}
  *
  * @example
@@ -357,8 +357,7 @@ const persistCollectionVars = (collection, scriptCollVars, collectionRootPath) =
   collectionRoot.request.vars.req = merged;
   collection.root = collectionRoot;
 
-  const format = collection.format;
-  const content = stringifyCollection(collectionRoot, collection.brunoConfig || {}, { format });
+  const content = stringifyCollection(collectionRoot, collection.brunoConfig || {}, { format: collection.format });
   const existing = fs.existsSync(collectionRootPath) ? fs.readFileSync(collectionRootPath, 'utf8') : null;
   if (existing !== null) {
     writeIfChanged(collectionRootPath, content, existing);
@@ -390,7 +389,7 @@ const persistCollectionVars = (collection, scriptCollVars, collectionRootPath) =
  *   `globalEnvVarOverrides` applies the same leak-guard to the global env file, seeded from
  *   `--global-env-var name=value`.
  *   `globalEnvFile.format` is yml-only because the CLI's `--global-env <name>` flag looks
- *   up `<workspace>/environments/<name>.yml` (no JSON/bru equivalent exists today).
+ *   up `<workspace>/environments/<name>.{yml,yaml}` (no JSON/bru equivalent exists today).
  * @returns {void}
  *
  * @example

--- a/packages/bruno-cli/tests/integration/run-sent-headers.spec.js
+++ b/packages/bruno-cli/tests/integration/run-sent-headers.spec.js
@@ -87,7 +87,7 @@ ${extra}`;
       'User-Agent': expect.stringMatching(/^bruno-runtime\//),
       'my-header-1': 'my-value-1'
     });
-  });
+  }, 60_000);
 
   it('leaves a header the user declared untouched', async () => {
     stageCollection(
@@ -101,7 +101,7 @@ ${extra}`;
 
     expect(report.results[0].request.headers['user-agent']).toBe('mine/1.0');
     expect(report.results[0].request.headers['User-Agent']).toBeUndefined();
-  });
+  }, 60_000);
 
   it('hands the same set to a post-response script', async () => {
     stageCollection(
@@ -118,5 +118,5 @@ script:post-response {
 
     const logged = JSON.parse(stdout.match(/SENT_HEADERS (\[.*\])/)[1]);
     expect(logged).toEqual(expect.arrayContaining(['Host', 'Connection', 'Accept-Encoding', 'User-Agent']));
-  });
+  }, 60_000);
 });

--- a/packages/bruno-cli/tests/integration/run-yaml-collection.spec.js
+++ b/packages/bruno-cli/tests/integration/run-yaml-collection.spec.js
@@ -1,0 +1,282 @@
+const { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const { runCli } = require('./helpers/run-cli');
+const constants = require('../../src/constants');
+
+// An OpenCollection whose files use `.yaml` instead of `.yml`. The content is identical — only
+// the extension differs — so every stage of the CLI (root detection, traversal, env lookup,
+// variable persistence) has to resolve the alternate extension while still handing the `yml`
+// serializer to @usebruno/filestore.
+
+const writeFixtureFile = (filePath, content) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+};
+
+const PING_REQUEST_YAML = `info:
+  name: ping
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{host}}/ping"
+
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        bru.setEnvVar("pinged", "yes");
+        bru.setCollectionVar("collFlag", "on");
+`;
+
+describe('CLI run — OpenCollection collections using the .yaml extension', () => {
+  let server;
+  let baseUrl;
+  let tmpDir;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-cli-yaml-collection-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const DEAD_HOST = 'http://127.0.0.1:1';
+
+  const seedCollection = ({ defaultEnvironment = null } = {}) => {
+    const presets = defaultEnvironment
+      ? `    presets:\n      defaultEnvironment: ${defaultEnvironment}\n`
+      : '';
+    writeFixtureFile(
+      path.join(tmpDir, 'opencollection.yaml'),
+      'opencollection: 1.0.0\n'
+      + 'info:\n  name: yaml-cli-collection\n'
+      + 'extensions:\n  bruno:\n'
+      + '    ignore:\n      - node_modules\n      - .git\n'
+      + presets
+      + 'request:\n  vars:\n    - name: collFlag\n      value: off\n'
+    );
+    writeFixtureFile(path.join(tmpDir, 'ping.yaml'), PING_REQUEST_YAML);
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'dev.yaml'),
+      `name: dev\nvariables:\n  - name: host\n    value: ${baseUrl}\n`
+    );
+    writeFixtureFile(
+      path.join(tmpDir, 'environments', 'dead.yaml'),
+      `name: dead\nvariables:\n  - name: host\n    value: ${DEAD_HOST}\n`
+    );
+  };
+
+  const expectSuccess = (result) => {
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+  };
+
+  it('runs a request from a .yaml collection with --env resolving environments/<name>.yaml', async () => {
+    seedCollection();
+
+    const result = await runCli(['run', 'ping.yaml', '--env', 'dev', '--sandbox', 'developer', '--noproxy'], tmpDir);
+
+    expectSuccess(result);
+    // A 200 proves {{host}} interpolated — an unresolved placeholder yields an invalid URL.
+    expect(result.stdout).toContain('ping (200 OK)');
+  }, 60_000);
+
+  it('runs the whole .yaml collection when no request path is given', async () => {
+    seedCollection();
+
+    // No path argument → the collection is traversed, which only finds ping.yaml if the
+    // traversal filter accepts the .yaml extension.
+    const result = await runCli(['run', '--env', 'dev', '--sandbox', 'developer', '--noproxy'], tmpDir);
+
+    expectSuccess(result);
+    expect(result.stdout).toContain('ping');
+  }, 60_000);
+
+  it('falls back to presets.defaultEnvironment resolved as environments/<name>.yaml', async () => {
+    seedCollection({ defaultEnvironment: 'dev' });
+
+    const result = await runCli(['run', 'ping.yaml', '--sandbox', 'developer', '--noproxy'], tmpDir);
+
+    expectSuccess(result);
+    expect(result.stdout).toContain('Using default environment: dev');
+  }, 60_000);
+
+  it('persists script-written env vars back into environments/<name>.yaml', async () => {
+    seedCollection();
+
+    const result = await runCli(['run', 'ping.yaml', '--env', 'dev', '--sandbox', 'developer', '--noproxy'], tmpDir);
+
+    expectSuccess(result);
+    const written = fs.readFileSync(path.join(tmpDir, 'environments', 'dev.yaml'), 'utf8');
+    expect(written).toMatch(/name:\s*pinged/);
+    expect(written).toMatch(/value:\s*yes/);
+    // The pre-existing entry survives the rewrite.
+    expect(written).toMatch(/name:\s*host/);
+  }, 60_000);
+
+  it('persists script-written collection vars back into opencollection.yaml', async () => {
+    seedCollection();
+
+    const result = await runCli(['run', 'ping.yaml', '--env', 'dev', '--sandbox', 'developer', '--noproxy'], tmpDir);
+
+    expectSuccess(result);
+    // Proves the collection root path was resolved as opencollection.yaml rather than
+    // silently falling through to collection.bru.
+    const written = fs.readFileSync(path.join(tmpDir, 'opencollection.yaml'), 'utf8');
+    expect(written).toMatch(/name:\s*collFlag/);
+    expect(written).toMatch(/value:\s*on/);
+    expect(fs.existsSync(path.join(tmpDir, 'collection.bru'))).toBe(false);
+  }, 60_000);
+
+  it('resolves a --env-file with a .yaml extension', async () => {
+    seedCollection();
+    writeFixtureFile(
+      path.join(tmpDir, 'External.yaml'),
+      `name: External\nvariables:\n  - name: host\n    value: ${baseUrl}\n`
+    );
+
+    const result = await runCli(
+      ['run', 'ping.yaml', '--env-file', 'External.yaml', '--sandbox', 'developer', '--noproxy'],
+      tmpDir
+    );
+
+    expectSuccess(result);
+    expect(result.stdout).toContain('ping (200 OK)');
+    // The .yaml env file is parsed and rewritten by the yml serializer, not the bru one.
+    const written = fs.readFileSync(path.join(tmpDir, 'External.yaml'), 'utf8');
+    expect(written).toMatch(/name:\s*pinged/);
+    expect(written).toMatch(/value:\s*yes/);
+  }, 60_000);
+
+  // The workspace marker and its global env files are resolved independently of the collection's
+  // layout, so each is accepted under either extension. A workspace can therefore be all-`.yaml`,
+  // all-`.yml`, or mixed.
+  describe('--global-env in a workspace using the .yaml extension', () => {
+    const GLOBAL_PING_REQUEST_YAML = `info:
+  name: global-ping
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{globalHost}}/ping"
+
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        bru.setGlobalEnvVar("globalPinged", "yes");
+`;
+
+    // `workspaceExt`/`envExt` are set per test so one tree shape covers every extension pairing.
+    const stageWorkspace = ({ workspaceExt, envExt }) => {
+      const workspaceDir = path.join(tmpDir, 'workspace');
+      const collectionDir = path.join(workspaceDir, 'yaml-cli-collection');
+
+      writeFixtureFile(
+        path.join(workspaceDir, `workspace${workspaceExt}`),
+        'opencollection: 1.0.0\n'
+        + 'info:\n  name: "Test Workspace"\n  type: workspace\n'
+        + 'collections:\n  - name: "yaml-cli-collection"\n    path: "yaml-cli-collection"\n'
+        + 'specs:\ndocs: \'\'\n'
+      );
+      writeFixtureFile(
+        path.join(workspaceDir, 'environments', `Global${envExt}`),
+        `name: Global\nvariables:\n  - name: globalHost\n    value: ${baseUrl}\n`
+      );
+      writeFixtureFile(
+        path.join(collectionDir, 'opencollection.yaml'),
+        'opencollection: 1.0.0\ninfo:\n  name: yaml-cli-collection\n'
+      );
+      writeFixtureFile(path.join(collectionDir, 'global-ping.yaml'), GLOBAL_PING_REQUEST_YAML);
+
+      return { workspaceDir, collectionDir };
+    };
+
+    it.each([
+      { workspaceExt: '.yaml', envExt: '.yaml', label: 'an all-.yaml workspace' },
+      { workspaceExt: '.yml', envExt: '.yaml', label: 'a .yml workspace with a .yaml global env' },
+      { workspaceExt: '.yaml', envExt: '.yml', label: 'a .yaml workspace with a .yml global env' }
+    ])('walks up to and loads the global env from $label', async ({ workspaceExt, envExt }) => {
+      const { collectionDir } = stageWorkspace({ workspaceExt, envExt });
+
+      // No --workspace-path: the CLI has to find the workspace marker by walking up from cwd.
+      const result = await runCli(
+        ['run', 'global-ping.yaml', '--global-env', 'Global', '--sandbox', 'developer', '--noproxy'],
+        collectionDir
+      );
+
+      expectSuccess(result);
+      // {{globalHost}} came from the global env file, so a 200 proves it was found and parsed.
+      expect(result.stdout).toContain('global-ping (200 OK)');
+    }, 60_000);
+
+    it('persists script-written global env vars back into environments/Global.yaml', async () => {
+      const { workspaceDir, collectionDir } = stageWorkspace({ workspaceExt: '.yaml', envExt: '.yaml' });
+
+      const result = await runCli(
+        ['run', 'global-ping.yaml', '--global-env', 'Global', '--sandbox', 'developer', '--noproxy'],
+        collectionDir
+      );
+
+      expectSuccess(result);
+      const written = fs.readFileSync(path.join(workspaceDir, 'environments', 'Global.yaml'), 'utf8');
+      expect(written).toMatch(/name:\s*globalPinged/);
+      expect(written).toMatch(/value:\s*yes/);
+      // Persistence writes back to the file it resolved — it must not create a .yml sibling.
+      expect(fs.existsSync(path.join(workspaceDir, 'environments', 'Global.yml'))).toBe(false);
+    }, 60_000);
+
+    it('accepts --workspace-path pointing at a .yaml workspace', async () => {
+      const { workspaceDir, collectionDir } = stageWorkspace({ workspaceExt: '.yaml', envExt: '.yaml' });
+
+      const result = await runCli(
+        [
+          'run', 'global-ping.yaml',
+          '--global-env', 'Global',
+          '--workspace-path', workspaceDir,
+          '--sandbox', 'developer', '--noproxy'
+        ],
+        collectionDir
+      );
+
+      expectSuccess(result);
+      expect(result.stdout).toContain('global-ping (200 OK)');
+    }, 60_000);
+
+    it('reports a missing global environment naming both extensions', async () => {
+      const { collectionDir } = stageWorkspace({ workspaceExt: '.yaml', envExt: '.yaml' });
+
+      const result = await runCli(
+        ['run', 'global-ping.yaml', '--global-env', 'Nope', '--sandbox', 'developer', '--noproxy'],
+        collectionDir
+      );
+
+      expect(result.code).toBe(constants.EXIT_STATUS.ERROR_GLOBAL_ENV_NOT_FOUND);
+      expect(`${result.stdout}\n${result.stderr}`).toContain('environments/Nope.yml (or .yaml)');
+    }, 60_000);
+  });
+});

--- a/packages/bruno-cli/tests/runner/collection-json-from-pathname.spec.js
+++ b/packages/bruno-cli/tests/runner/collection-json-from-pathname.spec.js
@@ -1,8 +1,10 @@
 const path = require('node:path');
 const fs = require('node:fs');
+const os = require('node:os');
 const { describe, it, expect } = require('@jest/globals');
 const constants = require('../../src/constants');
-const { createCollectionJsonFromPathname, getCollectionFormat, FORMAT_CONFIG } = require('../../src/utils/collection');
+const { createCollectionJsonFromPathname, getCollectionFormat, mergeScripts } = require('../../src/utils/collection');
+const { COLLECTION_LAYOUTS } = require('@usebruno/common');
 const { parseEnvironment } = require('@usebruno/filestore');
 
 describe('create collection json from pathname', () => {
@@ -211,12 +213,59 @@ describe('create collection json from pathname', () => {
     expect(getUsersReq).toHaveProperty('request.url', 'https://api.example.com/users');
     expect(getUsersReq.pathname).toContain('get-users.yml');
   });
+
+  it('creates a collection json from OpenCollection yaml files', () => {
+    const collectionPathname = path.join(__dirname, './fixtures/opencollection-yaml/collection');
+    const c = createCollectionJsonFromPathname(collectionPathname);
+
+    expect(c).toBeDefined();
+    expect(c).toHaveProperty('format', 'yaml');
+    expect(c).toHaveProperty('brunoConfig.opencollection', '1.0.0');
+    expect(c).toHaveProperty('brunoConfig.name', 'Test OpenCollection Yaml');
+    expect(c).toHaveProperty('brunoConfig.type', 'collection');
+    expect(c).toHaveProperty('brunoConfig.ignore', ['node_modules', '.git']);
+    expect(c).toHaveProperty('pathname', collectionPathname);
+
+    // collection root headers
+    expect(c).toHaveProperty('root.request.headers[0].name', 'X-Collection-Header');
+    expect(c).toHaveProperty('root.request.headers[0].value', 'collection-header-value');
+    expect(c).toHaveProperty('root.request.headers[0].enabled', true);
+
+    // folder.yaml is recognized as the folder root, so it is not itself listed as a request
+    const usersFolder = c.items.find((i) => i.name === 'users');
+    expect(usersFolder).toHaveProperty('type', 'folder');
+    expect(usersFolder).toHaveProperty('root.meta.name', 'Users');
+    expect(usersFolder).toHaveProperty('root.meta.seq', 1);
+    expect(usersFolder.items.map((i) => i.name)).toEqual(['Create User']);
+
+    // request in folder
+    const createUserReq = usersFolder.items[0];
+    expect(createUserReq).toHaveProperty('type', 'http-request');
+    expect(createUserReq).toHaveProperty('request.method', 'POST');
+    expect(createUserReq).toHaveProperty('request.url', 'https://api.example.com/users');
+    expect(createUserReq.pathname).toContain('create-user.yaml');
+
+    // root level request
+    const getUsersReq = c.items.find((i) => i.name === 'Get Users');
+    expect(getUsersReq).toHaveProperty('type', 'http-request');
+    expect(getUsersReq).toHaveProperty('request.method', 'GET');
+    expect(getUsersReq).toHaveProperty('request.url', 'https://api.example.com/users');
+    expect(getUsersReq.pathname).toContain('get-users.yaml');
+
+    // opencollection.yaml is the collection root, never traversed as a request
+    expect(c.items.some((i) => i.pathname?.endsWith('opencollection.yaml'))).toBe(false);
+  });
 });
 
 describe('getCollectionFormat', () => {
   it('returns yml for OpenCollection', () => {
     const collectionPath = path.join(__dirname, './fixtures/opencollection/collection');
     expect(getCollectionFormat(collectionPath)).toBe('yml');
+  });
+
+  it('returns yaml for OpenCollection with a .yaml root', () => {
+    const collectionPath = path.join(__dirname, './fixtures/opencollection-yaml/collection');
+    expect(getCollectionFormat(collectionPath)).toBe('yaml');
   });
 
   it('returns bru for Bruno collection', () => {
@@ -228,23 +277,18 @@ describe('getCollectionFormat', () => {
     const collectionPath = path.join(__dirname, './fixtures/collection-invalid');
     expect(getCollectionFormat(collectionPath)).toBe(null);
   });
-});
 
-describe('FORMAT_CONFIG', () => {
-  it('has correct config for yml format', () => {
-    expect(FORMAT_CONFIG.yml).toEqual({
-      ext: '.yml',
-      collectionFile: 'opencollection.yml',
-      folderFile: 'folder.yml'
-    });
-  });
-
-  it('has correct config for bru format', () => {
-    expect(FORMAT_CONFIG.bru).toEqual({
-      ext: '.bru',
-      collectionFile: 'collection.bru',
-      folderFile: 'folder.bru'
-    });
+  it('prefers .yml over .yaml when both roots exist', () => {
+    // Two collection roots in one directory is a broken state, but detection must still be
+    // deterministic rather than dependent on readdir order.
+    const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-format-'));
+    try {
+      fs.writeFileSync(path.join(collectionPath, 'opencollection.yml'), 'opencollection: "1.0.0"\n');
+      fs.writeFileSync(path.join(collectionPath, 'opencollection.yaml'), 'opencollection: "1.0.0"\n');
+      expect(getCollectionFormat(collectionPath)).toBe('yml');
+    } finally {
+      fs.rmSync(collectionPath, { recursive: true, force: true });
+    }
   });
 });
 
@@ -261,5 +305,55 @@ describe('OpenCollection environment parsing', () => {
     expect(env.variables[0]).toHaveProperty('value', 'https://api.dev.example.com');
     expect(env.variables[1]).toHaveProperty('name', 'apiKey');
     expect(env.variables[1]).toHaveProperty('value', 'dev-api-key-123');
+  });
+
+  it('parses YAML environment files through the yml serializer', () => {
+    const collectionPath = path.join(__dirname, './fixtures/opencollection-yaml/collection');
+    const format = getCollectionFormat(collectionPath);
+    const envPath = path.join(collectionPath, 'environments', `dev${COLLECTION_LAYOUTS[format].ext}`);
+    const envContent = fs.readFileSync(envPath, 'utf8');
+    const env = parseEnvironment(envContent, { format });
+
+    expect(env).toHaveProperty('name', 'Development');
+    expect(env.variables).toHaveLength(2);
+    expect(env.variables[0]).toHaveProperty('name', 'baseUrl');
+    expect(env.variables[0]).toHaveProperty('value', 'https://api.dev.example.com');
+  });
+});
+
+describe('mergeScripts source paths', () => {
+  const buildCollection = (format, collectionPathname) => ({
+    format,
+    pathname: collectionPathname,
+    root: { request: { script: { req: 'const collectionScript = true;' } } }
+  });
+
+  it('maps a yaml collection script to opencollection.yaml', () => {
+    const collectionPathname = path.join(os.tmpdir(), 'yaml-collection');
+    const collection = buildCollection('yaml', collectionPathname);
+    const request = { script: {} };
+
+    mergeScripts(collection, request, [], 'sequential');
+
+    expect(request.script.reqMetadata.segments[0].displayPath).toBe('opencollection.yaml');
+    expect(request.script.reqMetadata.segments[0].filePath).toBe(
+      path.join(collectionPathname, 'opencollection.yaml')
+    );
+  });
+
+  it('maps a yaml folder script to folder.yaml', () => {
+    const collectionPathname = path.join(os.tmpdir(), 'yaml-collection');
+    const folderPathname = path.join(collectionPathname, 'users');
+    const collection = buildCollection('yaml', collectionPathname);
+    const request = { script: {} };
+    const requestTreePath = [
+      { type: 'folder', pathname: folderPathname, root: { request: { script: { req: 'const folderScript = true;' } } } }
+    ];
+
+    mergeScripts(collection, request, requestTreePath, 'sequential');
+
+    const folderSegment = request.script.reqMetadata.segments.find((s) => s.displayPath !== 'opencollection.yaml');
+    expect(folderSegment.displayPath).toBe(path.join('users', 'folder.yaml'));
+    expect(folderSegment.filePath).toBe(path.join(folderPathname, 'folder.yaml'));
   });
 });

--- a/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/environments/dev.yaml
+++ b/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/environments/dev.yaml
@@ -1,0 +1,6 @@
+name: Development
+variables:
+  - name: baseUrl
+    value: https://api.dev.example.com
+  - name: apiKey
+    value: dev-api-key-123

--- a/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/get-users.yaml
+++ b/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/get-users.yaml
@@ -1,0 +1,8 @@
+info:
+  name: Get Users
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: https://api.example.com/users

--- a/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/opencollection.yaml
+++ b/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/opencollection.yaml
@@ -1,0 +1,15 @@
+opencollection: "1.0.0"
+info:
+  name: Test OpenCollection Yaml
+
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git
+
+request:
+  headers:
+    - name: X-Collection-Header
+      value: collection-header-value
+      enabled: true

--- a/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/users/create-user.yaml
+++ b/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/users/create-user.yaml
@@ -1,0 +1,14 @@
+info:
+  name: Create User
+  type: http
+  seq: 1
+
+http:
+  method: POST
+  url: https://api.example.com/users
+  body:
+    mode: json
+    json: |
+      {
+        "name": "John Doe"
+      }

--- a/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/users/folder.yaml
+++ b/packages/bruno-cli/tests/runner/fixtures/opencollection-yaml/collection/users/folder.yaml
@@ -1,0 +1,3 @@
+info:
+  name: Users
+  seq: 1

--- a/packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js
+++ b/packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js
@@ -2,7 +2,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { describe, it, expect, afterEach } = require('@jest/globals');
-const { parseRequest, parseFolder } = require('@usebruno/filestore');
+const { parseRequest, parseFolder, parseCollection, parseEnvironment } = require('@usebruno/filestore');
 const { createCollectionFromBrunoObject } = require('../../../src/utils/collection');
 
 describe('createCollectionFromBrunoObject', () => {
@@ -199,5 +199,140 @@ describe('createCollectionFromBrunoObject', () => {
         { format: 'bru' }
       )
     ).rejects.toThrow('Unsupported item type: unsupported-type');
+  });
+
+  // `.yaml` is an alternate extension for the same OpenCollection YAML content, so both layouts
+  // must produce identical bytes under different filenames — anything that diverges is a bug.
+  describe.each([
+    { format: 'yml', ext: '.yml', collectionFile: 'opencollection.yml', folderFile: 'folder.yml' },
+    { format: 'yaml', ext: '.yaml', collectionFile: 'opencollection.yaml', folderFile: 'folder.yaml' }
+  ])('$format layout', ({ format, ext, collectionFile, folderFile }) => {
+    const seed = (dirPath) =>
+      createCollectionFromBrunoObject(
+        {
+          name: 'opencollection-collection',
+          root: { request: { headers: [{ name: 'X-Collection-Header', value: 'v', enabled: true }] } },
+          environments: [{ name: 'Development', variables: [{ name: 'baseUrl', value: 'https://api.dev', enabled: true }] }],
+          items: [
+            {
+              type: 'folder',
+              name: 'Users',
+              seq: 3,
+              root: { meta: { name: 'Users' } },
+              items: [
+                {
+                  type: 'http-request',
+                  name: 'List Users',
+                  seq: 1,
+                  request: { method: 'GET', url: 'https://api.example.com/users' }
+                }
+              ]
+            },
+            {
+              type: 'http-request',
+              name: 'Get Users',
+              filename: `get-users${ext}`,
+              seq: 1,
+              request: { method: 'GET', url: 'https://api.example.com/users' }
+            }
+          ]
+        },
+        dirPath,
+        { format }
+      );
+
+    it(`writes the collection root as ${collectionFile} and no bruno.json`, async () => {
+      createOutputDir();
+      await seed(outputDir);
+
+      const rootPath = path.join(outputDir, collectionFile);
+      expect(fs.existsSync(rootPath)).toBe(true);
+      // bruno.json is a bru-format artifact; the opencollection config lives inside the root file.
+      expect(fs.existsSync(path.join(outputDir, 'bruno.json'))).toBe(false);
+
+      const parsed = parseCollection(fs.readFileSync(rootPath, 'utf8'), { format: 'yml' });
+      expect(parsed).toHaveProperty('brunoConfig.opencollection', '1.0.0');
+      expect(parsed).toHaveProperty('brunoConfig.name', 'opencollection-collection');
+      expect(parsed).toHaveProperty('collectionRoot.request.headers[0].name', 'X-Collection-Header');
+    });
+
+    it(`writes request files with the ${ext} extension`, async () => {
+      createOutputDir();
+      await seed(outputDir);
+
+      // Explicit filename already carries the extension; the name-derived one gets it appended.
+      const explicitPath = path.join(outputDir, `get-users${ext}`);
+      const derivedPath = path.join(outputDir, 'Users', `List Users${ext}`);
+
+      expect(fs.existsSync(explicitPath)).toBe(true);
+      expect(fs.existsSync(derivedPath)).toBe(true);
+
+      const request = parseRequest(fs.readFileSync(explicitPath, 'utf8'), { format: 'yml' });
+      expect(request).toHaveProperty('type', 'http-request');
+      expect(request).toHaveProperty('request.method', 'GET');
+      expect(request).toHaveProperty('request.url', 'https://api.example.com/users');
+    });
+
+    it(`writes the folder root as ${folderFile}`, async () => {
+      createOutputDir();
+      await seed(outputDir);
+
+      const folderRootPath = path.join(outputDir, 'Users', folderFile);
+      expect(fs.existsSync(folderRootPath)).toBe(true);
+
+      const folder = parseFolder(fs.readFileSync(folderRootPath, 'utf8'), { format: 'yml' });
+      expect(folder).toHaveProperty('meta.name', 'Users');
+      expect(folder).toHaveProperty('meta.seq', 3);
+    });
+
+    it(`writes environment files with the ${ext} extension`, async () => {
+      createOutputDir();
+      await seed(outputDir);
+
+      const envPath = path.join(outputDir, 'environments', `Development${ext}`);
+      expect(fs.existsSync(envPath)).toBe(true);
+
+      const env = parseEnvironment(fs.readFileSync(envPath, 'utf8'), { format: 'yml' });
+      expect(env).toHaveProperty('name', 'Development');
+      expect(env).toHaveProperty('variables[0].name', 'baseUrl');
+      expect(env).toHaveProperty('variables[0].value', 'https://api.dev');
+    });
+  });
+
+  it('writes byte-identical content for the yml and yaml layouts', async () => {
+    const collection = () => ({
+      name: 'parity-collection',
+      root: { request: { headers: [{ name: 'X-Header', value: 'v', enabled: true }] } },
+      items: [
+        {
+          type: 'folder',
+          name: 'Users',
+          seq: 1,
+          root: { meta: { name: 'Users' } },
+          items: [
+            { type: 'http-request', name: 'List Users', seq: 1, request: { method: 'GET', url: 'https://api.example.com/users' } }
+          ]
+        }
+      ]
+    });
+
+    const ymlDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-import-yml-'));
+    const yamlDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-import-yaml-'));
+
+    try {
+      await createCollectionFromBrunoObject(collection(), ymlDir, { format: 'yml' });
+      await createCollectionFromBrunoObject(collection(), yamlDir, { format: 'yaml' });
+
+      const read = (dir, file) => fs.readFileSync(path.join(dir, file), 'utf8');
+
+      expect(read(yamlDir, 'opencollection.yaml')).toBe(read(ymlDir, 'opencollection.yml'));
+      expect(read(yamlDir, path.join('Users', 'folder.yaml'))).toBe(read(ymlDir, path.join('Users', 'folder.yml')));
+      expect(read(yamlDir, path.join('Users', 'List Users.yaml'))).toBe(
+        read(ymlDir, path.join('Users', 'List Users.yml'))
+      );
+    } finally {
+      fs.rmSync(ymlDir, { recursive: true, force: true });
+      fs.rmSync(yamlDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js
+++ b/packages/bruno-cli/tests/utils/collection/create-collection-from-bruno-object.spec.js
@@ -299,6 +299,38 @@ describe('createCollectionFromBrunoObject', () => {
     });
   });
 
+  // An imported item's `filename` carries whatever extension its source used; writing it verbatim
+  // into a different layout produces `users.yml` in a `.yaml` collection, which the app ignores.
+  it.each([
+    ['users.bru', 'users.yaml'],
+    ['users.yml', 'users.yaml'],
+    ['users.yaml', 'users.yaml'],
+    ['users.YAML', 'users.yaml'],
+    ['my.request', 'my.request.yaml'],
+    [undefined, 'Get Users.yaml']
+  ])('normalizes an item filename of %s to %s for the yaml layout', async (filename, expected) => {
+    createOutputDir();
+
+    await createCollectionFromBrunoObject(
+      {
+        name: 'ext-normalization',
+        items: [
+          {
+            type: 'http-request',
+            name: 'Get Users',
+            ...(filename ? { filename } : {}),
+            seq: 1,
+            request: { method: 'GET', url: 'https://api.example.com/users' }
+          }
+        ]
+      },
+      outputDir,
+      { format: 'yaml' }
+    );
+
+    expect(fs.readdirSync(outputDir).filter((f) => f !== 'opencollection.yaml')).toEqual([expected]);
+  });
+
   it('writes byte-identical content for the yml and yaml layouts', async () => {
     const collection = () => ({
       name: 'parity-collection',

--- a/packages/bruno-cli/tests/utils/filesystem.spec.js
+++ b/packages/bruno-cli/tests/utils/filesystem.spec.js
@@ -1,4 +1,6 @@
-const { isLargeFile, isSafeFileName } = require('../../src/utils/filesystem');
+const os = require('os');
+const path = require('path');
+const { isLargeFile, isSafeFileName, resolveYamlPath } = require('../../src/utils/filesystem');
 const fs = require('fs-extra');
 
 describe('isSafeFileName', () => {
@@ -22,6 +24,48 @@ describe('isSafeFileName', () => {
     expect(isSafeFileName(undefined)).toBe(false);
     expect(isSafeFileName(null)).toBe(false);
     expect(isSafeFileName(42)).toBe(false);
+  });
+});
+
+describe('resolveYamlPath', () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-resolve-yaml-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('resolves a .yml file', () => {
+    fs.writeFileSync(path.join(dir, 'workspace.yml'), '');
+    expect(resolveYamlPath(dir, 'workspace')).toBe(path.join(dir, 'workspace.yml'));
+  });
+
+  it('resolves a .yaml file', () => {
+    fs.writeFileSync(path.join(dir, 'workspace.yaml'), '');
+    expect(resolveYamlPath(dir, 'workspace')).toBe(path.join(dir, 'workspace.yaml'));
+  });
+
+  it('prefers .yml when both extensions are present', () => {
+    fs.writeFileSync(path.join(dir, 'workspace.yml'), '');
+    fs.writeFileSync(path.join(dir, 'workspace.yaml'), '');
+    expect(resolveYamlPath(dir, 'workspace')).toBe(path.join(dir, 'workspace.yml'));
+  });
+
+  it('returns null when neither extension exists', () => {
+    expect(resolveYamlPath(dir, 'workspace')).toBe(null);
+  });
+
+  it('returns null for a missing directory', () => {
+    expect(resolveYamlPath(path.join(dir, 'nope'), 'workspace')).toBe(null);
+  });
+
+  it('does not match a bare basename with no extension', () => {
+    // A directory named `environments/Global` must not be mistaken for the env file.
+    fs.writeFileSync(path.join(dir, 'Global'), '');
+    expect(resolveYamlPath(dir, 'Global')).toBe(null);
   });
 });
 

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -370,6 +370,38 @@ describe('persistVariableUpdates — collection vars', () => {
     // Plain strings stay as raw `value: ...` — no type/data block, no `type: string`.
     expect(written).not.toMatch(/name:\s*k1[\s\S]*?type:\s*string/);
   });
+
+  it('writes collection vars back to opencollection.yaml for yaml-format collections', () => {
+    // A `.yaml` collection persists through the same serializer as `.yml`, writing back to the
+    // `opencollection.yaml` it was read from rather than creating a `.yml` sibling.
+    const collectionRootPath = writeFile('opencollection.yaml',
+      'opencollection: 1.0.0\ninfo:\n  name: yaml-collection\nrequest:\n  vars:\n    - name: k1\n      value: old\n'
+    );
+    const collection = {
+      format: 'yaml',
+      brunoConfig: { name: 'yaml-collection' },
+      root: {
+        meta: null,
+        request: {
+          headers: [],
+          auth: { mode: 'none' },
+          script: { req: null, res: null },
+          tests: null,
+          vars: { req: [{ uid: 'v1', name: 'k1', value: 'old', enabled: true, type: 'request' }], res: [] }
+        }
+      }
+    };
+    persistVariableUpdates(
+      { collectionVariables: { k1: 'new', k2: 'fresh' } },
+      { collection, collectionRootPath }
+    );
+    const written = fs.readFileSync(collectionRootPath, 'utf8');
+    expect(written).toMatch(/name:\s*k1/);
+    expect(written).toMatch(/value:\s*new/);
+    expect(written).toMatch(/name:\s*k2/);
+    expect(written).toMatch(/value:\s*fresh/);
+    expect(collection.root.request.vars.req.map((v) => v.name).sort()).toEqual(['k1', 'k2']);
+  });
 });
 
 describe('persistVariableUpdates — .bru env format', () => {

--- a/packages/bruno-common/src/collection-format/index.spec.ts
+++ b/packages/bruno-common/src/collection-format/index.spec.ts
@@ -1,0 +1,204 @@
+import {
+  COLLECTION_LAYOUTS,
+  COLLECTION_LAYOUT_ORDER,
+  COLLECTION_ROOT_BASENAMES,
+  FOLDER_ROOT_BASENAMES,
+  READABLE_COLLECTION_ROOT_BASENAMES,
+  YAML_EXTENSIONS,
+  getLayoutConfig,
+  getLayoutForFilename,
+  isCollectionMarkerBasename,
+  isCollectionRootBasename,
+  isFolderRootBasename,
+  isOpenCollectionLayout,
+  isRequestFilename,
+  isYamlFilename,
+  stripRequestExtension,
+  stripYamlExtension
+} from './index';
+
+describe('COLLECTION_LAYOUTS', () => {
+  it('describes every layout', () => {
+    expect(COLLECTION_LAYOUTS).toEqual({
+      yml: {
+        ext: '.yml',
+        collectionFile: 'opencollection.yml',
+        folderFile: 'folder.yml',
+        marker: 'opencollection.yml',
+        legacyCollectionFiles: ['collection.yml']
+      },
+      yaml: {
+        ext: '.yaml',
+        collectionFile: 'opencollection.yaml',
+        folderFile: 'folder.yaml',
+        marker: 'opencollection.yaml',
+        legacyCollectionFiles: []
+      },
+      bru: {
+        ext: '.bru',
+        collectionFile: 'collection.bru',
+        folderFile: 'folder.bru',
+        marker: 'bruno.json',
+        legacyCollectionFiles: []
+      }
+    });
+  });
+
+  it('detects a bru collection by bruno.json, not by the optional collection.bru', () => {
+    expect(COLLECTION_LAYOUTS.bru.marker).toBe('bruno.json');
+    for (const layout of ['yml', 'yaml'] as const) {
+      expect(COLLECTION_LAYOUTS[layout].marker).toBe(COLLECTION_LAYOUTS[layout].collectionFile);
+    }
+  });
+
+  it('covers every layout in the detection order, with .yml winning over .yaml', () => {
+    expect(COLLECTION_LAYOUT_ORDER).toEqual(['yml', 'yaml', 'bru']);
+    expect(COLLECTION_LAYOUT_ORDER.slice().sort()).toEqual(Object.keys(COLLECTION_LAYOUTS).sort());
+  });
+
+  it('derives every basename list and extension list from the layout table', () => {
+    expect(YAML_EXTENSIONS).toEqual(['.yml', '.yaml']);
+    expect(COLLECTION_ROOT_BASENAMES).toEqual(['opencollection.yml', 'opencollection.yaml', 'collection.bru']);
+    expect(FOLDER_ROOT_BASENAMES).toEqual(['folder.yml', 'folder.yaml', 'folder.bru']);
+  });
+
+  it('separates roots Bruno writes from roots it merely reads', () => {
+    // Legacy names must be recognized but never written, so the two lists differ by exactly them.
+    expect(READABLE_COLLECTION_ROOT_BASENAMES).toEqual([
+      'opencollection.yml',
+      'collection.yml',
+      'opencollection.yaml',
+      'collection.bru'
+    ]);
+    expect(COLLECTION_ROOT_BASENAMES).not.toContain('collection.yml');
+  });
+});
+
+describe('getLayoutConfig', () => {
+  it('returns the config for a known layout', () => {
+    expect(getLayoutConfig('yaml').ext).toBe('.yaml');
+  });
+
+  it('falls back to bru by default and to an explicit layout when given', () => {
+    expect(getLayoutConfig(undefined).ext).toBe('.bru');
+    expect(getLayoutConfig(null, 'yml').ext).toBe('.yml');
+    expect(getLayoutConfig('nonsense', 'yml').collectionFile).toBe('opencollection.yml');
+  });
+});
+
+describe('isOpenCollectionLayout', () => {
+  it('accepts both YAML layouts', () => {
+    expect(isOpenCollectionLayout('yml')).toBe(true);
+    expect(isOpenCollectionLayout('yaml')).toBe(true);
+  });
+
+  it('rejects bru and empty values', () => {
+    expect(isOpenCollectionLayout('bru')).toBe(false);
+    expect(isOpenCollectionLayout(null)).toBe(false);
+    expect(isOpenCollectionLayout(undefined)).toBe(false);
+  });
+});
+
+describe('isYamlFilename', () => {
+  it('accepts both extensions, case-insensitively', () => {
+    expect(isYamlFilename('dev.yml')).toBe(true);
+    expect(isYamlFilename('dev.yaml')).toBe(true);
+    expect(isYamlFilename('DEV.YAML')).toBe(true);
+    expect(isYamlFilename('/abs/path/opencollection.yaml')).toBe(true);
+  });
+
+  it('rejects other extensions and near-misses', () => {
+    expect(isYamlFilename('req.bru')).toBe(false);
+    expect(isYamlFilename('notes.yml.bak')).toBe(false);
+    expect(isYamlFilename('yaml')).toBe(false);
+    expect(isYamlFilename('')).toBe(false);
+    expect(isYamlFilename(null)).toBe(false);
+  });
+});
+
+describe('isRequestFilename', () => {
+  it('accepts every layout extension', () => {
+    expect(isRequestFilename('a.bru')).toBe(true);
+    expect(isRequestFilename('a.yml')).toBe(true);
+    expect(isRequestFilename('a.yaml')).toBe(true);
+    expect(isRequestFilename('A.YAML')).toBe(true);
+  });
+
+  it('rejects unrelated files', () => {
+    expect(isRequestFilename('bruno.json')).toBe(false);
+    expect(isRequestFilename('README.md')).toBe(false);
+  });
+});
+
+describe('stripYamlExtension / stripRequestExtension', () => {
+  it('drops only a trailing extension it recognizes', () => {
+    expect(stripYamlExtension('dev.yml')).toBe('dev');
+    expect(stripYamlExtension('dev.yaml')).toBe('dev');
+    expect(stripYamlExtension('DEV.YAML')).toBe('DEV');
+    expect(stripRequestExtension('get-users.bru')).toBe('get-users');
+    expect(stripRequestExtension('get-users.yaml')).toBe('get-users');
+  });
+
+  it('leaves an unrecognized extension alone rather than truncating it', () => {
+    // A generic "strip any extension" would mangle these.
+    expect(stripYamlExtension('api.v1.json')).toBe('api.v1.json');
+    expect(stripYamlExtension('my.request.bru')).toBe('my.request.bru');
+    expect(stripRequestExtension('notes.md')).toBe('notes.md');
+    expect(stripRequestExtension('no-extension')).toBe('no-extension');
+  });
+
+  it('keeps inner dots when stripping', () => {
+    expect(stripRequestExtension('my.request.v2.yaml')).toBe('my.request.v2');
+  });
+});
+
+describe('getLayoutForFilename', () => {
+  it('maps each extension to its layout', () => {
+    expect(getLayoutForFilename('a.bru')).toBe('bru');
+    expect(getLayoutForFilename('a.yml')).toBe('yml');
+    expect(getLayoutForFilename('a.yaml')).toBe('yaml');
+    expect(getLayoutForFilename('A.YAML')).toBe('yaml');
+  });
+
+  it('returns null for anything else', () => {
+    expect(getLayoutForFilename('bruno.json')).toBe(null);
+    expect(getLayoutForFilename('')).toBe(null);
+    expect(getLayoutForFilename(undefined)).toBe(null);
+  });
+});
+
+describe('basename predicates', () => {
+  it('accepts every collection root plus the legacy name', () => {
+    expect(isCollectionRootBasename('opencollection.yml')).toBe(true);
+    expect(isCollectionRootBasename('opencollection.yaml')).toBe(true);
+    expect(isCollectionRootBasename('collection.bru')).toBe(true);
+    expect(isCollectionRootBasename('collection.yml')).toBe(true);
+  });
+
+  it('rejects a request file and the bru config as a collection root', () => {
+    expect(isCollectionRootBasename('get-users.yaml')).toBe(false);
+    expect(isCollectionRootBasename('bruno.json')).toBe(false);
+  });
+
+  it('identifies folder roots', () => {
+    expect(isFolderRootBasename('folder.yml')).toBe(true);
+    expect(isFolderRootBasename('folder.yaml')).toBe(true);
+    expect(isFolderRootBasename('folder.bru')).toBe(true);
+    expect(isFolderRootBasename('folders.yml')).toBe(false);
+  });
+
+  it('identifies the collection marker, which for bru is bruno.json not collection.bru', () => {
+    expect(isCollectionMarkerBasename('bruno.json')).toBe(true);
+    expect(isCollectionMarkerBasename('opencollection.yaml')).toBe(true);
+    // `collection.bru` is a root file but not the marker — a stray one is not a collection.
+    expect(isCollectionMarkerBasename('collection.bru')).toBe(false);
+  });
+
+  it('matches case-insensitively, since Windows and macOS filesystems are', () => {
+    // `OpenCollection.YML` is the same file as `opencollection.yml` on those platforms; comparing
+    // exact-case would let it fall through and be classified as an ordinary request.
+    expect(isCollectionRootBasename('OpenCollection.YML')).toBe(true);
+    expect(isFolderRootBasename('Folder.Yml')).toBe(true);
+    expect(isCollectionMarkerBasename('Bruno.JSON')).toBe(true);
+  });
+});

--- a/packages/bruno-common/src/collection-format/index.ts
+++ b/packages/bruno-common/src/collection-format/index.ts
@@ -21,7 +21,12 @@ export interface CollectionLayoutConfig {
    * is `bruno.json`, not `collectionFile` — `collection.bru` is optional.
    */
   marker: string;
-  /** Root basenames this layout still reads but no longer writes. */
+  /**
+   * Root basenames this layout recognizes but neither writes nor detects by. These exist so a
+   * legacy root is not mistaken for an ordinary request when classifying files; opening a
+   * collection still requires {@link CollectionLayoutConfig.marker}, because a layout key alone
+   * cannot say which of several root filenames a given collection actually uses.
+   */
   legacyCollectionFiles: string[];
 }
 

--- a/packages/bruno-common/src/collection-format/index.ts
+++ b/packages/bruno-common/src/collection-format/index.ts
@@ -1,0 +1,159 @@
+/**
+ * How a collection's files are named on disk.
+ *
+ * A layout key is not the same thing as a *serialization format*. `.yml` and `.yaml` hold
+ * identical OpenCollection YAML, so `@usebruno/filestore` accepts either spelling and both are
+ * handled by its `yml` serializer — a layout key can be passed straight to any filestore
+ * `parse*`/`stringify*` call. What a layout key does determine is every filename Bruno writes,
+ * so read {@link COLLECTION_LAYOUTS} rather than interpolating the key into a filename.
+ */
+export type CollectionLayout = 'bru' | 'yml' | 'yaml';
+
+export interface CollectionLayoutConfig {
+  /** Extension of request and environment files, including the leading dot. */
+  ext: string;
+  /** Basename of the collection root file. */
+  collectionFile: string;
+  /** Basename of a folder root file. */
+  folderFile: string;
+  /**
+   * Basename whose presence identifies a directory as a collection of this layout. For `bru` this
+   * is `bruno.json`, not `collectionFile` — `collection.bru` is optional.
+   */
+  marker: string;
+  /** Root basenames this layout still reads but no longer writes. */
+  legacyCollectionFiles: string[];
+}
+
+export const COLLECTION_LAYOUTS: Record<CollectionLayout, CollectionLayoutConfig> = {
+  yml: {
+    ext: '.yml',
+    collectionFile: 'opencollection.yml',
+    folderFile: 'folder.yml',
+    marker: 'opencollection.yml',
+    // Predates `opencollection.yml`.
+    legacyCollectionFiles: ['collection.yml']
+  },
+  yaml: {
+    ext: '.yaml',
+    collectionFile: 'opencollection.yaml',
+    folderFile: 'folder.yaml',
+    marker: 'opencollection.yaml',
+    legacyCollectionFiles: []
+  },
+  bru: {
+    ext: '.bru',
+    collectionFile: 'collection.bru',
+    folderFile: 'folder.bru',
+    marker: 'bruno.json',
+    legacyCollectionFiles: []
+  }
+};
+
+/**
+ * Detection precedence. `yml` comes before `yaml` because `.yml` is what Bruno writes, so it wins
+ * if a directory somehow contains both roots. `bru` is last because a collection migrated to
+ * OpenCollection may still have a stale `bruno.json` beside its new root.
+ */
+export const COLLECTION_LAYOUT_ORDER: CollectionLayout[] = ['yml', 'yaml', 'bru'];
+
+/** The OpenCollection layouts — every layout whose files are YAML. */
+const OPEN_COLLECTION_LAYOUTS: CollectionLayout[] = ['yml', 'yaml'];
+
+/** Both extensions that carry OpenCollection YAML, in detection-precedence order. */
+export const YAML_EXTENSIONS = OPEN_COLLECTION_LAYOUTS.map((layout) => COLLECTION_LAYOUTS[layout].ext);
+
+/** Every extension a request file can use, in detection-precedence order. */
+const REQUEST_EXTENSIONS = COLLECTION_LAYOUT_ORDER.map((layout) => COLLECTION_LAYOUTS[layout].ext);
+
+/** Basenames Bruno writes as a collection root, across all layouts. */
+export const COLLECTION_ROOT_BASENAMES = COLLECTION_LAYOUT_ORDER.map(
+  (layout) => COLLECTION_LAYOUTS[layout].collectionFile
+);
+
+/**
+ * Every basename that may be a collection root on disk, including names Bruno no longer writes.
+ * Prefer {@link isCollectionRootBasename}, which matches this list case-insensitively.
+ */
+export const READABLE_COLLECTION_ROOT_BASENAMES = COLLECTION_LAYOUT_ORDER.flatMap((layout) => [
+  COLLECTION_LAYOUTS[layout].collectionFile,
+  ...COLLECTION_LAYOUTS[layout].legacyCollectionFiles
+]);
+
+/**
+ * The basenames whose presence identifies a directory as a collection, in detection-precedence
+ * order. Scanning for collections must use this rather than the root-file lists — a `bru`
+ * collection is identified by `bruno.json`, and a stray `collection.bru` is not a collection.
+ */
+export const COLLECTION_MARKER_BASENAMES = COLLECTION_LAYOUT_ORDER.map(
+  (layout) => COLLECTION_LAYOUTS[layout].marker
+);
+
+/** Basenames that mark a directory as a folder root, across all layouts. */
+export const FOLDER_ROOT_BASENAMES = COLLECTION_LAYOUT_ORDER.map(
+  (layout) => COLLECTION_LAYOUTS[layout].folderFile
+);
+
+const lowercaseExtension = (filename: string): string => {
+  const lastDot = filename.lastIndexOf('.');
+  return lastDot === -1 ? '' : filename.slice(lastDot).toLowerCase();
+};
+
+// Windows and macOS filesystems are case-insensitive, so `OpenCollection.YML` and `Folder.Yml`
+// are the same files as their lowercase spellings and must classify identically. Compare every
+// basename case-insensitively for the same reason extensions are folded above.
+const includesBasename = (basenames: string[], basename: string): boolean => {
+  const needle = basename.toLowerCase();
+  return basenames.some((candidate) => candidate.toLowerCase() === needle);
+};
+
+const stripExtensionIf = (filename: string, matches: (name: string) => boolean): string =>
+  matches(filename) ? filename.slice(0, filename.lastIndexOf('.')) : filename;
+
+/**
+ * The layout config for a layout key. Falls back when the key is missing or unrecognized, which
+ * happens in the renderer for a collection whose format has not loaded yet — pass the fallback
+ * that suits the caller rather than letting each site invent one.
+ */
+export const getLayoutConfig = (
+  layout: string | null | undefined,
+  fallback: CollectionLayout = 'bru'
+): CollectionLayoutConfig => COLLECTION_LAYOUTS[layout as CollectionLayout] || COLLECTION_LAYOUTS[fallback];
+
+/** True for both OpenCollection layouts — use instead of comparing a layout to `'yml'`. */
+export const isOpenCollectionLayout = (layout: string | null | undefined): boolean =>
+  OPEN_COLLECTION_LAYOUTS.includes(layout as CollectionLayout);
+
+/** True when the filename carries either OpenCollection YAML extension. */
+export const isYamlFilename = (filename: string | null | undefined): boolean =>
+  typeof filename === 'string' && YAML_EXTENSIONS.includes(lowercaseExtension(filename));
+
+/** True when the filename carries any layout's request extension. */
+export const isRequestFilename = (filename: string | null | undefined): boolean =>
+  typeof filename === 'string' && REQUEST_EXTENSIONS.includes(lowercaseExtension(filename));
+
+/** Drop a trailing `.yml`/`.yaml`, leaving any other filename untouched. */
+export const stripYamlExtension = (filename: string): string => stripExtensionIf(filename, isYamlFilename);
+
+/** Drop a trailing request extension (`.bru`/`.yml`/`.yaml`), leaving any other filename untouched. */
+export const stripRequestExtension = (filename: string): string =>
+  stripExtensionIf(filename, isRequestFilename);
+
+/** The layout a file belongs to, based on its extension, or null if it isn't a Bruno file. */
+export const getLayoutForFilename = (filename: string | null | undefined): CollectionLayout | null => {
+  if (typeof filename !== 'string') return null;
+  const ext = lowercaseExtension(filename);
+  return COLLECTION_LAYOUT_ORDER.find((layout) => COLLECTION_LAYOUTS[layout].ext === ext) || null;
+};
+
+/** True when `basename` is a collection root Bruno can read, including legacy names. */
+export const isCollectionRootBasename = (basename: string): boolean =>
+  includesBasename(READABLE_COLLECTION_ROOT_BASENAMES, basename);
+
+/** True when `basename` is any layout's folder root. */
+export const isFolderRootBasename = (basename: string): boolean =>
+  includesBasename(FOLDER_ROOT_BASENAMES, basename);
+
+/** True when `basename` is the marker that identifies a collection directory. */
+export const isCollectionMarkerBasename = (basename: string): boolean =>
+  includesBasename(COLLECTION_MARKER_BASENAMES, basename);

--- a/packages/bruno-common/src/index.ts
+++ b/packages/bruno-common/src/index.ts
@@ -18,3 +18,4 @@ export type {
 
 export * as utils from './utils';
 export * from './constants';
+export * from './collection-format';

--- a/packages/bruno-converters/src/common/index.js
+++ b/packages/bruno-converters/src/common/index.js
@@ -3,6 +3,7 @@ import get from 'lodash/get';
 import { customAlphabet } from 'nanoid';
 import cloneDeep from 'lodash/cloneDeep';
 import { collectionSchema } from '@usebruno/schema';
+import { isOpenCollectionLayout } from '@usebruno/common';
 
 export const safeParseJSON = (str) => {
   if (!str || !str.length || typeof str !== 'string') {
@@ -49,7 +50,7 @@ export const uuid = () => {
  *
  * @param {string} tag - The tag to sanitize
  * @param {Object} options - Sanitization options
- * @param {string} options.collectionFormat - The collection format ('yml' for OpenCollection YAML)
+ * @param {string} options.collectionFormat - The collection layout ('yml' or 'yaml' for OpenCollection YAML)
  * @returns {string|null} - The sanitized tag, or null if the result is empty
  */
 export const sanitizeTag = (tag, options = {}) => {
@@ -62,9 +63,9 @@ export const sanitizeTag = (tag, options = {}) => {
 
   let trimmed = usableTagString.trim();
 
-  // OpenCollection (yml) schema imposes no character restriction on tags.
+  // OpenCollection (yml/yaml) schema imposes no character restriction on tags.
   // Preserve the source value verbatim so folder names round-trip (BRU-3175).
-  if (options.collectionFormat === 'yml') {
+  if (isOpenCollectionLayout(options.collectionFormat)) {
     return trimmed || null;
   }
 

--- a/packages/bruno-converters/tests/common/sanitizeTag.spec.js
+++ b/packages/bruno-converters/tests/common/sanitizeTag.spec.js
@@ -149,6 +149,14 @@ describe('sanitizeTag', () => {
         expect(sanitizeTag('   ', { collectionFormat: 'yml' })).toBeNull();
       });
 
+      it('treats the yaml layout identically to yml', () => {
+        // A `.yaml` collection is the same OpenCollection schema; applying BRU's tag
+        // restrictions there would mangle tag names on import.
+        expect(sanitizeTag('Pets & Dogs', { collectionFormat: 'yaml' })).toBe('Pets & Dogs');
+        expect(sanitizeTag('API (v1)', { collectionFormat: 'yaml' })).toBe('API (v1)');
+        expect(sanitizeTag('   ', { collectionFormat: 'yaml' })).toBeNull();
+      });
+
       it('reads .name from tag-object input', () => {
         expect(sanitizeTag({ name: 'R&D' }, { collectionFormat: 'yml' })).toBe('R&D');
       });

--- a/packages/bruno-electron/src/app/apiSpecs.js
+++ b/packages/bruno-electron/src/app/apiSpecs.js
@@ -7,7 +7,8 @@ const { parseApiSpecContent } = require('../utils/apiSpecs');
 const {
   addApiSpecToWorkspace,
   readWorkspaceConfig,
-  getWorkspaceUid
+  getWorkspaceUid,
+  resolveWorkspaceFilePath
 } = require('../utils/workspace-config');
 
 const DEFAULT_WORKSPACE_NAME = 'My Workspace';
@@ -58,9 +59,7 @@ const openApiSpec = async (win, watcher, apiSpecPath, options = {}) => {
     const uid = generateUidBasedOnHash(apiSpecPath);
 
     if (options.workspacePath) {
-      const workspaceFilePath = path.join(options.workspacePath, 'workspace.yml');
-
-      if (fs.existsSync(workspaceFilePath)) {
+      if (resolveWorkspaceFilePath(options.workspacePath)) {
         const workspaceConfig = readWorkspaceConfig(options.workspacePath);
         const specs = workspaceConfig.specs;
 

--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -4,6 +4,7 @@ const path = require('path');
 const chokidar = require('chokidar');
 const {
   hasRequestExtension,
+  isCollectionRootFile,
   isWSLPath,
   normalizeAndResolvePath,
   sizeInMB,
@@ -19,6 +20,11 @@ const {
 
 const { uuid } = require('../utils/common');
 const { parseValueByDataType } = require('@usebruno/common/utils');
+const {
+  COLLECTION_LAYOUTS,
+  isCollectionRootBasename,
+  isOpenCollectionLayout
+} = require('@usebruno/common');
 const { getRequestUid } = require('../cache/requestUids');
 const { decryptStringSafe } = require('../utils/encryption');
 const { setBrunoConfig, getBrunoConfig } = require('../store/bruno-config');
@@ -68,29 +74,18 @@ const isEnvironmentsFolder = (pathname, collectionPath) => {
   return path.normalize(dirname) === path.normalize(envDirectory);
 };
 
-const isFolderRootFile = (pathname, collectionPath) => {
-  const basename = path.basename(pathname);
-  const format = getCollectionFormat(collectionPath);
+const isFolderRootFile = (pathname, layout) =>
+  path.basename(pathname).toLowerCase() === COLLECTION_LAYOUTS[layout].folderFile;
 
-  if (format === 'yml') {
-    return basename === 'folder.yml';
-  } else if (format === 'bru') {
-    return basename === 'folder.bru';
+// A watcher event can arrive while the collection's marker file is momentarily missing (e.g. a
+// migration rewriting the root). Log and skip that event rather than rejecting.
+const resolveCollectionFormat = (collectionPath) => {
+  try {
+    return getCollectionFormat(collectionPath);
+  } catch (error) {
+    console.error(`Error getting collection format for: ${collectionPath}`, error);
+    return null;
   }
-
-  return false;
-};
-
-const isCollectionRootFile = (pathname, collectionPath) => {
-  const dirname = path.dirname(pathname);
-  const basename = path.basename(pathname);
-
-  // return if we are not at the root of the collection
-  if (path.normalize(dirname) !== path.normalize(collectionPath)) {
-    return false;
-  }
-
-  return basename === 'collection.bru' || basename === 'opencollection.yml';
 };
 
 const envHasSecrets = (environment = {}) => {
@@ -248,8 +243,12 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
     return addEnvironmentFile(win, pathname, collectionUid, collectionPath);
   }
 
+  // Detecting the layout probes the filesystem, so resolve it once for the whole event. It can
+  // throw when the marker is momentarily absent (mid-migration), which is not this event's problem.
+  const format = resolveCollectionFormat(collectionPath);
+  if (!format) return;
+
   if (isCollectionRootFile(pathname, collectionPath)) {
-    const format = getCollectionFormat(collectionPath);
     const file = {
       meta: {
         collectionUid,
@@ -264,7 +263,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
       const parsed = await parseCollection(content, { format });
 
       let collectionRoot, brunoConfig;
-      if (format === 'yml') {
+      if (isOpenCollectionLayout(format)) {
         collectionRoot = parsed.collectionRoot;
         brunoConfig = parsed.brunoConfig;
       } else {
@@ -279,8 +278,8 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
       hydrateCollectionRootWithUuid(file.data);
       win.webContents.send('main:collection-tree-updated', 'addFile', file);
 
-      // in yml format, opencollection.yml also contains the bruno config
-      if (format === 'yml') {
+      // in an OpenCollection layout, the collection root file also contains the bruno config
+      if (isOpenCollectionLayout(format)) {
         // Transform the config to add exists metadata for protobuf files and import paths
         brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
@@ -300,7 +299,7 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
     return;
   }
 
-  if (isFolderRootFile(pathname, collectionPath)) {
+  if (isFolderRootFile(pathname, format)) {
     const file = {
       meta: {
         collectionUid,
@@ -311,7 +310,6 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
     };
 
     try {
-      const format = getCollectionFormat(collectionPath);
       const content = fs.readFileSync(pathname, 'utf8');
       file.data = await parseFolder(content, { format });
       stageToCache(collectionPath, pathname, file.data);
@@ -325,7 +323,6 @@ const add = async (win, pathname, collectionUid, collectionPath, useWorkerThread
     }
   }
 
-  const format = getCollectionFormat(collectionPath);
   if (hasRequestExtension(pathname, format)) {
     watcher.addFileToProcessing(collectionUid, pathname);
 
@@ -494,6 +491,11 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
     return changeEnvironmentFile(win, pathname, collectionUid, collectionPath);
   }
 
+  // Detecting the layout probes the filesystem, so resolve it once for the whole event. It can
+  // throw when the marker is momentarily absent (mid-migration), which is not this event's problem.
+  const format = resolveCollectionFormat(collectionPath);
+  if (!format) return;
+
   if (isCollectionRootFile(pathname, collectionPath)) {
     const file = {
       meta: {
@@ -506,11 +508,10 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
 
     try {
       const content = fs.readFileSync(pathname, 'utf8');
-      const format = getCollectionFormat(collectionPath);
       const parsed = await parseCollection(content, { format });
 
       let collectionRoot, brunoConfig;
-      if (format === 'yml') {
+      if (isOpenCollectionLayout(format)) {
         collectionRoot = parsed.collectionRoot;
         brunoConfig = parsed.brunoConfig;
       } else {
@@ -525,8 +526,8 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
       hydrateCollectionRootWithUuid(file.data);
       win.webContents.send('main:collection-tree-updated', 'change', file);
 
-      // in yml format, opencollection.yml also contains the bruno config
-      if (format === 'yml') {
+      // in an OpenCollection layout, the collection root file also contains the bruno config
+      if (isOpenCollectionLayout(format)) {
         // Transform the config to add exists metadata for protobuf files and import paths
         brunoConfig = await transformBrunoConfigAfterRead(brunoConfig, collectionPath);
 
@@ -546,7 +547,7 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
     return;
   }
 
-  if (isFolderRootFile(pathname, collectionPath)) {
+  if (isFolderRootFile(pathname, format)) {
     const file = {
       meta: {
         collectionUid,
@@ -557,7 +558,6 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
     };
 
     try {
-      const format = getCollectionFormat(collectionPath);
       const content = fs.readFileSync(pathname, 'utf8');
       file.data = await parseFolder(content, { format });
       stageToCache(collectionPath, pathname, file.data);
@@ -571,7 +571,6 @@ const change = async (win, pathname, collectionUid, collectionPath) => {
     }
   }
 
-  const format = getCollectionFormat(collectionPath);
   if (hasRequestExtension(pathname, format)) {
     const file = {
       meta: {
@@ -630,18 +629,14 @@ const unlink = (win, pathname, collectionUid, collectionPath) => {
       return unlinkEnvironmentFile(win, pathname, collectionUid);
     }
 
-    let format;
-    try {
-      format = getCollectionFormat(collectionPath);
-    } catch (error) {
-      console.error(`Error getting collection format for: ${collectionPath}`, error);
-      return;
-    }
+    const format = resolveCollectionFormat(collectionPath);
+    if (!format) return;
     if (hasRequestExtension(pathname, format)) {
       const basename = path.basename(pathname);
       const dirname = path.dirname(pathname);
 
-      if (basename === 'opencollection.yml' && path.normalize(dirname) === path.normalize(collectionPath)) {
+      // The collection root shares the request extension; it is not a request.
+      if (isCollectionRootBasename(basename) && path.normalize(dirname) === path.normalize(collectionPath)) {
         return;
       }
 
@@ -670,14 +665,9 @@ const unlinkDir = async (win, pathname, collectionUid, collectionPath) => {
       return;
     }
 
-    let format;
-    try {
-      format = getCollectionFormat(collectionPath);
-    } catch (error) {
-      console.error(`Error getting collection format for: ${collectionPath}`, error);
-      return;
-    }
-    const folderFilePath = path.join(pathname, `folder.${format}`);
+    const format = resolveCollectionFormat(collectionPath);
+    if (!format) return;
+    const folderFilePath = path.join(pathname, COLLECTION_LAYOUTS[format].folderFile);
 
     let name = path.basename(pathname);
 

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -2,10 +2,11 @@ const fs = require('fs');
 const path = require('path');
 const { ipcMain } = require('electron');
 const Yup = require('yup');
-const { isDirectory, getCollectionStats, normalizeAndResolvePath } = require('../utils/filesystem');
+const { isDirectory, getCollectionStats, normalizeAndResolvePath, resolveYamlPath } = require('../utils/filesystem');
 const { generateUidBasedOnHash } = require('../utils/common');
 const { transformBrunoConfigAfterRead } = require('../utils/transformBrunoConfig');
 const { parseCollection } = require('@usebruno/filestore');
+const { getLayoutForFilename } = require('@usebruno/common');
 
 // Track scratch collection paths (temp directories for workspace scratch requests)
 const scratchCollectionPaths = new Set();
@@ -59,25 +60,23 @@ const validateSchema = async (config) => {
 };
 
 const getCollectionConfigFile = async (pathname) => {
-  // Check for opencollection.yml first
-  const ocYmlPath = path.join(pathname, 'opencollection.yml');
-  if (fs.existsSync(ocYmlPath)) {
+  // An OpenCollection root holds the bruno config, so it takes precedence over bruno.json.
+  const rootPath = resolveYamlPath(pathname, 'opencollection');
+  if (rootPath) {
     try {
-      const content = fs.readFileSync(ocYmlPath, 'utf8');
-      const {
-        brunoConfig
-      } = parseCollection(content, { format: 'yml' });
+      const content = fs.readFileSync(rootPath, 'utf8');
+      const { brunoConfig } = parseCollection(content, { format: getLayoutForFilename(rootPath) });
       await validateSchema(brunoConfig);
       return brunoConfig;
     } catch (err) {
-      throw new Error(`Unable to parse opencollection.yml: ${err.message}`);
+      throw new Error(`Unable to parse ${path.basename(rootPath)}: ${err.message}`);
     }
   }
 
   // Fall back to bruno.json
   const configFilePath = path.join(pathname, 'bruno.json');
   if (!fs.existsSync(configFilePath)) {
-    throw new Error(`The collection is not valid (neither bruno.json nor opencollection.yml found)`);
+    throw new Error(`The collection is not valid (neither bruno.json nor an opencollection file found)`);
   }
 
   const config = await readConfigFile(configFilePath);

--- a/packages/bruno-electron/src/app/mock-server/mock-server-store.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server-store.js
@@ -2,9 +2,13 @@ const path = require('path');
 const fs = require('fs');
 const { parseMockServer, stringifyMockServer } = require('@usebruno/filestore');
 const { getMockResponseRouteKey } = require('@usebruno/common').utils;
+const { isYamlFilename } = require('@usebruno/common');
 const { generateUidBasedOnHash } = require('../../utils/common');
 const { sanitizeName, validateName } = require('../../utils/filesystem');
 
+// Mock server files the app creates use `.yml`; an existing `.yaml` file is read and rewritten
+// in place (the pathname is carried through, so writes never change the extension).
+const MOCK_SERVER_FILE_EXTENSION = '.yml';
 const DEFAULT_MOCK_SERVER_PORT = 4000;
 const DEFAULT_MOCK_SERVER_NAME = 'Mock Server';
 
@@ -77,7 +81,7 @@ const listMockServerFilePaths = (workspacePath) => {
   }
 
   return fs.readdirSync(mocksDir)
-    .filter((filename) => filename.toLowerCase().endsWith('.yml'))
+    .filter((filename) => isYamlFilename(filename))
     .map((filename) => path.join(mocksDir, filename));
 };
 
@@ -226,11 +230,11 @@ const createMockServerFilePathname = (workspacePath, name) => {
   const base = sanitized && validateName(sanitized) ? sanitized : 'mock-server';
   const mocksDir = getMocksDirPath(workspacePath);
 
-  let filename = `${base}.yml`;
+  let filename = `${base}${MOCK_SERVER_FILE_EXTENSION}`;
   let counter = 1;
   while (fs.existsSync(path.join(mocksDir, filename))) {
     counter += 1;
-    filename = `${base} ${counter}.yml`;
+    filename = `${base} ${counter}${MOCK_SERVER_FILE_EXTENSION}`;
   }
 
   return path.join(mocksDir, filename);

--- a/packages/bruno-electron/src/app/workspace-watcher.js
+++ b/packages/bruno-electron/src/app/workspace-watcher.js
@@ -4,9 +4,14 @@ const path = require('path');
 const chokidar = require('chokidar');
 const yaml = require('js-yaml');
 const { generateUidBasedOnHash, uuid } = require('../utils/common');
-const { getWorkspaceUid, normalizeWorkspaceConfig } = require('../utils/workspace-config');
+const { getWorkspaceUid, normalizeWorkspaceConfig, resolveWorkspaceFilePath } = require('../utils/workspace-config');
 const { parseEnvironment } = require('@usebruno/filestore');
 const { parseValueByDataType } = require('@usebruno/common/utils');
+const { YAML_EXTENSIONS, stripYamlExtension } = require('@usebruno/common');
+
+// Watch both YAML spellings: the file may not exist yet at watch time, and a workspace can
+// legitimately use either extension.
+const yamlGlobs = (dir, basename = '*') => YAML_EXTENSIONS.map((ext) => path.join(dir, `${basename}${ext}`));
 const EnvironmentSecretsStore = require('../store/env-secrets');
 const { decryptStringSafe } = require('../utils/encryption');
 const dotEnvWatcher = require('./dotenv-watcher');
@@ -29,9 +34,9 @@ const envHasSecrets = (environment) => {
 
 const handleWorkspaceFileChange = (win, workspacePath) => {
   try {
-    const workspaceFilePath = path.join(workspacePath, 'workspace.yml');
+    const workspaceFilePath = resolveWorkspaceFilePath(workspacePath);
 
-    if (!fs.existsSync(workspaceFilePath)) {
+    if (!workspaceFilePath) {
       return;
     }
 
@@ -59,7 +64,7 @@ const handleWorkspaceFileChange = (win, workspacePath) => {
 
 const parseGlobalEnvironmentFile = async (pathname, workspacePath, workspaceUid) => {
   const basename = path.basename(pathname);
-  const environmentName = basename.slice(0, -'.yml'.length);
+  const environmentName = stripYamlExtension(basename);
 
   const file = {
     meta: {
@@ -185,7 +190,7 @@ class WorkspaceWatcher {
       return;
     }
 
-    const mockServerWatcher = chokidar.watch(path.join(mocksDir, '*.yml'), {
+    const mockServerWatcher = chokidar.watch(yamlGlobs(mocksDir), {
       ignoreInitial: true,
       persistent: true,
       ignorePermissionErrors: true,
@@ -211,7 +216,7 @@ class WorkspaceWatcher {
   }
 
   addWatcher(win, workspacePath) {
-    const workspaceFilePath = path.join(workspacePath, 'workspace.yml');
+    const workspaceFilePaths = yamlGlobs(workspacePath, 'workspace');
     const environmentsDir = path.join(workspacePath, 'environments');
     const workspaceUid = getWorkspaceUid(workspacePath);
 
@@ -229,7 +234,7 @@ class WorkspaceWatcher {
         return;
       }
 
-      const watcher = chokidar.watch(workspaceFilePath, {
+      const watcher = chokidar.watch(workspaceFilePaths, {
         ignoreInitial: true,
         persistent: true,
         ignorePermissionErrors: true,
@@ -247,7 +252,7 @@ class WorkspaceWatcher {
       self._addMockServerWatcher(win, workspacePath, workspaceUid);
 
       if (fs.existsSync(environmentsDir)) {
-        const envWatcher = chokidar.watch(path.join(environmentsDir, `*.yml`), {
+        const envWatcher = chokidar.watch(yamlGlobs(environmentsDir), {
           ignoreInitial: true,
           persistent: true,
           ignorePermissionErrors: true,

--- a/packages/bruno-electron/src/ipc/apiSpec.js
+++ b/packages/bruno-electron/src/ipc/apiSpec.js
@@ -2,7 +2,7 @@ const { ipcMain } = require('electron');
 const { openApiSpecDialog, openApiSpec, validateApiSpec } = require('../app/apiSpecs');
 const { writeFile, isDirectory } = require('../utils/filesystem');
 const { removeApiSpecUid } = require('../cache/apiSpecUids');
-const { removeApiSpecFromWorkspace } = require('../utils/workspace-config');
+const { removeApiSpecFromWorkspace, resolveWorkspaceFilePath } = require('../utils/workspace-config');
 const { getCertsAndProxyConfig } = require('./network/cert-utils');
 const { makeAxiosInstance } = require('./network/axios-instance');
 const { proxySwaggerFetch } = require('./swagger-fetch');
@@ -59,9 +59,7 @@ const registerRendererEventHandlers = (mainWindow, watcher, lastOpenedApiSpecs) 
         removeApiSpecUid(pathname);
 
         if (workspacePath) {
-          const workspaceFilePath = path.join(workspacePath, 'workspace.yml');
-
-          if (fs.existsSync(workspaceFilePath)) {
+          if (resolveWorkspaceFilePath(workspacePath)) {
             await removeApiSpecFromWorkspace(workspacePath, pathname);
           }
         }

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -21,7 +21,16 @@ const {
   DEFAULT_COLLECTION_FORMAT
 } = require('@usebruno/filestore');
 const { dotenvToJson } = require('@usebruno/lang');
-const { utils } = require('@usebruno/common');
+const {
+  utils,
+  COLLECTION_LAYOUTS,
+  COLLECTION_MARKER_BASENAMES,
+  FOLDER_ROOT_BASENAMES,
+  READABLE_COLLECTION_ROOT_BASENAMES,
+  getLayoutForFilename,
+  isOpenCollectionLayout,
+  stripRequestExtension
+} = require('@usebruno/common');
 const brunoConverters = require('@usebruno/converters');
 const { postmanToBruno } = brunoConverters;
 const { cookiesStore } = require('../store/cookies');
@@ -55,8 +64,9 @@ const {
   isDotEnvFile,
   isValidDotEnvFilename,
   isBrunoConfigFile,
-  isBruEnvironmentConfig,
-  isCollectionRootBruFile,
+  isEnvironmentConfigFile,
+  isCollectionRootFile,
+  detectCollectionLayout,
   scanForBrunoFiles,
   withFileLock
 } = require('../utils/filesystem');
@@ -221,7 +231,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           ignore: ['node_modules', '.git']
         };
 
-        if (format === 'yml') {
+        if (isOpenCollectionLayout(format)) {
           const collectionRoot = {
             meta: {
               name: collectionName
@@ -233,8 +243,10 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
             type: 'collection',
             ignore: ['node_modules', '.git']
           };
-          const content = stringifyCollection(collectionRoot, brunoConfig, { format });
-          await writeFile(path.join(dirPath, 'opencollection.yml'), content);
+          const content = stringifyCollection(collectionRoot, brunoConfig, {
+            format
+          });
+          await writeFile(path.join(dirPath, COLLECTION_LAYOUTS[format].collectionFile), content);
         } else if (format === 'bru') {
           const content = await stringifyJson(brunoConfig);
           await writeFile(path.join(dirPath, 'bruno.json'), content);
@@ -278,8 +290,9 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       const format = getCollectionFormat(previousPath);
       let brunoConfig;
 
-      if (format === 'yml') {
-        const configFilePath = path.join(previousPath, 'opencollection.yml');
+      if (isOpenCollectionLayout(format)) {
+        const { collectionFile } = COLLECTION_LAYOUTS[format];
+        const configFilePath = path.join(previousPath, collectionFile);
         const content = fs.readFileSync(configFilePath, 'utf8');
         const {
           brunoConfig: parsedBrunoConfig,
@@ -290,7 +303,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         brunoConfig.name = collectionName;
 
         const newContent = stringifyCollection(collectionRoot, brunoConfig, { format });
-        await writeFile(path.join(dirPath, 'opencollection.yml'), newContent);
+        await writeFile(path.join(dirPath, collectionFile), newContent);
       } else if (format === 'bru') {
         const configFilePath = path.join(previousPath, 'bruno.json');
         const content = fs.readFileSync(configFilePath, 'utf8');
@@ -309,8 +322,14 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         const relativePath = path.relative(previousPath, sourceFilePath);
         const newFilePath = path.join(dirPath, relativePath);
 
-        // skip if the file is opencollection.yml or bruno.json at the root of the collection
-        const isRootConfigFile = (path.basename(sourceFilePath) === 'opencollection.yml' || path.basename(sourceFilePath) === 'bruno.json')
+        // Skip only the config file the branch above already wrote for the clone. A `bru`
+        // collection's `collection.bru` is NOT config — it carries collection-level auth,
+        // headers, vars, scripts and docs, so it must be copied like any other file.
+        const sourceBasename = path.basename(sourceFilePath);
+        const alreadyWrittenConfig = isOpenCollectionLayout(format)
+          ? COLLECTION_LAYOUTS[format].collectionFile
+          : 'bruno.json';
+        const isRootConfigFile = sourceBasename === alreadyWrittenConfig
           && path.dirname(sourceFilePath) === previousPath;
 
         if (isRootConfigFile) {
@@ -460,18 +479,19 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
     try {
       const format = getCollectionFormat(collectionPathname);
 
-      if (format === 'yml') {
-        const configFilePath = path.join(collectionPathname, 'opencollection.yml');
+      if (isOpenCollectionLayout(format)) {
+        const { collectionFile } = COLLECTION_LAYOUTS[format];
+        const configFilePath = path.join(collectionPathname, collectionFile);
         const content = fs.readFileSync(configFilePath, 'utf8');
         const {
           brunoConfig,
           collectionRoot
-        } = parseCollection(content, { format: 'yml' });
+        } = parseCollection(content, { format });
 
         brunoConfig.name = newName;
 
-        const newContent = stringifyCollection(collectionRoot, brunoConfig, { format: 'yml' });
-        await writeFile(path.join(collectionPathname, 'opencollection.yml'), newContent);
+        const newContent = stringifyCollection(collectionRoot, brunoConfig, { format });
+        await writeFile(path.join(collectionPathname, collectionFile), newContent);
       } else if (format === 'bru') {
         const configFilePath = path.join(collectionPathname, 'bruno.json');
         const content = fs.readFileSync(configFilePath, 'utf8');
@@ -499,7 +519,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       validatePathIsInsideCollection(folderPathname);
 
       const format = getCollectionFormat(collectionPathname);
-      const folderFilePath = path.join(folderPathname, `folder.${format}`);
+      const { folderFile } = COLLECTION_LAYOUTS[format];
+      const folderFilePath = path.join(folderPathname, folderFile);
 
       if (!folderRoot.meta) {
         folderRoot.meta = {
@@ -520,7 +541,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       validatePathIsInsideCollection(collectionPathname);
 
       const format = getCollectionFormat(collectionPathname);
-      const filename = format === 'yml' ? 'opencollection.yml' : 'collection.bru';
+      const { collectionFile: filename } = COLLECTION_LAYOUTS[format];
       const content = await stringifyCollection(collectionRoot, brunoConfig, { format });
 
       const filePath = path.join(collectionPathname, filename);
@@ -598,28 +619,34 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       const targetFormat = getCollectionFormat(collectionPath);
 
       const filename = targetFilename || path.basename(sourcePathname);
-      const filenameWithoutExt = filename.replace(/\.(bru|yml)$/, '');
-      const finalFilename = `${filenameWithoutExt}.${targetFormat}`;
+      const filenameWithoutExt = stripRequestExtension(filename);
+      const finalFilename = `${filenameWithoutExt}${COLLECTION_LAYOUTS[targetFormat].ext}`;
       const targetPathname = path.join(targetDirname, finalFilename);
 
       if (fs.existsSync(targetPathname)) {
         throw new Error(`A file with the name "${finalFilename}" already exists in the target location`);
       }
 
-      const actualSourceFormat = sourceFormat || 'yml';
-      const needsConversion = actualSourceFormat !== targetFormat;
+      // `.yml` and `.yaml` share a serializer, so moving between them is a plain copy. Collapse
+      // both sides onto the serializer that will actually run, so only a genuine bru<->YAML move
+      // round-trips through parse/stringify. An unrecognized layout is left alone so filestore
+      // still reports it rather than being silently treated as bru.
+      const serializerFor = (layout) => (isOpenCollectionLayout(layout) ? 'yml' : layout);
+      const targetSerializationFormat = serializerFor(targetFormat);
+      const sourceSerializationFormat = serializerFor(sourceFormat || 'yml');
+      const needsConversion = sourceSerializationFormat !== targetSerializationFormat;
 
       let finalContent;
       if (needsConversion) {
         const { parseRequest, stringifyRequest } = require('@usebruno/filestore');
         const sourceContent = await fs.promises.readFile(sourcePathname, 'utf8');
-        const parsedRequest = parseRequest(sourceContent, { format: actualSourceFormat });
+        const parsedRequest = parseRequest(sourceContent, { format: sourceSerializationFormat });
         const mergedRequest = { ...parsedRequest, ...request };
         syncExampleUidsCache(sourcePathname, mergedRequest.examples);
-        finalContent = stringifyRequest(mergedRequest, { format: targetFormat });
+        finalContent = stringifyRequest(mergedRequest, { format: targetSerializationFormat });
       } else {
         syncExampleUidsCache(sourcePathname, request.examples);
-        finalContent = await stringifyRequestViaWorker(request, { format: targetFormat });
+        finalContent = await stringifyRequestViaWorker(request, { format: targetSerializationFormat });
       }
 
       await writeFile(targetPathname, finalContent);
@@ -1368,14 +1395,15 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         }
 
         const getFilenameWithFormat = (item, format) => {
+          const targetExt = COLLECTION_LAYOUTS[format].ext;
           if (item?.filename) {
             const ext = path.extname(item.filename);
-            if (ext === '.bru' || ext === '.yml') {
-              return item.filename.replace(ext, `.${format}`);
+            if (getLayoutForFilename(item.filename)) {
+              return item.filename.replace(ext, targetExt);
             }
             return item.filename;
           }
-          return `${item.name}.${format}`;
+          return `${item.name}${targetExt}`;
         };
 
         // Recursive function to parse the collection items and create files/folders
@@ -1393,9 +1421,11 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               fs.mkdirSync(folderPath, { recursive: true });
 
               if (item?.root?.meta?.name) {
-                const folderFilePath = path.join(folderPath, `folder.${format}`);
+                const folderFilePath = path.join(folderPath, COLLECTION_LAYOUTS[format].folderFile);
                 item.root.meta.seq = item.seq;
-                const folderContent = await stringifyFolder(item.root, { format });
+                const folderContent = await stringifyFolder(item.root, {
+                  format
+                });
                 safeWriteFileSync(folderFilePath, folderContent);
               }
 
@@ -1456,10 +1486,12 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
           }
         }
 
-        if (format === 'yml') {
+        if (isOpenCollectionLayout(format)) {
           brunoConfig.opencollection = '1.0.0';
-          const collectionContent = await stringifyCollection(coll.root, brunoConfig, { format });
-          await writeFile(path.join(collectionPath, 'opencollection.yml'), collectionContent);
+          const collectionContent = await stringifyCollection(coll.root, brunoConfig, {
+            format
+          });
+          await writeFile(path.join(collectionPath, COLLECTION_LAYOUTS[format].collectionFile), collectionContent);
         } else if (format === 'bru') {
           const bruJsonConfig = { ...brunoConfig, version: '1' };
           if (brunoConfig.version) {
@@ -1553,7 +1585,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
 
             // Use the correct file extension based on target format
             const baseName = path.parse(item.filename).name;
-            const newFilename = format === 'yml' ? `${baseName}.yml` : `${baseName}.bru`;
+            const newFilename = `${baseName}${COLLECTION_LAYOUTS[format].ext}`;
             const filePath = path.join(currentPath, newFilename);
 
             safeWriteFileSync(filePath, content);
@@ -1705,9 +1737,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       validatePathIsInsideCollection(targetDirname);
 
       const sourceBasename = path.basename(sourcePathname);
-      const filenameWithoutExt = sourceBasename.replace(/\.(bru|yml|yaml)$/, '');
-      const targetExt = targetFormat === 'yml' ? 'yml' : 'bru';
-      const targetFilename = `${filenameWithoutExt}.${targetExt}`;
+      const filenameWithoutExt = stripRequestExtension(sourceBasename);
+      const targetFilename = `${filenameWithoutExt}${COLLECTION_LAYOUTS[targetFormat].ext}`;
       const targetPathname = path.join(targetDirname, targetFilename);
 
       if (fs.existsSync(targetPathname)) {
@@ -1766,20 +1797,18 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       const brunoConfigPath = path.join(collectionPath, 'bruno.json');
       const content = await stringifyJson(transformedBrunoConfig);
       await writeFile(brunoConfigPath, content);
-    } else if (format === 'yml') {
-      // opencollection.yml holds both config AND the collection root. If the caller
+    } else if (isOpenCollectionLayout(format)) {
+      // The OpenCollection root holds both config AND the collection root. If the caller
       // didn't supply a root (e.g. a config-only update before the tree finished
       // loading), recover it from disk so request defaults/docs/scripts aren't wiped.
+      const rootFilePath = path.join(collectionPath, COLLECTION_LAYOUTS[format].collectionFile);
       let rootToWrite = collectionRoot;
-      if (!rootToWrite) {
-        const ocYmlPath = path.join(collectionPath, 'opencollection.yml');
-        if (fs.existsSync(ocYmlPath)) {
-          const existing = fs.readFileSync(ocYmlPath, 'utf8');
-          rootToWrite = parseCollection(existing, { format }).collectionRoot;
-        }
+      if (!rootToWrite && fs.existsSync(rootFilePath)) {
+        const existing = fs.readFileSync(rootFilePath, 'utf8');
+        rootToWrite = parseCollection(existing, { format }).collectionRoot;
       }
       const content = await stringifyCollection(rootToWrite, transformedBrunoConfig, { format });
-      await writeFile(path.join(collectionPath, 'opencollection.yml'), content);
+      await writeFile(rootFilePath, content);
     } else {
       throw new Error(`Invalid collection format: ${format}`);
     }
@@ -2375,8 +2404,8 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       const format = getCollectionFormat(collectionPath);
 
       const filename = targetFilename || path.basename(sourcePathname);
-      const filenameWithoutExt = filename.replace(/\.(bru|yml)$/, '');
-      const finalFilename = `${filenameWithoutExt}.${format}`;
+      const filenameWithoutExt = stripRequestExtension(filename);
+      const finalFilename = `${filenameWithoutExt}${COLLECTION_LAYOUTS[format].ext}`;
       const targetPathname = path.join(targetDirname, finalFilename);
 
       if (fs.existsSync(targetPathname)) {
@@ -2504,12 +2533,12 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               }
             }
 
-            if (isBruEnvironmentConfig(filePath, collectionPath)) {
+            if (isEnvironmentConfigFile(filePath, collectionPath)) {
               try {
                 let bruContent = fs.readFileSync(filePath, 'utf8');
-                const environmentFilepathBasename = path.basename(filePath);
-                const environmentName = environmentFilepathBasename.substring(0, environmentFilepathBasename.length - 4);
-                let data = await parseEnvironment(bruContent);
+                let data = await parseEnvironment(bruContent, {
+                  format: getLayoutForFilename(filePath)
+                });
                 variables = {
                   ...variables,
                   envVariables: {
@@ -2523,19 +2552,22 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
               }
             }
 
-            if (isCollectionRootBruFile(filePath, collectionPath)) {
+            if (isCollectionRootFile(filePath, collectionPath)) {
               try {
                 let bruContent = fs.readFileSync(filePath, 'utf8');
-                let data = await parseCollection(bruContent);
+                let data = await parseCollection(bruContent, {
+                  format: getLayoutForFilename(filePath)
+                });
                 // TODO
                 continue;
               } catch (err) {
                 console.error(err);
               }
             }
-            if (!stats.isDirectory() && path.extname(filePath) === '.bru' && file !== 'folder.bru') {
+            const fileLayout = stats.isDirectory() ? null : getLayoutForFilename(file);
+            if (fileLayout && !FOLDER_ROOT_BASENAMES.includes(file) && !READABLE_COLLECTION_ROOT_BASENAMES.includes(file)) {
               const bruContent = fs.readFileSync(filePath, 'utf8');
-              const bruJson = parseRequest(bruContent);
+              const bruJson = parseRequest(bruContent, { format: fileLayout });
 
               currentDirBruJsons.push({
                 ...bruJson
@@ -2648,13 +2680,13 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       const zip = new AdmZip(zipFilePath);
       const entries = zip.getEntries().map((e) => e.entryName);
 
-      return entries.some(
-        (name) =>
-          name === 'bruno.json'
-          || name === 'opencollection.yml'
-          || /^[^/]+\/bruno\.json$/.test(name)
-          || /^[^/]+\/opencollection\.yml$/.test(name)
-      );
+      // A collection archive has its config either at the root or one directory down. Probe the
+      // same markers the import path detects with, so the two can't disagree about an archive.
+      return entries.some((name) => {
+        const segments = name.split('/');
+        return (segments.length === 1 || segments.length === 2)
+          && COLLECTION_MARKER_BASENAMES.includes(segments[segments.length - 1]);
+      });
     } catch {
       return false;
     }
@@ -2711,30 +2743,35 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         }
 
         const brunoJsonPath = path.join(collectionDir, 'bruno.json');
-        const openCollectionYmlPath = path.join(collectionDir, 'opencollection.yml');
+        const openCollectionLayout = detectCollectionLayout(collectionDir);
+        const openCollectionPath = isOpenCollectionLayout(openCollectionLayout)
+          ? path.join(collectionDir, COLLECTION_LAYOUTS[openCollectionLayout].collectionFile)
+          : null;
 
-        if (!fs.existsSync(brunoJsonPath) && !fs.existsSync(openCollectionYmlPath)) {
-          throw new Error('Invalid collection: Neither bruno.json nor opencollection.yml found in the ZIP file');
+        if (!fs.existsSync(brunoJsonPath) && !openCollectionPath) {
+          throw new Error('Invalid collection: Neither bruno.json nor an opencollection file found in the ZIP file');
         }
 
         // Ensure config files are not symlinks
         if (fs.existsSync(brunoJsonPath) && fs.lstatSync(brunoJsonPath).isSymbolicLink()) {
           throw new Error('Security error: bruno.json cannot be a symbolic link');
         }
-        if (fs.existsSync(openCollectionYmlPath) && fs.lstatSync(openCollectionYmlPath).isSymbolicLink()) {
-          throw new Error('Security error: opencollection.yml cannot be a symbolic link');
+        if (openCollectionPath && fs.lstatSync(openCollectionPath).isSymbolicLink()) {
+          throw new Error(
+            `Security error: ${COLLECTION_LAYOUTS[openCollectionLayout].collectionFile} cannot be a symbolic link`
+          );
         }
 
         let collectionName = 'Imported Collection';
         let brunoConfig = { name: collectionName, version: '1', type: 'collection', ignore: ['node_modules', '.git'] };
-        if (fs.existsSync(openCollectionYmlPath)) {
+        if (openCollectionPath) {
           try {
-            const content = fs.readFileSync(openCollectionYmlPath, 'utf8');
-            const parsed = parseCollection(content, { format: 'yml' });
+            const content = fs.readFileSync(openCollectionPath, 'utf8');
+            const parsed = parseCollection(content, { format: openCollectionLayout });
             brunoConfig = parsed.brunoConfig || brunoConfig;
             collectionName = brunoConfig.name || collectionName;
           } catch (e) {
-            console.error(`Error parsing opencollection.yml at ${openCollectionYmlPath}:`, e);
+            console.error(`Error parsing collection root at ${openCollectionPath}:`, e);
           }
         } else if (fs.existsSync(brunoJsonPath)) {
           try {

--- a/packages/bruno-electron/src/ipc/openapi-sync.js
+++ b/packages/bruno-electron/src/ipc/openapi-sync.js
@@ -13,6 +13,14 @@ const {
 } = require('@usebruno/filestore');
 const { openApiToBruno } = require('@usebruno/converters');
 const { writeFile, sanitizeName, getCollectionFormat, posixifyPath } = require('../utils/filesystem');
+const {
+  COLLECTION_LAYOUTS,
+  getLayoutForFilename,
+  isCollectionRootBasename,
+  isFolderRootBasename,
+  isOpenCollectionLayout,
+  isRequestFilename
+} = require('@usebruno/common');
 
 const RESERVED_FOLDER_NAMES = ['node_modules', '.git', 'environments', 'mocks'];
 const { getEnvVars } = require('../utils/collection');
@@ -71,6 +79,10 @@ const isPathInsideCollection = (targetPath, collectionPath) => {
   const resolvedCollection = path.resolve(collectionPath);
   return resolvedTarget.startsWith(resolvedCollection + path.sep) || resolvedTarget === resolvedCollection;
 };
+
+// A request file, excluding the folder and collection roots that share its extension.
+const isSyncableRequestFile = (basename) =>
+  isRequestFilename(basename) && !isFolderRootBasename(basename) && !isCollectionRootBasename(basename);
 
 /**
  * Validate that a URL uses http or https scheme only.
@@ -243,17 +255,18 @@ const normalizeUrlPath = (urlStr) => {
 
 /**
  * Load bruno config from disk. Returns { format, brunoConfig, collectionRoot }.
- * collectionRoot is only set for yml format collections.
+ * collectionRoot is only set for OpenCollection (yml/yaml) collections.
  */
 const loadBrunoConfig = (collectionPath) => {
   const format = getCollectionFormat(collectionPath);
   let brunoConfig;
   let collectionRoot;
 
-  if (format === 'yml') {
-    const configFilePath = path.join(collectionPath, 'opencollection.yml');
+  if (isOpenCollectionLayout(format)) {
+    const { collectionFile } = COLLECTION_LAYOUTS[format];
+    const configFilePath = path.join(collectionPath, collectionFile);
     if (!fs.existsSync(configFilePath)) {
-      throw new Error('opencollection.yml not found');
+      throw new Error(`${collectionFile} not found`);
     }
     const content = fs.readFileSync(configFilePath, 'utf8');
     const parsed = parseCollection(content, { format });
@@ -279,7 +292,7 @@ const loadBrunoConfig = (collectionPath) => {
 };
 
 /**
- * Save bruno config to disk (bruno.json or opencollection.yml).
+ * Save bruno config to disk (bruno.json or the collection's OpenCollection root).
  */
 const saveBrunoConfig = async (collectionPath, format, brunoConfig, collectionRoot) => {
   // Convert absolute openapi sourceUrls back to collection-relative for git-shareability
@@ -293,9 +306,9 @@ const saveBrunoConfig = async (collectionPath, format, brunoConfig, collectionRo
     }));
   }
 
-  if (format === 'yml') {
+  if (isOpenCollectionLayout(format)) {
     const content = await stringifyCollection(collectionRoot, configToSave, { format });
-    await writeFile(path.join(collectionPath, 'opencollection.yml'), content);
+    await writeFile(path.join(collectionPath, COLLECTION_LAYOUTS[format].collectionFile), content);
   } else {
     const brunoJsonPath = path.join(collectionPath, 'bruno.json');
     await writeFile(brunoJsonPath, JSON.stringify(configToSave, null, 2));
@@ -336,11 +349,10 @@ const findRequestFileOnDisk = (dirPath, method, urlPath) => {
     if (stats.isDirectory() && !RESERVED_FOLDER_NAMES.includes(file)) {
       const found = findRequestFileOnDisk(filePath, method, urlPath);
       if (found) return found;
-    } else if (file.endsWith('.bru') || file.endsWith('.yml') || file.endsWith('.yaml')) {
-      if (file.startsWith('folder.') || file.startsWith('collection.')) continue;
+    } else if (isSyncableRequestFile(file)) {
       try {
         const content = fs.readFileSync(filePath, 'utf8');
-        const fileFormat = file.endsWith('.yml') || file.endsWith('.yaml') ? 'yml' : 'bru';
+        const fileFormat = getLayoutForFilename(file);
         const request = parseRequest(content, { format: fileFormat });
         if (request?.request) {
           const reqMethod = request.request.method?.toUpperCase();
@@ -700,7 +712,7 @@ const mergeSpecIntoRequest = (existingRequest, specItem, { fullReset = false, pr
 
 /**
  * Ensure a tag-based folder exists in the collection directory.
- * Creates the folder and its folder.bru/folder.yml file if missing.
+ * Creates the folder and its folder root file if missing.
  * Returns the resolved target folder path (falls back to collectionPath on reserved/traversal names).
  */
 const ensureTagFolder = async (collectionPath, folderName, format) => {
@@ -716,7 +728,7 @@ const ensureTagFolder = async (collectionPath, folderName, format) => {
   }
   if (!fs.existsSync(targetFolder)) {
     fs.mkdirSync(targetFolder, { recursive: true });
-    const folderBruPath = path.join(targetFolder, `folder.${format}`);
+    const folderBruPath = path.join(targetFolder, COLLECTION_LAYOUTS[format].folderFile);
     const folderContent = await stringifyFolder({ meta: { name: safeFolderName } }, { format });
     await writeFile(folderBruPath, folderContent);
   }
@@ -1133,8 +1145,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
           const stats = fs.statSync(fullPath);
           if (stats.isDirectory()) {
             files.push(...scanCollectionFiles(fullPath, relPath));
-          } else if ((entry.endsWith('.bru') || entry.endsWith('.yml') || entry.endsWith('.yaml'))
-            && !entry.startsWith('folder.') && !entry.startsWith('collection.') && !entry.startsWith('opencollection.')) {
+          } else if (isSyncableRequestFile(entry)) {
             files.push({ fullPath, relativePath: relPath });
           }
         }
@@ -1146,7 +1157,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
       for (const { fullPath, relativePath } of collectionFiles) {
         try {
           const content = fs.readFileSync(fullPath, 'utf8');
-          const fileFormat = fullPath.endsWith('.yml') || fullPath.endsWith('.yaml') ? 'yml' : 'bru';
+          const fileFormat = getLayoutForFilename(fullPath);
           const parsed = parseRequest(content, { format: fileFormat });
           if (!parsed?.request) continue;
           collectionEndpoints.push({
@@ -1399,11 +1410,10 @@ const registerOpenAPISyncIpc = (mainWindow) => {
 
             if (stats.isDirectory() && !RESERVED_FOLDER_NAMES.includes(file)) {
               await findAndResetRequest(filePath);
-            } else if ((file.endsWith('.bru') || file.endsWith('.yml') || file.endsWith('.yaml'))
-              && !file.startsWith('folder.') && !file.startsWith('collection.')) {
+            } else if (isSyncableRequestFile(file)) {
               try {
                 const content = fs.readFileSync(filePath, 'utf8');
-                const fileFormat = file.endsWith('.yml') || file.endsWith('.yaml') ? 'yml' : 'bru';
+                const fileFormat = getLayoutForFilename(file);
                 const existingRequest = parseRequest(content, { format: fileFormat });
 
                 if (existingRequest?.request) {
@@ -1484,11 +1494,10 @@ const registerOpenAPISyncIpc = (mainWindow) => {
 
             if (stats.isDirectory() && !RESERVED_FOLDER_NAMES.includes(file)) {
               findAndRemoveRequest(filePath);
-            } else if ((file.endsWith('.bru') || file.endsWith('.yml') || file.endsWith('.yaml'))
-              && !file.startsWith('folder.') && !file.startsWith('collection.')) {
+            } else if (isSyncableRequestFile(file)) {
               try {
                 const content = fs.readFileSync(filePath, 'utf8');
-                const request = parseRequest(content, { format: file.endsWith('.yml') || file.endsWith('.yaml') ? 'yml' : 'bru' });
+                const request = parseRequest(content, { format: getLayoutForFilename(file) });
 
                 if (request?.request) {
                   const method = request.request.method?.toUpperCase();
@@ -1529,7 +1538,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
             }
             if (fs.existsSync(fullPath)) {
               try {
-                const fileFormat = fullPath.endsWith('.yml') || fullPath.endsWith('.yaml') ? 'yml' : 'bru';
+                const fileFormat = getLayoutForFilename(fullPath);
                 const content = fs.readFileSync(fullPath, 'utf8');
                 const parsed = parseRequest(content, { format: fileFormat });
                 if (parsed?.request) {
@@ -1636,7 +1645,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
               }
               if (fs.existsSync(fullPath)) {
                 try {
-                  const fileFormat = fullPath.endsWith('.yml') || fullPath.endsWith('.yaml') ? 'yml' : 'bru';
+                  const fileFormat = getLayoutForFilename(fullPath);
                   const existingContent = fs.readFileSync(fullPath, 'utf8');
                   const existingRequest = parseRequest(existingContent, { format: fileFormat });
                   const mergedRequest = mergeSpecIntoRequest(existingRequest, specItem, { fullReset: true });
@@ -1846,7 +1855,7 @@ const registerOpenAPISyncIpc = (mainWindow) => {
           }
 
           try {
-            const fileFormat = endpoint.pathname.endsWith('.yml') || endpoint.pathname.endsWith('.yaml') ? 'yml' : 'bru';
+            const fileFormat = getLayoutForFilename(endpoint.pathname);
             const existingContent = fs.readFileSync(endpoint.pathname, 'utf8');
             const existingRequest = parseRequest(existingContent, { format: fileFormat });
             const mergedRequest = mergeSpecIntoRequest(existingRequest, specItem, { fullReset: true });

--- a/packages/bruno-electron/src/ipc/workspace.js
+++ b/packages/bruno-electron/src/ipc/workspace.js
@@ -31,7 +31,8 @@ const {
   normalizeCollectionEntry,
   validateWorkspacePath,
   validateWorkspaceDirectory,
-  getWorkspaceUid
+  getWorkspaceUid,
+  resolveWorkspaceFilePath
 } = require('../utils/workspace-config');
 
 const DEFAULT_WORKSPACE_NAME = 'My Workspace';
@@ -216,10 +217,10 @@ const registerWorkspaceIpc = (mainWindow, workspaceWatcher) => {
         throw new Error('Workspace path is undefined');
       }
 
-      const workspaceFilePath = path.join(workspacePath, 'workspace.yml');
+      const workspaceFilePath = resolveWorkspaceFilePath(workspacePath);
 
-      if (!fs.existsSync(workspaceFilePath)) {
-        throw new Error('Invalid workspace: workspace.yml not found');
+      if (!workspaceFilePath) {
+        throw new Error('Invalid workspace: workspace.yml (or workspace.yaml) not found');
       }
 
       const yamlContent = fs.readFileSync(workspaceFilePath, 'utf8');
@@ -371,9 +372,9 @@ const registerWorkspaceIpc = (mainWindow, workspaceWatcher) => {
           }
         }
 
-        const workspaceYmlPath = path.join(workspaceDir, 'workspace.yml');
-        if (!fs.existsSync(workspaceYmlPath)) {
-          throw new Error('Invalid workspace: workspace.yml not found in the zip file');
+        const workspaceYmlPath = resolveWorkspaceFilePath(workspaceDir);
+        if (!workspaceYmlPath) {
+          throw new Error('Invalid workspace: workspace.yml (or workspace.yaml) not found in the zip file');
         }
 
         const workspaceConfig = yaml.load(fs.readFileSync(workspaceYmlPath, 'utf8'));
@@ -631,8 +632,8 @@ const registerWorkspaceIpc = (mainWindow, workspaceWatcher) => {
 
       for (const workspacePath of workspacePaths) {
         try {
-          const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
-          if (fs.existsSync(workspaceYmlPath)) {
+          const workspaceYmlPath = resolveWorkspaceFilePath(workspacePath);
+          if (workspaceYmlPath) {
             const workspaceConfig = yaml.load(fs.readFileSync(workspaceYmlPath, 'utf8')) || {};
             const collections = workspaceConfig.collections || [];
 

--- a/packages/bruno-electron/src/ipc/yml-migration.js
+++ b/packages/bruno-electron/src/ipc/yml-migration.js
@@ -14,6 +14,7 @@ const {
 } = require('@usebruno/filestore');
 const { transformProxyConfig } = require('@usebruno/requests');
 const { getCollectionFormat, getCollectionStats, writeFile } = require('../utils/filesystem');
+const { isOpenCollectionLayout } = require('@usebruno/common');
 const { openCollection } = require('../app/collections');
 const snapshotManager = require('../services/snapshot');
 const { unmount, clearCollectionIndex } = require('./mount');
@@ -261,7 +262,7 @@ const migrateCollectionToYml = async ({ mainWindow, watcher, collectionPathname,
   const brunoJsonPath = path.join(collectionPathname, 'bruno.json');
   let brunoConfig;
   try {
-    if (getCollectionFormat(collectionPathname) === 'yml') {
+    if (isOpenCollectionLayout(getCollectionFormat(collectionPathname))) {
       throw new Error('Collection is already in YML format');
     }
     brunoConfig = JSON.parse(fs.readFileSync(brunoJsonPath, 'utf8'));

--- a/packages/bruno-electron/src/store/default-workspace.js
+++ b/packages/bruno-electron/src/store/default-workspace.js
@@ -9,8 +9,12 @@ const {
   generateYamlContent,
   readWorkspaceConfig,
   validateWorkspaceConfig,
-  isValidCollectionEntry
+  isValidCollectionEntry,
+  resolveWorkspaceFilePath,
+  WORKSPACE_FILE_BASENAME
 } = require('../utils/workspace-config');
+const { ENV_FILE_EXTENSION } = require('./workspace-environments');
+const { isYamlFilename, stripYamlExtension } = require('@usebruno/common');
 
 const OPENCOLLECTION_VERSION = '1.0.0';
 const WORKSPACE_TYPE = 'workspace';
@@ -86,10 +90,10 @@ class DefaultWorkspaceManager {
     const envDir = path.join(workspacePath, 'environments');
     if (fs.existsSync(envDir)) {
       try {
-        const envFiles = fs.readdirSync(envDir).filter((f) => f.endsWith('.yml'));
+        const envFiles = fs.readdirSync(envDir).filter((f) => isYamlFilename(f));
         for (const file of envFiles) {
           const envPath = path.join(envDir, file);
-          recovered.environments.push({ path: envPath, name: path.basename(file, '.yml') });
+          recovered.environments.push({ path: envPath, filename: file });
         }
       } catch (error) {
         console.error('Failed to read environments during recovery:', error);
@@ -158,8 +162,7 @@ class DefaultWorkspaceManager {
       return false;
     }
 
-    const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
-    if (!fs.existsSync(workspaceYmlPath)) {
+    if (!resolveWorkspaceFilePath(workspacePath)) {
       return false;
     }
 
@@ -262,12 +265,12 @@ class DefaultWorkspaceManager {
       const envDir = path.join(workspacePath, 'environments');
       for (const env of recoveredData.environments) {
         try {
-          const destPath = path.join(envDir, `${env.name}.yml`);
+          const destPath = path.join(envDir, env.filename);
           if (fs.existsSync(env.path)) {
             fs.copyFileSync(env.path, destPath);
           }
         } catch (error) {
-          console.error('Failed to copy environment:', env.name, error);
+          console.error('Failed to copy environment:', env.filename, error);
         }
       }
     }
@@ -282,7 +285,7 @@ class DefaultWorkspaceManager {
     }
 
     const yamlContent = generateYamlContent(workspaceConfig);
-    await writeFile(path.join(workspacePath, 'workspace.yml'), yamlContent);
+    await writeFile(path.join(workspacePath, WORKSPACE_FILE_BASENAME), yamlContent);
 
     await this.setDefaultWorkspacePath(workspacePath);
 
@@ -345,8 +348,8 @@ class DefaultWorkspaceManager {
         if (fs.existsSync(environmentsDir)) {
           try {
             existingEnvNames = fs.readdirSync(environmentsDir)
-              .filter((f) => f.endsWith('.yml'))
-              .map((f) => f.replace('.yml', ''));
+              .filter((f) => isYamlFilename(f))
+              .map((f) => stripYamlExtension(f));
           } catch (error) {
             console.error('Failed to read environments directory:', error);
           }
@@ -363,7 +366,7 @@ class DefaultWorkspaceManager {
             continue;
           }
 
-          const envFilePath = path.join(environmentsDir, `${env.name}.yml`);
+          const envFilePath = path.join(environmentsDir, `${env.name}${ENV_FILE_EXTENSION}`);
           const environment = { name: env.name, variables: env.variables || [] };
           const content = stringifyEnvironment(environment, { format: 'yml' });
           await writeFile(envFilePath, content);

--- a/packages/bruno-electron/src/store/workspace-environments.js
+++ b/packages/bruno-electron/src/store/workspace-environments.js
@@ -3,14 +3,43 @@ const path = require('path');
 const _ = require('lodash');
 const { parseEnvironment, stringifyEnvironment } = require('@usebruno/filestore');
 const { parseValueByDataType } = require('@usebruno/common/utils');
-const { writeFile, createDirectory, withFileLock } = require('../utils/filesystem');
+const { writeFile, createDirectory, withFileLock, resolveYamlPath } = require('../utils/filesystem');
 const { generateUidBasedOnHash, uuid } = require('../utils/common');
 const { decryptStringSafe } = require('../utils/encryption');
 const EnvironmentSecretsStore = require('./env-secrets');
+const { YAML_EXTENSIONS, isYamlFilename, stripYamlExtension } = require('@usebruno/common');
 
 const environmentSecretsStore = new EnvironmentSecretsStore();
 
+// Extension used for global environment files the app creates. Existing files are read under
+// either YAML extension (see `isYamlFilename`); only newly created ones are pinned to `.yml`.
 const ENV_FILE_EXTENSION = '.yml';
+
+// Two files can claim the same environment name (`dev.yml` and `dev.yaml`). Secrets are keyed by
+// name, so loading both would serve one file's secrets to the other and overwrite them on save.
+// Keep only the file `getEnvironmentFilePath` would write to — `.yml` wins — and warn about the
+// shadowed twin instead of silently merging them.
+const dedupeByEnvironmentName = (environmentsDir, files) => {
+  const yamlFiles = files.filter((file) => isYamlFilename(file));
+  const winnerByName = new Map();
+
+  for (const extension of YAML_EXTENSIONS) {
+    for (const file of yamlFiles) {
+      if (!file.toLowerCase().endsWith(extension)) continue;
+      const name = stripYamlExtension(file);
+      if (winnerByName.has(name)) {
+        console.warn(
+          `Ignoring global environment "${path.join(environmentsDir, file)}": `
+          + `"${winnerByName.get(name)}" already defines the environment "${name}".`
+        );
+        continue;
+      }
+      winnerByName.set(name, file);
+    }
+  }
+
+  return [...winnerByName.values()];
+};
 
 class GlobalEnvironmentsManager {
   constructor() {}
@@ -25,7 +54,11 @@ class GlobalEnvironmentsManager {
   }
 
   getEnvironmentFilePath(workspacePath, environmentName) {
-    return path.join(this.getEnvironmentsDir(workspacePath), `${environmentName}${ENV_FILE_EXTENSION}`);
+    const environmentsDir = this.getEnvironmentsDir(workspacePath);
+    // Write back to the file that already exists, whichever extension it uses; a brand new
+    // environment gets ENV_FILE_EXTENSION.
+    return resolveYamlPath(environmentsDir, environmentName)
+      || path.join(environmentsDir, `${environmentName}${ENV_FILE_EXTENSION}`);
   }
 
   findEnvironmentFileByUid(workspacePath, environmentUid) {
@@ -35,19 +68,17 @@ class GlobalEnvironmentsManager {
       return null;
     }
 
-    const files = fs.readdirSync(environmentsDir);
+    const files = dedupeByEnvironmentName(environmentsDir, fs.readdirSync(environmentsDir));
 
     for (const file of files) {
-      if (file.endsWith(ENV_FILE_EXTENSION)) {
-        const filePath = path.join(environmentsDir, file);
-        const fileUid = generateUidBasedOnHash(filePath);
-        if (fileUid === environmentUid) {
-          return {
-            filePath,
-            fileName: file,
-            name: file.slice(0, -ENV_FILE_EXTENSION.length)
-          };
-        }
+      const filePath = path.join(environmentsDir, file);
+      const fileUid = generateUidBasedOnHash(filePath);
+      if (fileUid === environmentUid) {
+        return {
+          filePath,
+          fileName: file,
+          name: stripYamlExtension(file)
+        };
       }
     }
 
@@ -59,7 +90,7 @@ class GlobalEnvironmentsManager {
     const environment = await parseEnvironment(content, { format: 'yml' });
 
     const fileName = path.basename(filePath);
-    environment.name = fileName.slice(0, -ENV_FILE_EXTENSION.length);
+    environment.name = stripYamlExtension(fileName);
     environment.uid = generateUidBasedOnHash(filePath);
 
     _.each(environment.variables, (variable) => {
@@ -96,19 +127,17 @@ class GlobalEnvironmentsManager {
         };
       }
 
-      const files = fs.readdirSync(environmentsDir);
+      const files = dedupeByEnvironmentName(environmentsDir, fs.readdirSync(environmentsDir));
       const environments = [];
 
       for (const file of files) {
-        if (file.endsWith(ENV_FILE_EXTENSION)) {
-          const filePath = path.join(environmentsDir, file);
+        const filePath = path.join(environmentsDir, file);
 
-          try {
-            const environment = await this.parseEnvironmentFile(filePath, workspacePath);
-            environments.push(environment);
-          } catch (parseError) {
-            console.error(`Failed to parse environment file ${file}:`, parseError);
-          }
+        try {
+          const environment = await this.parseEnvironmentFile(filePath, workspacePath);
+          environments.push(environment);
+        } catch (parseError) {
+          console.error(`Failed to parse environment file ${file}:`, parseError);
         }
       }
 

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -5,6 +5,7 @@ const { sanitizeName, createDirectory, writeFile, safeWriteFileSync, getCollecti
 const { generateUidBasedOnHash, stringifyJson } = require('./common');
 const { stringifyRequestViaWorker, stringifyCollection, stringifyEnvironment, stringifyFolder, DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
 const { transformProxyConfig } = require('@usebruno/requests/dist/cjs');
+const { COLLECTION_LAYOUTS, isOpenCollectionLayout } = require('@usebruno/common');
 
 /**
  * Recursively find a unique folder name by appending incremental numbers
@@ -26,6 +27,11 @@ async function findUniqueFolderName(baseName, collectionLocation, counter = 0) {
  * @param {boolean} options.skipOpenEvent - If true, don't send main:collection-opened event (caller will handle it)
  */
 async function importCollection(collection, collectionLocation, mainWindow, uniqueFolderName = null, format = DEFAULT_COLLECTION_FORMAT, options = {}) {
+  const layoutConfig = COLLECTION_LAYOUTS[format];
+  if (!layoutConfig) {
+    throw new Error(`Invalid format: ${format}`);
+  }
+  const { ext, collectionFile, folderFile } = layoutConfig;
   // Use provided unique folder name or use collection name
   let folderName = uniqueFolderName ? sanitizeName(uniqueFolderName) : sanitizeName(collection.name);
   let collectionPath = path.join(collectionLocation, folderName);
@@ -38,7 +44,7 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
   const parseCollectionItems = async (items = [], currentPath) => {
     for (const item of items) {
       if (['http-request', 'graphql-request', 'grpc-request'].includes(item.type)) {
-        let sanitizedFilename = sanitizeName(item.filename || `${item.name}.${format}`);
+        let sanitizedFilename = sanitizeName(item.filename || `${item.name}${ext}`);
         const content = await stringifyRequestViaWorker(item, { format });
         const filePath = path.join(currentPath, sanitizedFilename);
         safeWriteFileSync(filePath, content);
@@ -49,7 +55,7 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
         fs.mkdirSync(folderPath);
 
         if (item.root?.meta?.name) {
-          const folderFilePath = path.join(folderPath, `folder.${format}`);
+          const folderFilePath = path.join(folderPath, folderFile);
           item.root.meta.seq = item.seq;
           const folderContent = await stringifyFolder(item.root, { format });
           safeWriteFileSync(folderFilePath, folderContent);
@@ -76,7 +82,7 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
 
     for (const env of environments) {
       const content = await stringifyEnvironment(env, { format });
-      let sanitizedEnvFilename = sanitizeName(`${env.name}.${format}`);
+      let sanitizedEnvFilename = sanitizeName(`${env.name}${ext}`);
       const filePath = path.join(envDirPath, sanitizedEnvFilename);
       safeWriteFileSync(filePath, content);
     }
@@ -105,10 +111,10 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
   const uid = generateUidBasedOnHash(collectionPath);
   let brunoConfig = getBrunoJsonConfig(collection);
 
-  if (format === 'yml') {
+  if (isOpenCollectionLayout(format)) {
     brunoConfig.opencollection = '1.0.0';
     const collectionContent = await stringifyCollection(collection.root, brunoConfig, { format });
-    await writeFile(path.join(collectionPath, 'opencollection.yml'), collectionContent);
+    await writeFile(path.join(collectionPath, collectionFile), collectionContent);
   } else if (format === 'bru') {
     const bruJsonConfig = { ...brunoConfig, version: '1' };
     if (brunoConfig.version) {
@@ -120,9 +126,7 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
     await writeFile(path.join(collectionPath, 'bruno.json'), stringifiedBrunoConfig);
 
     const collectionContent = await stringifyCollection(collection.root, brunoConfig, { format });
-    await writeFile(path.join(collectionPath, 'collection.bru'), collectionContent);
-  } else {
-    throw new Error(`Invalid format: ${format}`);
+    await writeFile(path.join(collectionPath, collectionFile), collectionContent);
   }
 
   const { size, filesCount } = await getCollectionStats(collectionPath);

--- a/packages/bruno-electron/src/utils/collection-import.js
+++ b/packages/bruno-electron/src/utils/collection-import.js
@@ -5,7 +5,7 @@ const { sanitizeName, createDirectory, writeFile, safeWriteFileSync, getCollecti
 const { generateUidBasedOnHash, stringifyJson } = require('./common');
 const { stringifyRequestViaWorker, stringifyCollection, stringifyEnvironment, stringifyFolder, DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
 const { transformProxyConfig } = require('@usebruno/requests/dist/cjs');
-const { COLLECTION_LAYOUTS, isOpenCollectionLayout } = require('@usebruno/common');
+const { COLLECTION_LAYOUTS, isOpenCollectionLayout, stripRequestExtension } = require('@usebruno/common');
 
 /**
  * Recursively find a unique folder name by appending incremental numbers
@@ -44,7 +44,9 @@ async function importCollection(collection, collectionLocation, mainWindow, uniq
   const parseCollectionItems = async (items = [], currentPath) => {
     for (const item of items) {
       if (['http-request', 'graphql-request', 'grpc-request'].includes(item.type)) {
-        let sanitizedFilename = sanitizeName(item.filename || `${item.name}${ext}`);
+        // Strip any recognized request extension so an item imported from a `.yml` source lands
+        // as `.yaml` in a yaml-layout collection — otherwise the watcher ignores the file.
+        const sanitizedFilename = `${sanitizeName(stripRequestExtension(item.filename || item.name))}${ext}`;
         const content = await stringifyRequestViaWorker(item, { format });
         const filePath = path.join(currentPath, sanitizedFilename);
         safeWriteFileSync(filePath, content);

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -8,6 +8,7 @@ const { preferencesUtil } = require('../store/preferences');
 const path = require('path');
 const { DEFAULT_COLLECTION_FORMAT } = require('@usebruno/filestore');
 const { parseValueByDataType } = require('@usebruno/common/utils');
+const { COLLECTION_LAYOUTS, isOpenCollectionLayout } = require('@usebruno/common');
 
 /**
  * Returns the variable's runtime value with datatype-driven coercion applied.
@@ -16,11 +17,6 @@ const { parseValueByDataType } = require('@usebruno/common/utils');
  * via the UI takes effect at request-execution time without requiring a save.
  */
 const resolveTypedValue = (v) => parseValueByDataType(v.value, v.dataType);
-
-const FORMAT_CONFIG = {
-  yml: { ext: '.yml', collectionFile: 'opencollection.yml', folderFile: 'folder.yml' },
-  bru: { ext: '.bru', collectionFile: 'collection.bru', folderFile: 'folder.bru' }
-};
 
 const mergeHeaders = (collection, request, requestTreePath, options = {}) => {
   const { includeDisabledHeaders = false } = options;
@@ -279,7 +275,7 @@ const mergeScripts = (collection, request, requestTreePath, scriptFlow) => {
 
   // Build source file info for error trace mapping
   const format = collection.format || 'bru';
-  const config = FORMAT_CONFIG[format];
+  const config = COLLECTION_LAYOUTS[format];
   const collectionSource = {
     type: 'collection',
     filePath: path.join(collection.pathname, config.collectionFile),
@@ -578,7 +574,7 @@ const parseYmlFileMeta = (data) => {
 
 // Format-aware meta parsing function
 const parseFileMeta = (data, format = DEFAULT_COLLECTION_FORMAT) => {
-  if (format === 'yml') {
+  if (isOpenCollectionLayout(format)) {
     return parseYmlFileMeta(data);
   } else {
     return parseBruFileMeta(data);

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -4,6 +4,14 @@ const fsPromises = require('fs/promises');
 const { dialog } = require('electron');
 const isValidPathname = require('is-valid-path');
 const os = require('os');
+const {
+  COLLECTION_LAYOUTS,
+  COLLECTION_LAYOUT_ORDER,
+  YAML_EXTENSIONS,
+  isCollectionMarkerBasename,
+  isCollectionRootBasename,
+  isRequestFilename
+} = require('@usebruno/common');
 
 const DEFAULT_GITIGNORE = [
   '# Secrets',
@@ -54,9 +62,7 @@ const isValidCollectionDirectory = (dirPath) => {
   if (!isDirectory(dirPath)) {
     return false;
   }
-  const brunoJsonPath = path.join(dirPath, 'bruno.json');
-  const opencollectionYmlPath = path.join(dirPath, 'opencollection.yml');
-  return fs.existsSync(brunoJsonPath) || fs.existsSync(opencollectionYmlPath);
+  return detectCollectionLayout(dirPath) !== null;
 };
 
 const hasSubDirectories = (dir) => {
@@ -145,12 +151,12 @@ const hasBruExtension = (filename) => {
 const hasRequestExtension = (filename, format = null) => {
   if (!filename || typeof filename !== 'string') return false;
 
+  // A layout pins the extension exactly; without one, accept any layout's extension.
   if (format) {
-    const ext = format === 'yml' ? 'yml' : 'bru';
-    return filename.toLowerCase().endsWith(`.${ext}`);
+    return filename.toLowerCase().endsWith(COLLECTION_LAYOUTS[format].ext);
   }
 
-  return ['bru', 'yml'].some((ext) => filename.toLowerCase().endsWith(`.${ext}`));
+  return isRequestFilename(filename);
 };
 
 const createDirectory = async (dir) => {
@@ -229,14 +235,12 @@ const searchForFiles = (dir, extension) => {
 
 // Search for request files based on collection filetype by reading config
 const searchForRequestFiles = (dir, collectionPath = null) => {
-  const format = getCollectionFormat(collectionPath || dir);
-  if (format === 'yml') {
-    return searchForFiles(dir, '.yml');
-  } else if (format === 'bru') {
-    return searchForFiles(dir, '.bru');
-  } else {
-    throw new Error(`Invalid format: ${format}`);
+  const layout = getCollectionFormat(collectionPath || dir);
+  const config = COLLECTION_LAYOUTS[layout];
+  if (!config) {
+    throw new Error(`Invalid format: ${layout}`);
   }
+  return searchForFiles(dir, config.ext);
 };
 
 const sanitizeName = (name) => {
@@ -274,18 +278,48 @@ const generateUniqueName = (baseName, checkExists) => {
   return uniqueName;
 };
 
+/**
+ * Resolve a YAML file that may carry either supported extension. `.yml` is tried first, so a
+ * Bruno-written file always wins when both are present.
+ *
+ * @param {string} dir - Directory to look in.
+ * @param {string} basename - File name without extension (e.g. `workspace`, or an environment name).
+ * @returns {string|null} Path of the first candidate that exists, or null if neither does.
+ */
+const resolveYamlPath = (dir, basename) => {
+  for (const extension of YAML_EXTENSIONS) {
+    const candidate = path.join(dir, `${basename}${extension}`);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+};
+
+/**
+ * The on-disk layout of a collection, or null when the directory is not a collection.
+ *
+ * @param {string} collectionPath
+ * @returns {'yml'|'yaml'|'bru'|null}
+ */
+const detectCollectionLayout = (collectionPath) => {
+  if (!collectionPath) return null;
+  return COLLECTION_LAYOUT_ORDER.find(
+    (layout) => fs.existsSync(path.join(collectionPath, COLLECTION_LAYOUTS[layout].marker))
+  ) || null;
+};
+
+/**
+ * The collection's layout key — `'yml'`, `'yaml'` or `'bru'`. Safe to hand straight to
+ * `@usebruno/filestore`, which accepts either YAML spelling. Callers that build filenames must
+ * read `COLLECTION_LAYOUTS[layout]` rather than interpolating the key.
+ */
 const getCollectionFormat = (collectionPath) => {
-  const ocYmlPath = path.join(collectionPath, 'opencollection.yml');
-  if (fs.existsSync(ocYmlPath)) {
-    return 'yml';
+  const layout = detectCollectionLayout(collectionPath);
+  if (!layout) {
+    throw new Error(`No collection configuration found at: ${collectionPath}`);
   }
-
-  const brunoJsonPath = path.join(collectionPath, 'bruno.json');
-  if (fs.existsSync(brunoJsonPath)) {
-    return 'bru';
-  }
-
-  throw new Error(`No collection configuration found at: ${collectionPath}`);
+  return layout;
 };
 
 const validateName = (name) => {
@@ -531,19 +565,21 @@ const isBrunoConfigFile = (pathname, collectionPath) => {
   return path.normalize(dirname) === path.normalize(collectionPath) && basename === 'bruno.json';
 };
 
-const isBruEnvironmentConfig = (pathname, collectionPath) => {
+// Accepts any layout's extension: a collection's environments are `.bru`, `.yml` or `.yaml`
+// depending on how the collection is laid out on disk.
+const isEnvironmentConfigFile = (pathname, collectionPath) => {
   const dirname = path.dirname(pathname);
   const envDirectory = path.join(collectionPath, 'environments');
   const basename = path.basename(pathname);
 
-  return path.normalize(dirname) === path.normalize(envDirectory) && hasBruExtension(basename);
+  return path.normalize(dirname) === path.normalize(envDirectory) && isRequestFilename(basename);
 };
 
-const isCollectionRootBruFile = (pathname, collectionPath) => {
+const isCollectionRootFile = (pathname, collectionPath) => {
   const dirname = path.dirname(pathname);
   const basename = path.basename(pathname);
 
-  return path.normalize(dirname) === path.normalize(collectionPath) && basename === 'collection.bru';
+  return path.normalize(dirname) === path.normalize(collectionPath) && isCollectionRootBasename(basename);
 };
 
 const scanForBrunoFiles = async (dir) => {
@@ -562,7 +598,7 @@ const scanForBrunoFiles = async (dir) => {
             return;
           }
           scanDir(fullPath);
-        } else if ((file === 'bruno.json' || file === 'opencollection.yml') && !brunoFolders.includes(currentDir)) {
+        } else if (isCollectionMarkerBasename(file) && !brunoFolders.includes(currentDir)) {
           brunoFolders.push(currentDir);
         }
       });
@@ -618,7 +654,9 @@ module.exports = {
   isDotEnvFile,
   isValidDotEnvFilename,
   isBrunoConfigFile,
-  isBruEnvironmentConfig,
-  isCollectionRootBruFile,
-  scanForBrunoFiles
+  isEnvironmentConfigFile,
+  isCollectionRootFile,
+  scanForBrunoFiles,
+  resolveYamlPath,
+  detectCollectionLayout
 };

--- a/packages/bruno-electron/src/utils/git.js
+++ b/packages/bruno-electron/src/utils/git.js
@@ -3,6 +3,12 @@ const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
 const { parseRequest } = require('@usebruno/filestore');
+const {
+  FOLDER_ROOT_BASENAMES,
+  READABLE_COLLECTION_ROOT_BASENAMES,
+  getLayoutForFilename,
+  isRequestFilename
+} = require('@usebruno/common');
 
 let collectionPathToGitRootPathMap = new Map();
 
@@ -1452,17 +1458,17 @@ const supportsVisualDiff = (filePath) => {
   if (!filePath) return false;
 
   const fileName = filePath.split('/').pop();
-  const excludedFiles = ['folder.yml', 'folder.bru', 'opencollection.yml', 'collection.bru'];
-  if (excludedFiles.includes(fileName)) {
+  // Folder and collection roots are not requests, so the request-shaped diff view can't render them.
+  if (FOLDER_ROOT_BASENAMES.includes(fileName) || READABLE_COLLECTION_ROOT_BASENAMES.includes(fileName)) {
     return false;
   }
 
-  return filePath.endsWith('.bru') || filePath.endsWith('.yml');
+  return isRequestFilename(filePath);
 };
 
 /**
  * Parse content for visual diff viewer
- * Uses parseRequest to get consistent BrunoItem structure for both .bru and .yml files
+ * Uses parseRequest to get consistent BrunoItem structure for .bru, .yml and .yaml files
  * @param {string} content - Raw file content
  * @param {string} filePath - Path to the file
  * @returns {object|null} Parsed BrunoItem or null if parsing fails
@@ -1470,12 +1476,9 @@ const supportsVisualDiff = (filePath) => {
 const parseContentForVisualDiff = (content, filePath) => {
   if (!content) return null;
   try {
-    if (filePath?.endsWith('.bru')) {
-      return parseRequest(content, { format: 'bru' });
-    } else if (filePath?.endsWith('.yml')) {
-      return parseRequest(content, { format: 'yml' });
-    }
-    return null;
+    const layout = getLayoutForFilename(filePath);
+    if (!layout) return null;
+    return parseRequest(content, { format: layout });
   } catch (err) {
     console.error('Error parsing content for visual diff:', err);
     return null;

--- a/packages/bruno-electron/src/utils/mount.js
+++ b/packages/bruno-electron/src/utils/mount.js
@@ -2,6 +2,11 @@ const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { posixifyPath } = require('./filesystem');
+const {
+  getLayoutForFilename,
+  isCollectionRootBasename,
+  isFolderRootBasename
+} = require('@usebruno/common');
 
 const DENY_DIRS = new Set(['node_modules', '.git', '.svn', '.hg', '.bruno']);
 const DEFAULT_DENYLIST = ['**/.DS_Store', '**/Thumbs.db'];
@@ -66,8 +71,6 @@ const walk = (root, denylist) => {
   return out;
 };
 
-const COLLECTION_ROOT_BASENAMES = new Set(['collection.bru', 'collection.yml', 'opencollection.yml']);
-const FOLDER_ROOT_BASENAMES = new Set(['folder.bru', 'folder.yml']);
 const BRUNO_CONFIG_BASENAME = 'bruno.json';
 const ENVIRONMENTS_DIR = 'environments';
 
@@ -80,16 +83,13 @@ const defaultClassify = (relativePath) => {
     return { format: 'json', type: 'config' };
   }
 
-  const ext = path.extname(basename).slice(1).toLowerCase();
-  let format;
-  if (ext === 'bru') format = 'bru';
-  else if (ext === 'yml' || ext === 'yaml') format = 'yml';
-  else return null;
+  const format = getLayoutForFilename(basename);
+  if (!format) return null;
 
-  if (COLLECTION_ROOT_BASENAMES.has(basename) && segments.length === 0) {
+  if (isCollectionRootBasename(basename) && segments.length === 0) {
     return { format, type: 'collection' };
   }
-  if (FOLDER_ROOT_BASENAMES.has(basename)) {
+  if (isFolderRootBasename(basename)) {
     return { format, type: 'folder' };
   }
   if (segments[0] === ENVIRONMENTS_DIR && segments.length === 1) {
@@ -99,8 +99,6 @@ const defaultClassify = (relativePath) => {
 };
 
 module.exports = {
-  COLLECTION_ROOT_BASENAMES,
-  FOLDER_ROOT_BASENAMES,
   BRUNO_CONFIG_BASENAME,
   ENVIRONMENTS_DIR,
   hashFile,

--- a/packages/bruno-electron/src/utils/transformBrunoConfig.js
+++ b/packages/bruno-electron/src/utils/transformBrunoConfig.js
@@ -1,8 +1,14 @@
 const path = require('path');
-const { isFile, isDirectory } = require('./filesystem');
+const { isFile, isDirectory, detectCollectionLayout } = require('./filesystem');
 const { transformProxyConfig } = require('@usebruno/requests');
 
 function transformBrunoConfigBeforeSave(brunoConfig) {
+  // `format` is detected from disk on every read (see transformBrunoConfigAfterRead) and is not
+  // part of the on-disk contract — writing it back would persist a derived value.
+  if (brunoConfig) {
+    delete brunoConfig.format;
+  }
+
   if (brunoConfig && !brunoConfig.opencollection) {
     const userVersion = brunoConfig.version;
     brunoConfig.version = '1'; // bru schema marker
@@ -43,6 +49,14 @@ function transformBrunoConfigBeforeSave(brunoConfig) {
 }
 
 async function transformBrunoConfigAfterRead(brunoConfig, collectionPathname) {
+  // Stamp the on-disk layout so the renderer knows which extension this collection uses.
+  // `opencollection` alone can't tell `.yml` from `.yaml`, and the renderer builds filenames
+  // for new requests/folders from this — deriving it there would write the wrong extension.
+  const layout = detectCollectionLayout(collectionPathname);
+  if (brunoConfig && layout) {
+    brunoConfig.format = layout;
+  }
+
   if (brunoConfig && !brunoConfig.opencollection) {
     if (brunoConfig.collectionVersion) {
       brunoConfig.version = brunoConfig.collectionVersion;

--- a/packages/bruno-electron/src/utils/workspace-config.js
+++ b/packages/bruno-electron/src/utils/workspace-config.js
@@ -1,13 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { writeFile, validateName, isValidCollectionDirectory } = require('./filesystem');
+const { writeFile, validateName, isValidCollectionDirectory, resolveYamlPath } = require('./filesystem');
 const { generateUidBasedOnHash } = require('./common');
 const { withLock, getWorkspaceLockKey } = require('./workspace-lock');
 
 // Normalize Windows backslash paths to forward slashes for cross-platform compatibility.
 const posixifyPath = (p) => (p ? p.replace(/\\/g, '/') : p);
 
+// New workspaces are created as `workspace.yml`; an existing `workspace.yaml` is read and
+// written in place.
+const WORKSPACE_FILE_BASENAME = 'workspace.yml';
 const WORKSPACE_TYPE = 'workspace';
 const OPENCOLLECTION_VERSION = '1.0.0';
 const GITIGNORE_MANAGED_BLOCK_START = '# Bruno managed collection remotes';
@@ -26,8 +29,16 @@ const quoteYamlValue = (value) => {
   return `"${escaped}"`;
 };
 
+// The workspace marker under whichever YAML extension it uses, or null when absent.
+// `.yml` wins if both exist, matching collection-root detection.
+const resolveWorkspaceFilePath = (workspacePath) => resolveYamlPath(workspacePath, 'workspace');
+
+// Where to write the marker: the existing file if there is one, otherwise a new `.yml`.
+const workspaceFilePathForWrite = (workspacePath) =>
+  resolveWorkspaceFilePath(workspacePath) || path.join(workspacePath, WORKSPACE_FILE_BASENAME);
+
 const writeWorkspaceFileAtomic = async (workspacePath, content) => {
-  const workspaceFilePath = path.join(workspacePath, 'workspace.yml');
+  const workspaceFilePath = workspaceFilePathForWrite(workspacePath);
   await writeFile(workspaceFilePath, content);
 
   // Previous atomic write implementation commented out due to permission issues on Linux
@@ -173,9 +184,8 @@ const validateWorkspacePath = (workspacePath) => {
     throw new Error(`Workspace path does not exist: ${workspacePath}`);
   }
 
-  const workspaceFilePath = path.join(workspacePath, 'workspace.yml');
-  if (!fs.existsSync(workspaceFilePath)) {
-    throw new Error('Invalid workspace: workspace.yml not found');
+  if (!resolveWorkspaceFilePath(workspacePath)) {
+    throw new Error('Invalid workspace: workspace.yml (or workspace.yaml) not found');
   }
 
   return true;
@@ -217,10 +227,10 @@ const normalizeWorkspaceConfig = (config) => {
 };
 
 const readWorkspaceConfig = (workspacePath) => {
-  const workspaceFilePath = path.join(workspacePath, 'workspace.yml');
+  const workspaceFilePath = resolveWorkspaceFilePath(workspacePath);
 
-  if (!fs.existsSync(workspaceFilePath)) {
-    throw new Error('Invalid workspace: workspace.yml not found');
+  if (!workspaceFilePath) {
+    throw new Error('Invalid workspace: workspace.yml (or workspace.yaml) not found');
   }
 
   const yamlContent = fs.readFileSync(workspaceFilePath, 'utf8');
@@ -702,6 +712,8 @@ const getWorkspaceUid = (workspacePath) => {
 };
 
 module.exports = {
+  WORKSPACE_FILE_BASENAME,
+  resolveWorkspaceFilePath,
   makeRelativePath,
   normalizeCollectionEntry,
   validateWorkspacePath,

--- a/packages/bruno-electron/src/utils/workspace-startup.js
+++ b/packages/bruno-electron/src/utils/workspace-startup.js
@@ -1,7 +1,6 @@
-const fs = require('fs');
 const path = require('path');
 const snapshotManager = require('../services/snapshot');
-const { readWorkspaceConfig, validateWorkspaceConfig } = require('./workspace-config');
+const { readWorkspaceConfig, validateWorkspaceConfig, resolveWorkspaceFilePath } = require('./workspace-config');
 
 const normalizeWorkspacePathname = (workspacePath) => {
   if (typeof workspacePath !== 'string' || !workspacePath.length) {
@@ -36,9 +35,7 @@ const prioritizeActiveWorkspacePath = (workspacePaths, activeWorkspacePath) => {
 };
 
 const isValidWorkspacePathOnDisk = (workspacePath, { validateConfig = false } = {}) => {
-  const workspaceYmlPath = path.join(workspacePath, 'workspace.yml');
-
-  if (!fs.existsSync(workspaceYmlPath)) {
+  if (!resolveWorkspaceFilePath(workspacePath)) {
     return false;
   }
 

--- a/packages/bruno-electron/tests/utils/collection-layout.spec.js
+++ b/packages/bruno-electron/tests/utils/collection-layout.spec.js
@@ -1,7 +1,10 @@
-jest.mock('electron', () => ({
-  dialog: { showOpenDialog: jest.fn(), showSaveDialog: jest.fn() },
-  app: { getPath: jest.fn(() => '/tmp') }
-}));
+jest.mock('electron', () => {
+  const os = require('os');
+  return {
+    dialog: { showOpenDialog: jest.fn(), showSaveDialog: jest.fn() },
+    app: { getPath: jest.fn(() => os.tmpdir()) }
+  };
+});
 
 const fs = require('fs');
 const os = require('os');
@@ -18,6 +21,7 @@ const {
   scanForBrunoFiles
 } = require('../../src/utils/filesystem');
 const { defaultClassify } = require('../../src/utils/mount');
+const { COLLECTION_LAYOUTS } = require('@usebruno/common');
 
 // A collection may be laid out as `.bru`, `.yml` or `.yaml`. Detection has to name the layout
 // (which drives every filename the app writes) rather than just the serializer, and `.yaml` must
@@ -37,6 +41,10 @@ describe('collection layout detection', () => {
   const seedRoot = (basename, content = 'opencollection: "1.0.0"\ninfo:\n  name: c\n') => {
     fs.writeFileSync(path.join(dir, basename), content);
   };
+
+  // The basename any write to this collection's root would target.
+  const getCollectionLayoutConfigFor = (collectionPath) =>
+    COLLECTION_LAYOUTS[detectCollectionLayout(collectionPath)].collectionFile;
 
   describe('detectCollectionLayout', () => {
     it('detects a .yml collection', () => {
@@ -65,6 +73,18 @@ describe('collection layout detection', () => {
       seedRoot('opencollection.yaml');
       fs.writeFileSync(path.join(dir, 'bruno.json'), '{"version":"1","name":"c","type":"collection"}');
       expect(detectCollectionLayout(dir)).toBe('yaml');
+    });
+
+    it('picks the canonically-cased root when both spellings coexist', () => {
+      // On a case-sensitive filesystem `OpenCollection.YML` and `opencollection.yml` can both
+      // exist. Detection goes through fs.existsSync on the layout's marker, so it resolves the
+      // canonical name and every later write targets that same file — an oddly-cased sibling is
+      // never written to and no second root is created.
+      seedRoot('opencollection.yml');
+      seedRoot('OpenCollection.YML');
+
+      expect(detectCollectionLayout(dir)).toBe('yml');
+      expect(getCollectionLayoutConfigFor(dir)).toBe('opencollection.yml');
     });
 
     it('returns null when the directory is not a collection', () => {

--- a/packages/bruno-electron/tests/utils/collection-layout.spec.js
+++ b/packages/bruno-electron/tests/utils/collection-layout.spec.js
@@ -1,0 +1,206 @@
+jest.mock('electron', () => ({
+  dialog: { showOpenDialog: jest.fn(), showSaveDialog: jest.fn() },
+  app: { getPath: jest.fn(() => '/tmp') }
+}));
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  detectCollectionLayout,
+  getCollectionFormat,
+  isValidCollectionDirectory,
+  hasRequestExtension,
+  searchForRequestFiles,
+  resolveYamlPath,
+  isEnvironmentConfigFile,
+  isCollectionRootFile,
+  scanForBrunoFiles
+} = require('../../src/utils/filesystem');
+const { defaultClassify } = require('../../src/utils/mount');
+
+// A collection may be laid out as `.bru`, `.yml` or `.yaml`. Detection has to name the layout
+// (which drives every filename the app writes) rather than just the serializer, and `.yaml` must
+// be a first-class layout everywhere `.yml` is.
+
+describe('collection layout detection', () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-layout-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const seedRoot = (basename, content = 'opencollection: "1.0.0"\ninfo:\n  name: c\n') => {
+    fs.writeFileSync(path.join(dir, basename), content);
+  };
+
+  describe('detectCollectionLayout', () => {
+    it('detects a .yml collection', () => {
+      seedRoot('opencollection.yml');
+      expect(detectCollectionLayout(dir)).toBe('yml');
+    });
+
+    it('detects a .yaml collection', () => {
+      seedRoot('opencollection.yaml');
+      expect(detectCollectionLayout(dir)).toBe('yaml');
+    });
+
+    it('detects a bru collection via bruno.json', () => {
+      fs.writeFileSync(path.join(dir, 'bruno.json'), '{"version":"1","name":"c","type":"collection"}');
+      expect(detectCollectionLayout(dir)).toBe('bru');
+    });
+
+    it('prefers .yml over .yaml when both roots exist', () => {
+      seedRoot('opencollection.yml');
+      seedRoot('opencollection.yaml');
+      expect(detectCollectionLayout(dir)).toBe('yml');
+    });
+
+    it('prefers an OpenCollection root over a leftover bruno.json', () => {
+      // A migrated collection can keep a stale bruno.json; the new root wins.
+      seedRoot('opencollection.yaml');
+      fs.writeFileSync(path.join(dir, 'bruno.json'), '{"version":"1","name":"c","type":"collection"}');
+      expect(detectCollectionLayout(dir)).toBe('yaml');
+    });
+
+    it('returns null when the directory is not a collection', () => {
+      expect(detectCollectionLayout(dir)).toBe(null);
+      expect(detectCollectionLayout('')).toBe(null);
+    });
+  });
+
+  describe('getCollectionFormat', () => {
+    it('returns the layout key, not just the serializer', () => {
+      seedRoot('opencollection.yaml');
+      expect(getCollectionFormat(dir)).toBe('yaml');
+    });
+
+    it('throws when there is no collection config', () => {
+      expect(() => getCollectionFormat(dir)).toThrow('No collection configuration found');
+    });
+  });
+
+  describe('isValidCollectionDirectory', () => {
+    it('accepts a .yaml collection', () => {
+      seedRoot('opencollection.yaml');
+      expect(isValidCollectionDirectory(dir)).toBe(true);
+    });
+
+    it('rejects a plain directory', () => {
+      expect(isValidCollectionDirectory(dir)).toBe(false);
+    });
+  });
+
+  describe('resolveYamlPath', () => {
+    it('resolves either extension, preferring .yml', () => {
+      fs.writeFileSync(path.join(dir, 'workspace.yaml'), '');
+      expect(resolveYamlPath(dir, 'workspace')).toBe(path.join(dir, 'workspace.yaml'));
+
+      fs.writeFileSync(path.join(dir, 'workspace.yml'), '');
+      expect(resolveYamlPath(dir, 'workspace')).toBe(path.join(dir, 'workspace.yml'));
+    });
+
+    it('returns null when neither exists', () => {
+      expect(resolveYamlPath(dir, 'workspace')).toBe(null);
+    });
+  });
+
+  describe('hasRequestExtension', () => {
+    it('accepts every layout extension when no layout is given', () => {
+      expect(hasRequestExtension('a.bru')).toBe(true);
+      expect(hasRequestExtension('a.yml')).toBe(true);
+      expect(hasRequestExtension('a.yaml')).toBe(true);
+      expect(hasRequestExtension('a.json')).toBe(false);
+    });
+
+    it('pins the extension when a layout is given', () => {
+      expect(hasRequestExtension('a.yaml', 'yaml')).toBe(true);
+      expect(hasRequestExtension('a.yml', 'yaml')).toBe(false);
+      expect(hasRequestExtension('a.yaml', 'yml')).toBe(false);
+      expect(hasRequestExtension('a.bru', 'bru')).toBe(true);
+    });
+
+    it('throws rather than silently assuming .bru for an unknown layout', () => {
+      // Every caller passes a layout from getCollectionFormat, so an unknown one is a caller
+      // bug; treating it as .bru would hide it and mis-classify a .yaml collection's files.
+      expect(() => hasRequestExtension('a.yaml', 'toml')).toThrow();
+    });
+  });
+
+  describe('searchForRequestFiles', () => {
+    it('finds .yaml requests in a .yaml collection and ignores .yml strays', () => {
+      seedRoot('opencollection.yaml');
+      fs.writeFileSync(path.join(dir, 'get-users.yaml'), 'info:\n  name: Get Users\n');
+      fs.writeFileSync(path.join(dir, 'stray.yml'), 'info:\n  name: Stray\n');
+
+      const found = searchForRequestFiles(dir).map((p) => path.basename(p));
+      expect(found).toContain('get-users.yaml');
+      expect(found).not.toContain('stray.yml');
+    });
+  });
+
+  describe('isEnvironmentConfigFile', () => {
+    it('accepts an environment under any layout extension', () => {
+      const envDir = path.join(dir, 'environments');
+      expect(isEnvironmentConfigFile(path.join(envDir, 'dev.yaml'), dir)).toBe(true);
+      expect(isEnvironmentConfigFile(path.join(envDir, 'dev.yml'), dir)).toBe(true);
+      expect(isEnvironmentConfigFile(path.join(envDir, 'dev.bru'), dir)).toBe(true);
+    });
+
+    it('rejects files outside the environments directory', () => {
+      expect(isEnvironmentConfigFile(path.join(dir, 'dev.yaml'), dir)).toBe(false);
+    });
+  });
+
+  describe('isCollectionRootFile', () => {
+    it('accepts every layout root at the collection root, including the legacy name', () => {
+      expect(isCollectionRootFile(path.join(dir, 'opencollection.yaml'), dir)).toBe(true);
+      expect(isCollectionRootFile(path.join(dir, 'opencollection.yml'), dir)).toBe(true);
+      expect(isCollectionRootFile(path.join(dir, 'collection.bru'), dir)).toBe(true);
+      expect(isCollectionRootFile(path.join(dir, 'collection.yml'), dir)).toBe(true);
+    });
+
+    it('rejects a request file and a nested root', () => {
+      expect(isCollectionRootFile(path.join(dir, 'get-users.yaml'), dir)).toBe(false);
+      expect(isCollectionRootFile(path.join(dir, 'sub', 'opencollection.yaml'), dir)).toBe(false);
+    });
+  });
+
+  describe('scanForBrunoFiles', () => {
+    it('discovers a nested .yaml collection', async () => {
+      const nested = path.join(dir, 'nested');
+      fs.mkdirSync(nested, { recursive: true });
+      fs.writeFileSync(path.join(nested, 'opencollection.yaml'), 'opencollection: "1.0.0"\n');
+
+      const found = await scanForBrunoFiles(dir);
+      expect(found).toEqual([nested]);
+    });
+  });
+});
+
+describe('mount classifier', () => {
+  it('classifies .yaml files by type, mapping them to the yaml layout', () => {
+    expect(defaultClassify('opencollection.yaml')).toEqual({ format: 'yaml', type: 'collection' });
+    expect(defaultClassify(path.join('users', 'folder.yaml'))).toEqual({ format: 'yaml', type: 'folder' });
+    expect(defaultClassify(path.join('environments', 'dev.yaml'))).toEqual({ format: 'yaml', type: 'environment' });
+    expect(defaultClassify(path.join('users', 'get-users.yaml'))).toEqual({ format: 'yaml', type: 'request' });
+  });
+
+  it('still classifies .yml and .bru files', () => {
+    expect(defaultClassify('opencollection.yml')).toEqual({ format: 'yml', type: 'collection' });
+    expect(defaultClassify('collection.bru')).toEqual({ format: 'bru', type: 'collection' });
+    expect(defaultClassify('bruno.json')).toEqual({ format: 'json', type: 'config' });
+  });
+
+  it('accepts the legacy collection.yml root name', () => {
+    expect(defaultClassify('collection.yml')).toEqual({ format: 'yml', type: 'collection' });
+  });
+
+  it('ignores files that belong to no layout', () => {
+    expect(defaultClassify('README.md')).toBe(null);
+  });
+});

--- a/packages/bruno-electron/tests/utils/transform-bruno-config.spec.js
+++ b/packages/bruno-electron/tests/utils/transform-bruno-config.spec.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { transformBrunoConfigBeforeSave, transformBrunoConfigAfterRead } = require('../../src/utils/transformBrunoConfig');
 
 describe('BrunoConfig Proxy Transform', () => {
@@ -566,5 +569,60 @@ describe('BrunoConfig Proxy Transform', () => {
 
       expect(afterSecondRead.proxy).toEqual(newConfig.proxy);
     });
+  });
+});
+
+// The renderer builds filenames for new requests/folders from `brunoConfig.format`, so the layout
+// detected on disk has to ride along on every read — and must never be written back, since it is
+// derived state, not part of the on-disk contract.
+describe('BrunoConfig layout stamping', () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-config-layout-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('stamps the yaml layout so the renderer can tell .yaml from .yml', async () => {
+    fs.writeFileSync(path.join(dir, 'opencollection.yaml'), 'opencollection: "1.0.0"\n');
+
+    const result = await transformBrunoConfigAfterRead({ opencollection: '1.0.0', name: 'c' }, dir);
+
+    expect(result.format).toBe('yaml');
+  });
+
+  test('stamps yml and bru layouts', async () => {
+    fs.writeFileSync(path.join(dir, 'opencollection.yml'), 'opencollection: "1.0.0"\n');
+    expect((await transformBrunoConfigAfterRead({ opencollection: '1.0.0' }, dir)).format).toBe('yml');
+
+    const bruDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-config-layout-bru-'));
+    try {
+      fs.writeFileSync(path.join(bruDir, 'bruno.json'), '{"version":"1","name":"c"}');
+      expect((await transformBrunoConfigAfterRead({ version: '1' }, bruDir)).format).toBe('bru');
+    } finally {
+      fs.rmSync(bruDir, { recursive: true, force: true });
+    }
+  });
+
+  test('re-stamps on every read so a renamed root cannot leave a stale layout', async () => {
+    fs.writeFileSync(path.join(dir, 'opencollection.yaml'), 'opencollection: "1.0.0"\n');
+    const config = { opencollection: '1.0.0', format: 'yml' };
+
+    expect((await transformBrunoConfigAfterRead(config, dir)).format).toBe('yaml');
+  });
+
+  test('leaves format alone when the directory is not a collection', async () => {
+    const result = await transformBrunoConfigAfterRead({ version: '1' }, dir);
+
+    expect(result.format).toBeUndefined();
+  });
+
+  test('strips the derived format before saving so it never reaches disk', () => {
+    const result = transformBrunoConfigBeforeSave({ opencollection: '1.0.0', name: 'c', format: 'yaml' });
+
+    expect(result.format).toBeUndefined();
   });
 });

--- a/packages/bruno-electron/tests/workspace-watcher-mock-servers.test.js
+++ b/packages/bruno-electron/tests/workspace-watcher-mock-servers.test.js
@@ -43,9 +43,17 @@ describe('WorkspaceWatcher mock servers', () => {
   let win;
   let watcher;
 
+  // The mock-server watcher is armed with one glob per supported YAML extension.
+  const mockServerGlobs = () => [
+    path.join(workspacePath, 'mocks', '*.yml'),
+    path.join(workspacePath, 'mocks', '*.yaml')
+  ];
+
   const findMockServerWatcher = () => {
-    const glob = path.join(workspacePath, 'mocks', '*.yml');
-    return chokidar.__watchers.find((item) => item.target === glob);
+    const globs = mockServerGlobs();
+    return chokidar.__watchers.find(
+      (item) => Array.isArray(item.target) && globs.every((glob) => item.target.includes(glob))
+    );
   };
 
   beforeEach(() => {
@@ -65,6 +73,39 @@ describe('WorkspaceWatcher mock servers', () => {
     jest.useRealTimers();
     await watcher.closeAllWatchers();
     fs.rmSync(workspacePath, { recursive: true, force: true });
+  });
+
+  it('watches both mocks/*.yml and mocks/*.yaml', () => {
+    watcher.addWatcher(win, workspacePath);
+    jest.advanceTimersByTime(100);
+
+    expect(findMockServerWatcher().target).toEqual(mockServerGlobs());
+  });
+
+  it('emits added/changed for a .yaml mock server file', () => {
+    // Hand-authored or converted workspaces may use `.yaml`; the watcher and reader must
+    // treat it exactly like `.yml`.
+    const instance = saveMockServer(workspacePath, {
+      name: 'Cat API Mock',
+      port: 4002,
+      sourceType: 'manual',
+      globalDelay: 0
+    });
+    const yamlPathname = instance.pathname.replace(/\.yml$/, '.yaml');
+    fs.renameSync(instance.pathname, yamlPathname);
+
+    watcher.addWatcher(win, workspacePath);
+    jest.advanceTimersByTime(100);
+
+    findMockServerWatcher().emit('add', yamlPathname);
+
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      'main:workspace-mock-server-added',
+      'workspace-1',
+      expect.objectContaining({
+        instance: expect.objectContaining({ uid: getMockServerUid(yamlPathname), name: 'Cat API Mock', port: 4002 })
+      })
+    );
   });
 
   it('watches mocks/*.yml and emits added/changed with the parsed mock server', () => {

--- a/packages/bruno-filestore/src/format-aliasing.spec.ts
+++ b/packages/bruno-filestore/src/format-aliasing.spec.ts
@@ -1,0 +1,112 @@
+import {
+  parseRequest,
+  stringifyRequest,
+  parseCollection,
+  stringifyCollection,
+  parseFolder,
+  stringifyFolder,
+  parseEnvironment,
+  stringifyEnvironment,
+  parseMockServer,
+  stringifyMockServer
+} from './index';
+import { isYamlFormat } from './types';
+
+// Parsers mint a fresh `uid` on every call, so two parses of identical bytes are never deeply
+// equal. Strip uids to compare the meaningful shape.
+const withoutUids = (value: any): any => {
+  if (Array.isArray(value)) return value.map(withoutUids);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).filter(([key]) => key !== 'uid').map(([key, v]) => [key, withoutUids(v)])
+    );
+  }
+  return value;
+};
+
+// `.yaml` and `.yml` are the same OpenCollection YAML under two extensions. Every entry point
+// must treat them identically, otherwise a `.yaml` collection either throws
+// `Unsupported format: yaml` or — worse — silently falls through to the `bru` serializer.
+
+describe('isYamlFormat', () => {
+  it('accepts both spellings', () => {
+    expect(isYamlFormat('yml')).toBe(true);
+    expect(isYamlFormat('yaml')).toBe(true);
+  });
+
+  it('rejects bru and unset', () => {
+    expect(isYamlFormat('bru')).toBe(false);
+    expect(isYamlFormat(undefined)).toBe(false);
+  });
+});
+
+describe('yaml is an alias for yml at every entry point', () => {
+  const requestObj: any = {
+    type: 'http-request',
+    name: 'Get Users',
+    seq: 1,
+    request: {
+      method: 'GET',
+      url: 'https://api.example.com/users',
+      headers: [{ name: 'X-Test', value: 'v', enabled: true }],
+      body: { mode: 'none' },
+      auth: { mode: 'none' }
+    }
+  };
+  const collectionRoot: any = {
+    request: { headers: [{ name: 'X-Collection', value: 'v', enabled: true }] }
+  };
+  const brunoConfig: any = { name: 'test-collection', opencollection: '1.0.0' };
+  const folderObj: any = { meta: { name: 'Users', seq: 1 } };
+  const environmentObj: any = {
+    name: 'Development',
+    variables: [{ name: 'baseUrl', value: 'https://api.dev', enabled: true, secret: false, type: 'text' }]
+  };
+  const mockServerObj: any = { name: 'Mock', port: 3000, enabled: true, responses: [] };
+
+  it('stringifyRequest produces identical bytes for yml and yaml', () => {
+    expect(stringifyRequest(requestObj, { format: 'yaml' })).toBe(stringifyRequest(requestObj, { format: 'yml' }));
+  });
+
+  it('parseRequest reads yaml-written content', () => {
+    const content = stringifyRequest(requestObj, { format: 'yaml' });
+    expect(withoutUids(parseRequest(content, { format: 'yaml' }))).toEqual(withoutUids(parseRequest(content, { format: 'yml' })));
+  });
+
+  it('stringifyCollection / parseCollection alias yaml', () => {
+    const content = stringifyCollection(collectionRoot, brunoConfig, { format: 'yaml' });
+    expect(content).toBe(stringifyCollection(collectionRoot, brunoConfig, { format: 'yml' }));
+    expect(withoutUids(parseCollection(content, { format: 'yaml' }))).toEqual(withoutUids(parseCollection(content, { format: 'yml' })));
+  });
+
+  it('stringifyFolder / parseFolder alias yaml', () => {
+    const content = stringifyFolder(folderObj, { format: 'yaml' });
+    expect(content).toBe(stringifyFolder(folderObj, { format: 'yml' }));
+    expect(withoutUids(parseFolder(content, { format: 'yaml' }))).toEqual(withoutUids(parseFolder(content, { format: 'yml' })));
+  });
+
+  it('stringifyEnvironment / parseEnvironment alias yaml', () => {
+    const content = stringifyEnvironment(environmentObj, { format: 'yaml' });
+    expect(content).toBe(stringifyEnvironment(environmentObj, { format: 'yml' }));
+    expect(withoutUids(parseEnvironment(content, { format: 'yaml' }))).toEqual(withoutUids(parseEnvironment(content, { format: 'yml' })));
+  });
+
+  it('stringifyMockServer / parseMockServer alias yaml', () => {
+    const content = stringifyMockServer(mockServerObj, { format: 'yaml' });
+    expect(content).toBe(stringifyMockServer(mockServerObj, { format: 'yml' }));
+    expect(withoutUids(parseMockServer(content, { format: 'yaml' }))).toEqual(withoutUids(parseMockServer(content, { format: 'yml' })));
+  });
+
+  it('never routes yaml to the bru serializer', () => {
+    // The bru serializer emits block syntax; the yml one emits YAML keys. If `yaml` ever fell
+    // through to the `else` branch this would start looking like a .bru file.
+    const content = stringifyRequest(requestObj, { format: 'yaml' });
+    expect(content).toContain('info:');
+    expect(content).not.toContain('meta {');
+  });
+
+  it('still rejects a genuinely unsupported format', () => {
+    expect(() => parseRequest('x', { format: 'toml' as any })).toThrow('Unsupported format: toml');
+    expect(() => stringifyRequest(requestObj, { format: 'toml' as any })).toThrow('Unsupported format: toml');
+  });
+});

--- a/packages/bruno-filestore/src/index.ts
+++ b/packages/bruno-filestore/src/index.ts
@@ -25,7 +25,8 @@ import BruParserWorker from './workers';
 import {
   ParseOptions,
   StringifyOptions,
-  CollectionFormat
+  CollectionFormat,
+  isYamlFormat
 } from './types';
 import { DEFAULT_COLLECTION_FORMAT } from './constants';
 import { bruRequestParseAndRedactBodyData } from './formats/bru/utils/request-parse-and-redact-body-data';
@@ -35,7 +36,7 @@ import { redactLargeBruTextBlocks, restoreRedactedBlocks } from './formats/bru/u
 export const parseRequest = (content: string, options: ParseOptions = { format: DEFAULT_COLLECTION_FORMAT }): any => {
   if (options.format === 'bru') {
     return parseBruRequest(content);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return parseYmlItem(content);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -51,7 +52,7 @@ export const parseRequestAndRedactBody = (content: string, options: ParseOptions
 export const stringifyRequest = (requestObj: BrunoItem, options: StringifyOptions = { format: DEFAULT_COLLECTION_FORMAT }): string => {
   if (options.format === 'bru') {
     return stringifyBruRequest(requestObj);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return stringifyYmlItem(requestObj);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -97,7 +98,7 @@ export const stringifyEnvironmentViaWorker = async (envObj: any, options: { form
 export const parseCollection = (content: string, options: ParseOptions = { format: DEFAULT_COLLECTION_FORMAT }): any => {
   if (options.format === 'bru') {
     return parseBruCollection(content);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return parseYmlCollection(content);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -106,7 +107,7 @@ export const parseCollection = (content: string, options: ParseOptions = { forma
 export const stringifyCollection = (collectionObj: BrunoCollection, brunoConfig: any, options: StringifyOptions = { format: DEFAULT_COLLECTION_FORMAT }): string => {
   if (options.format === 'bru') {
     return stringifyBruCollection(collectionObj, false);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return stringifyYmlCollection(collectionObj, brunoConfig);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -116,7 +117,7 @@ export const stringifyCollection = (collectionObj: BrunoCollection, brunoConfig:
 export const parseFolder = (content: string, options: ParseOptions = { format: DEFAULT_COLLECTION_FORMAT }): any => {
   if (options.format === 'bru') {
     return parseBruCollection(content);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return parseYmlFolder(content);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -125,7 +126,7 @@ export const parseFolder = (content: string, options: ParseOptions = { format: D
 export const stringifyFolder = (folderObj: any, options: StringifyOptions = { format: DEFAULT_COLLECTION_FORMAT }): string => {
   if (options.format === 'bru') {
     return stringifyBruCollection(folderObj, true);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return stringifyYmlFolder(folderObj);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -135,7 +136,7 @@ export const stringifyFolder = (folderObj: any, options: StringifyOptions = { fo
 export const parseEnvironment = (content: string, options: ParseOptions = { format: DEFAULT_COLLECTION_FORMAT }): any => {
   if (options.format === 'bru') {
     return parseBruEnvironment(content);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return parseYmlEnvironment(content);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -144,7 +145,7 @@ export const parseEnvironment = (content: string, options: ParseOptions = { form
 export const stringifyEnvironment = (envObj: BrunoEnvironment, options: StringifyOptions = { format: DEFAULT_COLLECTION_FORMAT }): string => {
   if (options.format === 'bru') {
     return stringifyBruEnvironment(envObj);
-  } else if (options.format === 'yml') {
+  } else if (isYamlFormat(options.format)) {
     return stringifyYmlEnvironment(envObj);
   }
   throw new Error(`Unsupported format: ${options.format}`);
@@ -152,14 +153,14 @@ export const stringifyEnvironment = (envObj: BrunoEnvironment, options: Stringif
 
 // mock server — workspace-level entity, opencollection yml only
 export const parseMockServer = (content: string, options: ParseOptions = { format: 'yml' }): any => {
-  if (options.format === 'yml') {
+  if (isYamlFormat(options.format)) {
     return parseYmlMockServer(content);
   }
   throw new Error(`Unsupported format: ${options.format}`);
 };
 
 export const stringifyMockServer = (mockServerObj: any, options: StringifyOptions = { format: 'yml' }): string => {
-  if (options.format === 'yml') {
+  if (isYamlFormat(options.format)) {
     return stringifyYmlMockServer(mockServerObj);
   }
   throw new Error(`Unsupported format: ${options.format}`);

--- a/packages/bruno-filestore/src/maxRedirects.spec.ts
+++ b/packages/bruno-filestore/src/maxRedirects.spec.ts
@@ -2,7 +2,8 @@ import { parseRequest, stringifyRequest } from './index';
 import { DEFAULT_MAX_REDIRECTS } from '@usebruno/common/utils';
 import type { CollectionFormat } from './types';
 
-const FORMATS: CollectionFormat[] = ['bru', 'yml'];
+// `yaml` is the same YAML under a different extension, so it must round-trip identically.
+const FORMATS: CollectionFormat[] = ['bru', 'yml', 'yaml'];
 
 const requestWithMaxRedirects = (maxRedirects: number) => ({
   uid: 'req-uid',
@@ -29,6 +30,19 @@ const roundTripRequest = (maxRedirects: number, format: CollectionFormat) =>
   parseRequest(stringifyRequest(requestWithMaxRedirects(maxRedirects) as any, { format }), { format })
     .settings.maxRedirects;
 
+const yamlDocument = (rawValue: string) => `info:
+  name: Get Users
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: https://restcountries.com/v2/alpha/in
+
+settings:
+  maxRedirects: ${rawValue}
+`;
+
 const HAND_EDITED_DOCUMENTS: Record<CollectionFormat, (rawValue: string) => string> = {
   bru: (rawValue) => `meta {
   name: Get Users
@@ -46,18 +60,8 @@ settings {
   maxRedirects: ${rawValue}
 }
 `,
-  yml: (rawValue) => `info:
-  name: Get Users
-  type: http
-  seq: 1
-
-http:
-  method: GET
-  url: https://restcountries.com/v2/alpha/in
-
-settings:
-  maxRedirects: ${rawValue}
-`
+  yml: (rawValue) => yamlDocument(rawValue),
+  yaml: (rawValue) => yamlDocument(rawValue)
 };
 
 // Parses a document stated byte-for-byte, for values Bruno's writer would never produce

--- a/packages/bruno-filestore/src/types.ts
+++ b/packages/bruno-filestore/src/types.ts
@@ -1,4 +1,16 @@
-export type CollectionFormat = 'bru' | 'yml';
+import { isOpenCollectionLayout, type CollectionLayout } from '@usebruno/common';
+
+/**
+ * On-disk format of a collection's files — the same thing `@usebruno/common` calls a layout.
+ *
+ * `'yml'` and `'yaml'` are the same OpenCollection YAML under two extensions, so both are handled
+ * by the `yml` serializer. Use {@link isYamlFormat} to branch, never `=== 'yml'`, so a `.yaml`
+ * collection is never mistaken for a `.bru` one.
+ */
+export type CollectionFormat = CollectionLayout;
+
+/** True for both spellings of OpenCollection YAML. */
+export const isYamlFormat = isOpenCollectionLayout;
 
 export interface ParseOptions {
   format?: CollectionFormat;

--- a/packages/bruno-filestore/src/workers/worker-script.ts
+++ b/packages/bruno-filestore/src/workers/worker-script.ts
@@ -15,7 +15,7 @@ import {
   stringifyYmlFolder,
   stringifyYmlEnvironment
 } from '../formats/yml';
-import { CollectionFormat } from '../types';
+import { CollectionFormat, isYamlFormat } from '../types';
 import { DEFAULT_COLLECTION_FORMAT } from '../constants';
 
 type TaskType
@@ -37,17 +37,17 @@ interface WorkerMessage {
 const runTask = (taskType: TaskType, data: any, format: CollectionFormat): any => {
   switch (taskType) {
     case 'parse':
-      return format === 'yml' ? parseYmlItem(data) : parseBruRequest(data);
+      return isYamlFormat(format) ? parseYmlItem(data) : parseBruRequest(data);
     case 'stringify':
-      return format === 'yml' ? stringifyYmlItem(data) : stringifyBruRequest(data);
+      return isYamlFormat(format) ? stringifyYmlItem(data) : stringifyBruRequest(data);
     case 'parseFolder':
-      return format === 'yml' ? parseYmlFolder(data) : parseBruCollection(data);
+      return isYamlFormat(format) ? parseYmlFolder(data) : parseBruCollection(data);
     case 'stringifyFolder':
-      return format === 'yml' ? stringifyYmlFolder(data) : stringifyBruCollection(data, true);
+      return isYamlFormat(format) ? stringifyYmlFolder(data) : stringifyBruCollection(data, true);
     case 'parseEnvironment':
-      return format === 'yml' ? parseYmlEnvironment(data) : parseBruEnvironment(data);
+      return isYamlFormat(format) ? parseYmlEnvironment(data) : parseBruEnvironment(data);
     case 'stringifyEnvironment':
-      return format === 'yml' ? stringifyYmlEnvironment(data) : stringifyBruEnvironment(data);
+      return isYamlFormat(format) ? stringifyYmlEnvironment(data) : stringifyBruEnvironment(data);
     default:
       throw new Error(`Unknown task type: ${taskType}`);
   }

--- a/packages/bruno-js/src/utils/error-formatter.js
+++ b/packages/bruno-js/src/utils/error-formatter.js
@@ -2,7 +2,12 @@ const fs = require('fs');
 const path = require('path');
 const YAML = require('yaml');
 const { NODEVM_SCRIPT_WRAPPER_OFFSET, QUICKJS_SCRIPT_WRAPPER_OFFSET } = require('./sandbox');
-const { isRequestFilename, isYamlFilename } = require('@usebruno/common');
+const { getLayoutForFilename, isRequestFilename, isYamlFilename } = require('@usebruno/common');
+
+// `.bru` must be recognized case-insensitively like every other layout extension — a `FOO.BRU`
+// request is a real file on Windows and macOS, and missing it here returns raw VM line numbers
+// instead of lines mapped into the script block.
+const isBruFilename = (filePath) => getLayoutForFilename(filePath) === 'bru';
 
 const posixifyPath = (p) => (p ? p.replace(/\\/g, '/') : p);
 
@@ -40,7 +45,7 @@ const BLOCK_PATTERNS = {
 
 /** Find the 1-indexed line where a script block's content starts in a .bru file */
 const findScriptBlockStartLine = (filePath, scriptType, cache = null) => {
-  if (!filePath.endsWith('.bru')) return null;
+  if (!isBruFilename(filePath)) return null;
 
   const cacheKey = `bru:${filePath}:${scriptType}`;
   if (cache?.has(cacheKey)) return cache.get(cacheKey);
@@ -66,7 +71,7 @@ const findScriptBlockStartLine = (filePath, scriptType, cache = null) => {
 
 /** Find the 1-indexed last content line of a script block in a .bru file (excludes closing }) */
 const findScriptBlockEndLine = (filePath, scriptType, cache = null) => {
-  if (!filePath.endsWith('.bru')) return null;
+  if (!isBruFilename(filePath)) return null;
 
   const cacheKey = `bru-end:${filePath}:${scriptType}`;
   if (cache?.has(cacheKey)) return cache.get(cacheKey);
@@ -191,7 +196,7 @@ const findYmlScriptBlockEndLine = (filePath, scriptType, cache = null) => {
 
 /** Adjust a runtime-reported line number to the actual line in the .bru/.yml/.yaml file */
 const adjustLineNumber = (filePath, reportedLine, isQuickJS, scriptType = null, cache = null, scriptMetadata = null) => {
-  const isBruFile = filePath.endsWith('.bru');
+  const isBruFile = isBruFilename(filePath);
   const isYmlFile = isYamlFilename(filePath);
 
   if (!isBruFile && !isYmlFile) {
@@ -240,7 +245,7 @@ const adjustLineNumber = (filePath, reportedLine, isQuickJS, scriptType = null, 
 
 /** Look up the script block start line for a .bru, .yml or .yaml file */
 const findBlockStart = (filePath, scriptType, cache) => {
-  if (filePath.endsWith('.bru')) return findScriptBlockStartLine(filePath, scriptType, cache);
+  if (isBruFilename(filePath)) return findScriptBlockStartLine(filePath, scriptType, cache);
   if (isYamlFilename(filePath)) return findYmlScriptBlockStartLine(filePath, scriptType, cache);
   return null;
 };
@@ -688,7 +693,7 @@ const formatErrorWithContextV2 = (error, scriptType, scriptMetadata, collectionP
     // so show lines relative to the script block, not absolute .bru file lines.
     const blockStartLine = findBlockStart(sourceFile, scriptType, cache);
 
-    const isBru = sourceFile.endsWith('.bru');
+    const isBru = isBruFilename(sourceFile);
     const isYml = isYamlFilename(sourceFile);
     const blockEndLine = isBru
       ? findScriptBlockEndLine(sourceFile, scriptType, cache)

--- a/packages/bruno-js/src/utils/error-formatter.js
+++ b/packages/bruno-js/src/utils/error-formatter.js
@@ -2,14 +2,11 @@ const fs = require('fs');
 const path = require('path');
 const YAML = require('yaml');
 const { NODEVM_SCRIPT_WRAPPER_OFFSET, QUICKJS_SCRIPT_WRAPPER_OFFSET } = require('./sandbox');
+const { isRequestFilename, isYamlFilename } = require('@usebruno/common');
 
 const posixifyPath = (p) => (p ? p.replace(/\\/g, '/') : p);
 
 const DEFAULT_CONTEXT_LINES = 5;
-const ALLOWED_SOURCE_EXTENSIONS = ['.bru', '.yml'];
-
-const isAllowedSourceFile = (filePath) =>
-  typeof filePath === 'string' && ALLOWED_SOURCE_EXTENSIONS.some((ext) => filePath.endsWith(ext));
 
 const SCRIPT_TYPES = Object.freeze({
   PRE_REQUEST: 'pre-request',
@@ -103,9 +100,9 @@ const findScriptBlockEndLine = (filePath, scriptType, cache = null) => {
   return result;
 };
 
-/** Find the 1-indexed line where a script block's content starts in a .yml file */
+/** Find the 1-indexed line where a script block's content starts in a .yml/.yaml file */
 const findYmlScriptBlockStartLine = (filePath, scriptType, cache = null) => {
-  if (!filePath.endsWith('.yml')) return null;
+  if (!isYamlFilename(filePath)) return null;
 
   const cacheKey = `yml:${filePath}:${scriptType}`;
   if (cache?.has(cacheKey)) return cache.get(cacheKey);
@@ -147,9 +144,9 @@ const findYmlScriptBlockStartLine = (filePath, scriptType, cache = null) => {
   return result;
 };
 
-/** Find the 1-indexed last content line of a script block in a .yml file */
+/** Find the 1-indexed last content line of a script block in a .yml/.yaml file */
 const findYmlScriptBlockEndLine = (filePath, scriptType, cache = null) => {
-  if (!filePath.endsWith('.yml')) return null;
+  if (!isYamlFilename(filePath)) return null;
 
   const cacheKey = `yml-end:${filePath}:${scriptType}`;
   if (cache?.has(cacheKey)) return cache.get(cacheKey);
@@ -192,10 +189,10 @@ const findYmlScriptBlockEndLine = (filePath, scriptType, cache = null) => {
   return result;
 };
 
-/** Adjust a runtime-reported line number to the actual line in the .bru/.yml file */
+/** Adjust a runtime-reported line number to the actual line in the .bru/.yml/.yaml file */
 const adjustLineNumber = (filePath, reportedLine, isQuickJS, scriptType = null, cache = null, scriptMetadata = null) => {
   const isBruFile = filePath.endsWith('.bru');
-  const isYmlFile = filePath.endsWith('.yml');
+  const isYmlFile = isYamlFilename(filePath);
 
   if (!isBruFile && !isYmlFile) {
     return reportedLine;
@@ -221,7 +218,7 @@ const adjustLineNumber = (filePath, reportedLine, isQuickJS, scriptType = null, 
         }
       } else {
         // Error is in a collection/folder-level script
-        // Cannot map to the request .bru/.yml file, return null to skip source context.
+        // Cannot map to the request source file, return null to skip source context.
         return null;
       }
     }
@@ -241,10 +238,10 @@ const adjustLineNumber = (filePath, reportedLine, isQuickJS, scriptType = null, 
   return scriptRelativeLine;
 };
 
-/** Look up the script block start line for a .bru or .yml file */
+/** Look up the script block start line for a .bru, .yml or .yaml file */
 const findBlockStart = (filePath, scriptType, cache) => {
   if (filePath.endsWith('.bru')) return findScriptBlockStartLine(filePath, scriptType, cache);
-  if (filePath.endsWith('.yml')) return findYmlScriptBlockStartLine(filePath, scriptType, cache);
+  if (isYamlFilename(filePath)) return findYmlScriptBlockStartLine(filePath, scriptType, cache);
   return null;
 };
 
@@ -262,7 +259,7 @@ const resolveSegmentError = (parsed, metadata, scriptType, cache) => {
 
   for (const segment of metadata.segments) {
     if (scriptRelativeLine >= segment.startLine && scriptRelativeLine <= segment.endLine) {
-      if (!isAllowedSourceFile(segment.filePath)) return null;
+      if (!isRequestFilename(segment.filePath)) return null;
 
       const blockStartLine = findBlockStart(segment.filePath, scriptType, cache);
       if (!blockStartLine) {
@@ -486,7 +483,7 @@ const formatErrorWithContext = (error, relativeFilePath = null, scriptType = nul
 
   const sourceFile = segmentResult ? segmentResult.filePath : filePath;
   const sourceLine = segmentResult ? segmentResult.line : adjustedLine;
-  const context = isAllowedSourceFile(sourceFile) ? getSourceContext(sourceFile, sourceLine, contextLines, cache) : null;
+  const context = isRequestFilename(sourceFile) ? getSourceContext(sourceFile, sourceLine, contextLines, cache) : null;
 
   if (!context) {
     return `${error.message}\n${error.stack || ''}`;
@@ -598,7 +595,7 @@ const resolveErrorContext = ({ adjustedLine, scriptRelativeLine, metadata, segme
     // returned scriptRelativeLine (not a real .bru file line), so stack frame adjustment
     // would produce misleading results — flag it as draft-only.
     const blockStartLine = findBlockStart(filePath, scriptType, cache);
-    const draftOnlyBlock = !blockStartLine && isAllowedSourceFile(filePath);
+    const draftOnlyBlock = !blockStartLine && isRequestFilename(filePath);
     // requestStartLine points to the IIFE wrapper line (`await (async () => {`),
     // so subtracting it yields a 1-based index into the user's script content.
     const lineInScript = scriptRelativeLine - metadata.requestStartLine;
@@ -692,14 +689,14 @@ const formatErrorWithContextV2 = (error, scriptType, scriptMetadata, collectionP
     const blockStartLine = findBlockStart(sourceFile, scriptType, cache);
 
     const isBru = sourceFile.endsWith('.bru');
-    const isYml = sourceFile.endsWith('.yml');
+    const isYml = isYamlFilename(sourceFile);
     const blockEndLine = isBru
       ? findScriptBlockEndLine(sourceFile, scriptType, cache)
       : isYml
         ? findYmlScriptBlockEndLine(sourceFile, scriptType, cache)
         : null;
 
-    // If this is a .bru/.yml file but the script block is missing or empty, there's nothing to show
+    // If this is a Bruno source file but the script block is missing or empty, there's nothing to show
     if ((isBru || isYml) && !blockEndLine) return null;
 
     const blockOffset = blockStartLine ? blockStartLine - 1 : 0;

--- a/packages/bruno-js/src/utils/error-formatter.spec.js
+++ b/packages/bruno-js/src/utils/error-formatter.spec.js
@@ -262,6 +262,18 @@ describe('Error Formatter', () => {
       expect(adjustLineNumber(bruFilePath, 4, false, 'post-response')).toBe(20);
     });
 
+    it('should adjust lines for an uppercase .BRU file exactly as for .bru', () => {
+      // `FOO.BRU` is a real file on Windows and macOS; a case-sensitive check here would skip
+      // script-block mapping and report the raw VM line instead.
+      const upperBruPath = path.join(testDir, 'upper.BRU');
+      fs.writeFileSync(upperBruPath, MULTI_BLOCK_BRU);
+
+      expect(adjustLineNumber(upperBruPath, 4, false, 'post-response'))
+        .toBe(adjustLineNumber(bruFilePath, 4, false, 'post-response'));
+      expect(findScriptBlockStartLine(upperBruPath, 'pre-request'))
+        .toBe(findScriptBlockStartLine(bruFilePath, 'pre-request'));
+    });
+
     it('should adjust lines for .yml files', () => {
       expect(adjustLineNumber(ymlFilePath, 10, true, 'pre-request')).toBe(8);
       expect(adjustLineNumber(ymlFilePath, 11, true, 'post-response')).toBe(13);

--- a/packages/bruno-js/src/utils/error-formatter.spec.js
+++ b/packages/bruno-js/src/utils/error-formatter.spec.js
@@ -126,6 +126,7 @@ describe('Error Formatter', () => {
   let testDir;
   let bruFilePath;
   let ymlFilePath;
+  let yamlFilePath;
   let bruWithCommentsPath;
   let collectionYmlPath;
 
@@ -139,6 +140,8 @@ describe('Error Formatter', () => {
     fs.writeFileSync(ymlFilePath, MULTI_BLOCK_YML);
     fs.writeFileSync(bruWithCommentsPath, BRU_WITH_COMMENTS);
     fs.writeFileSync(collectionYmlPath, COLLECTION_YML);
+    yamlFilePath = path.join(testDir, 'test.yaml');
+    fs.writeFileSync(yamlFilePath, MULTI_BLOCK_YML);
   });
 
   afterEach(() => {
@@ -202,6 +205,12 @@ describe('Error Formatter', () => {
       fs.writeFileSync(noRuntimePath, 'info:\n  name: simple\n  version: "1"\n');
       expect(findYmlScriptBlockStartLine(noRuntimePath, 'pre-request')).toBeNull();
     });
+
+    it('should treat .yaml identically to .yml', () => {
+      expect(findYmlScriptBlockStartLine(yamlFilePath, 'pre-request')).toBe(8);
+      expect(findYmlScriptBlockStartLine(yamlFilePath, 'post-response')).toBe(12);
+      expect(findYmlScriptBlockStartLine(yamlFilePath, 'test')).toBe(16);
+    });
   });
 
   describe('findYmlScriptBlockEndLine', () => {
@@ -225,6 +234,12 @@ describe('Error Formatter', () => {
     it('should return null for non-.yml files', () => {
       expect(findYmlScriptBlockEndLine('/some/file.js', 'pre-request')).toBeNull();
       expect(findYmlScriptBlockEndLine(bruFilePath, 'pre-request')).toBeNull();
+    });
+
+    it('should treat .yaml identically to .yml', () => {
+      expect(findYmlScriptBlockEndLine(yamlFilePath, 'pre-request')).toBe(9);
+      expect(findYmlScriptBlockEndLine(yamlFilePath, 'post-response')).toBe(13);
+      expect(findYmlScriptBlockEndLine(yamlFilePath, 'test')).toBe(18);
     });
 
     it('should return null for invalid YAML', () => {
@@ -251,6 +266,14 @@ describe('Error Formatter', () => {
       expect(adjustLineNumber(ymlFilePath, 10, true, 'pre-request')).toBe(8);
       expect(adjustLineNumber(ymlFilePath, 11, true, 'post-response')).toBe(13);
       expect(adjustLineNumber(ymlFilePath, 4, false, 'post-response')).toBe(13);
+    });
+
+    it('should adjust lines for .yaml files exactly as for .yml', () => {
+      // A .yaml source must map to the same lines; falling through to the raw reported line
+      // would point the user at the wrong place in their script.
+      expect(adjustLineNumber(yamlFilePath, 10, true, 'pre-request')).toBe(8);
+      expect(adjustLineNumber(yamlFilePath, 11, true, 'post-response')).toBe(13);
+      expect(adjustLineNumber(yamlFilePath, 4, false, 'post-response')).toBe(13);
     });
 
     it('should adjust lines correctly when script has comments', () => {

--- a/tests/collection/open/open-collection-selection.spec.ts
+++ b/tests/collection/open/open-collection-selection.spec.ts
@@ -3,9 +3,11 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { buildCommonLocators, closeAllCollections, toggleOpenCollectionItem, closeOpenCollectionModal } from '../../utils/page';
 
-const writeCollection = (dir: string, name: string) => {
+// `ext` selects the on-disk spelling: hand-authored, converted, or third-party-tool trees use
+// `.yaml`, and the app must open them exactly like `.yml`.
+const writeCollection = (dir: string, name: string, ext = '.yml') => {
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'opencollection.yml'), `opencollection: "1.0.0"\ninfo:\n  name: ${name}\n`);
+  fs.writeFileSync(path.join(dir, `opencollection${ext}`), `opencollection: "1.0.0"\ninfo:\n  name: ${name}\n`);
 };
 
 const writeBrunoJsonCollection = (dir: string, name: string) => {
@@ -16,9 +18,9 @@ const writeBrunoJsonCollection = (dir: string, name: string) => {
   );
 };
 
-const writeInvalidCollection = (dir: string) => {
+const writeInvalidCollection = (dir: string, ext = '.yml') => {
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'opencollection.yml'), 'opencollection: "1.0.0"\ninfo: {name:');
+  fs.writeFileSync(path.join(dir, `opencollection${ext}`), 'opencollection: "1.0.0"\ninfo: {name:');
 };
 
 const mockPickerPaths = async (electronApp: ElectronApplication, filePaths: string[]) => {
@@ -75,6 +77,37 @@ test.describe('Open Collection - selection flow', () => {
 
     await expect(locators.sidebar.collection('Single Collection')).toBeVisible();
     await expect(openCollectionModal(page)).toHaveCount(0);
+    await closeAllCollections(page);
+  });
+
+  test('opens an opencollection.yaml collection directly', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const dir = await createTmpDir('single-yaml-ext');
+    writeCollection(dir, 'Dotyaml Root', '.yaml');
+
+    await mockPickerPaths(electronApp, [dir]);
+    await openViaSidebar(page);
+
+    await expect(locators.sidebar.collection('Dotyaml Root')).toBeVisible();
+    await expect(openCollectionModal(page)).toHaveCount(0);
+    await closeAllCollections(page);
+  });
+
+  test('scans for a nested opencollection.yaml collection', async ({ page, electronApp, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const base = await createTmpDir('nested-yaml-ext');
+    writeCollection(path.join(base, 'nested'), 'Nested Dotyaml Tree', '.yaml');
+
+    await mockPickerPaths(electronApp, [base]);
+    await openViaSidebar(page);
+
+    await expect(openCollectionModal(page)).toBeVisible();
+    await expect(listTitles(page)).toHaveText('Nested Dotyaml Tree');
+
+    await toggleOpenCollectionItem(page, 'Nested Dotyaml Tree');
+    await locators.modal.button('Open').click();
+
+    await expect(locators.sidebar.collection('Nested Dotyaml Tree')).toBeVisible();
     await closeAllCollections(page);
   });
 
@@ -272,7 +305,7 @@ test.describe('Open Collection - selection flow', () => {
     await openViaSidebar(page);
 
     await expect(
-      page.getByText('No Bruno collections found. Couldn\'t find a bruno.json or opencollection.yml')
+      page.getByText('No Bruno collections found. Couldn\'t find a bruno.json or opencollection file')
     ).toBeVisible();
     await expect(openCollectionModal(page)).toHaveCount(0);
   });


### PR DESCRIPTION
### Description
Adds support for storing collections/requests as `.YAML` files, inline with YAML's other widely used filename.

### Problem
Currently, bruno only supports `.YML` files, and ignores files stored as `.YAML`, despite the format being identical, as described in https://github.com/usebruno/bruno/issues/9003

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [X] **The pull request only addresses one issue or adds one feature.**
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have added screenshots or gifs to help explain the change if applicable.**
- [X] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [X] **Create an issue and link to the pull request.** (#9003)
- [X] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for `.yaml` OpenCollections alongside `.yml`.
  * Workspace discovery now supports both `workspace.yml` and `workspace.yaml`.
  * Collection, request, folder, environment, and mock server handling now adapts to the selected format.
  * Existing YAML filenames are preserved when editing.

* **Bug Fixes**
  * Improved format detection, path resolution, collection switching, error context, and environment persistence.

* **Tests**
  * Expanded coverage for YAML parsing, execution, imports, persistence, watching, and file layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->