### PR TITLE
fix(redaction): added search limit for code blocks within app block.

### DIFF
--- a/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
+++ b/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
@@ -246,6 +246,50 @@ app {
 }
 `;
 
+const docsAboutAppCodeBru = `meta {
+  name: Docs About App Code
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://example.com
+}
+
+docs {
+  # How the app block works
+
+  app {
+    code: '''
+      <div>hi</div>
+    '''
+  }
+}
+`;
+
+const appWithoutCodeThenDocsBru = `meta {
+  name: No Code Then Docs
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://example.com
+}
+
+app {
+  enabled: true
+}
+
+docs {
+  Set the code like this:
+
+  code: '''
+    <div>hi</div>
+  '''
+}
+`;
+
 describe('redactLargeBruTextBlocks', () => {
   describe('matches a normal parse (ohm oracle)', () => {
     const requestCases = [
@@ -259,7 +303,9 @@ describe('redactLargeBruTextBlocks', () => {
       ['CRLF request-level app code', toCRLF(appBru)],
       ['standalone app item', standaloneAppBru],
       ['app block without code', appWithoutCodeBru],
-      ['app block with an empty code value', appEmptyCodeBru]
+      ['app block with an empty code value', appEmptyCodeBru],
+      ['docs documenting an app code block', docsAboutAppCodeBru],
+      ['app block without code followed by docs holding a code pair', appWithoutCodeThenDocsBru]
     ];
 
     it.each(requestCases)('%s', (_name, content) => {
@@ -324,6 +370,21 @@ body:json {
   it('leaves an app block whose code has no value untouched', () => {
     const { blocks } = redactLargeBruTextBlocks(appEmptyCodeBru);
     expect(blocks).toEqual([]);
+  });
+
+  it('leaves a code pair outside the app block untouched', () => {
+    const { blocks } = redactLargeBruTextBlocks(docsAboutAppCodeBru);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].value).toContain("code: '''");
+    expect(blocks[0].value).toContain('<div>hi</div>');
+    expect(blocks[0].value).not.toContain('__BRU_REDACTED_TEXT_BLOCK_');
+  });
+
+  it('leaves a code pair after an app block that has no code untouched', () => {
+    const { blocks } = redactLargeBruTextBlocks(appWithoutCodeThenDocsBru);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].value).toContain("code: '''");
+    expect(blocks[0].value).not.toContain('__BRU_REDACTED_TEXT_BLOCK_');
   });
 
   it('leaves dictionary body blocks untouched', () => {

--- a/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
+++ b/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
@@ -41,6 +41,7 @@ const tokenFor = (content: string): string => {
 const blockValue = (content: string[]): string =>
   outdentString(content.join('\n').replace(/^(?:\r?\n)+/, '').replace(/\r$/, ''));
 
+const APP_BLOCK_OPENING = /^app[ \t]*\{\r?$/;
 const MULTILINE_DELIMITER = '\'\'\'';
 const APP_CODE_PAIR = `code: ${MULTILINE_DELIMITER}`;
 
@@ -49,11 +50,23 @@ const appCodeValue = (code: string[]): string =>
 
 const redactAppCode = (source: string, blocks: RedactedBlock[]): string => {
   const lines = source.split('\n');
-  const opening = lines.findIndex((line) => line.trim() === APP_CODE_PAIR);
+
+  const start = lines.findIndex((line) => APP_BLOCK_OPENING.test(line));
+  if (start === -1) {
+    return source;
+  }
+
+  const closingBrace = lines.findIndex((line, index) => index > start && isClosing(line));
+  const end = closingBrace === -1 ? lines.length : closingBrace;
+
+  const opening = lines.findIndex((line, index) => index > start && index < end && line.trim() === APP_CODE_PAIR);
   if (opening === -1) {
     return source;
   }
-  const closing = lines.findIndex((line, index) => index > opening && line.trim() === MULTILINE_DELIMITER);
+
+  const closing = lines.findIndex(
+    (line, index) => index > opening && index < end && line.trim() === MULTILINE_DELIMITER
+  );
   if (closing === -1) {
     return source;
   }


### PR DESCRIPTION
- The redaction logic now limits the search for code: ''' block within the app block. It is safe to use code: ''' within other blocks.
- Added tests to validate different scenarios with the app block and code section.

Ticket - BRU-4350


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction of large text blocks by limiting code removal to valid code sections within app blocks.
  * Preserved code pairs found outside app blocks and left content unchanged when no valid app code section exists.
  * Added coverage for empty app code, documentation containing code pairs, and code following app blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->