### PR TITLE
fix(mock-server): syncing example logic change

### DIFF
--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -44,14 +44,22 @@ export const copyExampleToMockResponse = (example, parentRequest) => ({
   }
 });
 
+const getMockResponseMergeKey = (response) => {
+  const { exampleName, requestPathname } = response?.copiedFrom || {};
+
+  return exampleName && requestPathname
+    ? `example::${requestPathname}::${exampleName}`
+    : getMockResponseRouteKey(response);
+};
+
 const mergeMockResponsesByRouteKey = (existingResponses = [], nextResponses = [], { keepExistingName = false } = {}) => {
   const responses = [...existingResponses];
   const indexByRouteKey = new Map(
-    responses.map((response, index) => [getMockResponseRouteKey(response), index])
+    responses.map((response, index) => [getMockResponseMergeKey(response), index])
   );
 
   for (const nextResponse of nextResponses) {
-    const routeKey = getMockResponseRouteKey(nextResponse);
+    const routeKey = getMockResponseMergeKey(nextResponse);
     const existingIndex = indexByRouteKey.get(routeKey);
 
     if (existingIndex !== undefined) {
@@ -436,7 +444,7 @@ export const buildMockRouteTable = (responses = []) => {
           status: Number(item.response?.status) || 200,
           sourceFile: 'mock-response'
         })),
-        defaultResponse: items[0]?.name || null
+        defaultResponse: items.find((item) => !item.rules?.conditions?.length)?.name || null
       };
     })
     .sort((left, right) => (

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.sync.spec.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.sync.spec.js
@@ -49,13 +49,34 @@ describe('syncMockResponsesFromExamples', () => {
 
     const synced = syncMockResponsesFromExamples(existingResponses, exampleEntries);
 
-    expect(synced).toHaveLength(3);
+    expect(synced).toHaveLength(4);
     expect(synced.find((item) => item.uid === 'custom-1')?.response.body.content).toBe('{"custom":true}');
-    expect(synced.find((item) => item.uid === 'users-1')?.response.body.content).toBe('{"synced":true}');
+    expect(synced.find((item) => item.uid === 'users-1')?.response.body.content).toBe('{}');
+    const syncedUsers = synced.find((item) => item.name === 'Users success (mock)');
+    expect(syncedUsers?.response.body.content).toBe('{"synced":true}');
     const createdResponse = synced.find((item) => item.name === 'Create order (mock)');
     expect(createdResponse).toBeTruthy();
     expect(createdResponse.uid).toBeUndefined();
     expect(getMockResponseRouteKey(synced.find((item) => item.uid === 'users-1'))).toBe('GET /users::200');
+  });
+
+  it('keeps one response per example when examples share a route and status', () => {
+    const entryFor = (name) => ({
+      item: { pathname: 'users.bru', request: { url: '/users', method: 'GET' } },
+      example: {
+        name,
+        request: { url: '/users', method: 'GET' },
+        response: { status: 200, body: { type: 'json', content: `{"from":"${name}"}` } }
+      }
+    });
+
+    const synced = syncMockResponsesFromExamples([], [entryFor('First'), entryFor('Second')]);
+
+    expect(synced).toHaveLength(2);
+    expect(synced.map((item) => item.name)).toEqual(['First (mock)', 'Second (mock)']);
+
+    const resynced = syncMockResponsesFromExamples(synced, [entryFor('First'), entryFor('Second')]);
+    expect(resynced).toHaveLength(2);
   });
 });
 
@@ -88,6 +109,41 @@ describe('buildMockRouteTable', () => {
         defaultResponse: 'Users'
       }
     ]);
+  });
+
+  it('defaults to the first rule-less response, not the first response', () => {
+    const [route] = buildMockRouteTable([
+      {
+        uid: 'a',
+        name: 'Users page 1',
+        request: { url: '/users', method: 'GET' },
+        response: { status: 200 },
+        rules: { operator: 'AND', conditions: [{ target: 'query', key: 'page', operator: 'equals', value: '1' }] }
+      },
+      {
+        uid: 'b',
+        name: 'All users',
+        request: { url: '/users', method: 'GET' },
+        response: { status: 200 },
+        rules: { operator: 'AND', conditions: [] }
+      }
+    ]);
+
+    expect(route.defaultResponse).toBe('All users');
+  });
+
+  it('has no default when every response carries rules', () => {
+    const [route] = buildMockRouteTable([
+      {
+        uid: 'a',
+        name: 'Users page 1',
+        request: { url: '/users', method: 'GET' },
+        response: { status: 200 },
+        rules: { operator: 'AND', conditions: [{ target: 'query', key: 'page', operator: 'equals', value: '1' }] }
+      }
+    ]);
+
+    expect(route.defaultResponse).toBeNull();
   });
 });
 


### PR DESCRIPTION
### Description

JIRA: BRU-4342

Syncing a mock server with a collection dropped every example that shared a route and status code with another, so 10 examples could land as 1 mock response. 

### Problem

Sync merged examples by METHOD path::status key. So any two examples on the same route with the same status collapsed into one row, silently.

### Fix

Merge on copiedFrom when both fields are present, else it falls back to the route key. Also, spec-generated responses set exampleName: null, so spec sync keeps route identity and is unchanged.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock response synchronization when multiple examples share the same route.
  * Preserved existing responses and ensured stable results across repeated synchronizations.
  * Selected the first response without conditions as the default for a route.
  * Routes without an unconditional response no longer receive an incorrect default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->