### PR TITLE
fix(mock-server): fixing status text on response panel for mock response

### DIFF
--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -31,7 +31,7 @@ export const copyExampleToMockResponse = (example, parentRequest) => ({
   },
   response: {
     status: Number(example.response?.status) || 200,
-    statusText: example.response?.statusText || 'OK',
+    statusText: example.response?.statusText || '',
     headers: example.response?.headers || [],
     body: {
       type: example.response?.body?.type || 'json',

--- a/packages/bruno-app/src/utils/mock-server/mock-responses/editor.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses/editor.js
@@ -40,7 +40,7 @@ export const buildMockResponseEditorItem = (mockResponse) => {
     },
     response: {
       status: Number(mockResponse.response?.status) || 200,
-      statusText: mockResponse.response?.statusText || 'OK',
+      statusText: mockResponse.response?.statusText || '',
       headers: cloneDeep(mockResponse.response?.headers || []),
       body: cloneDeep(mockResponse.response?.body || { type: 'json', content: '' })
     }

--- a/packages/bruno-electron/src/app/mock-server/mock-server-store.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server-store.js
@@ -320,7 +320,7 @@ const createEmptyMockResponse = (name = 'New Mock Response') => ({
   },
   response: {
     status: 200,
-    statusText: 'OK',
+    statusText: '',
     headers: [],
     body: {
       type: 'json',

--- a/packages/bruno-filestore/src/formats/yml/parseMockServer.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseMockServer.ts
@@ -37,6 +37,9 @@ const toBrunoRuleConditions = (conditions: MockRuleCondition[] | null | undefine
 };
 
 const toBrunoMockRoute = (route: MockRouteEntry): BrunoMockRoute => {
+  const responseStatus = Number(route?.response?.status) || 200;
+  const responseStatusText = ensureString(route?.response?.statusText);
+
   const brunoRoute: BrunoMockRoute = {
     name: ensureString(route?.name, 'Untitled Mock Response'),
     description: ensureString(route?.description),
@@ -48,8 +51,8 @@ const toBrunoMockRoute = (route: MockRouteEntry): BrunoMockRoute => {
       body: toBrunoBody(route?.request?.body) || emptyRequestBody()
     },
     response: {
-      status: Number(route?.response?.status) || 200,
-      statusText: ensureString(route?.response?.statusText, 'OK'),
+      status: responseStatus,
+      statusText: responseStatusText === 'OK' && responseStatus !== 200 ? '' : responseStatusText,
       headers: toBrunoHttpHeaders(route?.response?.headers) || [],
       body: {
         type: ensureString(route?.response?.body?.type, 'json'),


### PR DESCRIPTION
### Description

JIRA: BRU-4348

When creating a mock server response with a status code outside the common dropdown set (e.g. 412 Precondition Failed), the mock response dashboard shows the correct numeric code but the wrong status label. On first save, the dashboard Expected Response header displays something like 412 OK instead of 412 Precondition Failed

### Problem

Mock responses hardcoded statusText: 'OK' regardless of status code

### Fix

Removed the default statusText text to OK and picking it up based on statusCode in the statusCodePhraseMap.

### Screenshots

Before


Uploading Screen Recording 2026-08-19 175942.mp4…





After



https://github.com/user-attachments/assets/6a0a2051-bf3b-4855-827e-26cf20b43007



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mock responses without a specified status text now display a blank value instead of automatically using “OK.”
  * Mock response parsing now keeps status codes and status text separate, preventing incorrect “OK” labels for non-200 responses.
  * Unspecified mock response statuses continue to default to 200.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->