### PR TITLE
feat(bruno-js): support raw response bodies in scripts

### DIFF
--- a/packages/bruno-js/src/bruno-response.js
+++ b/packages/bruno-js/src/bruno-response.js
@@ -42,8 +42,17 @@ class BrunoResponse {
     return this.res ? this.res.headers : null;
   }
 
-  getBody() {
-    return this.res ? this.res.data : null;
+  getBody(options = {}) {
+    if (!this.res) {
+      return null;
+    }
+
+    if (options.raw) {
+      const { dataBuffer } = this.res;
+      return dataBuffer === null || dataBuffer === undefined ? null : dataBuffer.toString();
+    }
+
+    return this.res.data;
   }
 
   getResponseTime() {

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.js
@@ -96,8 +96,8 @@ const addBrunoResponseShimToContext = (vm, res) => {
   vm.setProp(resFn, 'getHeaders', getHeaders);
   getHeaders.dispose();
 
-  let getBody = vm.newFunction('getBody', function () {
-    return marshallToVm(res.getBody(), vm);
+  let getBody = vm.newFunction('getBody', function (options = {}) {
+    return marshallToVm(res.getBody(vm.dump(options)), vm);
   });
   vm.setProp(resFn, 'getBody', getBody);
   getBody.dispose();

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -227,6 +227,32 @@ describe('runtime', () => {
         );
         expect(result.runtimeVariables.validation).toBeTruthy();
       });
+
+      it.each(['nodevm', 'quickjs'])('should return the raw response body in %s', async (runtimeName) => {
+        const rawBody = '1234567890'.repeat(7) + '1234567';
+        const script = `
+          bru.setVar('parsedBodyType', typeof res.getBody());
+          bru.setVar('rawBody', res.getBody({ raw: true }));
+        `;
+        const runtime = new ScriptRuntime({ runtime: runtimeName });
+        const result = await runtime.runResponseScript(
+          script,
+          { ...baseRequest },
+          {
+            ...baseResponse,
+            data: JSON.parse(rawBody),
+            dataBuffer: Buffer.from(rawBody)
+          },
+          {},
+          {},
+          '.',
+          () => {},
+          process.env
+        );
+
+        expect(result.runtimeVariables.parsedBodyType).toBe('number');
+        expect(result.runtimeVariables.rawBody).toBe(rawBody);
+      });
     });
   });
 


### PR DESCRIPTION
### Description

Adds support for reading the unparsed response body from post-response scripts with:

```js
res.getBody({ raw: true })
```

The existing `res.getBody()` and `res.body` behavior remains unchanged.

### Problem

Fixes #9008.

Response bodies are currently parsed as JSON before they are exposed to scripts. When an endpoint returns a long numeric value as its entire response body, JavaScript converts it to a `number` and loses precision.

For example, a 77-character session ID is exposed in scientific notation instead of preserving the exact response text.

### Fix

- Updated `BrunoResponse.getBody()` to accept a `{ raw: true }` option.
- Returned the original response text from the existing `dataBuffer`.
- Forwarded the `getBody` options through the QuickJS response shim.
- Added behavior-driven coverage for both Node VM and QuickJS runtimes.
- Kept the default parsed response behavior unchanged.

### Tests

- `npm test --workspace=packages/bruno-js -- --runInBand --runTestsByPath tests/runtime.spec.js`
- `npm test --workspace=packages/bruno-js -- --runInBand`
- `npx eslint packages/bruno-js/src/bruno-response.js packages/bruno-js/src/sandbox/quickjs/shims/bruno-response.js packages/bruno-js/tests/runtime.spec.js` (0 errors; existing warnings only)
- `git diff --check`

### Screenshots

Not applicable. This change affects the scripting API and does not change the UI.

| Before | After |
| --- | --- |
| `res.getBody({ raw: true })` returns the parsed, precision-lost number | `res.getBody({ raw: true })` returns the exact raw response text |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.** (Not applicable; scripting API only)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (#9008)
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving response bodies in their original raw format.
  * Response body retrieval continues to support parsed response data by default.
  * Added consistent raw body handling across supported script runtimes.

* **Bug Fixes**
  * Improved behavior when no response body is available by returning `null`.

* **Tests**
  * Added coverage for parsed and raw response body retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->