### PR TITLE
perf(cli): fetch the shell env only for commands that need it

### DIFF
--- a/packages/bruno-cli/readme.md
+++ b/packages/bruno-cli/readme.md
@@ -120,6 +120,20 @@ Import Options:
 | --client-cert-config         | Client certificate configuration by passing a JSON file                       |
 | --delay [number]             | Add delay to each request                                                     |
 
+## Environment Variables
+
+| Variable         | Details                                    |
+| ---------------- | ------------------------------------------ |
+| BRU_NO_SHELL_ENV | Skip reading the login shell environment   |
+
+Before running a collection, bru reads your login shell's environment to pick up `PATH` and proxy
+variables that a GUI app or cron job would not otherwise pass down. On macOS and Linux that costs
+roughly half a second per invocation; on Windows there is nothing to read, so the variable has no
+effect there.
+
+Set `BRU_NO_SHELL_ENV=1` when bru is invoked repeatedly as a subprocess by a caller that already
+provides a complete environment.
+
 ## Scripting
 
 Bruno cli returns the following exit status codes:

--- a/packages/bruno-cli/src/commands/import.js
+++ b/packages/bruno-cli/src/commands/import.js
@@ -6,6 +6,7 @@ const axios = require('axios');
 const { openApiToBruno, wsdlToBruno } = require('@usebruno/converters');
 const { exists, isDirectory, sanitizeName } = require('../utils/filesystem');
 const { createCollectionFromBrunoObject } = require('../utils/collection');
+const { ensureShellEnv } = require('../utils/shell-env');
 
 const command = 'import <type>';
 const desc = 'Import a collection from other formats';
@@ -223,6 +224,12 @@ const handler = async (argv) => {
     if (!output && !outputFile) {
       console.error(chalk.red('Either --output or --output-file is required'));
       process.exit(1);
+    }
+
+    // Only a remote source needs the shell environment, for proxy and CA settings. Importing a local
+    // file, or failing the checks above, should not wait on a shell.
+    if (isUrl(source)) {
+      await ensureShellEnv();
     }
 
     let brunoCollection;

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -20,6 +20,7 @@ const { hasExecutableTestInScript } = require('../utils/request');
 const { createSkippedFileResults } = require('../utils/run');
 const { sanitizeResultsForReporter } = require('../utils/sanitize-results');
 const { getSystemProxy } = require('@usebruno/requests');
+const { ensureShellEnv } = require('../utils/shell-env');
 const command = 'run [paths...]';
 const desc = 'Run one or more requests/folders';
 
@@ -293,6 +294,8 @@ const builder = async (yargs) => {
 };
 
 const handler = async function (argv) {
+  await ensureShellEnv();
+
   try {
     let {
       paths,

--- a/packages/bruno-cli/src/index.js
+++ b/packages/bruno-cli/src/index.js
@@ -1,6 +1,5 @@
 const yargs = require('yargs');
 const chalk = require('chalk');
-const { initializeShellEnv } = require('@usebruno/requests');
 
 const { CLI_EPILOGUE, CLI_VERSION } = require('./constants');
 
@@ -9,9 +8,6 @@ const printBanner = () => {
 };
 
 const run = async () => {
-  // Fetch shell environment (useful when CLI is run as subprocess from GUI app or cron)
-  await initializeShellEnv();
-
   const argLength = process.argv.length;
   const commandsToPrintBanner = ['--help', '-h'];
 

--- a/packages/bruno-cli/src/utils/shell-env.js
+++ b/packages/bruno-cli/src/utils/shell-env.js
@@ -1,0 +1,62 @@
+const chalk = require('chalk');
+const { initializeShellEnv } = require('@usebruno/requests');
+
+/**
+ * Reading the shell environment starts the user's login shell to pick up PATH and proxy variables
+ * that a GUI app or cron job would not otherwise pass down. On POSIX systems that costs roughly half
+ * a second; on Windows there is nothing to read and it returns immediately. Only the commands that
+ * actually need those variables ask for it, so `--version` and `--help` no longer pay for it.
+ *
+ * It is best-effort: if the shell fails, takes too long, or the user opted out, the command carries
+ * on with the environment it already has.
+ */
+
+// Matches the guard bruno-electron uses in src/store/shell-env-state.js. This frees the command to
+// get on with its work, but it cannot cancel a shell that is already running: a shell wedged on
+// input can still delay process exit, and can still add variables after the command has read them.
+const TIMEOUT_MS = 60_000;
+
+// For callers that run bru repeatedly as a subprocess and already pass down a complete environment,
+// where starting a shell is pure per-invocation latency.
+const isDisabled = () => {
+  const value = process.env.BRU_NO_SHELL_ENV;
+  return value !== undefined && value !== '' && value !== '0' && value !== 'false';
+};
+
+const applyShellEnv = () => {
+  if (isDisabled()) {
+    return Promise.resolve();
+  }
+
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error('Shell environment initialization timed out')), TIMEOUT_MS);
+  });
+
+  // The variables land on process.env, so callers only need to know the work is done.
+  return Promise.race([initializeShellEnv(), timeout])
+    .then(() => undefined)
+    .catch((err) => {
+      console.error(chalk.yellow(`Warning: could not read the shell environment (${err.message}). Continuing.`));
+    })
+    .finally(() => clearTimeout(timer));
+};
+
+/** @type {null | Promise<void>} */
+let shellEnvPromise = null;
+
+/**
+ * Resolves once the shell environment has been applied to process.env, or given up on. Safe to call
+ * repeatedly; the shell is only ever started once per process.
+ */
+const ensureShellEnv = () => {
+  if (!shellEnvPromise) {
+    shellEnvPromise = applyShellEnv();
+  }
+  return shellEnvPromise;
+};
+
+module.exports = {
+  ensureShellEnv,
+  TIMEOUT_MS
+};

--- a/packages/bruno-cli/src/utils/shell-env.js
+++ b/packages/bruno-cli/src/utils/shell-env.js
@@ -24,6 +24,11 @@ const isDisabled = () => {
   return value !== undefined && value !== '' && value !== '0' && value !== 'false';
 };
 
+const warnUnavailable = (reason) => {
+  const detail = reason ? ` (${reason})` : '';
+  console.error(chalk.yellow(`Warning: could not read the shell environment${detail}. Continuing.`));
+};
+
 const fetchAndApplyShellEnv = () => {
   if (isDisabled()) {
     return Promise.resolve();
@@ -39,11 +44,16 @@ const fetchAndApplyShellEnv = () => {
   // a run that has already read them.
   return Promise.race([fetchShellEnv(), timeout])
     .then((shellEnvVars) => {
+      // fetchShellEnv swallows whatever went wrong and reports null, so there is no reason to relay -
+      // but staying silent would leave missing proxy or CA settings with no explanation.
+      if (shellEnvVars === null) {
+        warnUnavailable();
+        return;
+      }
+
       applyShellEnv(shellEnvVars);
     })
-    .catch((err) => {
-      console.error(chalk.yellow(`Warning: could not read the shell environment (${err.message}). Continuing.`));
-    })
+    .catch((err) => warnUnavailable(err.message))
     .finally(() => clearTimeout(timer));
 };
 

--- a/packages/bruno-cli/src/utils/shell-env.js
+++ b/packages/bruno-cli/src/utils/shell-env.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const { initializeShellEnv } = require('@usebruno/requests');
+const { fetchShellEnv, applyShellEnv } = require('@usebruno/requests');
 
 /**
  * Reading the shell environment starts the user's login shell to pick up PATH and proxy variables
@@ -11,9 +11,10 @@ const { initializeShellEnv } = require('@usebruno/requests');
  * on with the environment it already has.
  */
 
-// Matches the guard bruno-electron uses in src/store/shell-env-state.js. This frees the command to
-// get on with its work, but it cannot cancel a shell that is already running: a shell wedged on
-// input can still delay process exit, and can still add variables after the command has read them.
+// Matches the guard bruno-electron uses in src/store/shell-env-state.js. It cannot cancel a shell
+// that is already running - shell-env exposes no signal or timeout - so a wedged shell can still
+// delay process exit. It does bound how long the command waits, and because the merge happens only
+// on the winning branch below, a result that arrives after the timeout is never applied.
 const TIMEOUT_MS = 60_000;
 
 // For callers that run bru repeatedly as a subprocess and already pass down a complete environment,
@@ -23,7 +24,7 @@ const isDisabled = () => {
   return value !== undefined && value !== '' && value !== '0' && value !== 'false';
 };
 
-const applyShellEnv = () => {
+const fetchAndApplyShellEnv = () => {
   if (isDisabled()) {
     return Promise.resolve();
   }
@@ -33,9 +34,13 @@ const applyShellEnv = () => {
     timer = setTimeout(() => reject(new Error('Shell environment initialization timed out')), TIMEOUT_MS);
   });
 
-  // The variables land on process.env, so callers only need to know the work is done.
-  return Promise.race([initializeShellEnv(), timeout])
-    .then(() => undefined)
+  // Fetching and applying are separate steps on purpose: if the timeout wins the race, the merge
+  // below never runs, so a late-arriving environment cannot change PATH or proxy settings underneath
+  // a run that has already read them.
+  return Promise.race([fetchShellEnv(), timeout])
+    .then((shellEnvVars) => {
+      applyShellEnv(shellEnvVars);
+    })
     .catch((err) => {
       console.error(chalk.yellow(`Warning: could not read the shell environment (${err.message}). Continuing.`));
     })
@@ -51,7 +56,7 @@ let shellEnvPromise = null;
  */
 const ensureShellEnv = () => {
   if (!shellEnvPromise) {
-    shellEnvPromise = applyShellEnv();
+    shellEnvPromise = fetchAndApplyShellEnv();
   }
   return shellEnvPromise;
 };

--- a/packages/bruno-cli/tests/utils/shell-env.spec.js
+++ b/packages/bruno-cli/tests/utils/shell-env.spec.js
@@ -1,0 +1,73 @@
+let mockInitialize;
+
+jest.mock('@usebruno/requests', () => ({
+  initializeShellEnv: (...args) => mockInitialize(...args)
+}));
+
+describe('shell env', () => {
+  let shellEnv;
+  const originalFlag = process.env.BRU_NO_SHELL_ENV;
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.BRU_NO_SHELL_ENV;
+    mockInitialize = jest.fn().mockResolvedValue({});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    shellEnv = require('../../src/utils/shell-env');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalFlag === undefined) {
+      delete process.env.BRU_NO_SHELL_ENV;
+    } else {
+      process.env.BRU_NO_SHELL_ENV = originalFlag;
+    }
+  });
+
+  it('resolves once the environment has been applied', async () => {
+    await expect(shellEnv.ensureShellEnv()).resolves.toBeUndefined();
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('spawns the login shell only once, however often it is asked', async () => {
+    await shellEnv.ensureShellEnv();
+    await shellEnv.ensureShellEnv();
+    await shellEnv.ensureShellEnv();
+
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the login shell when BRU_NO_SHELL_ENV is set', async () => {
+    process.env.BRU_NO_SHELL_ENV = '1';
+    await shellEnv.ensureShellEnv();
+
+    expect(mockInitialize).not.toHaveBeenCalled();
+  });
+
+  it.each(['0', 'false', ''])('treats BRU_NO_SHELL_ENV=%p as not opting out', async (value) => {
+    process.env.BRU_NO_SHELL_ENV = value;
+    await shellEnv.ensureShellEnv();
+
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns and continues when the shell cannot be read', async () => {
+    mockInitialize = jest.fn().mockRejectedValue(new Error('no shell for you'));
+
+    await expect(shellEnv.ensureShellEnv()).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('no shell for you'));
+  });
+
+  it('gives up rather than hanging when the shell never returns', async () => {
+    jest.useFakeTimers();
+    mockInitialize = jest.fn().mockReturnValue(new Promise(() => {}));
+
+    const pending = shellEnv.ensureShellEnv();
+    jest.advanceTimersByTime(shellEnv.TIMEOUT_MS);
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('timed out'));
+    jest.useRealTimers();
+  });
+});

--- a/packages/bruno-cli/tests/utils/shell-env.spec.js
+++ b/packages/bruno-cli/tests/utils/shell-env.spec.js
@@ -61,6 +61,16 @@ describe('shell env', () => {
 
     await expect(shellEnv.ensureShellEnv()).resolves.toBeUndefined();
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('no shell for you'));
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it('warns rather than silently continuing when the shell reports no environment', async () => {
+    // fetchShellEnv swallows its own errors and resolves null, so this is what a failed read looks like.
+    mockFetch = jest.fn().mockResolvedValue(null);
+
+    await expect(shellEnv.ensureShellEnv()).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('could not read the shell environment'));
+    expect(mockApply).not.toHaveBeenCalled();
   });
 
   it('gives up rather than waiting indefinitely when the shell never returns', async () => {

--- a/packages/bruno-cli/tests/utils/shell-env.spec.js
+++ b/packages/bruno-cli/tests/utils/shell-env.spec.js
@@ -1,7 +1,9 @@
-let mockInitialize;
+let mockFetch;
+let mockApply;
 
 jest.mock('@usebruno/requests', () => ({
-  initializeShellEnv: (...args) => mockInitialize(...args)
+  fetchShellEnv: (...args) => mockFetch(...args),
+  applyShellEnv: (...args) => mockApply(...args)
 }));
 
 describe('shell env', () => {
@@ -11,7 +13,8 @@ describe('shell env', () => {
   beforeEach(() => {
     jest.resetModules();
     delete process.env.BRU_NO_SHELL_ENV;
-    mockInitialize = jest.fn().mockResolvedValue({});
+    mockFetch = jest.fn().mockResolvedValue({ SHELL_VAR: 'from_shell' });
+    mockApply = jest.fn();
     jest.spyOn(console, 'error').mockImplementation(() => {});
     shellEnv = require('../../src/utils/shell-env');
   });
@@ -27,7 +30,8 @@ describe('shell env', () => {
 
   it('resolves once the environment has been applied', async () => {
     await expect(shellEnv.ensureShellEnv()).resolves.toBeUndefined();
-    expect(mockInitialize).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockApply).toHaveBeenCalledWith({ SHELL_VAR: 'from_shell' });
   });
 
   it('spawns the login shell only once, however often it is asked', async () => {
@@ -35,39 +39,61 @@ describe('shell env', () => {
     await shellEnv.ensureShellEnv();
     await shellEnv.ensureShellEnv();
 
-    expect(mockInitialize).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('skips the login shell when BRU_NO_SHELL_ENV is set', async () => {
     process.env.BRU_NO_SHELL_ENV = '1';
     await shellEnv.ensureShellEnv();
 
-    expect(mockInitialize).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it.each(['0', 'false', ''])('treats BRU_NO_SHELL_ENV=%p as not opting out', async (value) => {
     process.env.BRU_NO_SHELL_ENV = value;
     await shellEnv.ensureShellEnv();
 
-    expect(mockInitialize).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('warns and continues when the shell cannot be read', async () => {
-    mockInitialize = jest.fn().mockRejectedValue(new Error('no shell for you'));
+    mockFetch = jest.fn().mockRejectedValue(new Error('no shell for you'));
 
     await expect(shellEnv.ensureShellEnv()).resolves.toBeUndefined();
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('no shell for you'));
   });
 
-  it('gives up rather than hanging when the shell never returns', async () => {
+  it('gives up rather than waiting indefinitely when the shell never returns', async () => {
     jest.useFakeTimers();
-    mockInitialize = jest.fn().mockReturnValue(new Promise(() => {}));
+    mockFetch = jest.fn().mockReturnValue(new Promise(() => {}));
 
     const pending = shellEnv.ensureShellEnv();
     jest.advanceTimersByTime(shellEnv.TIMEOUT_MS);
 
     await expect(pending).resolves.toBeUndefined();
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('timed out'));
+    expect(mockApply).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('does not apply an environment that arrives after the timeout', async () => {
+    jest.useFakeTimers();
+    let resolveShell;
+    mockFetch = jest.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveShell = resolve;
+      })
+    );
+
+    const pending = shellEnv.ensureShellEnv();
+    jest.advanceTimersByTime(shellEnv.TIMEOUT_MS);
+    await pending;
+
+    // The shell finally answers, long after the command stopped waiting for it.
+    resolveShell({ PATH: '/late/bin', LATE_VAR: 'late' });
+    await Promise.resolve();
+
+    expect(mockApply).not.toHaveBeenCalled();
     jest.useRealTimers();
   });
 });

--- a/packages/bruno-requests/src/index.ts
+++ b/packages/bruno-requests/src/index.ts
@@ -8,7 +8,7 @@ export { transformProxyConfig } from './utils/proxy-util';
 export { default as createVaultClient, VaultError } from './utils/node-vault';
 export type { VaultClient, VaultConfig, VaultRequestOptions } from './utils/node-vault';
 export { getHttpHttpsAgents, resolveAgentsFromPac, PatchedHttpsProxyAgent } from './utils/http-https-agents';
-export { initializeShellEnv, fetchShellEnv } from './utils/shell-env';
+export { initializeShellEnv, fetchShellEnv, applyShellEnv } from './utils/shell-env';
 export { getOrCreateHttpsAgent, getOrCreateHttpAgent, clearAgentCache, getAgentCacheSize } from './utils/agent-cache';
 export { getPacResolver, clearPacCache } from './utils/pac-resolver';
 export type { PacWrapper, GetPacResolverParams } from './utils/pac-resolver';

--- a/packages/bruno-requests/src/utils/shell-env.spec.ts
+++ b/packages/bruno-requests/src/utils/shell-env.spec.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { initializeShellEnv } from './shell-env';
+import { initializeShellEnv, applyShellEnv } from './shell-env';
 
 let mockShellEnvResult: Record<string, string> = {};
 
@@ -90,5 +90,24 @@ describe('initializeShellEnv', () => {
 
     expect(result).toEqual({});
     expect(process.env.SHOULD_NOT_APPEAR).toBeUndefined();
+  });
+});
+
+describe('applyShellEnv', () => {
+  test('should apply a previously fetched environment without fetching again', () => {
+    delete process.env.APPLIED_VAR;
+
+    const result = applyShellEnv({ APPLIED_VAR: 'applied' });
+
+    expect(result).toEqual({ APPLIED_VAR: 'applied' });
+    expect(process.env.APPLIED_VAR).toBe('applied');
+    delete process.env.APPLIED_VAR;
+  });
+
+  test('should do nothing when there is no environment to apply', () => {
+    const before = { ...process.env };
+
+    expect(applyShellEnv(null)).toEqual({});
+    expect(process.env).toEqual(before);
   });
 });

--- a/packages/bruno-requests/src/utils/shell-env.ts
+++ b/packages/bruno-requests/src/utils/shell-env.ts
@@ -24,14 +24,14 @@ export const fetchShellEnv = async (): Promise<Record<string, string> | null> =>
 };
 
 /**
- * Initializes process.env with shell environment variables.
- * Should be called early in the app startup.
+ * Merges already-fetched shell environment variables into process.env.
  *
- * @returns The fetched shell environment variables
+ * Separate from the fetch so a caller that gives up waiting on the shell can decline to apply a
+ * result that arrives late, rather than having process.env change under a run already in progress.
+ *
+ * @returns The variables that were applied
  */
-export const initializeShellEnv = async (): Promise<Record<string, string>> => {
-  const shellEnvVars = await fetchShellEnv();
-
+export const applyShellEnv = (shellEnvVars: Record<string, string> | null): Record<string, string> => {
   if (shellEnvVars === null) {
     return {};
   }
@@ -45,3 +45,11 @@ export const initializeShellEnv = async (): Promise<Record<string, string>> => {
   }
   return shellEnvVars;
 };
+
+/**
+ * Initializes process.env with shell environment variables.
+ * Should be called early in the app startup.
+ *
+ * @returns The fetched shell environment variables
+ */
+export const initializeShellEnv = async (): Promise<Record<string, string>> => applyShellEnv(await fetchShellEnv());


### PR DESCRIPTION
### Description

`bru` reads the user's login shell environment before argv is parsed, so every invocation waits for
it — `bru --version` and `bru --help` included, which never use the result. This moves the read
behind command selection, adds the timeout and memoisation `bruno-electron` already has, and offers
an opt-out for callers that already pass down a complete environment.

`bru --version` goes from **~890ms to ~380ms** on macOS. `bru run` behaviour is unchanged.

Closes #9018

### Problem

`packages/bruno-cli/src/index.js` started `run()` with:

```js
await initializeShellEnv();
```

before yargs parsed anything. That starts `$SHELL -ilc` and dumps its environment — ~480ms on
macOS, more than half the wall clock of `bru --version`. Being blocking I/O rather than CPU work, it
does not show up in a CPU profile.

Confirmed by watching the process table during `bru --version`:

```
CHILD: /bin/zsh -ilc echo -n "_SHELL_ENV_DELIMITER_"; env; ...
```

Separately, the CLI awaited the raw call with **no timeout and no memoisation**, while
`bruno-electron` wraps the same function in `src/store/shell-env-state.js` with both. `fetchShellEnv`
catches failures but not a shell that never returns, so a `.zshrc` blocking on input hangs `bru`.

### Fix

The shell read moves to the commands that need those variables:

- **`run`** awaits it at the top of the handler — it always makes requests.
- **`import`** awaits it only when the source is a URL, the case needing proxy and CA settings.
  A local-file import, or a run that fails argument validation, no longer waits on a shell.
- **`--version` / `--help`** no longer start one at all.

Safe to defer because every consumer reads `process.env` lazily inside the handler —
`getSystemProxy()`, `ca-cert.ts`, `node-vault.ts`, and the `{{process.env.X}}` script vars — and no
module in `bruno-cli` or `@usebruno/requests` captures `process.env` at require time.

New `src/utils/shell-env.js` adds memoisation (the shell starts at most once per process) and a 60s
guard matching `TIMEOUT_MS` in the electron twin. Failure is degraded rather than fatal: a warning on
stderr and the command carries on with the environment it has. Both failure shapes warn — a rejection,
and the `null` that `fetchShellEnv()` resolves when it swallows a read error — so a skipped read cannot
silently explain away missing proxy or CA settings, while the success path stays quiet. That also removes the previous
uncaught-rejection path, where a failure before argv parsing rejected `run()` with nothing catching it.

`BRU_NO_SHELL_ENV=1` skips the shell entirely, for callers that run `bru` per request and already
pass a complete environment. Defaults to off, so GUI and cron invocations are unaffected. Documented
in the CLI readme.

A timed-out shell can no longer corrupt a run (second commit). `initializeShellEnv()` merges into
`process.env` itself, so losing the race did not prevent the mutation. The merge is now split out of
the fetch in `@usebruno/requests`: `applyShellEnv(vars)` does what `initializeShellEnv()` did after
awaiting, and `initializeShellEnv()` is the composition of the two, so its behaviour and signature are
unchanged for `bruno-electron`. The CLI races `fetchShellEnv()`, which does not touch `process.env`,
and applies only on the branch where the fetch won — so a late result is discarded rather than
applied. That matters because `getSystemProxy()`, `ca-cert.ts` and `node-vault.ts` all read
`process.env` at call time.

**Remaining limitation:** the child is not killed. `shell-env` exposes no `signal` or `timeout`, so
terminating it means replacing `shell-env` with a direct `child_process` spawn inside
`@usebruno/requests` — reimplementing its delimiter parsing, `strip-ansi` handling and zsh/bash
fallback for the desktop app too, whose shell-env path CI does not exercise. I have left that out
rather than fold a riskier shared-behaviour rewrite into a perf fix; happy to send it separately.

So a wedged shell can still delay process *exit* for a command that does not call `process.exit()`.
That was already the case before this PR — the old code awaited `initializeShellEnv()` with no timeout
at all, so a wedged shell blocked startup indefinitely — so this is strictly an improvement.

### Verification

- `npm test --workspace=packages/bruno-cli` — **205 passing**, including 10 new specs for the helper
  (memoisation, opt-out parsing, warn-and-continue, the timeout via fake timers, and that an
  environment resolving after the timeout is never applied).
- `npm test --workspace=packages/bruno-requests` — **481 passing**, including new specs for
  `applyShellEnv`.
- Verified against a real login shell that the merge still happens after the refactor (PATH grew by
  993 chars, 10 variables added) and that `BRU_NO_SHELL_ENV=1` changes nothing.
- Help and error output diffed against the previous implementation across 12 argv combinations
  (`--help`, `-h`, no args, unknown command, unknown flag, per-command help, missing required args):
  **byte-identical stdout, stderr and exit codes**.
- Shell start verified by process-table observation: absent for `--version`, `--help`, a local-file
  import and an argument-validation failure; present for `run` and for a URL import; absent under
  `BRU_NO_SHELL_ENV=1`. The detector was validated against the old behaviour first, so the negatives
  are real absences rather than a broken probe.
- ESLint clean on all changed files.

### Screenshots

Not applicable — no UI change. Timings above are reproducible with:

```bash
/usr/bin/time -p node packages/bruno-cli/bin/bru.js --version
```

Note that on macOS `/usr/bin/time` folds a waited-for child's CPU into `user`+`sys`, which makes this
look CPU-bound when it is really waiting on a subprocess. Also, `SHELL=/bin/sh` does not change the
cost: `default-shell` prefers `os.userInfo().shell` over `$SHELL`.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** — not applicable, no UI change
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** — #9018
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now load shell environment settings only when needed for remote imports and command execution.
  * Added support for opting out of shell environment loading with `BRU_NO_SHELL_ENV`.
  * Shell environment loading includes timeout, caching, and failure handling to keep commands responsive.
  * Environment settings are applied consistently, including PATH updates while preserving existing variables.

* **Documentation**
  * Documented `BRU_NO_SHELL_ENV`, including platform behavior and subprocess usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


