### PR TITLE
fix(filestore): declare and import nanoid correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39133,7 +39133,6 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@types/nanoid": "^2.1.0",
         "@usebruno/common": "0.1.0",
         "@usebruno/lang": "0.12.0",
         "ajv": "^8.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39138,6 +39138,7 @@
         "@usebruno/lang": "0.12.0",
         "ajv": "^8.18.0",
         "lodash": "4.18.1",
+        "nanoid": "3.3.18",
         "yaml": "2.3.4"
       },
       "devDependencies": {
@@ -39155,7 +39156,6 @@
         "@usebruno/schema-types": "0.0.1",
         "babel-jest": "^29.7.0",
         "jest": "^29.2.0",
-        "nanoid": "3.3.18",
         "rimraf": "^3.0.2",
         "rollup": "3.30.0",
         "rollup-plugin-dts": "^5.0.0",

--- a/packages/bruno-filestore/package.json
+++ b/packages/bruno-filestore/package.json
@@ -44,7 +44,6 @@
     "rollup": "3.30.0"
   },
   "dependencies": {
-    "@types/nanoid": "^2.1.0",
     "@usebruno/common": "0.1.0",
     "@usebruno/lang": "0.12.0",
     "ajv": "^8.18.0",

--- a/packages/bruno-filestore/package.json
+++ b/packages/bruno-filestore/package.json
@@ -33,7 +33,6 @@
     "@usebruno/schema-types": "0.0.1",
     "babel-jest": "^29.7.0",
     "jest": "^29.2.0",
-    "nanoid": "3.3.18",
     "rimraf": "^3.0.2",
     "rollup": "3.30.0",
     "rollup-plugin-dts": "^5.0.0",
@@ -50,6 +49,7 @@
     "@usebruno/lang": "0.12.0",
     "ajv": "^8.18.0",
     "lodash": "4.18.1",
+    "nanoid": "3.3.18",
     "yaml": "2.3.4"
   }
 }

--- a/packages/bruno-filestore/rollup.config.js
+++ b/packages/bruno-filestore/rollup.config.js
@@ -19,6 +19,7 @@ const externalDeps = [
   'lodash',
   'yaml',
   'ajv',
+  'nanoid',
   // Node built-ins
   'worker_threads',
   'path',

--- a/packages/bruno-filestore/src/utils/index.ts
+++ b/packages/bruno-filestore/src/utils/index.ts
@@ -1,4 +1,4 @@
-const { customAlphabet } = require('nanoid');
+import { customAlphabet } from 'nanoid';
 
 export const isString = (value: unknown): value is string => typeof value === 'string';
 


### PR DESCRIPTION
### Description

`@usebruno/filestore` requires `nanoid` at runtime but never declared it, so it is missing from the
installed package's dependency tree. This declares it, imports it properly so the ESM bundle works
too, and drops the deprecated `@types/nanoid` stub that was shipping in its place.

Closes #9020

### Problem

`packages/bruno-filestore/src/utils/index.ts` opened with:

```js
const { customAlphabet } = require('nanoid');
```

That call is **not** bundled away. `rollup.config.js` did not list `nanoid` in `externalDeps`, so it
reads as though rollup inlines it — but `@rollup/plugin-commonjs` leaves `require()` inside an ES
module untransformed unless `transformMixedEsModules` is set, which this config does not set. So it
passed through verbatim into the published bundles.

Meanwhile the manifest had the two nanoid entries **inverted**: `nanoid` under `devDependencies`,
which consumers never install, and `@types/nanoid` — build-time only — under `dependencies`.

**A clean install of the published package cannot be imported at all:**

```bash
cd $(mktemp -d)          # must not be under any node_modules
npm init -y
npm install @usebruno/filestore@0.11.0
node -e "require('@usebruno/filestore')"
```

```
Error: Cannot find module 'nanoid'
Require stack:
- node_modules/@usebruno/filestore/dist/cjs/index.js
```

Nothing in filestore's graph provides nanoid — `@usebruno/lang` pulls arcsecond/dotenv/lodash/ohm-js,
`@usebruno/common` has no dependencies.

**Why it usually goes unnoticed.** Installing the CLI alongside it masks the problem, because
`@usebruno/js`, `@usebruno/converters` and `@usebruno/schema` each declare `nanoid@3.3.8`, so npm
hoists a copy where filestore can reach it:

| install | nanoid | result |
| --- | --- | --- |
| `@usebruno/filestore` alone | absent | **fails on import** |
| `+ @usebruno/cli` | hoisted to top level | works |
| either, without hoisting (`--install-strategy=nested`, pnpm) | nested out of reach | **fails on import** |

That last row is the same failure mode as #8077, where `bru` installed with pnpm dies on
`Cannot find module 'qs'` from `@usebruno/requests`. Same root cause, different package: a runtime
import with no declaration, working only while a hoisted copy happens to be reachable.

Inside the monorepo it is invisible — six packages declare nanoid, so it is always hoisted to the
root. No Bruno developer will hit this; only consumers of the published package do.

### Fix

Three commits, each independently reviewable:

1. **Declare `nanoid` as a runtime dependency**, pinned `3.3.18` to match every other package in the
   repo. The lockfile entry moves with it so manifest and lock agree.
2. **Import it as an ES module** and add `nanoid` to `externalDeps`, so the ESM bundle emits an import
   instead of a bare `require` — which is undefined under native ESM — while CJS still gets a require:
   ```
   dist/cjs/index.js   require("nanoid")
   dist/esm/index.js   import{customAlphabet as u}from"nanoid"
   ```
3. **Drop `@types/nanoid`.** npm deprecates it outright — *"This is a stub types definition. nanoid
   provides its own type definitions, so you do not need this installed"* — and the `^2.1.0` pin
   resolved to 2.1.0, whose entire contents describe nanoid **v2**:
   ```ts
   declare function nanoid(size?: number): string;
   export = nanoid;
   ```
   No `customAlphabet`, while the code uses v3's. It never broke typing, because TypeScript resolves
   `nanoid` to the library's own bundled types and ignores the stub (confirmed with
   `--traceResolution`: `nanoid/index.d.ts@3.3.18`). So it was shipping to consumers for no benefit.

### Verification

- **The reported crash is gone end to end**: packed the tarball, installed it into an isolated
  directory with no monorepo above it, and `require('@usebruno/filestore')` succeeds. nanoid is
  present because it is now declared; `@types/nanoid` is no longer shipped.
- `npm test --workspace=packages/bruno-filestore` — **202 passing**; `tsc --noEmit` clean without the
  types stub; rollup build clean.
- `nanoid@3.3.18` is unchanged in the installed tree — same version, same integrity hash — so no
  consumer gets a different build. It is past the known 3.x advisories (fixed in 3.3.8) and matches
  all five sibling pins, so no version fragmentation.
- `uuid()` is not security-sensitive: every call site assigns an in-memory `uid` on parsed objects for
  UI identity, and those ids are never persisted to `.bru`, `.yml` or `bruno.json` — no `stringify*`
  path references them.
- nanoid 3.3.18 is pure JavaScript: no native bindings, no install scripts, no `os`/`cpu` gating.

### Out of scope

`dist/esm/workers/worker-script.js` still emits `require()`, because `rollup.config.js` declares that
output as `format: 'cjs'` despite its path. That predates this change and is harmless — the package is
not `type: module`, so a `.js` worker loads as CJS — so it is left alone rather than folded in.

More broadly, `@usebruno/requests` imports `qs`, `lodash`, `moment`, `proxy-from-env` and `hexy`
without declaring them, and `@usebruno/common` imports `lodash`/`lodash-es` while declaring no
dependencies. Those are the same defect class and would close #8077, but they belong in their own change.

### Screenshots

Not applicable — dependency and import wiring, no UI.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** — not applicable
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** — #9020
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime reliability for file storage functionality by ensuring required identifier generation is available when the application runs.
  * Enhanced compatibility with the application’s module and build systems, helping file storage features operate consistently across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->