### PR TITLE
perf(cli): register commands lazily instead of using commandDir

### DIFF
--- a/packages/bruno-cli/src/command-registry.js
+++ b/packages/bruno-cli/src/command-registry.js
@@ -1,0 +1,17 @@
+/**
+ * The commands yargs registers, and how each one is spelled on the command line.
+ *
+ * `command` and `desc` are written out here rather than read from the command modules, because
+ * requiring a module to read them would load it at startup — which is exactly what registering
+ * lazily avoids. tests/commands.spec.js asserts these stay in step with the modules.
+ *
+ * Alphabetical, so `bru --help` lists commands in a stable order.
+ */
+const COMMANDS = [
+  { name: 'import', command: 'import <type>', desc: 'Import a collection from other formats' },
+  { name: 'run', command: 'run [paths...]', desc: 'Run one or more requests/folders' }
+];
+
+module.exports = {
+  COMMANDS
+};

--- a/packages/bruno-cli/src/index.js
+++ b/packages/bruno-cli/src/index.js
@@ -19,11 +19,13 @@ const registerCommands = (yargsInstance) => {
   for (const { name, command, desc } of COMMANDS) {
     const load = () => require(`./commands/${name}`);
 
+    // Forward every argument: yargs passes a second value to the builder, and the module's own
+    // builder/handler signatures should stay authoritative rather than being narrowed here.
     yargsInstance.command(
       command,
       desc,
-      (subYargs) => load().builder(subYargs),
-      (argv) => load().handler(argv)
+      (...args) => load().builder(...args),
+      (...args) => load().handler(...args)
     );
   }
 

--- a/packages/bruno-cli/src/index.js
+++ b/packages/bruno-cli/src/index.js
@@ -3,9 +3,31 @@ const chalk = require('chalk');
 const { initializeShellEnv } = require('@usebruno/requests');
 
 const { CLI_EPILOGUE, CLI_VERSION } = require('./constants');
+const { COMMANDS } = require('./command-registry');
 
 const printBanner = () => {
   console.log(chalk.yellow(`Bru CLI ${CLI_VERSION}`));
+};
+
+/**
+ * Each command module is required inside its builder and handler, so it loads only when that command
+ * is actually invoked. `commands/run.js` pulls in the whole execution runtime — bruno-js, axios,
+ * recast, handlebars, jsonwebtoken, filestore, ohm — which `bru --version` and `bru --help` would
+ * otherwise load just to print one line.
+ */
+const registerCommands = (yargsInstance) => {
+  for (const { name, command, desc } of COMMANDS) {
+    const load = () => require(`./commands/${name}`);
+
+    yargsInstance.command(
+      command,
+      desc,
+      (subYargs) => load().builder(subYargs),
+      (argv) => load().handler(argv)
+    );
+  }
+
+  return yargsInstance;
 };
 
 const run = async () => {
@@ -19,9 +41,7 @@ const run = async () => {
     printBanner();
   }
 
-  const { argv } = yargs
-    .strict()
-    .commandDir('commands')
+  const { argv } = registerCommands(yargs.strict())
     .epilogue(CLI_EPILOGUE)
     .usage('Usage: $0 <command> [options]')
     .demandCommand(1, 'Woof!! Let\'s play with some APIs!!')

--- a/packages/bruno-cli/tests/commands.spec.js
+++ b/packages/bruno-cli/tests/commands.spec.js
@@ -39,4 +39,13 @@ describe('command registration', () => {
       expect(typeof mod.handler).toBe('function');
     }
   });
+
+  // .commandDir() also honoured these exports. Registering by hand does not, so a command adding one
+  // would lose it silently - fail here instead, as a prompt to wire it into the registry.
+  it.each(['aliases', 'middlewares', 'deprecated'])('does not silently drop a module\'s %s', (key) => {
+    for (const { name } of COMMANDS) {
+      const mod = require(path.join(COMMANDS_DIR, name));
+      expect(mod[key]).toBeUndefined();
+    }
+  });
 });

--- a/packages/bruno-cli/tests/commands.spec.js
+++ b/packages/bruno-cli/tests/commands.spec.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const { COMMANDS } = require('../src/command-registry');
+
+// The registry spells out each command's `command` and `desc` instead of reading them from the module,
+// so these tests are what keeps the two in step.
+
+const COMMANDS_DIR = path.join(__dirname, '../src/commands');
+
+describe('command registration', () => {
+  const moduleNames = fs
+    .readdirSync(COMMANDS_DIR)
+    .filter((f) => f.endsWith('.js') && !f.endsWith('.spec.js'))
+    .map((f) => path.basename(f, '.js'))
+    .sort();
+
+  it('registers every module in src/commands', () => {
+    expect(COMMANDS.map((c) => c.name).sort()).toEqual(moduleNames);
+  });
+
+  it('lists commands alphabetically, so help output has a stable order', () => {
+    const names = COMMANDS.map((c) => c.name);
+    expect(names).toEqual([...names].sort());
+  });
+
+  it.each(COMMANDS.map((c) => c.name))('mirrors the command and desc exported by %s.js', (name) => {
+    const entry = COMMANDS.find((c) => c.name === name);
+    const mod = require(path.join(COMMANDS_DIR, name));
+
+    expect(entry.command).toBe(mod.command);
+    expect(entry.desc).toBe(mod.desc);
+  });
+
+  it('exposes a builder and handler on every command module', () => {
+    for (const { name } of COMMANDS) {
+      const mod = require(path.join(COMMANDS_DIR, name));
+      expect(typeof mod.builder).toBe('function');
+      expect(typeof mod.handler).toBe('function');
+    }
+  });
+});


### PR DESCRIPTION
### Description

yargs' `.commandDir()` eagerly requires every module in `src/commands` at startup, so `bru --version`
and `bru --help` load the entire `bru run` execution runtime to print one line. This registers the two
commands explicitly and requires each module inside its builder and handler instead.

`bru --version` drops from **5182 to 816** module loads. `bru run` is unaffected.

Closes #9022

### Problem

`.commandDir()` requires each command file at registration time, so `commands/run.js` always loads.
Its top-level requires pull in the whole runtime — `../runner/run-single-request` transitively brings
in `@usebruno/js`, axios, recast, handlebars, jsonwebtoken, yup, `@usebruno/converters`,
`@usebruno/filestore` and ohm.

`--version` needs only `CLI_VERSION` from `src/constants.js`, which needs nothing but `package.json`:

```bash
$ NODE_DEBUG=module node packages/bruno-cli/bin/bru.js --version 2>&1 | grep -c run-single-request
41
```

### Fix

`src/command-registry.js` holds the small table of commands; `registerCommands()` wires each one with
`require()` inside the builder and handler, so a command's runtime loads only when that command runs.

The cost is that `command` and `desc` are written out rather than read from the module — reading them
would require the module and defeat the point. `tests/commands.spec.js` guards that:

- every module in `src/commands` is registered
- each entry's `command`/`desc` matches the module's exports
- the table stays alphabetical, so help output order is stable

I checked both guards actually fail: changing a `desc` in the registry fails the mirror test, and
dropping an extra command module into `src/commands` fails the registration test.

### Verification

- **Output is unchanged.** stdout, stderr and exit codes diffed against `.commandDir()` across 14 argv
  combinations — `--help`, `-h`, no args, unknown command, unknown flag, `run --help`, `import --help`,
  `run --bogus-flag`, `--version`, `import`, `run`, `import wsdl`, `import openapi`, `run -r` —
  **byte-identical** in every case, covering the `.strict()` and `.demandCommand()` paths.
- `npm test --workspace=packages/bruno-cli` — **203 passing**, including 8 new specs.
- `bru --version`: 5182 → 816 module loads, and `run-single-request` is no longer loaded at all.
- ESLint clean (the one `argv` unused warning in `index.js` predates this change).

### Notes for reviewers

- Registration order is kept alphabetical because `.commandDir()` sorted by filename; that is the only
  thing that would otherwise change in `--help` output.
- `.commandDir()` also honoured `aliases`, `middlewares` and `deprecated` exports, which
  hand-registration ignores. No command module exports any today, and there is now a test that fails
  if one starts to — so it cannot be lost silently.
- The builder/handler wrappers spread their arguments, since yargs 17 passes a second value to a
  builder (`helpOrVersionSet`). Nothing declares it today, but the wrapper no longer narrows what the
  modules can accept.
- This touches `src/index.js`, as does #9019. They are independent and each applies cleanly to `main`
  on its own — whichever lands second just needs a trivial rebase.

### Screenshots

Not applicable — no UI change. Reproduce the counts with:

```bash
NODE_DEBUG=module node packages/bruno-cli/bin/bru.js --version 2>&1 | grep -c load
```

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** — not applicable
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** — #9022
- [x] **I've run the claude code review skill locally.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved startup time for lightweight CLI commands such as `--version` and `--help`.
  * CLI command modules now load only when the selected command is run.

* **Maintenance**
  * Added centralized metadata for available `import` and `run` commands.
  * Added validation to ensure command registration remains complete, ordered, and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->