### PR TITLE
fix: conflicting dependencies after sec update hoisting

### DIFF
--- a/packages/bruno-app/rsbuild.config.mjs
+++ b/packages/bruno-app/rsbuild.config.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { createRequire } from 'node:module';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginBabel } from '@rsbuild/plugin-babel';
@@ -5,6 +7,10 @@ import { pluginStyledComponents } from '@rsbuild/plugin-styled-components';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginRemoteImages } from './plugins/remote-images/index.mjs';
+
+const require = createRequire(import.meta.url);
+const swaggerUiDir = path.dirname(require.resolve('swagger-ui-react'));
+const swaggerImmutable = require.resolve('immutable', { paths: [swaggerUiDir] });
 
 const remoteImageDomains = (process.env.BRUNO_REMOTE_IMAGE_DOMAINS || 'd3icksk7srk4uh.cloudfront.net')
   .split(',')
@@ -34,7 +40,13 @@ export default defineConfig({
       '**/test-utils/**',
       '**/*.test.*',
       '**/*.spec.*'
-    ]
+    ],
+    // swagger-ui-react nests immutable@3 (CJS default export). sass hoists
+    // immutable@5 to the repo root, which dropped that default; redux-immutable
+    // is also hoisted there, so without this alias it loads v5 and crashes.
+    alias: {
+      immutable$: swaggerImmutable
+    }
   },
   html: {
     title: 'Bruno'
@@ -50,7 +62,7 @@ export default defineConfig({
         }
       },
       ignoreWarnings: [
-        (warning) =>  warning.message.includes('Critical dependency: the request of a dependency is an expression') && warning?.moduleDescriptor?.name?.includes('flow-parser')
+        (warning) => warning.message.includes('Critical dependency: the request of a dependency is an expression') && warning?.moduleDescriptor?.name?.includes('flow-parser')
       ],
       // Add externals configuration to exclude Node.js libraries
       externals: {


### PR DESCRIPTION
### Description

We have different versions of `immutable` in the dependency tree, v5 from `sass` and v3/v4 `swagger-ui-react` , sass bundles it as a dep and so does `swagger-ui-react` but since we have a workspace the single deps get hoisted up. In which case the bundler first sees the `v5` from the tree and ends up using that. 

The PR simply forces the pickup to be from `swagger-ui-react` for the `bruno-app`. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading Swagger UI components.
  * Resolved module loading issues involving the `immutable` dependency.
  * Cleaned up warning handling for parser-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->