### PR TITLE
chore(telemetry): adds wsl usage telemetry

### DIFF
--- a/packages/bruno-app/src/providers/App/useIpcEvents.js
+++ b/packages/bruno-app/src/providers/App/useIpcEvents.js
@@ -52,6 +52,7 @@ import { addLog } from 'providers/ReduxStore/slices/logs';
 import { loadNotifications } from 'providers/ReduxStore/slices/notifications';
 import { updateSystemResources } from 'providers/ReduxStore/slices/performance';
 import { apiSpecAddFileEvent, apiSpecChangeFileEvent } from 'providers/ReduxStore/slices/apiSpec';
+import { markWSLCollectionOpened } from './useTelemetry';
 
 const useIpcEvents = () => {
   const dispatch = useDispatch();
@@ -144,6 +145,9 @@ const useIpcEvents = () => {
         await dispatch(openCollectionEvent(uid, pathname, brunoConfig, options));
       } finally {
         dispatch(hydrateSnapshotForOpenedCollection(pathname));
+        if (options?.isWsl) {
+          markWSLCollectionOpened();
+        }
       }
     });
 

--- a/packages/bruno-app/src/providers/App/useTelemetry.js
+++ b/packages/bruno-app/src/providers/App/useTelemetry.js
@@ -13,6 +13,7 @@ import { uuid } from 'utils/common';
 
 const posthogApiKey = process.env.NEXT_PUBLIC_POSTHOG_API_KEY;
 let posthogClient = null;
+let wslUsageCapturedThisSession = false;
 
 const isPlaywrightTestRunning = () => {
   return process.env.PLAYWRIGHT ? true : false;
@@ -42,12 +43,20 @@ const getAnonymousTrackingId = () => {
   return id;
 };
 
-const trackStart = (version) => {
+const canTrack = () => {
   if (isPlaywrightTestRunning()) {
-    return;
+    return false;
   }
 
   if (isDevEnv()) {
+    return false;
+  }
+
+  return Boolean(posthogApiKey && posthogApiKey.length);
+};
+
+const trackStart = (version) => {
+  if (!canTrack()) {
     return;
   }
 
@@ -63,6 +72,25 @@ const trackStart = (version) => {
   });
 };
 
+const markWSLCollectionOpened = () => {
+  if (wslUsageCapturedThisSession || !canTrack()) {
+    return;
+  }
+
+  wslUsageCapturedThisSession = true;
+
+  const trackingId = getAnonymousTrackingId();
+  const client = getPosthogClient();
+  client.capture({
+    distinctId: trackingId,
+    event: 'wsl_collection_opened',
+    properties: {
+      os: platformLib.os.family,
+      $set: { isWsl: true }
+    }
+  });
+};
+
 const useTelemetry = ({ version }) => {
   useEffect(() => {
     if (posthogApiKey && posthogApiKey.length) {
@@ -72,4 +100,5 @@ const useTelemetry = ({ version }) => {
   }, [posthogApiKey]);
 };
 
+export { markWSLCollectionOpened };
 export default useTelemetry;

--- a/packages/bruno-electron/src/app/collections.js
+++ b/packages/bruno-electron/src/app/collections.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { ipcMain } = require('electron');
 const Yup = require('yup');
-const { isDirectory, getCollectionStats, normalizeAndResolvePath } = require('../utils/filesystem');
+const { isDirectory, getCollectionStats, normalizeAndResolvePath, isWSLMountPath } = require('../utils/filesystem');
 const { generateUidBasedOnHash } = require('../utils/common');
 const { transformBrunoConfigAfterRead } = require('../utils/transformBrunoConfig');
 const { parseCollection } = require('@usebruno/filestore');
@@ -97,7 +97,7 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
       const { size, filesCount } = await getCollectionStats(collectionPath);
       brunoConfig.size = size;
       brunoConfig.filesCount = filesCount;
-      win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig, { silent: !!options.silent });
+      win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig, { silent: !!options.silent, isWsl: isWSLMountPath(collectionPath) });
       return {
         path: collectionPath,
         opened: true,
@@ -133,7 +133,7 @@ const openCollection = async (win, watcher, collectionPath, options = {}) => {
     brunoConfig.size = size;
     brunoConfig.filesCount = filesCount;
 
-    win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig, { silent: !!options.silent });
+    win.webContents.send('main:collection-opened', collectionPath, uid, brunoConfig, { silent: !!options.silent, isWsl: isWSLMountPath(collectionPath) });
     ipcMain.emit('main:collection-opened', win, collectionPath, uid, brunoConfig);
     return {
       path: collectionPath,

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -87,6 +87,17 @@ function isWSLPath(pathname) {
   return pathname.startsWith('\\\\') || pathname.startsWith('//') || pathname.startsWith('/wsl.localhost/') || pathname.startsWith('\\wsl.localhost');
 }
 
+function isWSLMountPath(pathname) {
+  if (!pathname || typeof pathname !== 'string') {
+    return false;
+  }
+  // Normalize slashes and collapse the leading run of slashes to exactly two,
+  // so "\\wsl.localhost\...", "//wsl.localhost/...", and the single-leading-
+  // slash "/wsl.localhost/..." form.
+  const normalized = pathname.toLowerCase().replace(/\//g, '\\').replace(/^\\+/, '\\\\');
+  return normalized.startsWith('\\\\wsl.localhost\\') || normalized.startsWith('\\\\wsl$\\');
+}
+
 function normalizeWSLPath(pathname) {
   // Replace the WSL path prefix and convert forward slashes to backslashes
   // This is done to achieve WSL paths (linux style) to Windows UNC equivalent (Universal Naming Conversion)
@@ -586,6 +597,7 @@ module.exports = {
   isValidCollectionDirectory,
   normalizeAndResolvePath,
   isWSLPath,
+  isWSLMountPath,
   normalizeWSLPath,
   writeFile,
   withFileLock,


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Added anonymous telemetry to track how many users open collections stored on WSL. 

When a collection is opened, the main process detects whether it is on a genuine WSL mount and sends a one-time PostHog event with isWsl: true, allowing us to count unique users regardless of when the event occurs.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting collections stored on Windows Subsystem for Linux (WSL) paths.
  * Added session-level telemetry for WSL collection openings.

* **Bug Fixes**
  * Improved collection-opening handling so WSL-specific information is preserved for both newly opened and already open collections.

* **Privacy & Reliability**
  * Telemetry is now disabled during development, Playwright tests, or when tracking configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->