### PR TITLE
specify script preservation for single Postman collections

### DIFF
--- a/packages/bruno-app/src/components/ChangelogTab/CHANGELOG.md
+++ b/packages/bruno-app/src/components/ChangelogTab/CHANGELOG.md
@@ -104,7 +104,8 @@ You can now store a default environment with a collection. Bruno selects it auto
 
 ### Import, Export, and Interoperability
 
-* Postman import preserves scripts, auth, NTLM config, binary bodies, and descriptions, and there is a new preserve scripts option for import and export
+* Postman import retains NTLM auth, binary bodies, and descriptions
+* Option to keep Postman scripts unchanged when importing or exporting a single collection
 * Postman export retains OAuth2, AWS, Digest, and OAuth1 auth settings
 * OpenAPI import keeps collection-level and tag-level descriptions and populates the Docs tab
 * OpenAPI export retains scheme-less request URLs


### PR DESCRIPTION
### Description

Updates the changelog wording to clarify that the option to preserve Postman scripts applies when importing or exporting a single Postman collection,.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified changelog entries for Postman import support, including NTLM authentication, binary request bodies, and descriptions.
  * Separately documented the option to preserve scripts during single-collection import and export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->