### PR TITLE
fix(mock-servers): fix multiple issues including the path-param varInfo popup

### DIFF
--- a/packages/bruno-app/src/components/AppView/EmptyAppState.js
+++ b/packages/bruno-app/src/components/AppView/EmptyAppState.js
@@ -10,7 +10,6 @@ const Wrapper = styled.div`
   justify-content: center;
   border: 1px dashed ${(props) => props.theme.border.border1};
   border-radius: 4px;
-  background: ${(props) => props.theme.background.surface0};
   color: ${(props) => props.theme.colors.text.muted};
 
   .empty-app-inner {

--- a/packages/bruno-app/src/components/AppView/StyledWrapper.js
+++ b/packages/bruno-app/src/components/AppView/StyledWrapper.js
@@ -38,7 +38,7 @@ const StyledWrapper = styled.div`
     border: 1px solid ${(props) => props.theme.border.border1};
     border-radius: 4px;
     overflow: hidden;
-    background: ${(props) => props.theme.background.surface0};
+    background: transparent;
   }
 
   .app-webview {

--- a/packages/bruno-app/src/components/AppView/webview-bridge.js
+++ b/packages/bruno-app/src/components/AppView/webview-bridge.js
@@ -21,14 +21,16 @@ export const toJsArg = (value) =>
 
 const FRAGMENT_STYLES = `<style>
   * { box-sizing: border-box; }
+  html, body {
+    background: transparent;
+  }
   body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     margin: 0;
-    background: #ffffff;
     color: #1e1e1e;
-    transition: background-color 0.15s, color 0.15s;
+    transition: color 0.15s;
   }
-  body.dark { background: #1e1e1e; color: #e0e0e0; }
+  body.dark { color: #e0e0e0; }
 </style>`;
 
 /**

--- a/packages/bruno-app/src/components/CollectionApp/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CollectionApp/StyledWrapper.js
@@ -70,7 +70,7 @@ const StyledWrapper = styled.div`
     border: 1px solid ${(props) => props.theme.border.border1};
     border-radius: 4px;
     overflow: hidden;
-    background: ${(props) => props.theme.background.surface0};
+    background: transparent;
   }
 
   .app-webview {

--- a/packages/bruno-app/src/components/MockServer/MockResponse/MockResponseRequestPane/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockResponse/MockResponseRequestPane/index.js
@@ -126,6 +126,7 @@ const MockResponseRequestPane = ({
             onSave={onSave}
             allowMethodSelect
             urlPrefix={mockServerPort ? `localhost:${mockServerPort}` : null}
+            highlightPathParams={false}
           />
         </div>
         <div className="try-action">

--- a/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleUrlBar/index.js
+++ b/packages/bruno-app/src/components/ResponseExample/ResponseExampleRequestPane/ResponseExampleUrlBar/index.js
@@ -6,7 +6,7 @@ import HttpMethodSelector from 'components/RequestPane/QueryUrl/HttpMethodSelect
 import StyledWrapper from './StyledWrapper';
 import get from 'lodash/get';
 
-const ResponseExampleUrlBar = ({ item, collection, editMode, onSave, exampleUid, allowMethodSelect = false, urlPrefix = null }) => {
+const ResponseExampleUrlBar = ({ item, collection, editMode, onSave, exampleUid, allowMethodSelect = false, urlPrefix = null, highlightPathParams = true }) => {
   const dispatch = useDispatch();
 
   const exampleData = useMemo(() => {
@@ -96,7 +96,7 @@ const ResponseExampleUrlBar = ({ item, collection, editMode, onSave, exampleUid,
             onSave={onSave}
             onChange={onChange}
             collection={collection}
-            highlightPathParams={true}
+            highlightPathParams={highlightPathParams}
             item={item}
             readOnly={!editMode}
           />

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -23,7 +23,7 @@ export const copyExampleToMockResponse = (example, parentRequest) => ({
     requestPathname: parentRequest?.pathname || null
   },
   request: {
-    url: extractMockRoutePath(example.request?.url || parentRequest?.request?.url || '/'),
+    url: extractMockRoutePath(example.request?.url || parentRequest?.request?.url || '/', { preserveTemplateVars: true }),
     method: (example.request?.method || parentRequest?.request?.method || 'GET').toUpperCase(),
     headers: example.request?.headers || [],
     params: example.request?.params || [],

--- a/packages/bruno-app/src/utils/mock-server/mock-responses/editor.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses/editor.js
@@ -32,7 +32,7 @@ export const buildMockResponseEditorItem = (mockResponse) => {
     description: mockResponse.description || '',
     type: 'http-request',
     request: {
-      url: extractMockResponseRoutePath(mockResponse.request?.url || '/'),
+      url: extractMockResponseRoutePath(mockResponse.request?.url || '/', { preserveTemplateVars: true }),
       method: (mockResponse.request?.method || 'GET').toUpperCase(),
       headers: cloneDeep(mockResponse.request?.headers || []),
       params: cloneDeep(mockResponse.request?.params || []),
@@ -86,7 +86,7 @@ export const mockResponseFromEditorItem = (item, responseUid, rules, savedMockRe
     description: example.description || '',
     request: {
       ...cloneDeep(example.request),
-      url: extractMockResponseRoutePath(example.request?.url)
+      url: extractMockResponseRoutePath(example.request?.url, { preserveTemplateVars: true })
     },
     response: cloneDeep(example.response),
     rules: stripConditionUids(rules),

--- a/packages/bruno-common/src/utils/url/index.spec.ts
+++ b/packages/bruno-common/src/utils/url/index.spec.ts
@@ -477,6 +477,13 @@ describe('extractMockRoutePath', () => {
   it('falls back to path when absolute URL has a templated host', () => {
     expect(extractMockRoutePath('https://{{host}}/v1/items')).toBe('/v1/items');
   });
+
+  it('keeps `{{var}}` intact when preserveTemplateVars is set', () => {
+    expect(extractMockRoutePath('{{baseUrl}}/users/{{userId}}', { preserveTemplateVars: true }))
+      .toBe('/users/{{userId}}');
+    expect(extractMockRoutePath('https://api.example.com/v1/{{resource}}', { preserveTemplateVars: true }))
+      .toBe('/v1/{{resource}}');
+  });
 });
 
 describe('getMockResponseRouteKey', () => {

--- a/packages/bruno-common/src/utils/url/index.ts
+++ b/packages/bruno-common/src/utils/url/index.ts
@@ -242,9 +242,11 @@ const stripOrigin = (url: string): string => {
 
 /**
  * Normalize a Bruno request URL to a mock-server route path.
- * Strips scheme/host, leading `{{var}}`, query strings; turns remaining `{{var}}` into `:var`.
+ * Strips scheme/host, leading `{{var}}`, query strings; turns remaining `{{var}}` into `:var`
+ * so it matches Express-style route params. Callers that persist or display the user-typed URL
+ * pass `preserveTemplateVars: true` to keep `{{var}}` intact.
  */
-const extractMockRoutePath = (rawUrl: unknown): string => {
+const extractMockRoutePath = (rawUrl: unknown, { preserveTemplateVars = false } = {}): string => {
   if (!rawUrl) {
     return '/';
   }
@@ -286,7 +288,11 @@ const extractMockRoutePath = (rawUrl: unknown): string => {
     }
   }
 
-  cleaned = cleaned.replace(/\{\{([^}]+)\}\}/g, ':$1');
+  if (preserveTemplateVars) {
+    cleaned = cleaned.replace(/%7B%7B([^%]+)%7D%7D/gi, '{{$1}}');
+  } else {
+    cleaned = cleaned.replace(/\{\{([^}]+)\}\}/g, ':$1');
+  }
 
   if (!cleaned.startsWith('/')) {
     cleaned = `/${cleaned}`;


### PR DESCRIPTION
### Description

- Suppress path-param popup in mock URL bar: Threaded a highlightPathParams prop through ResponseExampleUrlBar and pass false from MockResponseRequestPane, so /:id in a mock URL no longer gets the cm-variable-* class the hover popup keys off.
- Preserve {{var}} on mock URL save: Added a preserveTemplateVars option to extractMockRoutePath (also decodes the percent-encoded braces new URL() introduces) and pass it from mockResponseFromEditorItem, buildMockResponseEditorItem, and copyExampleToMockResponse; Express route registration in the electron main still gets :var.
- Transparent app webview container: Switched .app-webview-container from theme.background.surface0 to background: transparent in both AppView/StyledWrapper.js and CollectionApp/StyledWrapper.js.
- Transparent guest body for fragment apps: Replaced the hard-coded #ffffff / #1e1e1e body fills in FRAGMENT_STYLES with html, body { background: transparent }, so request-level apps show the underlying tab panel through the webview.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mock response routes now preserve template variables in request URLs.
  * Added support for controlling path-parameter highlighting in request URL editors.

* **Bug Fixes**
  * Improved mock response route extraction for templated URLs.
  * Updated webview backgrounds to display transparently and improve theme integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->