### PR TITLE
feat: add 1C:Enterprise HTTP snippet generation

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeViewToolbar/index.js
@@ -19,7 +19,9 @@ const CodeViewToolbar = () => {
       }
       acc[mainLang].push({
         ...lang,
-        libraryName: lang.name.split('-')[1] || 'default'
+        libraryName: lang.name.includes('-')
+          ? lang.name.slice(lang.name.indexOf('-') + 1)
+          : 'default'
       });
       return acc;
     }, {});
@@ -77,7 +79,7 @@ const CodeViewToolbar = () => {
             <div className="library-options">
               {availableLibraries.map((lib) => (
                 <button
-                  key={lib.libraryName}
+                  key={lib.name}
                   className={`lib-btn ${generateCodePrefs.library === lib.libraryName ? 'active' : ''}`}
                   onClick={() => handleLibraryChange(lib.libraryName)}
                 >

--- a/packages/bruno-app/src/utils/codegenerator/onec/__tests__/bsl.spec.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/__tests__/bsl.spec.js
@@ -1,0 +1,85 @@
+import { isMultiline, quote, withoutQueryString, toEntries, namedEntries, objectEntries, fileBodyParam, fileNameFromPath, jsonBodyText, prettyJsonBodyText, assignStringBody, formFieldEntries, hasDuplicateKeys, formUrlEncodedText } from '../bsl';
+
+describe('1C BSL string helpers', () => {
+  test('quote splits CR, LF and CRLF into 1C continuation lines', () => {
+    expect(quote('line1\nline2')).toBe('"line1\n|line2"');
+    expect(quote('line1\rline2')).toBe('"line1\n|line2"');
+    expect(quote('line1\r\nline2')).toBe('"line1\n|line2"');
+  });
+
+  test('isMultiline treats CR-only text as multiline', () => {
+    expect(isMultiline('line1\rline2')).toBe(true);
+    expect(isMultiline('single')).toBe(false);
+  });
+
+  test('quote escapes quotes inside a single line', () => {
+    expect(quote('say "hello"')).toBe('"say ""hello"""');
+  });
+
+  test('withoutQueryString keeps the fragment', () => {
+    expect(withoutQueryString('https://example.com/path?q=1#frag')).toBe('https://example.com/path#frag');
+    expect(withoutQueryString('https://example.com/path')).toBe('https://example.com/path');
+  });
+
+  test('fileNameFromPath keeps only the last path segment', () => {
+    expect(fileNameFromPath('/home/aleksandr/amdgpu-install_6.3.60300-1_all.deb')).toBe(
+      'amdgpu-install_6.3.60300-1_all.deb'
+    );
+    expect(fileNameFromPath('C:\\docs\\a.pdf')).toBe('a.pdf');
+    expect(fileNameFromPath('doc.pdf')).toBe('doc.pdf');
+  });
+
+  test('fileBodyParam reads a non-multipart HAR file body', () => {
+    expect(fileBodyParam({
+      mimeType: 'image/png',
+      text: '/tmp/a.png',
+      params: [{ name: 'upload', fileName: '/tmp/a.png', contentType: 'image/png' }]
+    })).toEqual({
+      path: '/tmp/a.png',
+      contentType: 'image/png'
+    });
+    expect(fileBodyParam({ mimeType: 'multipart/form-data', params: [{ fileName: 'a' }] })).toBeNull();
+  });
+
+  test('formFieldEntries prefers the params array so duplicate names survive', () => {
+    expect(formFieldEntries({
+      paramsObj: { tag: '3' },
+      params: [
+        { name: 'tag', value: '1' },
+        { name: 'tag', value: '2' },
+        { name: 'tag', value: '3' }
+      ]
+    })).toEqual([
+      ['tag', '1'],
+      ['tag', '2'],
+      ['tag', '3']
+    ]);
+    expect(formFieldEntries({ paramsObj: { title: 'bruno' } })).toEqual([['title', 'bruno']]);
+    expect(hasDuplicateKeys([['tag', '1'], ['tag', '2']])).toBe(true);
+    expect(hasDuplicateKeys([['tag', '1'], ['other', '2']])).toBe(false);
+    expect(formUrlEncodedText({ text: 'tag=1&tag=2', paramsObj: { tag: '2' } })).toBe('tag=1&tag=2');
+  });
+
+  test('jsonBodyText prefers HAR text and stringifies jsonObj as fallback', () => {
+    expect(jsonBodyText({ text: '{"title":"bruno"}', jsonObj: { title: 'other' } })).toBe('{"title":"bruno"}');
+    expect(jsonBodyText({ jsonObj: { user: { id: 1 }, tags: ['a', 'b'] } })).toBe(
+      '{"user":{"id":1},"tags":["a","b"]}'
+    );
+    expect(jsonBodyText({})).toBeUndefined();
+  });
+
+  test('prettyJsonBodyText formats objects as a tab-indented multiline literal', () => {
+    expect(prettyJsonBodyText({ jsonObj: { user: { id: 1 }, tags: ['a', 'b'] } })).toBe(
+      '{\n\t"user": {\n\t\t"id": 1\n\t},\n\t"tags": [\n\t\t"a",\n\t\t"b"\n\t]\n}'
+    );
+    expect(assignStringBody(prettyJsonBodyText({ text: '{"title":"bruno"}' }), 'ru')).toEqual([
+      'ДанныеСтрокой = "{\n|\t""title"": ""bruno""\n|}";'
+    ]);
+  });
+
+  test('toEntries normalizes objects and named arrays', () => {
+    expect(objectEntries({ a: 1 })).toEqual([['a', 1]]);
+    expect(namedEntries([{ name: 'a', value: 1 }])).toEqual([['a', 1]]);
+    expect(toEntries([{ name: 'a' }])).toEqual([['a', '']]);
+  });
+});

--- a/packages/bruno-app/src/utils/codegenerator/onec/__tests__/connector.spec.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/__tests__/connector.spec.js
@@ -1,0 +1,240 @@
+import { connectorEn, connectorRu } from '../connector';
+import { createRequest } from './createRequest';
+
+const request = (overrides = {}) => createRequest({
+  url: 'https://httpbin.org/get',
+  fullUrl: 'https://httpbin.org/get',
+  ...overrides
+});
+
+describe('1C Connector HTTPSnippet clients', () => {
+  test('generates GET without headers', () => {
+    expect(connectorRu.convert(request())).toBe(
+      [
+        'Результат = КоннекторHTTP.Get("https://httpbin.org/get");',
+        '',
+        'Сообщить(Результат.КодСостояния);',
+        'ТекстОтвета = КоннекторHTTP.КакТекст(Результат);',
+        'Сообщить(ТекстОтвета);'
+      ].join('\n')
+    );
+  });
+
+  test('generates GET with query parameters', () => {
+    const snippet = connectorRu.convert(request({
+      fullUrl: 'https://httpbin.org/get?search=bruno',
+      queryObj: { search: 'bruno' }
+    }));
+
+    expect(snippet).toContain('ПараметрыЗапроса = Новый Структура;');
+    expect(snippet).toContain('ПараметрыЗапроса.Вставить("search", "bruno");');
+    expect(snippet).toContain(
+      'КоннекторHTTP.Get("https://httpbin.org/get", ПараметрыЗапроса)'
+    );
+  });
+
+  test('generates JSON POST with data and headers', () => {
+    const snippet = connectorRu.convert(request({
+      method: 'POST',
+      url: 'https://httpbin.org/post',
+      fullUrl: 'https://httpbin.org/post',
+      allHeaders: {
+        'Content-Type': 'application/json',
+        'X-Header': 'value'
+      },
+      postData: {
+        mimeType: 'application/json',
+        text: '{"title":"bruno"}',
+        jsonObj: { title: 'bruno' }
+      }
+    }));
+
+    expect(snippet).toContain('Заголовки.Вставить("X-Header", "value");');
+    expect(snippet).toContain('Заголовки.Вставить("Content-Type", "application/json");');
+    expect(snippet).toContain('ДанныеСтрокой = "{');
+    expect(snippet).toContain('|\t""title"": ""bruno""');
+    expect(snippet).toContain(
+      'Результат = КоннекторHTTP.Post("https://httpbin.org/post", ДанныеСтрокой, ДополнительныеПараметры);'
+    );
+    expect(snippet).toContain('Сообщить(Результат.КодСостояния);');
+    expect(snippet).toContain('ТекстОтвета = КоннекторHTTP.КакТекст(Результат);');
+    expect(snippet).not.toContain('PostJson');
+  });
+
+  test('keeps nested JSON as a string and adds Content-Type when missing', () => {
+    const snippet = connectorRu.convert(request({
+      method: 'POST',
+      url: 'https://httpbin.org/post',
+      fullUrl: 'https://httpbin.org/post',
+      postData: {
+        mimeType: 'application/json',
+        jsonObj: { user: { id: 1 }, tags: ['a', 'b'] }
+      }
+    }));
+
+    expect(snippet).toContain('Заголовки.Вставить("Content-Type", "application/json");');
+    expect(snippet).toContain('ДанныеСтрокой = "{');
+    expect(snippet).toContain('|\t""user"": {');
+    expect(snippet).toContain('|\t\t""id"": 1');
+    expect(snippet).toContain(
+      'Результат = КоннекторHTTP.Post("https://httpbin.org/post", ДанныеСтрокой, ДополнительныеПараметры);'
+    );
+    expect(snippet).not.toContain('PostJson');
+    expect(snippet).not.toContain('Данные = Новый Структура');
+  });
+
+  test('sends repeated form fields as a raw urlencoded string', () => {
+    const snippet = connectorRu.convert(request({
+      method: 'POST',
+      url: 'https://httpbin.org/post',
+      fullUrl: 'https://httpbin.org/post',
+      allHeaders: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      postData: {
+        mimeType: 'application/x-www-form-urlencoded',
+        text: 'tag=1&tag=2&tag=3',
+        paramsObj: { tag: '3' },
+        params: [
+          { name: 'tag', value: '1' },
+          { name: 'tag', value: '2' },
+          { name: 'tag', value: '3' }
+        ]
+      }
+    }));
+
+    expect(snippet).toContain('Данные = "tag=1&tag=2&tag=3";');
+    expect(snippet).toContain('Заголовки.Вставить("Content-Type", "application/x-www-form-urlencoded");');
+    expect(snippet).not.toContain('Данные = Новый Структура');
+    expect(snippet).not.toContain('Данные.Вставить("tag", "3")');
+  });
+
+  test('generates form-urlencoded POST with structure data', () => {
+    const snippet = connectorRu.convert(request({
+      method: 'POST',
+      url: 'https://httpbin.org/post',
+      fullUrl: 'https://httpbin.org/post',
+      postData: {
+        mimeType: 'application/x-www-form-urlencoded',
+        paramsObj: { title: 'bruno' }
+      }
+    }));
+
+    expect(snippet).toContain('Данные = Новый Структура;');
+    expect(snippet).toContain('Данные.Вставить("title", "bruno");');
+    expect(snippet).toContain(
+      'Результат = КоннекторHTTP.Post("https://httpbin.org/post", Данные);'
+    );
+    expect(snippet).toContain('КоннекторHTTP.КакТекст(Результат)');
+  });
+
+  test('uses English module and field names', () => {
+    const snippet = connectorEn.convert(request({
+      allHeaders: { 'X-Header': 'value' }
+    }));
+
+    expect(snippet).toContain('Headers = New Map;');
+    expect(snippet).toContain('AdditionalParameters = New Structure;');
+    expect(snippet).toContain('AdditionalParameters.Insert("Headers", Headers);');
+    expect(snippet).toContain(
+      'Result = HTTPConnector.Get("https://httpbin.org/get", Undefined, AdditionalParameters);'
+    );
+  });
+
+  test('puts POST query parameters into additional parameters and extracts the body', () => {
+    const snippet = connectorRu.convert(request({
+      method: 'POST',
+      url: 'http://localhost:3000?q=q1',
+      fullUrl: 'http://localhost:3000?q=q1',
+      queryObj: { q: 'q1' },
+      allHeaders: {
+        'Content-Type': 'multipart/form-data; boundary=----011000010111000001101001'
+      },
+      postData: {
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: '1', value: '2' }
+        ]
+      }
+    }));
+
+    expect(snippet).toContain('Разделитель = СтрЗаменить(Строка(Новый УникальныйИдентификатор), "-", "");');
+    expect(snippet).toContain('Заголовки.Вставить("Content-Type", "multipart/form-data; boundary=" + Разделитель);');
+    expect(snippet).toContain('ПараметрыЗапроса = Новый Структура;');
+    expect(snippet).toContain('ПараметрыЗапроса.Вставить("q", "q1");');
+    expect(snippet).toContain('ДополнительныеПараметры.Вставить("Заголовки", Заголовки);');
+    expect(snippet).toContain('ДополнительныеПараметры.Вставить("ПараметрыЗапроса", ПараметрыЗапроса);');
+    expect(snippet).toContain(
+      'Результат = КоннекторHTTP.Post("http://localhost:3000", ДанныеТела, ДополнительныеПараметры);'
+    );
+    expect(snippet).not.toContain('Post("http://localhost:3000?q=q1"');
+    expect(snippet).not.toContain('011000010111000001101001');
+    expect(snippet).not.toContain('// multipart body is not expanded');
+  });
+
+  test('uploads a binary file body from the client to the server', () => {
+    const snippet = connectorRu.convert(request({
+      method: 'POST',
+      url: 'https://example.com/upload',
+      fullUrl: 'https://example.com/upload',
+      postData: {
+        mimeType: 'application/pdf',
+        text: 'C:\\docs\\a.pdf',
+        params: [
+          { name: 'file', value: 'C:\\docs\\a.pdf', fileName: 'C:\\docs\\a.pdf', contentType: 'application/pdf' }
+        ]
+      }
+    }));
+
+    expect(snippet).toContain('ПоместитьФайл(АдресФайла, ПолноеИмяФайла, , Ложь, УникальныйИдентификатор);');
+    expect(snippet).toContain('ДвоичныеДанныеФайла = ПолучитьИзВременногоХранилища(АдресФайла);');
+    expect(snippet).toContain('КоннекторHTTP.Post("https://example.com/upload", ДвоичныеДанныеФайла');
+    expect(snippet).not.toContain('Данные = "C:\\docs\\a.pdf"');
+  });
+
+  test('generates Options() for OPTIONS requests', () => {
+    const ru = connectorRu.convert(request({
+      method: 'OPTIONS',
+      url: 'https://httpbin.org/anything',
+      fullUrl: 'https://httpbin.org/anything'
+    }));
+
+    expect(ru).toContain('КоннекторHTTP.Options("https://httpbin.org/anything")');
+    expect(ru).not.toContain('Post(');
+    expect(ru).not.toContain('ВызватьHTTPМетод');
+  });
+
+  test('comments that CallHTTPMethod must be exported for unknown verbs', () => {
+    const ru = connectorRu.convert(request({
+      method: 'TRACE',
+      url: 'https://httpbin.org/anything',
+      fullUrl: 'https://httpbin.org/anything'
+    }));
+    const en = connectorEn.convert(request({
+      method: 'TRACE',
+      url: 'https://httpbin.org/anything',
+      fullUrl: 'https://httpbin.org/anything'
+    }));
+
+    expect(ru).toContain(
+      '// Сделайте экспортной КоннекторHTTP.ВызватьHTTPМетод и вызовите её для метода TRACE.'
+    );
+    expect(ru).toContain(
+      'КоннекторHTTP.ВызватьHTTPМетод(Неопределено, "TRACE", "https://httpbin.org/anything", Неопределено)'
+    );
+    expect(en).toContain(
+      '// Export HTTPConnector.CallHTTPMethod and call it for the TRACE method.'
+    );
+    expect(en).toContain(
+      'HTTPConnector.CallHTTPMethod(Undefined, "TRACE", "https://httpbin.org/anything", Undefined)'
+    );
+  });
+
+  test('keeps Authorization header', () => {
+    const snippet = connectorRu.convert(request({
+      allHeaders: { Authorization: 'Bearer secret' }
+    }));
+
+    expect(snippet).toContain('Заголовки.Вставить("Authorization", "Bearer secret");');
+  });
+});

--- a/packages/bruno-app/src/utils/codegenerator/onec/__tests__/createRequest.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/__tests__/createRequest.js
@@ -1,0 +1,6 @@
+export const createRequest = (overrides = {}) => ({
+  method: 'GET',
+  url: 'https://example.com/',
+  fullUrl: 'https://example.com/',
+  ...overrides
+});

--- a/packages/bruno-app/src/utils/codegenerator/onec/__tests__/json-body.spec.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/__tests__/json-body.spec.js
@@ -1,0 +1,43 @@
+import { nativeRu } from '../native';
+import { connectorRu } from '../connector';
+import { opiRu } from '../opi';
+import { assignStringBody, prettyJsonBodyText } from '../bsl';
+import { createRequest } from './createRequest';
+
+describe('1C JSON string body is identical across clients', () => {
+  const request = createRequest({
+    method: 'POST',
+    fullUrl: 'https://httpbin.org/post',
+    postData: {
+      mimeType: 'application/json',
+      jsonObj: { user: { id: 1 }, tags: ['a', 'b'] },
+      text: '{"user":{"id":1},"tags":["a","b"]}'
+    }
+  });
+
+  test('uses ДанныеСтрокой and the same | escaped multiline literal', () => {
+    const assignment = assignStringBody(prettyJsonBodyText(request.postData), 'ru').join('\n');
+
+    expect(assignment).toBe(
+      [
+        'ДанныеСтрокой = "{',
+        '|\t""user"": {',
+        '|\t\t""id"": 1',
+        '|\t},',
+        '|\t""tags"": [',
+        '|\t\t""a"",',
+        '|\t\t""b""',
+        '|\t]',
+        '|}";'
+      ].join('\n')
+    );
+
+    expect(nativeRu.convert(request)).toContain(assignment);
+    expect(connectorRu.convert(request)).toContain(assignment);
+    expect(opiRu.convert(request)).toContain(assignment);
+
+    expect(nativeRu.convert(request)).toContain('HTTPЗапрос.УстановитьТелоИзСтроки(ДанныеСтрокой);');
+    expect(connectorRu.convert(request)).toContain('КоннекторHTTP.Post("https://httpbin.org/post", ДанныеСтрокой');
+    expect(opiRu.convert(request)).toContain('.УстановитьСтроковоеТело(ДанныеСтрокой)');
+  });
+});

--- a/packages/bruno-app/src/utils/codegenerator/onec/__tests__/native.spec.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/__tests__/native.spec.js
@@ -1,0 +1,290 @@
+import { nativeEn, nativeRu } from '../native';
+import { createRequest } from './createRequest';
+
+describe('1C native HTTP snippet clients', () => {
+  test('generates an HTTPS GET request without a body', () => {
+    const result = nativeRu.convert(createRequest());
+
+    expect(result).toBe(
+      [
+        'ЗащищенноеСоединение = Новый ЗащищенноеСоединениеOpenSSL;',
+        'Соединение = Новый HTTPСоединение("example.com", 443, , , , 30, ЗащищенноеСоединение);',
+        '',
+        'HTTPЗапрос = Новый HTTPЗапрос("/");',
+        '',
+        'HTTPОтвет = Соединение.ВызватьHTTPМетод("GET", HTTPЗапрос);',
+        '',
+        'Сообщить(HTTPОтвет.КодСостояния);',
+        'ТекстОтвета = HTTPОтвет.ПолучитьТелоКакСтроку();',
+        'Сообщить(ТекстОтвета);'
+      ].join('\n')
+    );
+  });
+
+  test('generates a JSON POST request with headers and raw text body', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        url: 'https://httpbin.org/post',
+        fullUrl: 'https://httpbin.org/post',
+        allHeaders: {
+          'X-Header': 'value',
+          'Content-Type': 'application/json'
+        },
+        postData: {
+          mimeType: 'application/json',
+          text: '{\n\t"title": "bruno"\n}',
+          jsonObj: { title: 'bruno' }
+        }
+      })
+    );
+
+    expect(result).toBe(
+      [
+        'Заголовки = Новый Соответствие;',
+        'Заголовки.Вставить("X-Header", "value");',
+        'Заголовки.Вставить("Content-Type", "application/json");',
+        '',
+        'ЗащищенноеСоединение = Новый ЗащищенноеСоединениеOpenSSL;',
+        'Соединение = Новый HTTPСоединение("httpbin.org", 443, , , , 30, ЗащищенноеСоединение);',
+        '',
+        'HTTPЗапрос = Новый HTTPЗапрос("/post", Заголовки);',
+        '',
+        'ДанныеСтрокой = "{',
+        '|\t""title"": ""bruno""',
+        '|}";',
+        'HTTPЗапрос.УстановитьТелоИзСтроки(ДанныеСтрокой);',
+        '',
+        'HTTPОтвет = Соединение.ВызватьHTTPМетод("POST", HTTPЗапрос);',
+        '',
+        'Сообщить(HTTPОтвет.КодСостояния);',
+        'ТекстОтвета = HTTPОтвет.ПолучитьТелоКакСтроку();',
+        'Сообщить(ТекстОтвета);'
+      ].join('\n')
+    );
+  });
+
+  test('keeps nested JSON as a string and adds Content-Type when missing', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        fullUrl: 'https://httpbin.org/post',
+        postData: {
+          mimeType: 'application/json',
+          jsonObj: { user: { id: 1 }, tags: ['a', 'b'] }
+        }
+      })
+    );
+
+    expect(result).toContain('Заголовки.Вставить("Content-Type", "application/json");');
+    expect(result).toContain('ДанныеСтрокой = "{');
+    expect(result).toContain('|\t""user"": {');
+    expect(result).toContain('|\t\t""id"": 1');
+    expect(result).toContain('|\t""tags"": [');
+    expect(result).toContain('HTTPЗапрос.УстановитьТелоИзСтроки(ДанныеСтрокой);');
+    expect(result).not.toContain('Структура');
+    expect(result).not.toContain('УстановитьТелоИзСтроки("{');
+  });
+
+  test('keeps a form-urlencoded body as text', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        fullUrl: 'https://example.com/login',
+        allHeaders: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        postData: {
+          mimeType: 'application/x-www-form-urlencoded',
+          text: 'user=bruno&active=true',
+          paramsObj: { user: 'bruno', active: 'true' }
+        }
+      })
+    );
+
+    expect(result).toContain('HTTPЗапрос.УстановитьТелоИзСтроки("user=bruno&active=true");');
+    expect(result).not.toContain('Структура');
+  });
+
+  test('keeps repeated form field names from the HAR text', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        fullUrl: 'https://example.com/tags',
+        allHeaders: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        postData: {
+          mimeType: 'application/x-www-form-urlencoded',
+          text: 'tag=1&tag=2&tag=3',
+          paramsObj: { tag: '3' },
+          params: [
+            { name: 'tag', value: '1' },
+            { name: 'tag', value: '2' },
+            { name: 'tag', value: '3' }
+          ]
+        }
+      })
+    );
+
+    expect(result).toContain('HTTPЗапрос.УстановитьТелоИзСтроки("tag=1&tag=2&tag=3");');
+    expect(result).not.toContain('Структура');
+  });
+
+  test('uses the query string from fullUrl in the resource address', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        url: 'https://example.com/search',
+        fullUrl: 'https://example.com/search?q=bruno&page=2'
+      })
+    );
+
+    expect(result).toContain('HTTPЗапрос = Новый HTTPЗапрос("/search?q=bruno&page=2");');
+  });
+
+  test('omits the OpenSSL secure connection for HTTP', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        url: 'http://example.com/status',
+        fullUrl: 'http://example.com/status'
+      })
+    );
+
+    expect(result).toContain('Соединение = Новый HTTPСоединение("example.com", 80, , , , 30);');
+    expect(result).not.toContain('ЗащищенноеСоединениеOpenSSL');
+  });
+
+  test('generates English platform keywords and names', () => {
+    const result = nativeEn.convert(
+      createRequest({
+        fullUrl: 'https://example.com/items',
+        allHeaders: { Accept: 'application/json' }
+      })
+    );
+
+    expect(result).toContain('Headers = New Map;');
+    expect(result).toContain('SecureConnection = New OpenSSLSecureConnection;');
+    expect(result).toContain(
+      'Connection = New HTTPConnection("example.com", 443, , , , 30, SecureConnection);'
+    );
+    expect(result).toContain('HTTPRequest = New HTTPRequest("/items", Headers);');
+    expect(result).toContain('HTTPResponse = Connection.CallHTTPMethod("GET", HTTPRequest);');
+  });
+
+  test('builds multipart body with DataWriter like the Infostart sample', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        url: 'http://localhost:3000',
+        fullUrl: 'http://localhost:3000',
+        allHeaders: {
+          'Content-Type': 'multipart/form-data; boundary=----011000010111000001101001',
+          'Authorization': 'Basic MToy'
+        },
+        postData: {
+          mimeType: 'multipart/form-data',
+          params: [
+            { name: '1', value: '2' },
+            { name: 'file', fileName: 'doc.pdf', contentType: 'application/pdf' }
+          ]
+        }
+      })
+    );
+
+    expect(result).toContain('Разделитель = СтрЗаменить(Строка(Новый УникальныйИдентификатор), "-", "");');
+    expect(result).toContain('Тело = Новый ПотокВПамяти;');
+    expect(result).toContain('ЗаписьДанных = Новый ЗаписьДанных(Тело, , , Символы.ВК + Символы.ПС, "");');
+    expect(result).toContain('ЗаписьДанных.ЗаписатьСтроку("Content-Disposition: form-data; name=""1""");');
+    expect(result).toContain('ЗаписьДанных.ЗаписатьСтроку("2");');
+    expect(result).toContain('ПолноеИмяФайла = "doc.pdf";');
+    expect(result).toContain('ПоместитьФайл(АдресФайла, ПолноеИмяФайла, , Ложь, УникальныйИдентификатор);');
+    expect(result).toContain('ДвоичныеДанныеФайла = ПолучитьИзВременногоХранилища(АдресФайла);');
+    expect(result).toContain('ЗаписьДанных.Записать(ДвоичныеДанныеФайла);');
+    expect(result).not.toContain('Новый ДвоичныеДанные(ПолноеИмяФайла)');
+    expect(result).toContain('ЗаписьДанных.ЗаписатьСтроку("");');
+    expect(result).toContain('ДанныеТела = Тело.ЗакрытьИПолучитьДвоичныеДанные();');
+    expect(result).toContain('Заголовки.Вставить("Content-Type", "multipart/form-data; boundary=" + Разделитель);');
+    expect(result).toContain('HTTPЗапрос.УстановитьТелоИзДвоичныхДанных(ДанныеТела);');
+    expect(result).not.toContain('УстановитьТелоИзСтроки');
+    expect(result).not.toContain('011000010111000001101001');
+  });
+
+  test('escapes quotes in multipart field names and content types', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        fullUrl: 'http://localhost:3000',
+        postData: {
+          mimeType: 'multipart/form-data',
+          params: [
+            { name: 'foo"bar', value: '2' },
+            { name: 'file', fileName: '/home/aleksandr/a"b.pdf', contentType: 'application/pdf";x' }
+          ]
+        }
+      })
+    );
+
+    expect(result).toContain(
+      'ЗаписьДанных.ЗаписатьСтроку("Content-Disposition: form-data; name=""foo""bar""");'
+    );
+    expect(result).toContain(
+      'ЗаписьДанных.ЗаписатьСтроку("Content-Disposition: form-data; name=""file""; filename=""a""b.pdf""");'
+    );
+    expect(result).toContain('ЗаписьДанных.ЗаписатьСтроку("Content-Type: application/pdf"";x");');
+  });
+
+  test('treats CR-only request bodies as multiline 1C strings', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        fullUrl: 'https://example.com/post',
+        postData: {
+          mimeType: 'text/plain',
+          text: 'line1\rline2'
+        }
+      })
+    );
+
+    expect(result).toContain('ТекстТела = "line1\n|line2";');
+    expect(result).toContain('HTTPЗапрос.УстановитьТелоИзСтроки(ТекстТела);');
+  });
+
+  test('uploads a binary file body from the client to the server', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        method: 'POST',
+        fullUrl: 'https://example.com/upload',
+        postData: {
+          mimeType: 'image/png',
+          text: '/tmp/a.png',
+          params: [
+            { name: 'upload', value: '/tmp/a.png', fileName: '/tmp/a.png', contentType: 'image/png' }
+          ]
+        }
+      })
+    );
+
+    expect(result).toContain('&НаКлиенте');
+    expect(result).toContain('Процедура ВыполнитьЗапрос()');
+    expect(result).toContain('ПолноеИмяФайла = "/tmp/a.png";');
+    expect(result).toContain('ПоместитьФайл(АдресФайла, ПолноеИмяФайла, , Ложь, УникальныйИдентификатор);');
+    expect(result).toContain('ВыполнитьЗапросНаСервере(АдресФайла);');
+    expect(result).toContain('&НаСервере');
+    expect(result).toContain('ДвоичныеДанныеФайла = ПолучитьИзВременногоХранилища(АдресФайла);');
+    expect(result).toContain('HTTPЗапрос.УстановитьТелоИзДвоичныхДанных(ДвоичныеДанныеФайла);');
+    expect(result).toContain('Заголовки.Вставить("Content-Type", "image/png");');
+    expect(result).not.toContain('УстановитьТелоИзСтроки("/tmp/a.png")');
+  });
+
+  test('escapes quotes in header values', () => {
+    const result = nativeRu.convert(
+      createRequest({
+        allHeaders: {
+          'X-Quoted': 'say "hello"'
+        }
+      })
+    );
+
+    expect(result).toContain('Заголовки.Вставить("X-Quoted", "say ""hello""");');
+  });
+});

--- a/packages/bruno-app/src/utils/codegenerator/onec/__tests__/opi.spec.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/__tests__/opi.spec.js
@@ -1,0 +1,190 @@
+import { opiEn, opiRu } from '../opi';
+import { createRequest } from './createRequest';
+
+describe('OPI HTTPSnippet clients', () => {
+  test('generates URL parameters for a GET request', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'GET',
+      fullUrl: 'https://httpbin.org/get?page=2&active=true',
+      queryObj: { page: '2', active: 'true' }
+    }));
+
+    expect(result).toContain('ПараметрыURL.Вставить("page", "2");');
+    expect(result).toContain('.Инициализировать("https://httpbin.org/get")');
+    expect(result).toContain('.УстановитьПараметрыURL(ПараметрыURL)');
+  });
+
+  test('sends a JSON body as a raw string', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'POST',
+      fullUrl: 'https://httpbin.org/post',
+      headersObj: { 'Content-Type': 'application/json' },
+      postData: {
+        mimeType: 'application/json',
+        jsonObj: { title: 'bruno' },
+        text: '{"title":"bruno"}'
+      }
+    }));
+
+    expect(result).toContain('ДанныеСтрокой = "{');
+    expect(result).toContain('|\t""title"": ""bruno""');
+    expect(result).toContain('.УстановитьСтроковоеТело(ДанныеСтрокой)');
+    expect(result).toContain('.ДобавитьЗаголовок("Content-Type", "application/json")');
+    expect(result).toContain('.ОбработатьЗапрос("POST");');
+    expect(result).not.toContain('УстановитьJsonТело');
+    expect(result).not.toContain('Новый Структура');
+  });
+
+  test('keeps nested JSON and arrays as a string', () => {
+    const nested = '{"user":{"id":1},"tags":["a","b"]}';
+    const result = opiRu.convert(createRequest({
+      method: 'POST',
+      fullUrl: 'https://httpbin.org/post',
+      postData: {
+        mimeType: 'application/json',
+        jsonObj: { user: { id: 1 }, tags: ['a', 'b'] },
+        text: nested
+      }
+    }));
+
+    expect(result).toContain('ДанныеСтрокой = "{');
+    expect(result).toContain('|\t""user"": {');
+    expect(result).toContain('|\t\t""id"": 1');
+    expect(result).toContain('.УстановитьСтроковоеТело(ДанныеСтрокой)');
+    expect(result).toContain('.ДобавитьЗаголовок("Content-Type", "application/json")');
+    expect(result).not.toContain('Неопределено');
+  });
+
+  test('sends unique form fields as a structure', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'POST',
+      fullUrl: 'https://httpbin.org/post',
+      postData: {
+        mimeType: 'application/x-www-form-urlencoded',
+        paramsObj: { title: 'bruno' },
+        params: [{ name: 'title', value: 'bruno' }]
+      }
+    }));
+
+    expect(result).toContain('Данные = Новый Структура;');
+    expect(result).toContain('Данные.Вставить("title", "bruno");');
+    expect(result).toContain('.УстановитьFormТело(Данные)');
+  });
+
+  test('sends repeated form fields as a raw urlencoded string', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'POST',
+      fullUrl: 'https://httpbin.org/post',
+      headersObj: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      postData: {
+        mimeType: 'application/x-www-form-urlencoded',
+        text: 'tag=1&tag=2&tag=3',
+        paramsObj: { tag: '3' },
+        params: [
+          { name: 'tag', value: '1' },
+          { name: 'tag', value: '2' },
+          { name: 'tag', value: '3' }
+        ]
+      }
+    }));
+
+    expect(result).toContain('Данные = "tag=1&tag=2&tag=3";');
+    expect(result).toContain('.УстановитьСтроковоеТело(Данные)');
+    expect(result).toContain('.ДобавитьЗаголовок("Content-Type", "application/x-www-form-urlencoded")');
+    expect(result).not.toContain('УстановитьFormТело');
+    expect(result).not.toContain('Данные = Новый Структура');
+  });
+
+  test('generates a text body and returns a string', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'POST',
+      fullUrl: 'https://httpbin.org/post',
+      postData: {
+        mimeType: 'text/plain',
+        text: 'hello'
+      }
+    }));
+
+    expect(result).toContain('.УстановитьСтроковоеТело("hello")');
+    expect(result).toContain('ТекстОтвета = Результат.ВернутьОтветКакСтроку();');
+  });
+
+  test('adds a custom header', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'GET',
+      fullUrl: 'https://httpbin.org/get',
+      allHeaders: { 'X-Header': 'value' }
+    }));
+
+    expect(result).toContain('.ДобавитьЗаголовок("X-Header", "value")');
+  });
+
+  test('uses English OPI fluent API keywords', () => {
+    const result = opiEn.convert(createRequest({
+      method: 'PATCH',
+      fullUrl: 'https://httpbin.org/patch'
+    }));
+
+    expect(result).toContain('Result = OPI_HTTPRequests.NewRequest()');
+    expect(result).toContain('.Initialize("https://httpbin.org/patch")');
+    expect(result).toContain('.ProcessRequest("PATCH")');
+  });
+
+  test('builds multipart body with a UUID boundary instead of the HAR delimiter', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'POST',
+      fullUrl: 'https://httpbin.org/post',
+      allHeaders: {
+        'Content-Type': 'multipart/form-data; boundary=----011000010111000001101001'
+      },
+      postData: {
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: '1', value: '2' },
+          { name: 'file', fileName: 'doc.pdf', contentType: 'application/pdf' }
+        ]
+      }
+    }));
+
+    expect(result).toContain('Разделитель = СтрЗаменить(Строка(Новый УникальныйИдентификатор), "-", "");');
+    expect(result).toContain('.УстановитьДвоичноеТело(ДанныеТела)');
+    expect(result).toContain('.ДобавитьЗаголовок("Content-Type", "multipart/form-data; boundary=" + Разделитель)');
+    expect(result).not.toContain('011000010111000001101001');
+    expect(result).toContain('ПоместитьФайл(АдресФайла, ПолноеИмяФайла, , Ложь, УникальныйИдентификатор);');
+    expect(result).toContain('ДвоичныеДанныеФайла = ПолучитьИзВременногоХранилища(АдресФайла);');
+    expect(result).not.toContain('УстановитьДвоичноеТело("doc.pdf")');
+    expect(result).not.toContain('несколько файлов уходят одним двоичным multipart-телом');
+  });
+
+  test('comments that several multipart files share one OPI binary body', () => {
+    const result = opiRu.convert(createRequest({
+      method: 'POST',
+      fullUrl: 'https://httpbin.org/post',
+      postData: {
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'file1', fileName: 'a.pdf' },
+          { name: 'file2', fileName: 'b.pdf' }
+        ]
+      }
+    }));
+
+    expect(result).toContain(
+      '// OPI: несколько файлов уходят одним двоичным multipart-телом, отдельного метода на каждый файл нет.'
+    );
+    expect(result).toContain('.УстановитьДвоичноеТело(ДанныеТела)');
+    expect(result).toContain('ПоместитьФайл(АдресФайла1, ПолноеИмяФайла1, , Ложь, УникальныйИдентификатор);');
+    expect(result).toContain('ПоместитьФайл(АдресФайла2, ПолноеИмяФайла2, , Ложь, УникальныйИдентификатор);');
+  });
+
+  test('uses bearer authorization method when possible', () => {
+    const result = opiEn.convert(createRequest({
+      method: 'GET',
+      fullUrl: 'https://httpbin.org/bearer',
+      headersObj: { Authorization: 'Bearer secret-token' }
+    }));
+
+    expect(result).toContain('.AddBearerAuthorization("secret-token")');
+    expect(result).not.toContain('.AddHeader("Authorization"');
+  });
+});

--- a/packages/bruno-app/src/utils/codegenerator/onec/bsl.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/bsl.js
@@ -1,0 +1,445 @@
+import { platform } from './keywords';
+
+const LINE_BREAK = /\r\n|\r|\n/;
+
+export const isMultiline = (value) => {
+  return LINE_BREAK.test(String(value));
+};
+
+export const quote = (value = '') => {
+  const escaped = String(value).replace(/"/g, '""');
+  const lines = escaped.split(LINE_BREAK);
+
+  if (lines.length === 1) {
+    return `"${escaped}"`;
+  }
+
+  return `"${lines[0]}\n${lines.slice(1).map((line) => `|${line}`).join('\n')}"`;
+};
+
+export const literal = (value, lang) => {
+  const kw = platform[lang];
+
+  if (value === null || value === undefined) {
+    return kw.Undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? kw.True : kw.False;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return quote(value);
+};
+
+export const isJsonMime = (mimeType = '') => {
+  return /json/i.test(mimeType);
+};
+
+export const jsonBodyText = (postData = {}) => {
+  if (postData.text !== undefined && postData.text !== null && String(postData.text).length) {
+    return String(postData.text);
+  }
+
+  if (postData.jsonObj !== undefined) {
+    return JSON.stringify(postData.jsonObj);
+  }
+
+  return undefined;
+};
+
+export const prettyJsonBodyText = (postData = {}) => {
+  const text = jsonBodyText(postData);
+  if (text === undefined) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed !== null && typeof parsed === 'object') {
+      return JSON.stringify(parsed, null, '\t');
+    }
+  } catch {
+    return text;
+  }
+
+  return text;
+};
+
+export const stringBodyVariable = {
+  ru: 'ДанныеСтрокой',
+  en: 'DataAsString'
+};
+
+export const assignStringBody = (text, lang) => {
+  return multilineStringAssign(stringBodyVariable[lang], text);
+};
+
+export const isFormUrlEncoded = (mimeType = '') => {
+  return /x-www-form-urlencoded/i.test(mimeType);
+};
+
+export const isMultipart = (mimeType = '') => {
+  return /multipart\/form-data/i.test(mimeType);
+};
+
+export const fileNameFromPath = (filePath = '') => {
+  const segments = String(filePath).split(/[/\\]/).filter(Boolean);
+  return segments.length ? segments[segments.length - 1] : String(filePath);
+};
+
+export const multipartVariableNames = {
+  ru: {
+    boundary: 'Разделитель',
+    bodyStream: 'Тело',
+    dataWriter: 'ЗаписьДанных',
+    bodyData: 'ДанныеТела',
+    filePath: 'ПолноеИмяФайла',
+    fileData: 'ДвоичныеДанныеФайла'
+  },
+  en: {
+    boundary: 'Boundary',
+    bodyStream: 'Body',
+    dataWriter: 'DataWriter',
+    bodyData: 'BodyData',
+    filePath: 'FilePath',
+    fileData: 'FileBinaryData'
+  }
+};
+
+export const contentTypeMultipartExpression = (boundaryVariable) => {
+  return `"multipart/form-data; boundary=" + ${boundaryVariable}`;
+};
+
+export const withoutContentType = (headerEntries = []) => {
+  return headerEntries.filter(([name]) => String(name).toLowerCase() !== 'content-type');
+};
+
+export const multipartParams = (postData = {}) => {
+  if (Array.isArray(postData.params)) {
+    return postData.params.filter((param) => param && param.name !== undefined);
+  }
+
+  if (postData.paramsObj && typeof postData.paramsObj === 'object') {
+    return Object.entries(postData.paramsObj).map(([name, value]) => {
+      if (value && typeof value === 'object') {
+        return { name, ...value };
+      }
+
+      return { name, value };
+    });
+  }
+
+  return [];
+};
+
+export const fileBodyParam = (postData = {}) => {
+  if (isMultipart(postData.mimeType)) {
+    return null;
+  }
+
+  const params = Array.isArray(postData.params) ? postData.params : [];
+  const fileParam = params.find((param) => param && param.fileName);
+  if (!fileParam) {
+    return null;
+  }
+
+  return {
+    path: fileParam.fileName || fileParam.value || postData.text || '',
+    contentType: fileParam.contentType || postData.mimeType || 'application/octet-stream'
+  };
+};
+
+export const collectClientFilePaths = (postData = {}) => {
+  const fileBody = fileBodyParam(postData);
+  if (fileBody?.path) {
+    return [fileBody.path];
+  }
+
+  if (!isMultipart(postData.mimeType)) {
+    return [];
+  }
+
+  return multipartParams(postData)
+    .filter((param) => param.fileName)
+    .map((param) => param.fileName);
+};
+
+export const describeClientFiles = (paths, lang) => {
+  const uniquePaths = [...new Set((paths || []).filter(Boolean))];
+  const names = multipartVariableNames[lang];
+  const addressName = lang === 'ru' ? 'АдресФайла' : 'FileAddress';
+
+  return uniquePaths.map((path, index) => {
+    const suffix = uniquePaths.length > 1 ? String(index + 1) : '';
+    return {
+      path,
+      pathVar: `${names.filePath}${suffix}`,
+      addressVar: `${addressName}${suffix}`,
+      dataVar: `${names.fileData}${suffix}`
+    };
+  });
+};
+
+export const wrapWithClientFileTransfer = (serverLines, files, lang) => {
+  if (!files.length) {
+    return joinLines(serverLines);
+  }
+
+  const kw = platform[lang];
+  const executeRequest = lang === 'ru' ? 'ВыполнитьЗапрос' : 'ExecuteRequest';
+  const executeRequestOnServer = lang === 'ru' ? 'ВыполнитьЗапросНаСервере' : 'ExecuteRequestOnServer';
+  const header = lang === 'ru'
+    ? '// Вставить в модуль формы. Файл читается на клиенте и передается на сервер.'
+    : '// Paste into a form module. The file is read on the client and sent to the server.';
+
+  const lines = [
+    header,
+    '',
+    kw.AtClient,
+    `${kw.Procedure} ${executeRequest}()`,
+    ''
+  ];
+
+  files.forEach((file) => {
+    lines.push(`\t${file.pathVar} = ${quote(file.path)};`);
+    lines.push(`\t${file.addressVar} = "";`);
+    lines.push(`\t${kw.PutFile}(${file.addressVar}, ${file.pathVar}, , ${kw.False}, ${kw.FormUUID});`);
+    lines.push('');
+  });
+
+  lines.push(`\t${executeRequestOnServer}(${files.map((file) => file.addressVar).join(', ')});`);
+  lines.push('');
+  lines.push(kw.EndProcedure);
+  lines.push('');
+  lines.push(kw.AtServer);
+  lines.push(`${kw.Procedure} ${executeRequestOnServer}(${files.map((file) => file.addressVar).join(', ')})`);
+  lines.push('');
+
+  files.forEach((file) => {
+    lines.push(`\t${file.dataVar} = ${kw.GetFromTempStorage}(${file.addressVar});`);
+  });
+  lines.push('');
+
+  serverLines.forEach((line) => {
+    lines.push(line ? `\t${line}` : '');
+  });
+
+  lines.push('');
+  lines.push(kw.EndProcedure);
+
+  return joinLines(lines);
+};
+
+export const appendMultipartBody = (lines, params, lang, uploadedFiles = []) => {
+  const kw = platform[lang];
+  const names = multipartVariableNames[lang];
+
+  lines.push(
+    `${names.boundary} = ${kw.StrReplace}(${kw.String}(${kw.New} ${kw.UUID}), "-", "");`,
+    '',
+    `${names.bodyStream} = ${kw.New} ${kw.MemoryStream};`,
+    `${names.dataWriter} = ${kw.New} ${kw.DataWriter}(${names.bodyStream}, , , ${kw.CharsCR} + ${kw.CharsLF}, "");`
+  );
+
+  const hasMultipleFiles = params.filter((item) => item.fileName).length > 1;
+
+  params.forEach((param, index) => {
+    const fileName = param.fileName;
+    const partContentType = param.contentType || (fileName ? 'application/octet-stream' : '');
+    const disposition = fileName
+      ? `Content-Disposition: form-data; name="${param.name}"; filename="${fileNameFromPath(fileName)}"`
+      : `Content-Disposition: form-data; name="${param.name}"`;
+
+    lines.push(`${names.dataWriter}.${kw.WriteLine}("--" + ${names.boundary});`);
+    lines.push(`${names.dataWriter}.${kw.WriteLine}(${quote(disposition)});`);
+
+    if (partContentType) {
+      lines.push(`${names.dataWriter}.${kw.WriteLine}(${quote(`Content-Type: ${partContentType}`)});`);
+    }
+
+    lines.push(`${names.dataWriter}.${kw.WriteLine}("");`);
+
+    if (fileName) {
+      const uploaded = uploadedFiles.find((file) => file.path === fileName);
+      if (uploaded) {
+        lines.push(`${names.dataWriter}.${kw.Write}(${uploaded.dataVar});`);
+      } else {
+        const pathName = hasMultipleFiles
+          ? `${names.filePath}${index + 1}`
+          : names.filePath;
+        const dataName = hasMultipleFiles
+          ? `${names.fileData}${index + 1}`
+          : names.fileData;
+        lines.push(`${pathName} = ${quote(fileName)};`);
+        lines.push(`${dataName} = ${kw.New} ${kw.BinaryData}(${pathName});`);
+        lines.push(`${names.dataWriter}.${kw.Write}(${dataName});`);
+      }
+      lines.push(`${names.dataWriter}.${kw.WriteLine}("");`);
+    } else {
+      lines.push(`${names.dataWriter}.${kw.WriteLine}(${quote(param.value ?? '')});`);
+    }
+  });
+
+  lines.push(
+    `${names.dataWriter}.${kw.WriteLine}("--" + ${names.boundary} + "--");`,
+    `${names.dataWriter}.${kw.Close}();`,
+    `${names.bodyData} = ${names.bodyStream}.${kw.CloseAndGetBinaryData}();`
+  );
+
+  return names;
+};
+
+export const objectEntries = (value) => {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? Object.entries(value)
+    : [];
+};
+
+export const namedEntries = (value) => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item) => item && item.name !== undefined)
+    .map((item) => [item.name, item.value]);
+};
+
+export const toEntries = (value = {}) => {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item) => item && item.name !== undefined)
+      .map((item) => [item.name, item.value ?? '']);
+  }
+
+  return objectEntries(value);
+};
+
+export const formFieldEntries = (postData = {}) => {
+  const fromParams = namedEntries(postData.params);
+  if (fromParams.length) {
+    return fromParams;
+  }
+
+  return objectEntries(postData.paramsObj);
+};
+
+export const hasDuplicateKeys = (entries = []) => {
+  const seen = new Set();
+
+  for (const [key] of entries) {
+    if (seen.has(key)) {
+      return true;
+    }
+
+    seen.add(key);
+  }
+
+  return false;
+};
+
+export const formUrlEncodedText = (postData = {}) => {
+  if (postData.text !== undefined && postData.text !== null && String(postData.text).length) {
+    return String(postData.text);
+  }
+
+  const entries = formFieldEntries(postData);
+  if (!entries.length) {
+    return undefined;
+  }
+
+  return entries
+    .map(([name, value]) => `${encodeURIComponent(String(name ?? ''))}=${encodeURIComponent(String(value ?? ''))}`)
+    .join('&');
+};
+
+export const withoutQueryString = (fullUrl = '') => {
+  const queryStart = fullUrl.indexOf('?');
+  if (queryStart === -1) {
+    return fullUrl;
+  }
+
+  const fragmentStart = fullUrl.indexOf('#', queryStart);
+  return fragmentStart === -1
+    ? fullUrl.slice(0, queryStart)
+    : `${fullUrl.slice(0, queryStart)}${fullUrl.slice(fragmentStart)}`;
+};
+
+export const getHeader = (headers = {}, name) => {
+  const target = String(name).toLowerCase();
+  const key = Object.keys(headers).find((header) => header.toLowerCase() === target);
+  return key ? { name: key, value: headers[key] } : null;
+};
+
+export const parseRequestUrl = (fullUrl = '') => {
+  try {
+    const parsed = new URL(fullUrl);
+    const isHttps = parsed.protocol === 'https:';
+    const port = parsed.port ? Number(parsed.port) : isHttps ? 443 : 80;
+    const path = `${parsed.pathname || '/'}${parsed.search || ''}`;
+
+    return {
+      href: fullUrl,
+      host: parsed.hostname,
+      port,
+      path,
+      pathname: parsed.pathname || '/',
+      search: parsed.search || '',
+      isHttps
+    };
+  } catch (error) {
+    return {
+      href: fullUrl,
+      host: fullUrl,
+      port: 80,
+      path: '/',
+      pathname: '/',
+      search: '',
+      isHttps: false
+    };
+  }
+};
+
+const pushMapEntries = (lines, variableName, entries, lang) => {
+  const kw = platform[lang];
+  (entries || []).forEach(([key, value]) => {
+    lines.push(`${variableName}.${kw.Insert}(${quote(key)}, ${literal(value, lang)});`);
+  });
+};
+
+export const declareMap = (variableName, entries, lang) => {
+  const kw = platform[lang];
+  const lines = [`${variableName} = ${kw.New} ${kw.Map};`];
+  pushMapEntries(lines, variableName, entries, lang);
+  return lines;
+};
+
+export const declareStructure = (variableName, entries, lang) => {
+  const kw = platform[lang];
+  const lines = [`${variableName} = ${kw.New} ${kw.Structure};`];
+  pushMapEntries(lines, variableName, entries, lang);
+  return lines;
+};
+
+export const responseOutputLines = ({ lang, statusExpression, textExpression }) => {
+  const kw = platform[lang];
+  const textVariable = lang === 'ru' ? 'ТекстОтвета' : 'ResponseText';
+
+  return [
+    `${kw.Message}(${statusExpression});`,
+    `${textVariable} = ${textExpression};`,
+    `${kw.Message}(${textVariable});`
+  ];
+};
+
+export const multilineStringAssign = (variableName, text = '') => {
+  return [`${variableName} = ${quote(text)};`];
+};
+
+export const joinLines = (lines) => {
+  return lines.filter((line) => line !== undefined).join('\n');
+};

--- a/packages/bruno-app/src/utils/codegenerator/onec/connector.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/connector.js
@@ -1,0 +1,247 @@
+import { platform, connector as connectorKw } from './keywords';
+import {
+  quote,
+  isJsonMime,
+  prettyJsonBodyText,
+  assignStringBody,
+  stringBodyVariable,
+  isFormUrlEncoded,
+  isMultipart,
+  objectEntries,
+  namedEntries,
+  formFieldEntries,
+  hasDuplicateKeys,
+  formUrlEncodedText,
+  withoutQueryString,
+  withoutContentType,
+  declareMap,
+  declareStructure,
+  multilineStringAssign,
+  responseOutputLines,
+  joinLines,
+  multipartParams,
+  appendMultipartBody,
+  contentTypeMultipartExpression,
+  fileBodyParam,
+  collectClientFilePaths,
+  describeClientFiles,
+  wrapWithClientFileTransfer
+} from './bsl';
+
+const requestHeaders = (request) => {
+  const allHeaders = request.allHeaders;
+  if (Array.isArray(allHeaders)) {
+    return namedEntries(allHeaders);
+  }
+  if (allHeaders && typeof allHeaders === 'object' && Object.keys(allHeaders).length) {
+    return Object.entries(allHeaders);
+  }
+
+  const headers = request.headersObj;
+  return Array.isArray(headers) ? namedEntries(headers) : objectEntries(headers);
+};
+
+const CONNECTOR_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'MKCOL'];
+
+const connectorMethodName = (method) => {
+  if (method === 'MKCOL') {
+    return 'Mkcol';
+  }
+
+  return `${method.charAt(0)}${method.slice(1).toLowerCase()}`;
+};
+
+const methodHasDataArgument = (method) => {
+  return ['POST', 'PUT', 'PATCH', 'DELETE', 'MKCOL'].includes(method);
+};
+
+const exportCallHTTPMethodComment = (method, lang, moduleName, callName) => {
+  if (lang === 'ru') {
+    return `// Сделайте экспортной ${moduleName}.${callName} и вызовите её для метода ${method}.`;
+  }
+
+  return `// Export ${moduleName}.${callName} and call it for the ${method} method.`;
+};
+
+const appendSection = (lines, section) => {
+  if (!section.length) {
+    return;
+  }
+
+  if (lines.length) {
+    lines.push('');
+  }
+  lines.push(...section);
+};
+
+const convertConnector = (request = {}, lang) => {
+  const kw = platform[lang];
+  const connector = connectorKw[lang];
+  const method = String(request.method || 'GET').toUpperCase();
+  const fullUrl = request.fullUrl || request.url || '';
+  const postData = request.postData || {};
+  const jsonText = isJsonMime(postData.mimeType) ? prettyJsonBodyText(postData) : undefined;
+  const hasJsonBody = jsonText !== undefined;
+  const methodIsSupported = CONNECTOR_METHODS.includes(method);
+  const methodName = connectorMethodName(method);
+  const queryAsSecondArgument = method === 'GET';
+  const lines = [];
+  const parts = multipartParams(postData);
+  const useMultipart = isMultipart(postData.mimeType) && parts.length > 0;
+  const fileBody = fileBodyParam(postData);
+  const files = describeClientFiles(collectClientFilePaths(postData), lang);
+  let multipartNames;
+
+  if (useMultipart) {
+    multipartNames = appendMultipartBody(lines, parts, lang, files);
+  }
+
+  let headers = useMultipart
+    ? withoutContentType(requestHeaders(request))
+    : requestHeaders(request);
+  if (fileBody && !headers.some(([name]) => String(name).toLowerCase() === 'content-type')) {
+    headers = [...headers, ['Content-Type', fileBody.contentType]];
+  }
+  if (isJsonMime(postData.mimeType) && !headers.some(([name]) => String(name).toLowerCase() === 'content-type')) {
+    headers = [...headers, ['Content-Type', postData.mimeType || 'application/json']];
+  }
+
+  const queryEntries = objectEntries(request.queryObj);
+  const queryInAdditionalParameters = queryEntries.length > 0 && !queryAsSecondArgument;
+  const hasAdditionalParameters = headers.length > 0 || queryInAdditionalParameters || useMultipart;
+
+  if (headers.length || useMultipart) {
+    const headerLines = declareMap(connector.headers, headers, lang);
+    if (useMultipart) {
+      headerLines.push(
+        `${connector.headers}.${kw.Insert}("Content-Type", ${contentTypeMultipartExpression(multipartNames.boundary)});`
+      );
+    }
+    appendSection(lines, headerLines);
+  }
+
+  if (queryEntries.length) {
+    appendSection(lines, declareStructure(connector.queryParameters, queryEntries, lang));
+  }
+
+  let dataArgument = kw.Undefined;
+  const dataLines = [];
+  if (useMultipart) {
+    dataArgument = multipartNames.bodyData;
+  } else if (fileBody && files[0]) {
+    dataArgument = files[0].dataVar;
+  } else if (hasJsonBody && !queryAsSecondArgument) {
+    dataLines.push(...assignStringBody(jsonText, lang));
+    dataArgument = stringBodyVariable[lang];
+  } else if (isFormUrlEncoded(postData.mimeType)) {
+    const parameters = formFieldEntries(postData);
+    if (parameters.length && !hasDuplicateKeys(parameters)) {
+      dataLines.push(...declareStructure(connector.data, parameters, lang));
+      dataArgument = connector.data;
+    } else {
+      const formText = formUrlEncodedText(postData);
+      if (formText !== undefined) {
+        dataLines.push(...multilineStringAssign(connector.data, formText));
+        dataArgument = connector.data;
+      }
+    }
+  } else if (postData.text) {
+    dataLines.push(...multilineStringAssign(connector.data, postData.text));
+    dataArgument = connector.data;
+  }
+
+  appendSection(lines, dataLines);
+
+  const useGenericCall = !methodIsSupported;
+  const needsAdditionalParameters = hasAdditionalParameters
+    || (useGenericCall && dataArgument !== kw.Undefined);
+
+  if (needsAdditionalParameters) {
+    const extraLines = [
+      `${connector.additionalParameters} = ${kw.New} ${kw.Structure};`
+    ];
+    if (headers.length || useMultipart) {
+      extraLines.push(
+        `${connector.additionalParameters}.${kw.Insert}(${quote(connector.headers)}, ${connector.headers});`
+      );
+    }
+    if (queryInAdditionalParameters) {
+      extraLines.push(
+        `${connector.additionalParameters}.${kw.Insert}(${quote(connector.queryParameters)}, ${connector.queryParameters});`
+      );
+    }
+    if (useGenericCall && dataArgument !== kw.Undefined) {
+      extraLines.push(
+        `${connector.additionalParameters}.${kw.Insert}(${quote(connector.data)}, ${dataArgument});`
+      );
+    }
+    appendSection(lines, extraLines);
+  }
+
+  const callUrl = queryEntries.length ? withoutQueryString(fullUrl) : fullUrl;
+  const callLines = [];
+  if (useGenericCall) {
+    callLines.push(
+      exportCallHTTPMethodComment(method, lang, connector.module, connector.callHTTPMethod)
+    );
+    const genericArguments = [
+      kw.Undefined,
+      quote(method),
+      quote(callUrl),
+      needsAdditionalParameters ? connector.additionalParameters : kw.Undefined
+    ];
+    callLines.push(
+      `${connector.result} = ${connector.module}.${connector.callHTTPMethod}(${genericArguments.join(', ')});`
+    );
+  } else {
+    const argumentsList = [quote(callUrl)];
+
+    if (queryAsSecondArgument) {
+      if (queryEntries.length || needsAdditionalParameters) {
+        argumentsList.push(queryEntries.length ? connector.queryParameters : kw.Undefined);
+      }
+    } else if (methodHasDataArgument(method) && (dataArgument !== kw.Undefined || needsAdditionalParameters)) {
+      argumentsList.push(dataArgument);
+    }
+
+    if (needsAdditionalParameters) {
+      argumentsList.push(connector.additionalParameters);
+    }
+
+    callLines.push(
+      `${connector.result} = ${connector.module}.${methodName}(${argumentsList.join(', ')});`
+    );
+  }
+
+  callLines.push(
+    '',
+    ...responseOutputLines({
+      lang,
+      statusExpression: `${connector.result}.${kw.StatusCode}`,
+      textExpression: `${connector.module}.${connector.asText}(${connector.result})`
+    })
+  );
+  appendSection(lines, callLines);
+
+  return wrapWithClientFileTransfer(lines, files, lang);
+};
+
+export const connectorRu = {
+  info: {
+    key: 'connector-ru',
+    title: 'Connector (RU)',
+    link: 'https://github.com/vbondarevsky/Connector',
+    description: 'КоннекторHTTP HTTP client'
+  },
+  convert: (request) => convertConnector(request, 'ru')
+};
+
+export const connectorEn = {
+  info: {
+    key: 'connector-en',
+    title: 'Connector (EN)',
+    link: 'https://github.com/vbondarevsky/Connector',
+    description: 'HTTPConnector HTTP client'
+  },
+  convert: (request) => convertConnector(request, 'en')
+};

--- a/packages/bruno-app/src/utils/codegenerator/onec/index.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/index.js
@@ -1,0 +1,21 @@
+import { addTarget } from 'httpsnippet';
+import { nativeEn, nativeRu } from './native';
+import { connectorEn, connectorRu } from './connector';
+import { opiEn, opiRu } from './opi';
+
+addTarget({
+  info: {
+    key: '1c',
+    title: '1C',
+    extname: '.bsl',
+    default: 'native-ru'
+  },
+  clientsById: {
+    'native-ru': nativeRu,
+    'native-en': nativeEn,
+    'connector-ru': connectorRu,
+    'connector-en': connectorEn,
+    'opi-ru': opiRu,
+    'opi-en': opiEn
+  }
+});

--- a/packages/bruno-app/src/utils/codegenerator/onec/keywords.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/keywords.js
@@ -1,0 +1,143 @@
+/**
+ * RU/EN dictionaries for 1C:Enterprise platform types and HTTP client libraries.
+ * Used by native, Connector and OPI snippet clients.
+ */
+
+export const platform = {
+  ru: {
+    New: 'Новый',
+    Map: 'Соответствие',
+    Structure: 'Структура',
+    Undefined: 'Неопределено',
+    True: 'Истина',
+    False: 'Ложь',
+    Insert: 'Вставить',
+    HTTPConnection: 'HTTPСоединение',
+    HTTPRequest: 'HTTPЗапрос',
+    HTTPResponse: 'HTTPОтвет',
+    OpenSSLSecureConnection: 'ЗащищенноеСоединениеOpenSSL',
+    SetBodyFromString: 'УстановитьТелоИзСтроки',
+    SetBodyFromBinaryData: 'УстановитьТелоИзДвоичныхДанных',
+    CallHTTPMethod: 'ВызватьHTTPМетод',
+    UUID: 'УникальныйИдентификатор',
+    String: 'Строка',
+    StrReplace: 'СтрЗаменить',
+    MemoryStream: 'ПотокВПамяти',
+    DataWriter: 'ЗаписьДанных',
+    WriteLine: 'ЗаписатьСтроку',
+    Write: 'Записать',
+    Close: 'Закрыть',
+    CloseAndGetBinaryData: 'ЗакрытьИПолучитьДвоичныеДанные',
+    BinaryData: 'ДвоичныеДанные',
+    CharsCR: 'Символы.ВК',
+    CharsLF: 'Символы.ПС',
+    Message: 'Сообщить',
+    StatusCode: 'КодСостояния',
+    GetBodyAsString: 'ПолучитьТелоКакСтроку',
+    AtClient: '&НаКлиенте',
+    AtServer: '&НаСервере',
+    Procedure: 'Процедура',
+    EndProcedure: 'КонецПроцедуры',
+    PutFile: 'ПоместитьФайл',
+    GetFromTempStorage: 'ПолучитьИзВременногоХранилища',
+    FormUUID: 'УникальныйИдентификатор'
+  },
+  en: {
+    New: 'New',
+    Map: 'Map',
+    Structure: 'Structure',
+    Undefined: 'Undefined',
+    True: 'True',
+    False: 'False',
+    Insert: 'Insert',
+    HTTPConnection: 'HTTPConnection',
+    HTTPRequest: 'HTTPRequest',
+    HTTPResponse: 'HTTPResponse',
+    OpenSSLSecureConnection: 'OpenSSLSecureConnection',
+    SetBodyFromString: 'SetBodyFromString',
+    SetBodyFromBinaryData: 'SetBodyFromBinaryData',
+    CallHTTPMethod: 'CallHTTPMethod',
+    UUID: 'UUID',
+    String: 'String',
+    StrReplace: 'StrReplace',
+    MemoryStream: 'MemoryStream',
+    DataWriter: 'DataWriter',
+    WriteLine: 'WriteLine',
+    Write: 'Write',
+    Close: 'Close',
+    CloseAndGetBinaryData: 'CloseAndGetBinaryData',
+    BinaryData: 'BinaryData',
+    CharsCR: 'Chars.CR',
+    CharsLF: 'Chars.LF',
+    Message: 'Message',
+    StatusCode: 'StatusCode',
+    GetBodyAsString: 'GetBodyAsString',
+    AtClient: '&AtClient',
+    AtServer: '&AtServer',
+    Procedure: 'Procedure',
+    EndProcedure: 'EndProcedure',
+    PutFile: 'PutFile',
+    GetFromTempStorage: 'GetFromTempStorage',
+    FormUUID: 'UUID'
+  }
+};
+
+export const connector = {
+  ru: {
+    module: 'КоннекторHTTP',
+    headers: 'Заголовки',
+    additionalParameters: 'ДополнительныеПараметры',
+    data: 'Данные',
+    result: 'Результат',
+    queryParameters: 'ПараметрыЗапроса',
+    asText: 'КакТекст',
+    callHTTPMethod: 'ВызватьHTTPМетод'
+  },
+  en: {
+    module: 'HTTPConnector',
+    headers: 'Headers',
+    additionalParameters: 'AdditionalParameters',
+    data: 'Data',
+    result: 'Result',
+    queryParameters: 'QueryParameters',
+    asText: 'AsText',
+    callHTTPMethod: 'CallHTTPMethod'
+  }
+};
+
+export const opi = {
+  ru: {
+    module: 'OPI_ЗапросыHTTP',
+    newRequest: 'НовыйЗапрос',
+    initialize: 'Инициализировать',
+    setUrlParams: 'УстановитьПараметрыURL',
+    setStringBody: 'УстановитьСтроковоеТело',
+    setFormBody: 'УстановитьFormТело',
+    setBinaryBody: 'УстановитьДвоичноеТело',
+    addHeader: 'ДобавитьЗаголовок',
+    addBearerAuthorization: 'ДобавитьBearerАвторизацию',
+    processRequest: 'ОбработатьЗапрос',
+    returnText: 'ВернутьОтветКакСтроку',
+    returnStatusCode: 'ВернутьКодСостояния',
+    result: 'Результат',
+    data: 'Данные',
+    params: 'ПараметрыURL'
+  },
+  en: {
+    module: 'OPI_HTTPRequests',
+    newRequest: 'NewRequest',
+    initialize: 'Initialize',
+    setUrlParams: 'SetURLParams',
+    setStringBody: 'SetStringBody',
+    setFormBody: 'SetFormBody',
+    setBinaryBody: 'SetBinaryBody',
+    addHeader: 'AddHeader',
+    addBearerAuthorization: 'AddBearerAuthorization',
+    processRequest: 'ProcessRequest',
+    returnText: 'ReturnResponseAsString',
+    returnStatusCode: 'ReturnStatusCode',
+    result: 'Result',
+    data: 'Data',
+    params: 'URLParameters'
+  }
+};

--- a/packages/bruno-app/src/utils/codegenerator/onec/native.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/native.js
@@ -1,0 +1,170 @@
+import { platform } from './keywords';
+import {
+  quote,
+  isJsonMime,
+  prettyJsonBodyText,
+  assignStringBody,
+  stringBodyVariable,
+  isFormUrlEncoded,
+  formUrlEncodedText,
+  isMultipart,
+  isMultiline,
+  parseRequestUrl,
+  declareMap,
+  multilineStringAssign,
+  responseOutputLines,
+  joinLines,
+  multipartParams,
+  appendMultipartBody,
+  withoutContentType,
+  contentTypeMultipartExpression,
+  fileBodyParam,
+  collectClientFilePaths,
+  describeClientFiles,
+  wrapWithClientFileTransfer
+} from './bsl';
+
+const variableNames = {
+  ru: {
+    headers: 'Заголовки',
+    secureConnection: 'ЗащищенноеСоединение',
+    connection: 'Соединение',
+    request: 'HTTPЗапрос',
+    response: 'HTTPОтвет',
+    bodyText: 'ТекстТела'
+  },
+  en: {
+    headers: 'Headers',
+    secureConnection: 'SecureConnection',
+    connection: 'Connection',
+    request: 'HTTPRequest',
+    response: 'HTTPResponse',
+    bodyText: 'BodyText'
+  }
+};
+
+const convertNative = (request = {}, lang) => {
+  const kw = platform[lang];
+  const names = variableNames[lang];
+  const parsedUrl = parseRequestUrl(request.fullUrl || request.url || '');
+  const headers = request.allHeaders || request.headersObj || {};
+  let headerEntries = Object.entries(headers);
+  const postData = request.postData || {};
+  const method = String(request.method || 'GET').toUpperCase();
+  const parts = multipartParams(postData);
+  const useMultipartWriter = isMultipart(postData.mimeType) && parts.length > 0;
+  const fileBody = fileBodyParam(postData);
+  const files = describeClientFiles(collectClientFilePaths(postData), lang);
+  const lines = [];
+  let multipartNames;
+
+  if (fileBody && !headerEntries.some(([name]) => String(name).toLowerCase() === 'content-type')) {
+    headerEntries = [...headerEntries, ['Content-Type', fileBody.contentType]];
+  }
+  if (isJsonMime(postData.mimeType) && !headerEntries.some(([name]) => String(name).toLowerCase() === 'content-type')) {
+    headerEntries = [...headerEntries, ['Content-Type', postData.mimeType || 'application/json']];
+  }
+
+  if (useMultipartWriter) {
+    multipartNames = appendMultipartBody(lines, parts, lang, files);
+    lines.push('');
+  }
+
+  const visibleHeaders = useMultipartWriter ? withoutContentType(headerEntries) : headerEntries;
+  if (visibleHeaders.length || useMultipartWriter) {
+    const headerLines = declareMap(names.headers, visibleHeaders, lang);
+    if (useMultipartWriter) {
+      headerLines.push(
+        `${names.headers}.${kw.Insert}("Content-Type", ${contentTypeMultipartExpression(multipartNames.boundary)});`
+      );
+    }
+    lines.push(...headerLines, '');
+  }
+
+  if (parsedUrl.isHttps) {
+    lines.push(
+      `${names.secureConnection} = ${kw.New} ${kw.OpenSSLSecureConnection};`,
+      `${names.connection} = ${kw.New} ${kw.HTTPConnection}(${quote(parsedUrl.host)}, ${
+        parsedUrl.port
+      }, , , , 30, ${names.secureConnection});`,
+      ''
+    );
+  } else {
+    lines.push(
+      `${names.connection} = ${kw.New} ${kw.HTTPConnection}(${quote(parsedUrl.host)}, ${parsedUrl.port}, , , , 30);`,
+      ''
+    );
+  }
+
+  const hasHeaders = visibleHeaders.length > 0 || useMultipartWriter;
+  const requestArguments = hasHeaders
+    ? `${quote(parsedUrl.path)}, ${names.headers}`
+    : quote(parsedUrl.path);
+  lines.push(`${names.request} = ${kw.New} ${kw.HTTPRequest}(${requestArguments});`);
+
+  if (useMultipartWriter) {
+    lines.push(`${names.request}.${kw.SetBodyFromBinaryData}(${multipartNames.bodyData});`);
+  } else if (fileBody && files[0]) {
+    lines.push(`${names.request}.${kw.SetBodyFromBinaryData}(${files[0].dataVar});`);
+  } else {
+    if (isJsonMime(postData.mimeType)) {
+      const jsonText = prettyJsonBodyText(postData);
+      if (jsonText !== undefined) {
+        lines.push('');
+        lines.push(...assignStringBody(jsonText, lang));
+        lines.push(`${names.request}.${kw.SetBodyFromString}(${stringBodyVariable[lang]});`);
+      }
+    } else {
+      const rawText = isFormUrlEncoded(postData.mimeType)
+        ? formUrlEncodedText(postData)
+        : (postData.text !== undefined && postData.text !== null && String(postData.text).length
+            ? String(postData.text)
+            : undefined);
+
+      if (rawText !== undefined) {
+        if (isMultiline(rawText)) {
+          lines.push('');
+          lines.push(...multilineStringAssign(names.bodyText, rawText));
+          lines.push(`${names.request}.${kw.SetBodyFromString}(${names.bodyText});`);
+        } else {
+          lines.push(`${names.request}.${kw.SetBodyFromString}(${quote(rawText)});`);
+        }
+      }
+    }
+  }
+
+  lines.push(
+    '',
+    `${names.response} = ${names.connection}.${kw.CallHTTPMethod}(${quote(method)}, ${names.request});`,
+    '',
+    ...responseOutputLines({
+      lang,
+      statusExpression: `${names.response}.${kw.StatusCode}`,
+      textExpression: `${names.response}.${kw.GetBodyAsString}()`
+    })
+  );
+
+  return wrapWithClientFileTransfer(lines, files, lang);
+};
+
+const link = 'https://1c-dn.com/library/html/7ebc2431-4d0c-4d5b-8c0a-36c0bdc8c0c0.htm';
+
+export const nativeRu = {
+  info: {
+    key: 'native-ru',
+    title: 'Native (RU)',
+    link,
+    description: '1C:Enterprise native HTTPConnection'
+  },
+  convert: (request) => convertNative(request, 'ru')
+};
+
+export const nativeEn = {
+  info: {
+    key: 'native-en',
+    title: 'Native (EN)',
+    link,
+    description: '1C:Enterprise native HTTPConnection'
+  },
+  convert: (request) => convertNative(request, 'en')
+};

--- a/packages/bruno-app/src/utils/codegenerator/onec/opi.js
+++ b/packages/bruno-app/src/utils/codegenerator/onec/opi.js
@@ -1,0 +1,198 @@
+import { opi as opiKw } from './keywords';
+import {
+  quote,
+  literal,
+  isJsonMime,
+  prettyJsonBodyText,
+  assignStringBody,
+  stringBodyVariable,
+  isFormUrlEncoded,
+  isMultipart,
+  getHeader,
+  toEntries,
+  objectEntries,
+  formFieldEntries,
+  hasDuplicateKeys,
+  formUrlEncodedText,
+  withoutQueryString,
+  declareStructure,
+  multilineStringAssign,
+  responseOutputLines,
+  joinLines,
+  multipartParams,
+  appendMultipartBody,
+  contentTypeMultipartExpression,
+  fileBodyParam,
+  collectClientFilePaths,
+  describeClientFiles,
+  wrapWithClientFileTransfer
+} from './bsl';
+
+const getHeaders = (request) => {
+  const allHeaders = request.allHeaders;
+  if (Array.isArray(allHeaders) ? allHeaders.length : objectEntries(allHeaders).length) {
+    return toEntries(allHeaders);
+  }
+
+  return toEntries(request.headersObj || {});
+};
+
+const getMimeType = (postData, headers) => {
+  const contentType = getHeader(Object.fromEntries(headers), 'Content-Type');
+  return postData?.mimeType || contentType?.value || '';
+};
+
+const addBody = (lines, chain, postData, mimeType, lang, files = []) => {
+  if (!postData) {
+    return { managesContentType: false };
+  }
+
+  const kw = opiKw[lang];
+  const fileBody = fileBodyParam(postData);
+
+  if (isJsonMime(mimeType)) {
+    const jsonText = prettyJsonBodyText(postData);
+    if (jsonText !== undefined) {
+      lines.push(...assignStringBody(jsonText, lang), '');
+      chain.push(`${kw.setStringBody}(${stringBodyVariable[lang]})`);
+      return { managesContentType: false };
+    }
+  }
+
+  if (isFormUrlEncoded(mimeType)) {
+    const formEntries = formFieldEntries(postData);
+    if (formEntries.length && !hasDuplicateKeys(formEntries)) {
+      lines.push(...declareStructure(kw.data, formEntries, lang), '');
+      chain.push(`${kw.setFormBody}(${kw.data})`);
+      return { managesContentType: true };
+    }
+
+    const formText = formUrlEncodedText(postData);
+    if (formText !== undefined) {
+      lines.push(...multilineStringAssign(kw.data, formText), '');
+      chain.push(`${kw.setStringBody}(${kw.data})`);
+      return { managesContentType: false };
+    }
+  }
+
+  if (isMultipart(mimeType)) {
+    const parts = multipartParams(postData);
+    if (parts.length) {
+      // OPI has no per-file upload method. Every part, including extra files, is packed into one binary body.
+      const names = appendMultipartBody(lines, parts, lang, files);
+      const fileParts = parts.filter((part) => part.fileName);
+      if (fileParts.length > 1) {
+        lines.push(lang === 'ru'
+          ? '// OPI: несколько файлов уходят одним двоичным multipart-телом, отдельного метода на каждый файл нет.'
+          : '// OPI: multiple files are sent as one binary multipart body; there is no per-file method.');
+      }
+      lines.push('');
+      chain.push(`${kw.setBinaryBody}(${names.bodyData})`);
+      return {
+        managesContentType: true,
+        contentTypeExpression: contentTypeMultipartExpression(names.boundary)
+      };
+    }
+  }
+
+  if (fileBody && files[0]) {
+    chain.push(`${kw.setBinaryBody}(${files[0].dataVar})`);
+    return { managesContentType: false };
+  }
+
+  if (postData.text) {
+    chain.push(`${kw.setStringBody}(${literal(postData.text, lang)})`);
+  }
+
+  return { managesContentType: false };
+};
+
+const addHeaders = (chain, headers, body, lang) => {
+  const kw = opiKw[lang];
+
+  headers.forEach(([name, value]) => {
+    if (body.managesContentType && String(name).toLowerCase() === 'content-type') {
+      return;
+    }
+
+    const bearerMatch = String(value).match(/^Bearer\s+(.+)$/i);
+    if (String(name).toLowerCase() === 'authorization' && bearerMatch) {
+      chain.push(`${kw.addBearerAuthorization}(${literal(bearerMatch[1], lang)})`);
+      return;
+    }
+
+    chain.push(`${kw.addHeader}(${quote(name)}, ${literal(value, lang)})`);
+  });
+
+  if (body.contentTypeExpression) {
+    chain.push(`${kw.addHeader}("Content-Type", ${body.contentTypeExpression})`);
+  }
+};
+
+const convertOpi = (request = {}, lang) => {
+  const kw = opiKw[lang];
+  const lines = [];
+  const chain = [];
+  const queryEntries = toEntries(request.queryObj || {});
+  const fullUrl = request.fullUrl || request.url || '';
+  const initializeUrl = queryEntries.length ? withoutQueryString(fullUrl) : fullUrl;
+  const headers = getHeaders(request);
+  const mimeType = getMimeType(request.postData, headers);
+  const files = describeClientFiles(collectClientFilePaths(request.postData), lang);
+  const fileBody = fileBodyParam(request.postData);
+  if (fileBody && !getHeader(Object.fromEntries(headers), 'Content-Type')) {
+    headers.push(['Content-Type', fileBody.contentType]);
+  }
+  if (isJsonMime(mimeType) && !getHeader(Object.fromEntries(headers), 'Content-Type')) {
+    headers.push(['Content-Type', request.postData?.mimeType || 'application/json']);
+  }
+
+  if (queryEntries.length) {
+    lines.push(...declareStructure(kw.params, queryEntries, lang), '');
+  }
+
+  chain.push(`${kw.initialize}(${quote(initializeUrl)})`);
+  if (queryEntries.length) {
+    chain.push(`${kw.setUrlParams}(${kw.params})`);
+  }
+
+  const body = addBody(lines, chain, request.postData, mimeType, lang, files);
+  addHeaders(chain, headers, body, lang);
+
+  chain.push(`${kw.processRequest}(${quote(String(request.method || 'GET').toUpperCase())})`);
+
+  const fluentLines = [
+    `${kw.result} = ${kw.module}.${kw.newRequest}()`,
+    ...chain.map((method, index) => `\t.${method}${index === chain.length - 1 ? ';' : ''}`)
+  ];
+
+  lines.push(...fluentLines, '');
+  lines.push(
+    ...responseOutputLines({
+      lang,
+      statusExpression: `${kw.result}.${kw.returnStatusCode}()`,
+      textExpression: `${kw.result}.${kw.returnText}()`
+    })
+  );
+  return wrapWithClientFileTransfer(lines, files, lang);
+};
+
+export const opiRu = {
+  info: {
+    key: 'opi-ru',
+    title: 'OPI (RU)',
+    link: 'https://openintegrations.dev/docs/Instructions/HTTP',
+    description: 'Open Integrations Package HTTP client'
+  },
+  convert: (request) => convertOpi(request, 'ru')
+};
+
+export const opiEn = {
+  info: {
+    key: 'opi-en',
+    title: 'OPI (EN)',
+    link: 'https://en.openintegrations.dev/docs/Instructions/HTTP',
+    description: 'Open Integrations Package HTTP client'
+  },
+  convert: (request) => convertOpi(request, 'en')
+};

--- a/packages/bruno-app/src/utils/codegenerator/targets.js
+++ b/packages/bruno-app/src/utils/codegenerator/targets.js
@@ -1,3 +1,4 @@
+import './onec';
 import { targets } from 'httpsnippet';
 
 export const getLanguages = () => {
@@ -10,12 +11,14 @@ export const getLanguages = () => {
         ? [{
             name: title,
             target: key,
-            client: clients[0]
+            client: clients[0],
+            language: key === '1c' ? 'text/plain' : undefined
           }]
         : clients.map((client) => ({
             name: `${title}-${client}`,
             target: key,
-            client
+            client,
+            language: key === '1c' ? 'text/plain' : undefined
           }));
     allLanguages.push(...languages);
 

--- a/packages/bruno-app/src/utils/codegenerator/targets.spec.js
+++ b/packages/bruno-app/src/utils/codegenerator/targets.spec.js
@@ -1,0 +1,13 @@
+import { getLanguages } from './targets';
+
+describe('code generator languages', () => {
+  test('marks 1C clients as plain text for the code view', () => {
+    const languages = getLanguages().filter((language) => language.target === '1c');
+
+    expect(languages).toHaveLength(6);
+    languages.forEach((language) => {
+      expect(language.name).toMatch(/^1C-/);
+      expect(language.language).toBe('text/plain');
+    });
+  });
+});


### PR DESCRIPTION
Generate Code now includes native, Connector, and OPI clients in Russian and English so 1C developers can copy a request without rewriting it by hand.

### Description

Adds **1C:Enterprise (BSL)** targets to Generate Code: native platform HTTP, [Connector](https://github.com/vbondarevsky/Connector), and [OPI HTTP](https://openintegrations.dev/docs/Instructions/HTTP), each in Russian and English (`1C-native-ru` … `1C-opi-en`).
The clients register through `httpsnippet.addTarget()` inside Bruno. JSON bodies are emitted as a shared `ДанныеСтрокой` / `DataAsString` multiline literal. Duplicate form field names stay in the raw urlencoded string. File bodies use the form-module client→server transfer pattern.
Closes #9037

### Problem

Generate Code has no 1C:Enterprise target. 1C developers rewrite Bruno requests by hand for `HTTPConnection`, Connector, or OPI.
Related issue: #9037

### Fix

- Register a `1c` HTTPSnippet target with six clients (native / Connector / OPI × RU / EN).
- Parse Generate Code library ids after the first hyphen so `1C-native-ru` does not collapse to Shell-curl.
- Mark 1C snippets as `text/plain` in the code view.
- Cover JSON, form-urlencoded (including repeated field names), multipart, and file bodies with Jest tests under `packages/bruno-app/src/utils/codegenerator/onec`.

### Screenshots

<img width="414" height="588" alt="image" src="https://github.com/user-attachments/assets/a0901f12-91f5-49d7-af99-c3a2007b89fd" />

<img width="866" height="458" alt="image" src="https://github.com/user-attachments/assets/c18ecd07-8a1a-416c-8201-eda1a65c93de" />

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 1C:Enterprise code generation for native HTTP, Connector, and OPI clients.
  * Supports Russian and English output, with JSON, form, text, multipart, file uploads, headers, authentication, queries, and response handling.
  * Added 1C syntax highlighting and six selectable generation targets.
* **Bug Fixes**
  * Improved language-library name handling so complete names remain visible and selectable.
* **Tests**
  * Added comprehensive coverage for 1C request generation, formatting, localization, and body handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->