### PR TITLE
feat(collection-security): normalize collection paths for consistent security config retrieval

### DIFF
--- a/packages/bruno-electron/src/store/collection-security.js
+++ b/packages/bruno-electron/src/store/collection-security.js
@@ -1,6 +1,13 @@
 const _ = require('lodash');
 const Store = require('electron-store');
 
+// Compare collection paths after posixifying + stripping trailing slashes so a
+// path.resolve trip on Windows (which produces backslashes) or a seeded fixture
+// still matches the entry a caller wrote earlier. Mirrors normalizePath in
+// bruno-app/src/utils/common/path.js — collection paths are compared this way
+// everywhere else in the app.
+const normalizeCollectionPath = (p) => (p ? p.replace(/\\/g, '/').replace(/\/+$/, '') : p);
+
 class CollectionSecurityStore {
   constructor() {
     this.store = new Store({
@@ -10,12 +17,13 @@ class CollectionSecurityStore {
   }
 
   setSecurityConfigForCollection(collectionPathname, securityConfig) {
+    const normalizedPathname = normalizeCollectionPath(collectionPathname);
     const collections = this.store.get('collections') || [];
-    const collection = _.find(collections, (c) => c.path === collectionPathname);
+    const collection = _.find(collections, (c) => normalizeCollectionPath(c.path) === normalizedPathname);
 
     if (!collection) {
       collections.push({
-        path: collectionPathname,
+        path: normalizedPathname,
         securityConfig: {
           jsSandboxMode: securityConfig.jsSandboxMode
         }
@@ -30,8 +38,9 @@ class CollectionSecurityStore {
   }
 
   getSecurityConfigForCollection(collectionPathname) {
+    const normalizedPathname = normalizeCollectionPath(collectionPathname);
     const collections = this.store.get('collections') || [];
-    const collection = _.find(collections, (c) => c.path === collectionPathname);
+    const collection = _.find(collections, (c) => normalizeCollectionPath(c.path) === normalizedPathname);
     return collection?.securityConfig || {};
   }
 }

--- a/packages/bruno-electron/src/store/tests/collection-security.spec.js
+++ b/packages/bruno-electron/src/store/tests/collection-security.spec.js
@@ -1,0 +1,68 @@
+jest.mock('electron-store', () => {
+  return jest.fn().mockImplementation(function () {
+    this.__data = {};
+    this.get = (key) => this.__data[key];
+    this.set = (key, value) => { this.__data[key] = value; };
+    return this;
+  });
+});
+
+const CollectionSecurityStore = require('../collection-security');
+
+describe('CollectionSecurityStore', () => {
+  let store;
+  let backingStore;
+
+  beforeEach(() => {
+    store = new CollectionSecurityStore();
+    backingStore = store.store;
+  });
+
+  it('returns an empty config when no entry exists for the collection', () => {
+    expect(store.getSecurityConfigForCollection('/tmp/collection')).toEqual({});
+  });
+
+  it('round-trips the same path form (POSIX)', () => {
+    store.setSecurityConfigForCollection('/tmp/collection', { jsSandboxMode: 'safe' });
+    expect(store.getSecurityConfigForCollection('/tmp/collection')).toEqual({ jsSandboxMode: 'safe' });
+  });
+
+  it('resolves a Windows-style query against a POSIX-style stored key', () => {
+    // This is the e2e fixture case: playwright seeds collection-security.json with
+    // forward slashes (via {{workspacePath}}/{{collectionPath}} template rendering),
+    // but at runtime path.resolve(workspacePath, 'collections/foo') on Windows produces
+    // backslashes. Both sides must normalize before comparing.
+    backingStore.set('collections', [
+      { path: 'C:/Users/tester/ws/collections/foo', securityConfig: { jsSandboxMode: 'safe' } }
+    ]);
+
+    expect(store.getSecurityConfigForCollection('C:\\Users\\tester\\ws\\collections\\foo'))
+      .toEqual({ jsSandboxMode: 'safe' });
+  });
+
+  it('resolves a POSIX-style query against a Windows-style stored key', () => {
+    backingStore.set('collections', [
+      { path: 'C:\\Users\\tester\\ws\\collections\\foo', securityConfig: { jsSandboxMode: 'developer' } }
+    ]);
+
+    expect(store.getSecurityConfigForCollection('C:/Users/tester/ws/collections/foo'))
+      .toEqual({ jsSandboxMode: 'developer' });
+  });
+
+  it('ignores trailing slashes when matching', () => {
+    store.setSecurityConfigForCollection('/tmp/collection/', { jsSandboxMode: 'safe' });
+    expect(store.getSecurityConfigForCollection('/tmp/collection')).toEqual({ jsSandboxMode: 'safe' });
+  });
+
+  it('updates an existing entry rather than adding a duplicate on separator mismatch', () => {
+    backingStore.set('collections', [
+      { path: 'C:/Users/tester/ws/collections/foo', securityConfig: { jsSandboxMode: 'safe' } }
+    ]);
+
+    store.setSecurityConfigForCollection('C:\\Users\\tester\\ws\\collections\\foo', { jsSandboxMode: 'developer' });
+
+    const collections = backingStore.get('collections');
+    expect(collections).toHaveLength(1);
+    expect(collections[0].securityConfig).toEqual({ jsSandboxMode: 'developer' });
+  });
+});


### PR DESCRIPTION
### Problem

E2E specs seed `init-user-data/collection-security.json` with template paths (`{{collectionPath}}` / `{{workspacePath}}`) that Playwright renders in POSIX form. `CollectionSecurityStore` looked them up with raw `===`. On Windows, `path.resolve(workspacePath, 'collections/foo')` normalizes to backslashes, so the runtime query no longer matches the seeded key and `jsSandboxMode` is silently dropped.

### Fix

Normalize collection paths (posixify + strip trailing slash) on both write and read in `CollectionSecurityStore`, mirroring `normalizePath` used elsewhere in the app. The Playwright fixture is unchanged — POSIX template vars are the right form to write to disk.

Added `src/store/tests/collection-security.spec.js` covering mixed-separator lookup, trailing-slash tolerance, and no-duplicate on overwrite.

### Verification

- `npm test --workspace=packages/bruno-electron -- src/store/tests/` — 22 passed
- Playwright: `api-setGlobalEnvVar-restart`, `api-setGlobalEnvVar-secret`, `json-response-formatting` — 4 passed

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**