### PR TITLE
feat(query-editor): add code mirror search and replace in query editor

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -136,10 +136,6 @@ const StyledWrapper = styled.div`
     text-decoration: unset;
   }
 
-  .cm-search-line-highlight {
-    background: ${(props) => props.theme.codemirror.searchLineHighlightCurrent};
-  }
-
   @keyframes cm-error-line-flash {
     0%, 60% {
       background-color: ${(props) => props.theme.status.danger.background};
@@ -164,14 +160,6 @@ const StyledWrapper = styled.div`
       animation: none;
       background-color: ${(props) => props.theme.status.danger.background};
     }
-  }
-
-  .cm-search-match {
-    background: rgba(255, 193, 7, 0.25);
-  }
-
-  .cm-search-current {
-    background: rgba(255, 193, 7, 0.4);
   }
 
   .lint-error-tooltip {

--- a/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeMirrorSearch/StyledWrapper.js
@@ -128,10 +128,6 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.brand};
     background-color: ${(props) => rgba(props.theme.brand, 0.1)};
   }
-
-  .cm-search-line-highlight {
-    background: ${(props) => props.theme.codemirror.searchLineHighlightCurrent};
-  }
 `;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/StyledWrapper.js
@@ -1,6 +1,18 @@
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
+  .editor-container {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    min-height: 0;
+    position: relative;
+  }
+
+  &.search-bar-visible {
+    min-height: 90px;
+  }
+
   div.CodeMirror {
     background: ${(props) => props.theme.codemirror.bg};
     border: solid 1px ${(props) => props.theme.codemirror.border};
@@ -76,10 +88,6 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.colors.text.danger} !important;
     background: ${(props) => props.theme.status.danger.background} !important;
     text-decoration: unset;
-  }
-
-  .CodeMirror-search-hint {
-    display: inline;
   }
 `;
 

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -6,6 +6,7 @@
  */
 
 import React, { createRef } from 'react';
+import classnames from 'classnames';
 import isEqual from 'lodash/isEqual';
 import MD from 'markdown-it';
 import { format } from 'prettier/standalone';
@@ -260,7 +261,9 @@ export default class QueryEditor extends React.Component {
   render() {
     return (
       <StyledWrapper
-        className={`h-full w-full flex flex-col relative graphiql-container ${this.state.searchBarVisible ? 'search-bar-visible' : ''}`}
+        className={classnames('h-full w-full flex flex-col relative graphiql-container', {
+          'search-bar-visible': this.state.searchBarVisible
+        })}
         aria-label="Query Editor"
         font={this.props.font}
         fontSize={this.props.fontSize}

--- a/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
+++ b/packages/bruno-app/src/components/RequestPane/QueryEditor/index.js
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { createRef } from 'react';
 import isEqual from 'lodash/isEqual';
 import MD from 'markdown-it';
 import { format } from 'prettier/standalone';
@@ -17,6 +17,8 @@ import StyledWrapper from './StyledWrapper';
 import onHasCompletion from './onHasCompletion';
 import { setupLinkAware } from 'utils/codemirror/linkAware';
 import { setupCodeMirrorResizeRefresh } from 'utils/codemirror/resize';
+import CodeMirrorSearch from 'components/CodeMirrorSearch';
+import { buildSearchKeyBindings } from 'components/CodeMirrorSearch/searchKeyBindings';
 
 const CodeMirror = require('codemirror');
 
@@ -51,6 +53,11 @@ export default class QueryEditor extends React.Component {
     // unnecessary updates during the update lifecycle.
     this.cachedValue = props.value || '';
     this.variables = {};
+    this.searchBarRef = createRef();
+
+    this.state = {
+      searchBarVisible: false
+    };
   }
 
   componentDidMount() {
@@ -135,8 +142,12 @@ export default class QueryEditor extends React.Component {
             this.props.onMergeQuery();
           }
         },
-        'Cmd-F': 'findPersistent',
-        'Ctrl-F': 'findPersistent',
+        ...buildSearchKeyBindings({
+          setState: (update, cb) => this.setState(update, cb),
+          searchBarRef: this.searchBarRef,
+          isSearchBarVisible: () => this.state.searchBarVisible,
+          isReadOnly: () => this.props.readOnly
+        }),
         'Cmd-Enter': runShortcut,
         'Ctrl-Enter': runShortcut
       }
@@ -242,17 +253,28 @@ export default class QueryEditor extends React.Component {
     // this.editor.setOption('mode', 'brunovariables');
   };
 
+  setEditorNode = (node) => {
+    this._node = node;
+  };
+
   render() {
     return (
       <StyledWrapper
-        className="h-full w-full flex flex-col relative graphiql-container"
+        className={`h-full w-full flex flex-col relative graphiql-container ${this.state.searchBarVisible ? 'search-bar-visible' : ''}`}
         aria-label="Query Editor"
         font={this.props.font}
         fontSize={this.props.fontSize}
-        ref={(node) => {
-          this._node = node;
-        }}
-      />
+      >
+        <CodeMirrorSearch
+          ref={this.searchBarRef}
+          visible={this.state.searchBarVisible}
+          editor={this.editor}
+          readOnly={this.props.readOnly}
+          onClose={() => this.setState({ searchBarVisible: false })}
+        />
+        {/* CodeMirror owns this node's children, so React must not render into it. */}
+        <div className="editor-container" ref={this.setEditorNode} />
+      </StyledWrapper>
     );
   }
 

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -264,6 +264,18 @@ const GlobalStyle = createGlobalStyle`
     .cm-variable-prompt {
       color: ${(props) => props.theme.codemirror.variable.prompt};
     }
+
+    /* Applied by CodeMirrorSearch via markText/addLineClass, so they land inside
+       the editor and cannot be styled from the search bar's own wrapper. */
+    .cm-search-line-highlight {
+      background: ${(props) => props.theme.codemirror.searchLineHighlightCurrent};
+    }
+    .cm-search-match {
+      background: ${(props) => rgba(props.theme.codemirror.searchMatch, 0.25)};
+    }
+    .cm-search-current {
+      background: ${(props) => rgba(props.theme.codemirror.searchMatchActive, 0.4)};
+    }
   }
   .CodeMirror-brunoVarInfo {
     color: ${(props) => props.theme.text};

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -264,9 +264,6 @@ const GlobalStyle = createGlobalStyle`
     .cm-variable-prompt {
       color: ${(props) => props.theme.codemirror.variable.prompt};
     }
-
-    /* Applied by CodeMirrorSearch via markText/addLineClass, so they land inside
-       the editor and cannot be styled from the search bar's own wrapper. */
     .cm-search-line-highlight {
       background: ${(props) => props.theme.codemirror.searchLineHighlightCurrent};
     }


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Adds  the search/replace bar to the GraphQL query editor, which was still using CodeMirror's legacy `findPersistent` dialog.

BRU-4215

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
Current Query editor didn't integrated code mirror search at all so cmd/ctrl+f showing the code mirror search.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
**Query editor**

- Replaced findPersistent with buildSearchKeyBindings(...) and <CodeMirrorSearch /> to use CodeMirror’s standard search shortcuts: Cmd/Ctrl+F, Cmd+Alt+F / Ctrl+H, and Esc.
- Added a dedicated .editor-container for CodeMirror, matching the CodeEditor pattern and preventing React and CodeMirror from sharing the same node.
- Kept the container as a flex column with position: relative so hintOptions.container preserves autocomplete popup positioning.
- Added a min-height guard to prevent the editor from collapsing in a squeezed pane.

**Highlight styles**

- Consolidated the three .cm-search-* rules into the existing .CodeMirror block in globalStyles.js and removed the scattered duplicates.
- Kept the existing .CodeMirror .cm-search-* specificity so styling behavior remains unchanged.
- Updated search highlights to use the theme values with transparency:

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="554" height="245" alt="image" src="https://github.com/user-attachments/assets/29ce4b9f-e107-4fb5-a011-f7a437244c89" />| <img width="555" height="234" alt="image" src="https://github.com/user-attachments/assets/0b6b6cc4-b7cf-4894-a767-9cfb8fd99e63" />|

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated search bar to the query editor.
  * Search bar visibility now adjusts the editor layout automatically.
  * Search results and the active match are highlighted with theme-aware colors.

* **Bug Fixes**
  * Improved search behavior and keyboard shortcut integration within the query editor.
  * Removed outdated search styling that could cause inconsistent highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->