### PR TITLE
fix: use NtlmClient as an adapter of axios instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29434,6 +29434,7 @@
         "graphql": "^16.10.0",
         "graphql-yoga": "^5.10.6",
         "http-proxy": "^1.18.1",
+        "js-md4": "^0.3.2",
         "js-yaml": "4.3.1",
         "jsonwebtoken": "^9.0.3",
         "lodash": "4.18.1",

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -259,7 +259,7 @@ const ResponsePane = ({ item, collection }) => {
           </div>
         </>
       ) : null}
-      <div className="flex items-center response-pane-status">
+      <div className="flex items-center response-pane-status" data-testid="response-pane-status">
         <StatusCode status={response.status} isStreaming={item.response?.stream?.running} />
         {item.response?.stream?.running
           ? <ResponseStopWatch startTimestamp={item.requestSent?.timestamp} />

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -18,6 +18,7 @@ const path = require('path');
 const { parseDataFromResponse } = require('../utils/common');
 const { getCookieStringForUrl, saveCookies } = require('../utils/cookies');
 const { createFormData } = require('../utils/form-data');
+const axios = require('axios');
 const { NtlmClient } = require('axios-ntlm');
 const { addDigestInterceptor, addEdgeGridInterceptor, getHttpHttpsAgents, makeAxiosInstance: makeAxiosInstanceForOauth2, applyOAuth1ToRequest } = require('@usebruno/requests');
 const { getCACertificates, transformProxyConfig, applySentHeadersToRequest } = require('@usebruno/requests');
@@ -397,7 +398,9 @@ const runSingleRequest = async function (
     const noproxy = get(options, 'noproxy', false);
     const cachedSystemProxy = get(options, 'cachedSystemProxy', null);
     const disableCache = !get(options, 'cacheSslSession', false);
-    const httpsAgentRequestFields = {};
+    // NTLM authenticates the connection rather than the request, so its handshake only completes
+    // when every leg reuses one socket.
+    const httpsAgentRequestFields = request.ntlmConfig ? { keepAlive: true } : {};
 
     if (insecure) {
       httpsAgentRequestFields['rejectUnauthorized'] = false;
@@ -678,7 +681,7 @@ const runSingleRequest = async function (
         request.timeout = requestTimeout;
       }
 
-      let axiosInstance = makeAxiosInstance({
+      const axiosInstance = makeAxiosInstance({
         requestMaxRedirects: requestMaxRedirects,
         disableCookies: options.disableCookies,
         followRedirects: followRedirects,
@@ -692,7 +695,8 @@ const runSingleRequest = async function (
       });
 
       if (request.ntlmConfig) {
-        axiosInstance = NtlmClient(request.ntlmConfig, axiosInstance.defaults);
+        const ntlmInstance = NtlmClient(request.ntlmConfig, {});
+        axiosInstance.defaults.adapter = (config) => ntlmInstance.request({ ...config, adapter: axios.getAdapter('http') });
         delete request.ntlmConfig;
       }
 

--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -5,7 +5,7 @@ const { createFormData } = require('./form-data');
 const { setupProxyAgents } = require('./proxy-util');
 const { isSameOrigin, DEFAULT_MAX_REDIRECTS } = require('@usebruno/common').utils;
 const { applyOmitHeaders, shouldOmitConnection } = require('@usebruno/common');
-const { getSentHeaders, applyOmitConnectionToAxiosConfig } = require('@usebruno/requests');
+const { getSentHeaders, applyOmitConnectionToAxiosConfig, handleNtlmRedirect } = require('@usebruno/requests');
 
 const redirectResponseCodes = [301, 302, 303, 307, 308];
 const METHOD_CHANGING_REDIRECTS = [301, 302, 303];
@@ -183,6 +183,8 @@ function makeAxiosInstance({
           }
 
           const requestConfig = createRedirectConfig(error, redirectUrl);
+
+          handleNtlmRedirect(requestConfig, error.config.url, redirectUrl, forwardAuthorizationHeader);
 
           if (!isSameOrigin(error.config.url, redirectUrl)) {
             /* AWS SigV4 signs a request for a specific host; re-signing after a cross-origin

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -8,7 +8,7 @@ const { addCookieToJar, getCookieStringForUrl } = require('../../utils/cookies')
 const { preferencesUtil } = require('../../store/preferences');
 const { safeStringifyJSON } = require('../../utils/common');
 const { createFormData } = require('../../utils/form-data');
-const { getSentHeaders, applyOmitConnectionToAxiosConfig } = require('@usebruno/requests');
+const { getSentHeaders, applyOmitConnectionToAxiosConfig, handleNtlmRedirect } = require('@usebruno/requests');
 const { isSameOrigin, DEFAULT_MAX_REDIRECTS } = require('@usebruno/common').utils;
 const { applyOmitHeaders } = require('@usebruno/common');
 
@@ -377,6 +377,8 @@ function makeAxiosInstance({
               ...error.config.headers
             }
           };
+
+          handleNtlmRedirect(requestConfig, error.config.url, redirectUrl, forwardAuthorizationHeader);
 
           if (!isSameOrigin(error.config.url, redirectUrl)) {
             /* AWS SigV4 signs a request for a specific host; re-signing after a cross-origin

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -157,7 +157,7 @@ const configureRequest = async (
 
   const { promptVariables = {} } = collection;
   let { proxyMode, proxyModeReason, proxyConfig, httpsAgentRequestFields, interpolationOptions } = certsAndProxyConfig;
-  let axiosInstance = makeAxiosInstance({
+  const axiosInstance = makeAxiosInstance({
     proxyMode,
     proxyModeReason,
     proxyConfig,
@@ -169,7 +169,8 @@ const configureRequest = async (
   });
 
   if (request.ntlmConfig) {
-    axiosInstance = NtlmClient(request.ntlmConfig, axiosInstance.defaults);
+    const ntlmInstance = NtlmClient(request.ntlmConfig, {});
+    axiosInstance.defaults.adapter = (config) => ntlmInstance.request({ ...config, adapter: axios.getAdapter('http') });
     delete request.ntlmConfig;
   }
 

--- a/packages/bruno-requests/src/auth/index.ts
+++ b/packages/bruno-requests/src/auth/index.ts
@@ -2,3 +2,4 @@ export { addDigestInterceptor } from './digestauth-helper';
 export { getOAuth2Token } from './oauth2-helper';
 export { createOAuth1Authorizer, computeBodyHash, applyOAuth1ToRequest } from './oauth1-request-authorization';
 export { addEdgeGridInterceptor, signEdgeGridRequest } from './edgegrid-helper';
+export { handleNtlmRedirect } from './ntlm';

--- a/packages/bruno-requests/src/auth/ntlm.spec.ts
+++ b/packages/bruno-requests/src/auth/ntlm.spec.ts
@@ -1,0 +1,57 @@
+import { isNtlmAuthHeader, handleNtlmRedirect } from './ntlm';
+
+describe('isNtlmAuthHeader', () => {
+  it.each(['NTLM TlRMTVNTUAAD', 'ntlm TlRMTVNTUAAD', '  NTLM TlRMTVNTUAAD'])(
+    'recognises %s as a credential bound to the connection it was negotiated on',
+    (header) => {
+      expect(isNtlmAuthHeader(header)).toBe(true);
+    }
+  );
+
+  it.each(['Bearer abc', 'Basic dXNlcjpwYXNz', 'Negotiate YIIF', 'AWS4-HMAC-SHA256 Credential=abc', 'NTLMish token', '', undefined, null, 42])(
+    'leaves %s alone',
+    (header) => {
+      expect(isNtlmAuthHeader(header)).toBe(false);
+    }
+  );
+});
+
+describe('handleNtlmRedirect', () => {
+  const ntlmHeaders = { 'Authorization': 'NTLM TlRMTVNTUAAD', 'X-retry': 'false', 'Accept': '*/*' };
+
+  it('drops the finished message, X-retry and the adapter when the redirect stays on the origin', () => {
+    const requestConfig = { headers: { ...ntlmHeaders }, adapter: 'ntlm' };
+
+    handleNtlmRedirect(requestConfig, 'https://a.test/x', 'https://a.test/y', false);
+
+    expect(requestConfig.headers).toEqual({ Accept: '*/*' });
+    expect(requestConfig.adapter).toBeUndefined();
+  });
+
+  it('drops the finished message but keeps the adapter when the redirect goes to another host', () => {
+    const requestConfig = { headers: { ...ntlmHeaders }, adapter: 'ntlm' };
+
+    handleNtlmRedirect(requestConfig, 'https://a.test/x', 'https://b.test/y', false);
+
+    expect(requestConfig.headers).toEqual({ Accept: '*/*' });
+    expect(requestConfig.adapter).toBe('ntlm');
+  });
+
+  it('drops the adapter for another host too when the request forwards Authorization on redirect', () => {
+    const requestConfig = { headers: { ...ntlmHeaders }, adapter: 'ntlm' };
+
+    handleNtlmRedirect(requestConfig, 'https://a.test/x', 'https://b.test/y', true);
+
+    expect(requestConfig.headers).toEqual({ Accept: '*/*' });
+    expect(requestConfig.adapter).toBeUndefined();
+  });
+
+  it('leaves a request that carries any other credential alone', () => {
+    const requestConfig = { headers: { 'Authorization': 'Bearer abc', 'X-retry': 'false' }, adapter: 'ntlm' };
+
+    handleNtlmRedirect(requestConfig, 'https://a.test/x', 'https://a.test/y', true);
+
+    expect(requestConfig.headers).toEqual({ 'Authorization': 'Bearer abc', 'X-retry': 'false' });
+    expect(requestConfig.adapter).toBe('ntlm');
+  });
+});

--- a/packages/bruno-requests/src/auth/ntlm.ts
+++ b/packages/bruno-requests/src/auth/ntlm.ts
@@ -1,0 +1,41 @@
+import { AxiosRequestConfig } from 'axios';
+import { isSameOrigin } from '@usebruno/common/utils';
+
+// The scheme is not in IANA's http registry; it is specified by [MS-NTHT] NTLM Over HTTP Protocol,
+// https://learn.microsoft.com/openspecs/windows_protocols/ms-ntht/f09cf6e1-529e-403b-a8a5-7368ee096a6a
+const NTLM_SCHEME = /^NTLM(\s|$)/i;
+
+export const isNtlmAuthHeader = (value: unknown): boolean =>
+  typeof value === 'string' && NTLM_SCHEME.test(value.trim());
+
+const carriesNtlm = (headers: Record<string, unknown>): boolean =>
+  Object.keys(headers).some((key) => key.toLowerCase() === 'authorization' && isNtlmAuthHeader(headers[key]));
+
+export const handleNtlmRedirect = (
+  requestConfig: AxiosRequestConfig,
+  fromUrl: string,
+  redirectUrl: string,
+  forwardAuthorizationHeader: boolean
+): void => {
+  const headers = requestConfig.headers ?? {};
+
+  if (!carriesNtlm(headers)) {
+    return;
+  }
+
+  // A finished message proves nothing on the socket a redirect opens, and X-retry
+  // would stop the library negotiating a new one.
+  Object.keys(headers).forEach((key) => {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === 'x-retry' || lowerKey === 'authorization') {
+      delete headers[key];
+    }
+  });
+
+  // Dropping the inherited plain adapter puts the ntlm code back in the path to answer a fresh
+  // challenge. Another host only earns that when the request forwards Authorization; otherwise the
+  // redirect ends on its 401, as curl does by default.
+  if (isSameOrigin(fromUrl, redirectUrl) || forwardAuthorizationHeader) {
+    delete requestConfig.adapter;
+  }
+};

--- a/packages/bruno-requests/src/index.ts
+++ b/packages/bruno-requests/src/index.ts
@@ -1,4 +1,12 @@
-export { addDigestInterceptor, getOAuth2Token, createOAuth1Authorizer, computeBodyHash, applyOAuth1ToRequest, addEdgeGridInterceptor } from './auth';
+export {
+  addDigestInterceptor,
+  getOAuth2Token,
+  createOAuth1Authorizer,
+  computeBodyHash,
+  applyOAuth1ToRequest,
+  addEdgeGridInterceptor,
+  handleNtlmRedirect
+} from './auth';
 export { GrpcClient, generateGrpcSampleMessage } from './grpc';
 export { WsClient } from './ws/ws-client';
 export { default as cookies } from './cookies';

--- a/packages/bruno-tests/package.json
+++ b/packages/bruno-tests/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "description": "",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./ntlm": {
+      "types": "./src/ntlm/index.d.ts",
+      "default": "./src/ntlm/index.js"
+    }
+  },
   "scripts": {
     "start": "node .",
     "start:grpc": "node ./src/grpc/index.js"
@@ -27,11 +34,12 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.21.2",
-    "graphql": "^16.10.0",
-    "graphql-yoga": "^5.10.6",
     "express-basic-auth": "^1.2.1",
     "fast-xml-parser": "^5.7.0",
+    "graphql": "^16.10.0",
+    "graphql-yoga": "^5.10.6",
     "http-proxy": "^1.18.1",
+    "js-md4": "^0.3.2",
     "js-yaml": "4.3.1",
     "jsonwebtoken": "^9.0.3",
     "lodash": "4.18.1",

--- a/packages/bruno-tests/src/ntlm/certificates.js
+++ b/packages/bruno-tests/src/ntlm/certificates.js
@@ -1,0 +1,39 @@
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+let opensslChecked = false;
+
+const assertOpensslAvailable = () => {
+  if (opensslChecked) return;
+  try {
+    execFileSync('openssl', ['version'], { stdio: 'ignore' });
+  } catch {
+    throw new Error('The NTLM TLS test server needs `openssl` on PATH to generate its certificates; install openssl or skip the TLS specs.');
+  }
+  opensslChecked = true;
+};
+
+const generateSelfSignedCert = (dir, name, commonName) => {
+  assertOpensslAvailable();
+
+  const keyPath = path.join(dir, `${name}-key.pem`);
+  const certPath = path.join(dir, `${name}-cert.pem`);
+
+  try {
+    execFileSync('openssl', [
+      'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+      '-keyout', keyPath,
+      '-out', certPath,
+      '-days', '1',
+      '-subj', `/CN=${commonName}`,
+      '-addext', 'subjectAltName=DNS:localhost,IP:127.0.0.1'
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+  } catch (error) {
+    const detail = error.stderr?.toString().trim() || error.message;
+    throw new Error(`Could not generate the ${name} certificate with openssl: ${detail}`);
+  }
+
+  return { keyPath, certPath };
+};
+
+module.exports = { generateSelfSignedCert };

--- a/packages/bruno-tests/src/ntlm/index.d.ts
+++ b/packages/bruno-tests/src/ntlm/index.d.ts
@@ -1,0 +1,28 @@
+export type NtlmRequest = {
+  socketId: number;
+  type: number | null;
+  url: string;
+  body: string;
+  headers: Record<string, string | undefined>;
+  clientCertName?: string;
+  provedPassword?: boolean;
+};
+
+export type NtlmEndpoint = {
+  baseUrl: string;
+  requests: NtlmRequest[];
+  certPath?: string;
+  clientCertPath?: string;
+  clientKeyPath?: string;
+  clientCertName: string;
+  messageTypesSeen: () => Array<number | null>;
+  negotiations: () => NtlmRequest[];
+  connectionsUsed: () => number;
+  close: () => Promise<void>;
+};
+
+export const startNtlmServer: (options?: {
+  tls?: boolean;
+  password?: string;
+  requireClientCert?: boolean;
+}) => Promise<NtlmEndpoint>;

--- a/packages/bruno-tests/src/ntlm/index.js
+++ b/packages/bruno-tests/src/ntlm/index.js
@@ -1,0 +1,3 @@
+const { startNtlmServer } = require('./server');
+
+module.exports = { startNtlmServer };

--- a/packages/bruno-tests/src/ntlm/messages.js
+++ b/packages/bruno-tests/src/ntlm/messages.js
@@ -1,0 +1,110 @@
+const crypto = require('node:crypto');
+
+const md4 = require('js-md4');
+
+const NEGOTIATE_UNICODE = 1;
+const NEGOTIATE_NTLM2_KEY = 1 << 19;
+const NEGOTIATE_TARGET_INFO = 1 << 23;
+
+const HEADER_SCHEME = 'NTLM ';
+const SIGNATURE = 'NTLMSSP\0';
+const MESSAGE_TYPE_OFFSET = SIGNATURE.length;
+const CHALLENGE_MESSAGE_TYPE = 2;
+const TARGET_NAME_FIELDS_OFFSET = 12;
+const NEGOTIATE_FLAGS_OFFSET = 20;
+const SERVER_CHALLENGE_OFFSET = 24;
+const TARGET_INFO_FIELDS_OFFSET = 40;
+const HEADER_SIZE = 48;
+const TARGET_INFO_TERMINATOR_SIZE = 4;
+const NT_RESPONSE_OFFSET = 20;
+const DOMAIN_OFFSET = 28;
+const USERNAME_OFFSET = 36;
+const PROOF_SIZE = 16;
+
+// A security buffer points at data after the header: its length, its max length (which senders set to the same), then where it starts.
+const writeSecurityBuffer = (message, offset, { length, start }) => {
+  message.writeUInt16LE(length, offset);
+  message.writeUInt16LE(length, offset + 2);
+  message.writeUInt32LE(start, offset + 4);
+};
+
+const readSecurityBuffer = (message, offset) => {
+  const length = message.readUInt16LE(offset);
+  const start = message.readUInt32LE(offset + 4);
+  return message.subarray(start, start + length);
+};
+
+/**
+ * Only the challenge is built here, since type 1 and type 3 come from the client under test. The
+ * caller keeps the nonce with its connection because the client keys its proof by it, so a proof
+ * answering one connection cannot be replayed onto another.
+ */
+const type2Message = (challenge) => {
+  const message = Buffer.alloc(HEADER_SIZE + TARGET_INFO_TERMINATOR_SIZE);
+
+  message.write(SIGNATURE, 0, 'ascii');
+  message.writeUInt32LE(CHALLENGE_MESSAGE_TYPE, MESSAGE_TYPE_OFFSET);
+  writeSecurityBuffer(message, TARGET_NAME_FIELDS_OFFSET, { length: 0, start: HEADER_SIZE });
+  message.writeUInt32LE(NEGOTIATE_UNICODE | NEGOTIATE_NTLM2_KEY | NEGOTIATE_TARGET_INFO, NEGOTIATE_FLAGS_OFFSET);
+  challenge.copy(message, SERVER_CHALLENGE_OFFSET);
+  writeSecurityBuffer(message, TARGET_INFO_FIELDS_OFFSET, { length: TARGET_INFO_TERMINATOR_SIZE, start: HEADER_SIZE });
+
+  return `${HEADER_SCHEME}${message.toString('base64')}`;
+};
+
+const decodeHeader = (authorization) =>
+  (authorization?.startsWith(HEADER_SCHEME) ? Buffer.from(authorization.slice(HEADER_SCHEME.length), 'base64') : null);
+
+const messageType = (authorization) => {
+  const message = decodeHeader(authorization);
+
+  if (!message || message.toString('ascii', 0, SIGNATURE.length) !== SIGNATURE) {
+    return null;
+  }
+
+  return message.readUInt32LE(MESSAGE_TYPE_OFFSET);
+};
+
+const parseType3Message = (authorization) => {
+  const message = decodeHeader(authorization);
+
+  return {
+    ntResponse: readSecurityBuffer(message, NT_RESPONSE_OFFSET),
+    domain: readSecurityBuffer(message, DOMAIN_OFFSET).toString('ucs2'),
+    username: readSecurityBuffer(message, USERNAME_OFFSET).toString('ucs2')
+  };
+};
+
+const ntlmHashOf = (password) => {
+  const hash = md4.create();
+  hash.update(Buffer.from(password, 'ucs2'));
+  return Buffer.from(hash.buffer());
+};
+
+/**
+ * The proof is recomputed rather than trusted, so no test can pass against a server that accepts
+ * any credentials. The arithmetic is the one in MS-NLMP 3.3.2 so an unmodified client verifies
+ * here, with the password standing in for the hash a domain controller would hold instead.
+ */
+const provesPassword = (authorization, password, challenge) => {
+  const { ntResponse, domain, username } = parseType3Message(authorization);
+
+  if (ntResponse.length <= PROOF_SIZE) {
+    return false;
+  }
+
+  const proof = ntResponse.subarray(0, PROOF_SIZE);
+  const blob = ntResponse.subarray(PROOF_SIZE);
+  const ntlmv2Hash = crypto
+    .createHmac('md5', ntlmHashOf(password))
+    .update(Buffer.from(`${username.toUpperCase()}${domain}`, 'ucs2'))
+    .digest();
+  const expected = crypto
+    .createHmac('md5', ntlmv2Hash)
+    .update(Buffer.concat([challenge, blob]))
+    .digest();
+
+  return crypto.timingSafeEqual(proof, expected);
+};
+
+module.exports = { type2Message, messageType, provesPassword };

--- a/packages/bruno-tests/src/ntlm/server.js
+++ b/packages/bruno-tests/src/ntlm/server.js
@@ -1,0 +1,128 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const os = require('node:os');
+const path = require('node:path');
+
+const { type2Message, messageType, provesPassword } = require('./messages');
+const { generateSelfSignedCert } = require('./certificates');
+
+const CLIENT_CERT_NAME = 'bruno-ntlm-client';
+
+const readBody = (req) =>
+  new Promise((resolve) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => resolve(body));
+  });
+
+/**
+ * Authentication is bound to the connection, the way IIS does it, so a handshake split across
+ * sockets fails here instead of passing quietly. Every request is recorded to make that reuse
+ * observable, and `/redirect?to=<url>` takes its target from the request so no test configures it.
+ */
+const handleRequest = ({ password, requests }) => async (req, res) => {
+  const body = await readBody(req);
+  const authorization = req.headers.authorization;
+  const [pathname, query] = req.url.split('?');
+
+  const record = {
+    socketId: req.socket.ntlmSocketId,
+    type: messageType(authorization),
+    url: req.url,
+    body,
+    headers: req.headers,
+    clientCertName: req.socket.getPeerCertificate?.()?.subject?.CN
+  };
+  requests.push(record);
+
+  const challengeWith = (header) => {
+    res.writeHead(401, { 'www-authenticate': header, 'content-length': 0 });
+    return res.end();
+  };
+
+  switch (messageType(authorization)) {
+    case 1: {
+      const nonce = crypto.randomBytes(8);
+      req.socket.ntlmChallenge = nonce;
+      return challengeWith(type2Message(nonce));
+    }
+    case 3: {
+      const nonce = req.socket.ntlmChallenge;
+      record.provedPassword = Boolean(nonce) && provesPassword(authorization, password, nonce);
+
+      if (!record.provedPassword) {
+        return challengeWith('Negotiate, NTLM');
+      }
+      if (pathname === '/redirect') {
+        res.writeHead(302, { 'location': new URLSearchParams(query).get('to'), 'content-length': 0 });
+        return res.end();
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      return res.end(JSON.stringify({ authenticated: true, url: pathname }));
+    }
+    default:
+      return challengeWith('NTLM');
+  }
+};
+
+const createCertificates = (requireClientCert) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-ntlm-tls-'));
+
+  return {
+    dir,
+    server: generateSelfSignedCert(dir, 'server', 'localhost'),
+    client: requireClientCert ? generateSelfSignedCert(dir, 'client', CLIENT_CERT_NAME) : null
+  };
+};
+
+const tlsOptionsFor = ({ server, client }) => ({
+  key: fs.readFileSync(server.keyPath),
+  cert: fs.readFileSync(server.certPath),
+  ...(client ? { requestCert: true, rejectUnauthorized: true, ca: [fs.readFileSync(client.certPath)] } : {})
+});
+
+const startNtlmServer = async ({ tls = false, password = 'pass', requireClientCert = false } = {}) => {
+  const requests = [];
+  const sockets = [];
+  const handler = handleRequest({ password, requests });
+
+  const certificates = tls ? createCertificates(requireClientCert) : null;
+  const listener = certificates
+    ? https.createServer(tlsOptionsFor(certificates), handler)
+    : http.createServer(handler);
+
+  let socketId = 0;
+  listener.on(tls ? 'secureConnection' : 'connection', (socket) => {
+    socket.ntlmSocketId = ++socketId;
+    sockets.push(socket);
+  });
+
+  await new Promise((resolve) => listener.listen(0, '127.0.0.1', resolve));
+  const { port } = listener.address();
+  const scheme = tls ? 'https' : 'http';
+
+  return {
+    baseUrl: `${scheme}://127.0.0.1:${port}`,
+    requests,
+    certPath: certificates?.server.certPath,
+    clientCertPath: certificates?.client?.certPath,
+    clientKeyPath: certificates?.client?.keyPath,
+    clientCertName: CLIENT_CERT_NAME,
+    messageTypesSeen: () => requests.map((request) => request.type),
+    negotiations: () => requests.filter((request) => request.type === 1),
+    connectionsUsed: () => new Set(requests.map((request) => request.socketId)).size,
+    close: async () => {
+      sockets.forEach((socket) => socket.destroy());
+      await new Promise((resolve) => listener.close(resolve));
+      if (certificates) {
+        fs.rmSync(certificates.dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      }
+    }
+  };
+};
+
+module.exports = { startNtlmServer };

--- a/tests/auth/ntlm/fixtures/collections/ntlm-tls/api.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm-tls/api.yml
@@ -1,0 +1,13 @@
+info:
+  name: api
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{process.env.NTLM_BASE_URL}}/api"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""

--- a/tests/auth/ntlm/fixtures/collections/ntlm-tls/bruno.json
+++ b/tests/auth/ntlm/fixtures/collections/ntlm-tls/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "ntlm-tls",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/tests/auth/ntlm/fixtures/collections/ntlm-tls/opencollection.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm-tls/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: ntlm-tls

--- a/tests/auth/ntlm/fixtures/collections/ntlm/api.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/api.yml
@@ -1,0 +1,22 @@
+info:
+  name: api
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{process.env.NTLM_BASE_URL}}/api"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("api authenticates", function() {
+          expect(res.status).to.equal(200);
+          expect(res.body.authenticated).to.equal(true);
+        });

--- a/tests/auth/ntlm/fixtures/collections/ntlm/body.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/body.yml
@@ -1,0 +1,28 @@
+info:
+  name: body
+  type: http
+  seq: 5
+
+http:
+  method: POST
+  url: "{{process.env.NTLM_BASE_URL}}/api"
+  headers:
+    - name: Content-Type
+      value: application/json
+    - name: X-Dropped
+      value: dropped
+  body:
+    type: json
+    data: |-
+      {"hello":"world"}
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        req.deleteHeader("X-Dropped");

--- a/tests/auth/ntlm/fixtures/collections/ntlm/bruno.json
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "ntlm",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/tests/auth/ntlm/fixtures/collections/ntlm/no-auth.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/no-auth.yml
@@ -1,0 +1,10 @@
+info:
+  name: no-auth
+  type: http
+  seq: 6
+
+http:
+  method: GET
+  url: "{{process.env.NTLM_BASE_URL}}/api"
+  auth:
+    type: none

--- a/tests/auth/ntlm/fixtures/collections/ntlm/opencollection.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: ntlm

--- a/tests/auth/ntlm/fixtures/collections/ntlm/other-host-blocked.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/other-host-blocked.yml
@@ -1,0 +1,23 @@
+info:
+  name: other-host-blocked
+  type: http
+  seq: 4
+
+http:
+  method: GET
+  url: "{{process.env.NTLM_BASE_URL}}/redirect?to={{process.env.NTLM_REDIRECT_URL}}/api"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""
+settings:
+  forwardAuthorizationHeader: false
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("another host is left unauthenticated", function() {
+          expect(res.status).to.equal(401);
+        });

--- a/tests/auth/ntlm/fixtures/collections/ntlm/other-host-forwarded.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/other-host-forwarded.yml
@@ -1,0 +1,22 @@
+info:
+  name: other-host-forwarded
+  type: http
+  seq: 3
+
+http:
+  method: GET
+  url: "{{process.env.NTLM_BASE_URL}}/redirect?to={{process.env.NTLM_REDIRECT_URL}}/api"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("another host authenticates when the request forwards authorization", function() {
+          expect(res.status).to.equal(200);
+          expect(res.body.authenticated).to.equal(true);
+        });

--- a/tests/auth/ntlm/fixtures/collections/ntlm/redirect.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/redirect.yml
@@ -1,0 +1,22 @@
+info:
+  name: redirect
+  type: http
+  seq: 2
+
+http:
+  method: GET
+  url: "{{process.env.NTLM_BASE_URL}}/redirect?to={{process.env.NTLM_BASE_URL}}/landing"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("redirect authenticates on the new connection", function() {
+          expect(res.status).to.equal(200);
+          expect(res.body.url).to.equal("/landing");
+        });

--- a/tests/auth/ntlm/fixtures/collections/ntlm/wrong-password.yml
+++ b/tests/auth/ntlm/fixtures/collections/ntlm/wrong-password.yml
@@ -1,0 +1,13 @@
+info:
+  name: wrong-password
+  type: http
+  seq: 7
+
+http:
+  method: GET
+  url: "{{process.env.NTLM_BASE_URL}}/api"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: notThePassword
+    domain: ""

--- a/tests/auth/ntlm/init-user-data-client-cert/preferences.json
+++ b/tests/auth/ntlm/init-user-data-client-cert/preferences.json
@@ -1,0 +1,20 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/ntlm-tls"
+  ],
+  "preferences": {
+    "request": {
+      "sslVerification": false,
+      "clientCertificates": {
+        "certs": [
+          {
+            "domain": "127.0.0.1",
+            "type": "cert",
+            "certFilePath": "{{clientCertPath}}",
+            "keyFilePath": "{{clientKeyPath}}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/auth/ntlm/init-user-data-custom-ca/preferences.json
+++ b/tests/auth/ntlm/init-user-data-custom-ca/preferences.json
@@ -1,0 +1,14 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/ntlm-tls"
+  ],
+  "preferences": {
+    "request": {
+      "sslVerification": true,
+      "customCaCertificate": {
+        "enabled": true,
+        "filePath": "{{certPath}}"
+      }
+    }
+  }
+}

--- a/tests/auth/ntlm/init-user-data-tls-off/preferences.json
+++ b/tests/auth/ntlm/init-user-data-tls-off/preferences.json
@@ -1,0 +1,10 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/ntlm-tls"
+  ],
+  "preferences": {
+    "request": {
+      "sslVerification": false
+    }
+  }
+}

--- a/tests/auth/ntlm/init-user-data-verify-on/preferences.json
+++ b/tests/auth/ntlm/init-user-data-verify-on/preferences.json
@@ -1,0 +1,10 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/ntlm-tls"
+  ],
+  "preferences": {
+    "request": {
+      "sslVerification": true
+    }
+  }
+}

--- a/tests/auth/ntlm/init-user-data/preferences.json
+++ b/tests/auth/ntlm/init-user-data/preferences.json
@@ -1,0 +1,5 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/ntlm"
+  ]
+}

--- a/tests/auth/ntlm/ntlm-tls.spec.ts
+++ b/tests/auth/ntlm/ntlm-tls.spec.ts
@@ -1,0 +1,128 @@
+import * as path from 'path';
+import { test, expect, closeElectronApp, type ElectronApplication } from '../../../playwright';
+import { buildCommonLocators, openRequest, sendRequest, waitForReadyPage } from '../../utils/page';
+import { startNtlmServer, type NtlmEndpoint } from '@usebruno/tests/ntlm';
+import { SELF_SIGNED_CERTIFICATE, TLS_HANDSHAKE_FAILURE } from '../../utils/constants';
+
+const PASSWORD = 'Br!unoNtlm';
+
+test.describe('ntlm against an endpoint with a self signed certificate', () => {
+  let endpoint: NtlmEndpoint;
+  let app: ElectronApplication;
+
+  test.afterEach(async () => {
+    await endpoint?.close();
+    if (app) await closeElectronApp(app);
+  });
+
+  test('authenticates when certificate verification is off', async ({ launchElectronApp, collectionFixturePath }) => {
+    endpoint = await startNtlmServer({ password: PASSWORD, tls: true });
+
+    app = await launchElectronApp({
+      initUserDataPath: path.join(__dirname, 'init-user-data-tls-off'),
+      templateVars: { collectionPath: collectionFixturePath! },
+      dotEnv: { NTLM_BASE_URL: endpoint.baseUrl }
+    });
+    const page = await waitForReadyPage(app);
+
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm-tls', 'api');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('the server saw one full handshake on one connection', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.connectionsUsed()).toBe(1);
+    });
+  });
+
+  test('authenticates when the certificate is trusted as a custom ca', async ({ launchElectronApp, collectionFixturePath }) => {
+    endpoint = await startNtlmServer({ password: PASSWORD, tls: true });
+
+    app = await launchElectronApp({
+      initUserDataPath: path.join(__dirname, 'init-user-data-custom-ca'),
+      templateVars: { collectionPath: collectionFixturePath!, certPath: endpoint.certPath! },
+      dotEnv: { NTLM_BASE_URL: endpoint.baseUrl }
+    });
+    const page = await waitForReadyPage(app);
+
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm-tls', 'api');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('the server saw one full handshake on one connection', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.connectionsUsed()).toBe(1);
+    });
+  });
+
+  test('never reaches the server when certificate verification is left on', async ({ launchElectronApp, collectionFixturePath }) => {
+    endpoint = await startNtlmServer({ password: PASSWORD, tls: true });
+
+    app = await launchElectronApp({
+      initUserDataPath: path.join(__dirname, 'init-user-data-verify-on'),
+      templateVars: { collectionPath: collectionFixturePath! },
+      dotEnv: { NTLM_BASE_URL: endpoint.baseUrl }
+    });
+    const page = await waitForReadyPage(app);
+    const { request, response } = buildCommonLocators(page);
+
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm-tls', 'api');
+      await request.sendButton().click();
+    });
+
+    await test.step('the request fails on the certificate before any leg is sent', async () => {
+      await expect(response.errorMessage()).toContainText(SELF_SIGNED_CERTIFICATE, { timeout: 30000 });
+      expect(endpoint.requests).toEqual([]);
+    });
+  });
+
+  test('presents the client certificate on every request when the endpoint demands one', async ({
+    launchElectronApp,
+    collectionFixturePath
+  }) => {
+    endpoint = await startNtlmServer({ password: PASSWORD, tls: true, requireClientCert: true });
+
+    app = await launchElectronApp({
+      initUserDataPath: path.join(__dirname, 'init-user-data-client-cert'),
+      templateVars: { collectionPath: collectionFixturePath!, clientCertPath: endpoint.clientCertPath!, clientKeyPath: endpoint.clientKeyPath! },
+      dotEnv: { NTLM_BASE_URL: endpoint.baseUrl }
+    });
+    const page = await waitForReadyPage(app);
+
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm-tls', 'api');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('every leg presented the client certificate on one connection', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.requests.map((request) => request.clientCertName)).toEqual(Array(3).fill(endpoint.clientCertName));
+      expect(endpoint.connectionsUsed()).toBe(1);
+    });
+  });
+
+  test('never reaches that endpoint when no client certificate is configured', async ({ launchElectronApp, collectionFixturePath }) => {
+    endpoint = await startNtlmServer({ password: PASSWORD, tls: true, requireClientCert: true });
+
+    app = await launchElectronApp({
+      initUserDataPath: path.join(__dirname, 'init-user-data-tls-off'),
+      templateVars: { collectionPath: collectionFixturePath! },
+      dotEnv: { NTLM_BASE_URL: endpoint.baseUrl }
+    });
+    const page = await waitForReadyPage(app);
+    const { request, response } = buildCommonLocators(page);
+
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm-tls', 'api');
+      await request.sendButton().click();
+    });
+
+    await test.step('the handshake is refused for want of a certificate before any leg is sent', async () => {
+      await expect(response.errorMessage()).toContainText(TLS_HANDSHAKE_FAILURE, { timeout: 30000 });
+      expect(endpoint.requests).toEqual([]);
+    });
+  });
+});

--- a/tests/auth/ntlm/ntlm.spec.ts
+++ b/tests/auth/ntlm/ntlm.spec.ts
@@ -1,0 +1,195 @@
+import * as path from 'path';
+import { test, expect, closeElectronApp, type ElectronApplication, type Page } from '../../../playwright';
+import {
+  buildCommonLocators,
+  openRequest,
+  selectResponsePaneTab,
+  sendRequest,
+  waitForReadyPage
+} from '../../utils/page';
+import { buildTimelineHeaderLocators } from '../../utils/page/timeline-headers';
+import { startNtlmServer, type NtlmEndpoint } from '@usebruno/tests/ntlm';
+
+const PASSWORD = 'Br!unoNtlm';
+
+test.describe('ntlm over a real connection', () => {
+  let endpoint: NtlmEndpoint;
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeEach(async ({ launchElectronApp, collectionFixturePath }) => {
+    endpoint = await startNtlmServer({ password: PASSWORD });
+
+    app = await launchElectronApp({
+      initUserDataPath: path.join(__dirname, 'init-user-data'),
+      templateVars: { collectionPath: collectionFixturePath! },
+      dotEnv: { NTLM_BASE_URL: endpoint.baseUrl }
+    });
+
+    page = await waitForReadyPage(app);
+  });
+
+  test.afterEach(async () => {
+    await endpoint?.close();
+    if (app) await closeElectronApp(app);
+  });
+
+  test('negotiates and authenticates over a single connection', async () => {
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm', 'api');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('the server saw one full handshake on one connection', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.requests.map((request) => request.provedPassword)).toEqual([undefined, undefined, true]);
+      expect(endpoint.connectionsUsed()).toBe(1);
+    });
+  });
+
+  test('is challenged without authenticating when the request has no ntlm auth', async () => {
+    await test.step('send a request without auth', async () => {
+      await openRequest(page, 'ntlm', 'no-auth');
+      await sendRequest(page, 401);
+    });
+
+    await test.step('the server saw only the anonymous request', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null]);
+    });
+  });
+
+  test('is refused when the password is wrong', async () => {
+    await test.step('send a request with the wrong password', async () => {
+      await openRequest(page, 'ntlm', 'wrong-password');
+      await sendRequest(page, 401);
+    });
+
+    await test.step('the server rejected the finished message', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.requests.map((request) => request.provedPassword)).toEqual([undefined, undefined, false]);
+    });
+  });
+
+  test('sends the body on every request of the handshake and drops a header removed by a script', async () => {
+    await test.step('send a request with a body and a pre-request script', async () => {
+      await openRequest(page, 'ntlm', 'body');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('every leg carried the body and none carried the dropped header', async () => {
+      expect(endpoint.requests.map((request) => request.body)).toEqual(['{"hello":"world"}', '{"hello":"world"}', '{"hello":"world"}']);
+      expect(endpoint.requests.map((request) => request.headers['x-dropped'])).toEqual([undefined, undefined, undefined]);
+    });
+  });
+
+  test('negotiates again for the connection a same host redirect moves onto', async () => {
+    await test.step('send a request that is redirected on the same host', async () => {
+      await openRequest(page, 'ntlm', 'redirect');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('the server saw a handshake on each of two connections', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3, null, 1, 3]);
+      expect(endpoint.connectionsUsed()).toBe(2);
+    });
+  });
+
+  test('only ever puts X-retry on a request that carries the finished message', async () => {
+    await test.step('send a request that is redirected on the same host', async () => {
+      await openRequest(page, 'ntlm', 'redirect');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('X-retry travelled only with the type 3 messages', async () => {
+      const carryingRetry = endpoint.requests.filter((request) => request.headers['x-retry'] !== undefined);
+
+      expect(carryingRetry.map((request) => request.type)).toEqual([3, 3]);
+    });
+  });
+
+  test('logs only the request that carried the finished message on the timeline', async () => {
+    const { timeline } = buildCommonLocators(page);
+    const timelineHeaders = buildTimelineHeaderLocators(page);
+
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm', 'api');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('the timeline shows one hop carrying the NTLM header', async () => {
+      await selectResponsePaneTab(page, 'Timeline');
+      await timeline.itemHeader(timeline.items().first()).click();
+      await timelineHeaders.networkTab().click();
+
+      const hops = await timelineHeaders.requestHops();
+
+      expect(hops.map((hop) => hop.request)).toEqual([`GET ${endpoint.baseUrl}/api`]);
+      expect(hops.map((hop) => hop.headerLines.join('\n'))).toEqual([expect.stringMatching(/authorization: NTLM/i)]);
+    });
+  });
+
+  test('reports how long the answer took', async () => {
+    const { response } = buildCommonLocators(page);
+
+    await test.step('send a request with ntlm auth', async () => {
+      await openRequest(page, 'ntlm', 'api');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('the status line shows status, duration and size', async () => {
+      await expect(response.status()).toHaveText(/^200 OK \d+(ms|\.\d+s)\d+B$/);
+    });
+  });
+});
+
+test.describe('ntlm when a redirect leaves for another host', () => {
+  let endpoint: NtlmEndpoint;
+  let otherHost: NtlmEndpoint;
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeEach(async ({ launchElectronApp, collectionFixturePath }) => {
+    endpoint = await startNtlmServer({ password: PASSWORD });
+    otherHost = await startNtlmServer({ password: PASSWORD });
+
+    app = await launchElectronApp({
+      initUserDataPath: path.join(__dirname, 'init-user-data'),
+      templateVars: { collectionPath: collectionFixturePath! },
+      dotEnv: { NTLM_BASE_URL: endpoint.baseUrl, NTLM_REDIRECT_URL: otherHost.baseUrl }
+    });
+
+    page = await waitForReadyPage(app);
+  });
+
+  test.afterEach(async () => {
+    await endpoint?.close();
+    await otherHost?.close();
+    if (app) await closeElectronApp(app);
+  });
+
+  test('negotiates with the host a redirect leaves for when the request forwards authorization', async () => {
+    await test.step('send a request redirected to another host with authorization forwarding on', async () => {
+      await openRequest(page, 'ntlm', 'other-host-forwarded');
+      await sendRequest(page, 200);
+    });
+
+    await test.step('both hosts saw a full handshake', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(otherHost.messageTypesSeen()).toEqual([null, 1, 3]);
+    });
+  });
+
+  test('leaves that host unauthenticated when the request does not forward authorization', async () => {
+    await test.step('send a request redirected to another host with authorization forwarding off', async () => {
+      await openRequest(page, 'ntlm', 'other-host-blocked');
+      await sendRequest(page, 401);
+    });
+
+    await test.step('the other host saw only an anonymous request carrying neither Authorization nor X-retry', async () => {
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(otherHost.messageTypesSeen()).toEqual([null]);
+      expect(otherHost.requests[0].headers.authorization).toBeUndefined();
+      expect(otherHost.requests[0].headers['x-retry']).toBeUndefined();
+    });
+  });
+});

--- a/tests/runner/cli-ntlm/cli-ntlm.spec.ts
+++ b/tests/runner/cli-ntlm/cli-ntlm.spec.ts
@@ -1,0 +1,69 @@
+import * as path from 'path';
+import { test, expect } from '../../../playwright';
+import { cliOutput, runCLIAsync } from '../../utils/cli';
+import { startNtlmServer, type NtlmEndpoint } from '@usebruno/tests/ntlm';
+
+const COLLECTION = path.resolve(__dirname, 'collection');
+const PASSWORD = 'Br!unoNtlm';
+
+// The two tls cases spawn the cli, generate a certificate and complete a handshake: ~11s on a
+// windows runner against ~2s locally, close enough to the 30s default to be worth the headroom.
+test.describe.configure({ timeout: 60_000 });
+
+test.describe('CLI run against an ntlm endpoint', () => {
+  let endpoint: NtlmEndpoint;
+
+  test.afterEach(async () => {
+    await endpoint?.close();
+  });
+
+  test('authenticates over a single connection', async () => {
+    endpoint = await startNtlmServer({ password: PASSWORD });
+
+    const run = await runCLIAsync(COLLECTION, `run api.yml --noproxy --env-var baseUrl=${endpoint.baseUrl}`);
+
+    await test.step('the run passed and the server saw one handshake on one connection', async () => {
+      expect(run.code, cliOutput(run)).toBe(0);
+      expect(run.stdout).toContain('api authenticates');
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.connectionsUsed()).toBe(1);
+    });
+  });
+
+  test('negotiates for each request of a collection run, and again for the connection a redirect moves onto', async () => {
+    endpoint = await startNtlmServer({ password: PASSWORD });
+
+    const run = await runCLIAsync(COLLECTION, `run . --noproxy --env-var baseUrl=${endpoint.baseUrl}`);
+
+    await test.step('both requests passed and the server saw three negotiations', async () => {
+      expect(endpoint.negotiations()).toHaveLength(3);
+      expect(run.stdout).toContain('redirect authenticates');
+      expect(run.stdout).toContain('2 (2 Passed)');
+      expect(run.code, cliOutput(run)).toBe(0);
+    });
+  });
+
+  test('authenticates against a self-signed endpoint when certificate checks are off', async () => {
+    endpoint = await startNtlmServer({ tls: true, password: PASSWORD });
+
+    const run = await runCLIAsync(COLLECTION, `run api.yml --insecure --noproxy --env-var baseUrl=${endpoint.baseUrl}`);
+
+    await test.step('the run passed and the server saw one handshake on one connection', async () => {
+      expect(run.code, cliOutput(run)).toBe(0);
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.connectionsUsed()).toBe(1);
+    });
+  });
+
+  test('authenticates against a self-signed endpoint trusted through --cacert', async () => {
+    endpoint = await startNtlmServer({ tls: true, password: PASSWORD });
+
+    const run = await runCLIAsync(COLLECTION, `run api.yml --cacert "${endpoint.certPath}" --noproxy --env-var baseUrl=${endpoint.baseUrl}`);
+
+    await test.step('the run passed and the server saw one handshake on one connection', async () => {
+      expect(run.code, cliOutput(run)).toBe(0);
+      expect(endpoint.messageTypesSeen()).toEqual([null, 1, 3]);
+      expect(endpoint.connectionsUsed()).toBe(1);
+    });
+  });
+});

--- a/tests/runner/cli-ntlm/collection/api.yml
+++ b/tests/runner/cli-ntlm/collection/api.yml
@@ -1,0 +1,22 @@
+info:
+  name: api
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{baseUrl}}/api"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("api authenticates", function() {
+          expect(res.status).to.equal(200);
+          expect(res.body.authenticated).to.equal(true);
+        });

--- a/tests/runner/cli-ntlm/collection/bruno.json
+++ b/tests/runner/cli-ntlm/collection/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "ntlm",
+  "type": "collection",
+  "ignore": []
+}

--- a/tests/runner/cli-ntlm/collection/opencollection.yml
+++ b/tests/runner/cli-ntlm/collection/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: ntlm

--- a/tests/runner/cli-ntlm/collection/redirect.yml
+++ b/tests/runner/cli-ntlm/collection/redirect.yml
@@ -1,0 +1,22 @@
+info:
+  name: redirect
+  type: http
+  seq: 2
+
+http:
+  method: GET
+  url: "{{baseUrl}}/redirect?to={{baseUrl}}/api"
+  auth:
+    type: ntlm
+    username: ntlmtest
+    password: Br!unoNtlm
+    domain: ""
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test("redirect authenticates", function() {
+          expect(res.status).to.equal(200);
+          expect(res.body.authenticated).to.equal(true);
+        });

--- a/tests/ssl/client-certs/tests/collection-client-certs-disabled-bru/https.spec.ts
+++ b/tests/ssl/client-certs/tests/collection-client-certs-disabled-bru/https.spec.ts
@@ -1,14 +1,9 @@
 import { test, expect } from '../../../../../playwright';
 import { setSandboxMode, openRequest } from '../../../../utils/page';
 import { buildCommonLocators } from '../../../../utils/page/locators';
+import { TLS_HANDSHAKE_FAILURE } from '../../../../utils/constants';
 
 const COLLECTION = 'client-certs-disabled-bru';
-
-// Node surfaces the server's mTLS rejection as an OpenSSL handshake alert (e.g.
-// "tlsv13 alert certificate required" / "sslv3 alert handshake failure"). Match the
-// family of TLS/client-cert failures so an unrelated error (DNS, timeout, script) can't
-// satisfy the test.
-const TLS_HANDSHAKE_FAILURE = /certificate required|handshake failure|bad certificate|tlsv1.*alert|sslv3 alert|SSL alert number|SSL routines/i;
 
 // The collection's client certificate is present but flagged `disabled: true`, so Bruno
 // withholds it. The mTLS server rejects the request at the TLS handshake — the error

--- a/tests/ssl/client-certs/tests/collection-client-certs-disabled-yml/https.spec.ts
+++ b/tests/ssl/client-certs/tests/collection-client-certs-disabled-yml/https.spec.ts
@@ -1,14 +1,9 @@
 import { test, expect } from '../../../../../playwright';
 import { setSandboxMode, openRequest } from '../../../../utils/page';
 import { buildCommonLocators } from '../../../../utils/page/locators';
+import { TLS_HANDSHAKE_FAILURE } from '../../../../utils/constants';
 
 const COLLECTION = 'client-certs-disabled-yml';
-
-// Node surfaces the server's mTLS rejection as an OpenSSL handshake alert (e.g.
-// "tlsv13 alert certificate required" / "sslv3 alert handshake failure"). Match the
-// family of TLS/client-cert failures so an unrelated error (DNS, timeout, script) can't
-// satisfy the test.
-const TLS_HANDSHAKE_FAILURE = /certificate required|handshake failure|bad certificate|tlsv1.*alert|sslv3 alert|SSL alert number|SSL routines/i;
 
 // The opencollection.yml cert entry carries `disabled: true`, so Bruno withholds it. The
 // mTLS server rejects the request at the TLS handshake — the error surfaced in the

--- a/tests/ssl/client-certs/tests/global-client-certs-disabled/https.spec.ts
+++ b/tests/ssl/client-certs/tests/global-client-certs-disabled/https.spec.ts
@@ -1,14 +1,9 @@
 import { test, expect } from '../../../../../playwright';
 import { setSandboxMode, openRequest } from '../../../../utils/page';
 import { buildCommonLocators } from '../../../../utils/page/locators';
+import { TLS_HANDSHAKE_FAILURE } from '../../../../utils/constants';
 
 const COLLECTION = 'global-client-certs-disabled';
-
-// Node surfaces the server's mTLS rejection as an OpenSSL handshake alert (e.g.
-// "tlsv13 alert certificate required" / "sslv3 alert handshake failure"). Match the
-// family of TLS/client-cert failures so an unrelated error (DNS, timeout, script) can't
-// satisfy the test.
-const TLS_HANDSHAKE_FAILURE = /certificate required|handshake failure|bad certificate|tlsv1.*alert|sslv3 alert|SSL alert number|SSL routines/i;
 
 // The global client certificate in Preferences carries `disabled: true`, so Bruno
 // withholds it. The mTLS server rejects the request at the TLS handshake — the error

--- a/tests/utils/cli.ts
+++ b/tests/utils/cli.ts
@@ -1,0 +1,16 @@
+import { exec } from 'child_process';
+import * as path from 'path';
+
+const BRU_BIN = path.resolve(__dirname, '../../packages/bruno-cli/bin/bru.js');
+
+// An in-process test server can only keep serving while the CLI runs if the event loop stays free.
+export const runCLIAsync = (cwd: string, args: string): Promise<{ code: number; stdout: string; stderr: string }> =>
+  new Promise((resolve) => {
+    exec(`node "${BRU_BIN}" ${args}`, { cwd, env: { ...process.env, FORCE_COLOR: '0' } }, (error, stdout, stderr) =>
+      resolve({ code: error ? (typeof error.code === 'number' ? error.code : 1) : 0, stdout, stderr })
+    );
+  });
+
+/** A failed run says nothing on its own, so the exit code assertion carries what the cli printed. */
+export const cliOutput = ({ code, stdout, stderr }: { code: number; stdout: string; stderr: string }) =>
+  `bru exited ${code}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`;

--- a/tests/utils/constants/index.ts
+++ b/tests/utils/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './variables';
+export * from './tls';

--- a/tests/utils/constants/tls.ts
+++ b/tests/utils/constants/tls.ts
@@ -1,0 +1,6 @@
+// Node surfaces the server's mTLS rejection as an OpenSSL handshake alert (e.g.
+// "tlsv13 alert certificate required" / "sslv3 alert handshake failure"). Match the
+// family of TLS/client-cert failures so an unrelated error (DNS, timeout, script) can't
+// satisfy the test.
+export const TLS_HANDSHAKE_FAILURE = /certificate required|handshake failure|bad certificate|tlsv1.*alert|sslv3 alert|SSL alert number|SSL routines/i;
+export const SELF_SIGNED_CERTIFICATE = /self[ -]signed certificate/i;

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -215,6 +215,7 @@ export const buildCommonLocators = (page: Page) => ({
   },
   response: {
     statusCode: () => page.getByTestId('response-status-code'),
+    status: () => page.getByTestId('response-pane-status'),
     elapsedTime: () => page.getByTestId('response-elapsed-time'),
     // Rendered by every response pane (http, grpc, ws) only while a response exists, so its
     // absence doubles as the "response is cleared" signal.


### PR DESCRIPTION
### Description

Ref: BRU-1448
Fixes #4895

Updates NtlmClient to be an adapter instead of replacing our axios instance, causing the interceptors to not be attached to it.

Also on cli since https agent request field didn't had keepAlive, so this also adds that so that the handshake connection remains alive throughout.

### Problem

NTLM failed because we replaced the axiosInstance that included Bruno interceptors for timeline, settings, etc., creating an inconsistent anomaly in Bruno.


### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
- Use NtlmClient as an adapter instead of replacing our axiosInstance
- This preserves settings and interceptors in the NTLM flow
- CLI doesn’t keep the connection alive while running single request via HTTPS, this adds keepAlive to CLI for ntlm requests

Also adds Playwright and CLI tests for NTLM behavior over TLS and to verify interceptors apply.

### Screenshots

| Before | After |
| --- | --- |
| NTLM HTTPS request gives SSL issue, HTTP opens correct | NTLM HTTPS request picks the certificate and works, HTTP remains same in behaviour |
| <video src="https://github.com/user-attachments/assets/15b0b40c-3dad-45f3-98b1-f3f9bcb14fb5" width="100%" /> | <video src="https://github.com/user-attachments/assets/e9de023e-c9fe-47e1-a590-a34f71a1e646" width="100%" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NTLM authentication reliability by maintaining a single connection throughout the handshake.
  - Preserved request interceptors during NTLM-authenticated requests.
  - Improved NTLM support across redirects, streamed responses, request bodies, cookies, proxies, and HTTPS connections.
  - Added support for custom certificate authorities and configurable TLS verification.

- **Tests**
  - Added comprehensive coverage for successful authentication, connection reuse, proxy scenarios, redirects, TLS, client certificates, and authentication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->