### PR TITLE
feat(sidebar): adds debounce on sidebar search

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/index.js
@@ -11,6 +11,7 @@ import { isScratchCollection } from 'utils/collections';
 import useDebounce from 'hooks/useDebounce';
 
 const SEARCH_DEBOUNCE_MS = 300;
+const isEmptyQuery = (value) => value === '';
 
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
@@ -24,8 +25,7 @@ const getSidebarEntryName = (entry) => {
 
 const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismissCreate, onOpenAdvancedCreate }) => {
   const [searchText, setSearchText] = useState('');
-  const debouncedSearchText = useDebounce(searchText, SEARCH_DEBOUNCE_MS);
-  const filterText = searchText === '' ? '' : debouncedSearchText;
+  const filterText = useDebounce(searchText, SEARCH_DEBOUNCE_MS, { skipDebounce: isEmptyQuery });
   const { collections, collectionSortOrder } = useSelector((state) => state.collections);
   const { workspaces, activeWorkspaceUid } = useSelector((state) => state.workspaces);
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/index.js
@@ -25,7 +25,7 @@ const getSidebarEntryName = (entry) => {
 
 const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismissCreate, onOpenAdvancedCreate }) => {
   const [searchText, setSearchText] = useState('');
-  const filterText = useDebounce(searchText, SEARCH_DEBOUNCE_MS, { skipDebounce: isEmptyQuery });
+  const debouncedSearchText = useDebounce(searchText, SEARCH_DEBOUNCE_MS, { skipDebounce: isEmptyQuery });
   const { collections, collectionSortOrder } = useSelector((state) => state.collections);
   const { workspaces, activeWorkspaceUid } = useSelector((state) => state.workspaces);
 
@@ -97,7 +97,7 @@ const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismis
         )}
         {sidebarEntries.map((entry) => {
           if (entry.kind === 'loaded') {
-            return <Collection searchText={filterText} collection={entry.collection} key={entry.key} />;
+            return <Collection searchText={debouncedSearchText} collection={entry.collection} key={entry.key} />;
           }
           return <GitRemoteCollectionRow entry={entry.entry} key={entry.key} />;
         })}

--- a/packages/bruno-app/src/components/Sidebar/Collections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/index.js
@@ -8,6 +8,9 @@ import CollectionSearch from './CollectionSearch/index';
 import InlineCollectionCreator from './InlineCollectionCreator';
 import path, { normalizePath } from 'utils/common/path';
 import { isScratchCollection } from 'utils/collections';
+import useDebounce from 'hooks/useDebounce';
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
@@ -21,6 +24,8 @@ const getSidebarEntryName = (entry) => {
 
 const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismissCreate, onOpenAdvancedCreate }) => {
   const [searchText, setSearchText] = useState('');
+  const debouncedSearchText = useDebounce(searchText, SEARCH_DEBOUNCE_MS);
+  const filterText = searchText === '' ? '' : debouncedSearchText;
   const { collections, collectionSortOrder } = useSelector((state) => state.collections);
   const { workspaces, activeWorkspaceUid } = useSelector((state) => state.workspaces);
 
@@ -92,7 +97,7 @@ const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismis
         )}
         {sidebarEntries.map((entry) => {
           if (entry.kind === 'loaded') {
-            return <Collection searchText={searchText} collection={entry.collection} key={entry.key} />;
+            return <Collection searchText={filterText} collection={entry.collection} key={entry.key} />;
           }
           return <GitRemoteCollectionRow entry={entry.entry} key={entry.key} />;
         })}

--- a/packages/bruno-app/src/hooks/useDebounce/index.js
+++ b/packages/bruno-app/src/hooks/useDebounce/index.js
@@ -1,9 +1,30 @@
 import { useState, useEffect } from 'react';
 
-function useDebounce(value, delay) {
+/**
+ * Debounces a value on the trailing edge.
+ *
+ * `value` is compared by identity, so pass a primitive. A value recreated on
+ * every render (object, array, inline literal) restarts the timer each render
+ * and may never settle.
+ *
+ * @param {*} value
+ * @param {number} delay - Debounce delay in milliseconds.
+ * @param {object} [options]
+ * @param {(value: *) => boolean} [options.skipDebounce] - Values matching
+ *   this predicate are applied immediately instead of being debounced.
+ *   This is useful for reset values, such as an empty search query, so a
+ *   stale debounced value cannot remain while the input is being cleared.
+ */
+function useDebounce(value, delay, { skipDebounce } = {}) {
   const [debouncedValue, setDebouncedValue] = useState(value);
+  const isImmediate = typeof skipDebounce === 'function' && skipDebounce(value);
 
   useEffect(() => {
+    if (isImmediate) {
+      setDebouncedValue(value);
+      return;
+    }
+
     const handler = setTimeout(() => {
       setDebouncedValue(value);
     }, delay);
@@ -11,9 +32,9 @@ function useDebounce(value, delay) {
     return () => {
       clearTimeout(handler);
     };
-  }, [value, delay]);
+  }, [value, delay, isImmediate]);
 
-  return debouncedValue;
+  return isImmediate ? value : debouncedValue;
 }
 
 export default useDebounce;

--- a/packages/bruno-app/src/hooks/useDebounce/index.js
+++ b/packages/bruno-app/src/hooks/useDebounce/index.js
@@ -1,19 +1,12 @@
 import { useState, useEffect } from 'react';
 
 /**
- * Debounces a value on the trailing edge.
- *
- * `value` is compared by identity, so pass a primitive. A value recreated on
- * every render (object, array, inline literal) restarts the timer each render
- * and may never settle.
  *
  * @param {*} value
  * @param {number} delay - Debounce delay in milliseconds.
  * @param {object} [options]
  * @param {(value: *) => boolean} [options.skipDebounce] - Values matching
- *   this predicate are applied immediately instead of being debounced.
- *   This is useful for reset values, such as an empty search query, so a
- *   stale debounced value cannot remain while the input is being cleared.
+ *   this are applied immediately instead of being debounced.
  */
 function useDebounce(value, delay, { skipDebounce } = {}) {
   const [debouncedValue, setDebouncedValue] = useState(value);

--- a/packages/bruno-app/src/hooks/useDebounce/index.spec.js
+++ b/packages/bruno-app/src/hooks/useDebounce/index.spec.js
@@ -1,0 +1,114 @@
+import { renderHook, act } from '@testing-library/react';
+import useDebounce from './index';
+
+const DELAY = 300;
+const isEmpty = (value) => value === '';
+
+const renderDebounce = (initialValue, options) =>
+  renderHook(({ value }) => useDebounce(value, DELAY, options), {
+    initialProps: { value: initialValue }
+  });
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the initial value without waiting for the delay', () => {
+    const { result } = renderDebounce('abc');
+
+    expect(result.current).toBe('abc');
+  });
+
+  it('holds the previous value until the delay elapses', () => {
+    const { result, rerender } = renderDebounce('abc');
+
+    rerender({ value: 'abcd' });
+    expect(result.current).toBe('abc');
+
+    act(() => {
+      jest.advanceTimersByTime(DELAY - 1);
+    });
+    expect(result.current).toBe('abc');
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('abcd');
+  });
+
+  it('restarts the delay on each change so only the last value lands', () => {
+    const { result, rerender } = renderDebounce('a');
+
+    rerender({ value: 'ab' });
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    rerender({ value: 'abc' });
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe('abc');
+  });
+
+  describe('skipDebounce', () => {
+    it('applies a matching value without waiting for the delay', () => {
+      const { result, rerender } = renderDebounce('abc', { skipDebounce: isEmpty });
+
+      act(() => {
+        jest.advanceTimersByTime(DELAY);
+      });
+      expect(result.current).toBe('abc');
+
+      rerender({ value: '' });
+      expect(result.current).toBe('');
+    });
+
+    it('does not resurface the cleared value when a new one is typed inside the delay', () => {
+      const { result, rerender } = renderDebounce('abc', { skipDebounce: isEmpty });
+
+      act(() => {
+        jest.advanceTimersByTime(DELAY);
+      });
+      expect(result.current).toBe('abc');
+
+      rerender({ value: '' });
+      expect(result.current).toBe('');
+
+      // Retyped well inside the delay: the pending clear is cancelled, so without
+      // the immediate path the hook would still be holding 'abc' here.
+      rerender({ value: 'x' });
+      act(() => {
+        jest.advanceTimersByTime(DELAY - 1);
+      });
+      expect(result.current).toBe('');
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+      expect(result.current).toBe('x');
+    });
+
+    it('leaves non-matching values on the trailing edge', () => {
+      const { result, rerender } = renderDebounce('abc', { skipDebounce: isEmpty });
+
+      rerender({ value: 'abcd' });
+      expect(result.current).toBe('abc');
+
+      act(() => {
+        jest.advanceTimersByTime(DELAY);
+      });
+      expect(result.current).toBe('abcd');
+    });
+  });
+});


### PR DESCRIPTION
### Description

Debounces the collection sidebar search so the collection tree is filtered on a 300ms instead of on every keystroke.

### Problem

Each keystroke re-ran `doesCollectionHaveItemsMatchingSearchText` for every collection, which flattens
that collection's entire item tree on every call, then re-filtered each item row beneath it.
On workspaces with large collections this makes typing in the sidebar search visibly laggy.

### Fix

- `Sidebar/Collections/index.js` now derives `useDebounce(searchText, 300)` and passes that to `<Collection />` while `<CollectionSearch />` keeps receiving the immediate value, so the tree walk runs once per pause rather than per character. 
- An empty query bypasses the debounce, so clearing the box restores the full list instantly instead of after the delay.
- `useDebounce` accepts `{ skipDebounce }`; a matching value is returned and committed straight away and
cancels anything in flight, so nothing stale is left queued behind a clear.
- added unit tests for useDebounce

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Collection searches in the sidebar now wait 300 ms after typing before updating results.
  * Clearing the search applies immediately for a faster reset.
  * Search text is trimmed before filtering, providing more consistent results.
* **Bug Fixes**
  * Improved search reliability when entering new text while previous results are still updating.
  * Added coverage for delayed updates, immediate clearing, and rapid search changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->