### PR TITLE
feat: allow duplicate request names

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
+++ b/packages/bruno-app/src/components/Sidebar/NewRequest/index.js
@@ -11,7 +11,7 @@ import { newEphemeralHttpRequest } from 'providers/ReduxStore/slices/collections
 import { newHttpRequest, newGrpcRequest, newWsRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import HttpMethodSelector from 'components/RequestPane/QueryUrl/HttpMethodSelector';
-import { getDefaultRequestPaneTab } from 'utils/collections';
+import { generateUniqueRequestFilename, getDefaultRequestPaneTab } from 'utils/collections';
 import { getRequestFromCurlCommand } from 'utils/curl';
 import { IconArrowBackUp, IconCaretDown, IconEdit } from '@tabler/icons';
 import { sanitizeName, validateName, validateNameError } from 'utils/common/regex';
@@ -149,7 +149,9 @@ const NewRequest = ({ collectionUid, item, isEphemeral, onClose }) => {
     onSubmit: (values) => {
       const isGrpcRequest = values.requestType === 'grpc-request';
       const isWsRequest = values.requestType === 'ws-request';
-      const filename = values.filename;
+      const filename = values.filename === sanitizeName(values.requestName)
+        ? generateUniqueRequestFilename(collection, values.filename, item ? item.uid : null)
+        : values.filename;
 
       if (isGrpcRequest) {
         dispatch(

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1876,16 +1876,18 @@ export const generateUniqueRequestFilename = (collection, filename, itemUid = nu
     return filename;
   }
 
+  const normalizeFilename = (value) => value.trim().replace(/\.(bru|yml|yaml)$/i, '').toLowerCase();
+
   const existingFilenames = new Set(
     (parentItem.items || [])
       .filter((item) => isItemARequest(item))
-      .map((item) => item.filename.trim().replace(/\.(bru|yml|yaml)$/i, ''))
+      .map((item) => normalizeFilename(item.filename))
   );
 
   let candidate = filename;
   let counter = 1;
 
-  while (existingFilenames.has(candidate)) {
+  while (existingFilenames.has(normalizeFilename(candidate))) {
     candidate = `${filename}${counter}`;
     counter += 1;
   }

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1859,6 +1859,41 @@ export const isVariableSecret = (scopeInfo) => {
 };
 
 /**
+ * Generates an available request filename within a collection or folder.
+ *
+ * @param {Object} collection - The collection object
+ * @param {string} filename - The filename without its request extension
+ * @param {string|null} itemUid - The parent folder UID, or null for the collection root
+ * @returns {string} An available filename without its request extension
+ */
+export const generateUniqueRequestFilename = (collection, filename, itemUid = null) => {
+  if (!collection) {
+    return filename;
+  }
+
+  const parentItem = itemUid ? findItemInCollection(collection, itemUid) : collection;
+  if (!parentItem) {
+    return filename;
+  }
+
+  const existingFilenames = new Set(
+    (parentItem.items || [])
+      .filter((item) => isItemARequest(item))
+      .map((item) => item.filename.trim().replace(/\.(bru|yml|yaml)$/i, ''))
+  );
+
+  let candidate = filename;
+  let counter = 1;
+
+  while (existingFilenames.has(candidate)) {
+    candidate = `${filename}${counter}`;
+    counter += 1;
+  }
+
+  return candidate;
+};
+
+/**
  * Generate a unique request name by checking existing filenames in the collection and filesystem
  * @param {Object} collection - The collection object
  * @param {string} baseName - The base name (default: 'Untitled')

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -174,6 +174,20 @@ describe('generateUniqueRequestFilename', () => {
     expect(generateUniqueRequestFilename(collection, 'users')).toBe('users2');
   });
 
+  it('treats filenames as case-insensitive when selecting a suffix', () => {
+    const collectionWithMixedCaseFilename = {
+      items: [
+        {
+          type: 'http-request',
+          filename: 'Users.bru',
+          request: {}
+        }
+      ]
+    };
+
+    expect(generateUniqueRequestFilename(collectionWithMixedCaseFilename, 'users')).toBe('users1');
+  });
+
   it('checks filename collisions only within the selected folder', () => {
     expect(generateUniqueRequestFilename(collection, 'users', 'folder-1')).toBe('users1');
   });

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -1,5 +1,10 @@
 const { describe, it, expect } = require('@jest/globals');
-import { mergeHeaders, transformRequestToSaveToFilesystem, getCollectionItemCounts } from './index';
+import {
+  generateUniqueRequestFilename,
+  getCollectionItemCounts,
+  mergeHeaders,
+  transformRequestToSaveToFilesystem
+} from './index';
 
 describe('mergeHeaders', () => {
   it('should include headers from collection, folder and request (with correct precedence)', () => {
@@ -130,5 +135,46 @@ describe('getCollectionItemCounts', () => {
   it('returns zero counts for empty or missing items', () => {
     expect(getCollectionItemCounts([])).toEqual({ folderCount: 0, requestCount: 0 });
     expect(getCollectionItemCounts(undefined)).toEqual({ folderCount: 0, requestCount: 0 });
+  });
+});
+
+describe('generateUniqueRequestFilename', () => {
+  const collection = {
+    items: [
+      {
+        type: 'http-request',
+        filename: 'users.bru',
+        request: {}
+      },
+      {
+        type: 'graphql-request',
+        filename: 'users1.bru',
+        request: {}
+      },
+      {
+        uid: 'folder-1',
+        type: 'folder',
+        filename: 'nested',
+        items: [
+          {
+            type: 'http-request',
+            filename: 'users.bru',
+            request: {}
+          }
+        ]
+      }
+    ]
+  };
+
+  it('returns the original filename when it is available', () => {
+    expect(generateUniqueRequestFilename(collection, 'orders')).toBe('orders');
+  });
+
+  it('adds the next numeric suffix at the collection root', () => {
+    expect(generateUniqueRequestFilename(collection, 'users')).toBe('users2');
+  });
+
+  it('checks filename collisions only within the selected folder', () => {
+    expect(generateUniqueRequestFilename(collection, 'users', 'folder-1')).toBe('users1');
   });
 });

--- a/tests/collection/create-requests/http-requests.spec.ts
+++ b/tests/collection/create-requests/http-requests.spec.ts
@@ -1,12 +1,16 @@
+import fs from 'fs';
+import path from 'path';
 import { test, expect } from '../../../playwright';
 import { buildCommonLocators } from '../../utils/page/locators';
 import { closeAllCollections } from '../../utils/page';
 
 test.describe('Create HTTP Requests', () => {
   let locators: ReturnType<typeof buildCommonLocators>;
+  let mountedCollectionPath: string;
 
-  test.beforeAll(async ({ pageWithUserData: page }) => {
+  test.beforeAll(async ({ pageWithUserData: page, collectionFixturePath }) => {
     locators = buildCommonLocators(page);
+    mountedCollectionPath = collectionFixturePath!;
   });
 
   test.afterAll(async ({ pageWithUserData: page }) => {
@@ -65,6 +69,43 @@ test.describe('Create HTTP Requests', () => {
       // Open request and verify it is the active request
       await folderRequestItem.click();
       await expect(locators.tabs.activeRequestTab()).toContainText('Folder HTTP Request');
+    });
+  });
+
+  test('Allows HTTP requests to share the same request name', async ({ pageWithUserData: page }) => {
+    await test.step('Create GET /users', async () => {
+      await locators.sidebar.collection('create-requests').hover();
+      await locators.actions.collectionActions('create-requests').click();
+      await locators.dropdown.item('New Request').click();
+
+      await locators.modal.newRequestName().fill('/users');
+      await locators.modal.newRequestUrl().click();
+      await page.keyboard.type('https://echo.usebruno.com/users');
+      await locators.modal.button('Create').click();
+    });
+
+    await test.step('Create POST /users', async () => {
+      await locators.sidebar.collection('create-requests').hover();
+      await locators.actions.collectionActions('create-requests').click();
+      await locators.dropdown.item('New Request').click();
+
+      await locators.modal.newRequestMethodSelector().click();
+      await locators.modal.newRequestMethodOption('post').click();
+      await locators.modal.newRequestName().fill('/users');
+      await locators.modal.newRequestUrl().click();
+      await page.keyboard.type('https://echo.usebruno.com/users');
+      await locators.modal.button('Create').click();
+    });
+
+    await test.step('Verify both requests and their unique files', async () => {
+      await expect(locators.sidebar.request('/users')).toHaveCount(2);
+
+      await expect.poll(() => {
+        return [
+          fs.existsSync(path.join(mountedCollectionPath, 'users.bru')),
+          fs.existsSync(path.join(mountedCollectionPath, 'users1.bru'))
+        ];
+      }).toEqual([true, true]);
     });
   });
 });

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -99,6 +99,9 @@ export const buildCommonLocators = (page: Page) => ({
     card: () => page.locator('.bruno-modal-card'),
     footer: () => page.locator('.bruno-modal-footer'),
     submitButton: () => page.locator('.bruno-modal-footer .submit'),
+    newRequestName: () => page.getByTestId('request-name'),
+    newRequestUrl: () => page.getByTestId('new-request-url').locator('.CodeMirror'),
+    newRequestMethodSelector: () => page.locator('.bruno-modal').getByTestId('method-selector'),
     newRequestMethodOption: (id: string) => page.getByTestId(`method-selector-${id.toLowerCase()}`),
     backdrop: () => page.locator('.bruno-modal-backdrop')
   },


### PR DESCRIPTION
### Description

Allows requests in the same collection or folder to share a display name while keeping their files unique on disk.

### Problem

Creating requests with the same name but different HTTP methods currently produces the same derived filename, so the second request fails with a duplicate filename error.

Fixes #9035.

### Fix

- Generate the next available filename (`users.bru`, `users1.bru`, and so on) when the filename is automatically derived from the request name.
- Preserve manually edited filenames so existing validation behavior remains unchanged.
- Add unit coverage for root-level and folder-level filename collisions.
- Add Playwright coverage that creates `GET /users` and `POST /users` and verifies both request files exist.

### Testing

- `npm test --workspace=packages/bruno-app -- src/utils/collections/index.spec.js --runInBand --forceExit`
- `npx playwright test tests/collection/create-requests/http-requests.spec.ts --project=default --workers=1`
- `npm run lint -- packages/bruno-app/src/components/Sidebar/NewRequest/index.js packages/bruno-app/src/utils/collections/index.js packages/bruno-app/src/utils/collections/index.spec.js tests/collection/create-requests/http-requests.spec.ts tests/utils/page/locators.ts`
- `npm run build:web`

### Screenshots

Not included; the behavior is covered by the added Playwright test.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate request filenames when creating requests with the same name.
  * Automatically adds a numeric suffix to conflicting filenames while preserving custom filenames.
  * Handles filename uniqueness separately within nested folders.
  * Detects filename conflicts regardless of capitalization or surrounding whitespace.

* **Tests**
  * Added coverage for duplicate request creation, case-insensitive matching, folder-specific collisions, and generated filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->