### PR TITLE
feat(app): support for app drafts in migration and save requests modal

### DIFF
--- a/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
+++ b/packages/bruno-app/src/components/MigrateCollectionToYmlModal/index.js
@@ -89,6 +89,13 @@ const collectCollectionDrafts = (collection) => {
     });
   });
 
+  each(filter(items, (item) => item.type === 'app' && hasRequestChanges(item)), (item) => {
+    drafts.push({
+      ...item,
+      collectionUid: collection.uid
+    });
+  });
+
   return drafts;
 };
 
@@ -193,7 +200,7 @@ const MigrateCollectionToYmlModal = () => {
     try {
       const collectionLevelDrafts = collectionDrafts.filter((d) => d.type === 'collection');
       const folderDrafts = collectionDrafts.filter((d) => d.type === 'folder');
-      const requestDrafts = collectionDrafts.filter((d) => isItemARequest(d));
+      const requestDrafts = collectionDrafts.filter((d) => isItemARequest(d) || d.type === 'app');
       const transientRequestDrafts = requestDrafts.filter((d) => d.isTransient);
       const nonTransientRequestDrafts = requestDrafts.filter((d) => !d.isTransient);
       const environmentDrafts = collectionDrafts.filter((d) => d.type === 'collection-environment');
@@ -270,6 +277,8 @@ const MigrateCollectionToYmlModal = () => {
         return `Folder: ${draft.name}`;
       case 'collection-environment':
         return `Environment: ${draft.name}`;
+      case 'app':
+        return `App: ${draft.name || draft.filename}`;
       default:
         return `Request: ${draft.filename || draft.name}`;
     }

--- a/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
+++ b/packages/bruno-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
@@ -30,6 +30,7 @@ const SaveRequestsModal = ({ onClose, forceCloseTabs = false, tabUidsToClose = [
     const collectionDrafts = [];
     const folderDrafts = [];
     const environmentDrafts = [];
+    const appDrafts = [];
     const relevantTabs = forceCloseTabs ? tabs.filter((t) => tabUidsToClose.includes(t.uid)) : tabs;
     const tabsByCollection = groupBy(relevantTabs, (t) => t.collectionUid);
 
@@ -72,6 +73,14 @@ const SaveRequestsModal = ({ onClose, forceCloseTabs = false, tabUidsToClose = [
           });
         });
 
+        const apps = filter(items, (item) => item.type === 'app' && hasRequestChanges(item));
+        each(apps, (draft) => {
+          appDrafts.push({
+            ...draft,
+            collectionUid: collectionUid
+          });
+        });
+
         // Folder drafts
         const folders = filter(items, (item) => item.type === 'folder' && item.draft);
         each(folders, (folder) => {
@@ -99,7 +108,7 @@ const SaveRequestsModal = ({ onClose, forceCloseTabs = false, tabUidsToClose = [
       }
     }
 
-    return [...collectionDrafts, ...folderDrafts, ...environmentDrafts, ...requestDrafts];
+    return [...collectionDrafts, ...folderDrafts, ...environmentDrafts, ...appDrafts, ...requestDrafts];
   }, [collections, tabs, globalEnvironments, globalEnvironmentDraft, forceCloseTabs, tabUidsToClose]);
 
   const totalDraftsCount = allDrafts.length;
@@ -133,7 +142,7 @@ const SaveRequestsModal = ({ onClose, forceCloseTabs = false, tabUidsToClose = [
             dispatch(clearGlobalEnvironmentDraft());
             break;
           default:
-            // Request drafts
+            // Request and app drafts both live on collection items.
             dispatch(deleteRequestDraft({ collectionUid: draft.collectionUid, itemUid: draft.uid }));
             break;
         }
@@ -150,7 +159,7 @@ const SaveRequestsModal = ({ onClose, forceCloseTabs = false, tabUidsToClose = [
       // Separate drafts by type
       const collectionDrafts = allDrafts.filter((d) => d.type === 'collection');
       const folderDrafts = allDrafts.filter((d) => d.type === 'folder');
-      const requestDrafts = allDrafts.filter((d) => isItemARequest(d));
+      const requestDrafts = allDrafts.filter((d) => isItemARequest(d) || d.type === 'app');
       const transientRequestDrafts = requestDrafts.filter((d) => d.isTransient);
       const nonTransientRequestDrafts = requestDrafts.filter((d) => !d.isTransient);
       const collectionEnvironmentDrafts = allDrafts.filter((d) => d.type === 'collection-environment');
@@ -266,6 +275,9 @@ const SaveRequestsModal = ({ onClose, forceCloseTabs = false, tabUidsToClose = [
               break;
             case 'global-environment':
               prefix = 'Global Environment: ';
+              break;
+            case 'app':
+              prefix = 'App: ';
               break;
             default:
               prefix = 'Request: ';


### PR DESCRIPTION
### Description

BRU-4178

When app had any draft and user tried closing the app or migrate bru colleciton to yml with app draft and unsaved changes were lost as it does not show up in the save or discard modal


### Screenshots

<img width="1582" height="1035" alt="Screenshot 2026-08-21 at 11 44 12 AM" src="https://github.com/user-attachments/assets/c1a1434c-951d-46b8-9cbe-7ad2e8085325" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting and saving unsaved app changes alongside request and folder changes.
  - App drafts now appear in migration and close-confirmation dialogs with clear labels.
  - Users can save or discard app changes using the existing draft management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->