### PR TITLE
feat(yml-migration): strip .bru extension from runRequest calls

### DIFF
--- a/packages/bruno-electron/src/ipc/yml-migration.js
+++ b/packages/bruno-electron/src/ipc/yml-migration.js
@@ -27,25 +27,292 @@ const MIGRATION_IGNORED_DIRS = new Set(['node_modules', '.git']);
 // so a cancel takes effect at the next file boundary — never mid-write.
 const migrationCancellations = new Set();
 
-// Rewrites the string literal argument of `bru.runRequest("path.bru")` to drop the
-// trailing `.bru`. The network handler (ipc/network/index.js — `runRequestByItemPathname`)
+// Rewrites `bru.runRequest("path.bru")` in a script fragment so the trailing `.bru`
+// is dropped. The network handler (ipc/network/index.js — `runRequestByItemPathname`)
 // appends the collection's current format extension when the pathname has none, so an
-// extensionless path resolves correctly in both bru and yml collections — a migrated
-// script that still says `"foo.bru"` would otherwise try to load a file that no longer
-// exists. Emitting extensionless paths also keeps the script portable across any future
-// format change without another script rewrite.
+// extensionless path resolves correctly in both bru and yml collections. A migrated
+// script that still names `"foo.bru"` would otherwise try to load a file that no
+// longer exists; emitting extensionless paths also keeps the script portable across
+// any future format change.
 //
-// Matches `bru.runRequest(` (with optional whitespace) followed by a matching quoted
-// path ending in `.bru`. The path content excludes the opening quote and newlines,
-// covering every realistic callsite while keeping the pattern linear-time on script
-// length.
-const RUN_REQUEST_BRU_EXT_REGEX = /(\bbru\.runRequest\s*\(\s*(['"`]))([^'"`\r\n]*?)\.bru\2/g;
+// The rewriter walks the script once through a small state machine so it never
+// rewrites text that isn't a real call:
+//   - line and block comments are copied through untouched
+//   - single/double-quoted string literals are treated as opaque
+//   - template literals are scanned char-by-char, but `${...}` substitutions drop
+//     back into code mode with brace-depth tracking so a call nested inside a
+//     template still gets rewritten
+//   - regex literals are detected by lookback (whether the position expects a value
+//     or an operator) and skipped as opaque, so patterns like `/bru\.runRequest\(/`
+//     never trigger a false match
+// Only calls at code level whose sole argument is one string literal ending in
+// `.bru` are rewritten — commented-out calls, matches embedded in an outer literal,
+// and compound arguments such as `bru.runRequest("a.bru" + suffix)` are emitted
+// verbatim. Linear-time on script length; a cheap `indexOf` fast path skips scripts
+// that don't mention runRequest.
+
+const RUN_REQUEST_CALL_TOKEN = 'bru.runRequest';
+const BRU_EXTENSION = '.bru';
+const IDENT_CHAR_REGEX = /[A-Za-z0-9_$]/;
+const REGEX_FLAG_REGEX = /[dgimsuy]/;
+// Keywords after which a `/` opens a regex literal, not a division. The full JS
+// keyword set is much larger, but only value-expecting ones can precede a regex.
+const VALUE_EXPECTING_KEYWORDS = new Set([
+  'return', 'typeof', 'delete', 'throw', 'in', 'of', 'void', 'new',
+  'instanceof', 'await', 'yield', 'do', 'else', 'case'
+]);
+
+const isWhitespaceChar = (ch) => ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f' || ch === '\v';
+
+// Returns the index just past the closing quote of a JS string starting at `start`.
+// Honours `\` escapes; single/double quoted strings terminate at an unescaped newline
+// so a syntactically broken script cannot swallow the rest of the scanner input.
+// Not used for template literals — those are scanned inline so substitutions can
+// re-enter code mode.
+const findStringLiteralEnd = (code, start, quote) => {
+  const n = code.length;
+  let j = start + 1;
+  while (j < n) {
+    const ch = code[j];
+    if (ch === '\\') {
+      j += 2;
+      continue;
+    }
+    if (ch === quote) return j + 1;
+    if (ch === '\n' || ch === '\r') return j;
+    j++;
+  }
+  return n;
+};
+
+// Attempts to read a JS regex literal starting at `start` (which must be `/`).
+// Returns the end index just past the closing `/` and any flag chars, or -1 when
+// the `/` is not a valid regex (unterminated, contains a raw newline). Character
+// classes `[...]` are respected so `/`s inside them don't close the literal.
+const findRegexLiteralEnd = (code, start) => {
+  const n = code.length;
+  let j = start + 1;
+  let inCharClass = false;
+  while (j < n) {
+    const ch = code[j];
+    if (ch === '\\') {
+      j += 2;
+      continue;
+    }
+    if (ch === '\n' || ch === '\r') return -1;
+    if (inCharClass) {
+      if (ch === ']') inCharClass = false;
+    } else if (ch === '[') {
+      inCharClass = true;
+    } else if (ch === '/') {
+      j++;
+      while (j < n && REGEX_FLAG_REGEX.test(code[j])) j++;
+      return j;
+    }
+    j++;
+  }
+  return -1;
+};
+
+// Decides whether a `/` at position `pos` starts a regex literal (value-expecting
+// context) or a division (operator-expecting context), based on the last significant
+// character emitted and — when that char is an identifier char — the whole preceding
+// word so keywords like `return /re/` are recognised as regex.
+const startsRegexLiteral = (out, prevSignificant) => {
+  if (prevSignificant === '') return true;
+  if (prevSignificant === ')' || prevSignificant === ']') return false;
+  if (prevSignificant === '`' || prevSignificant === '"' || prevSignificant === '\'') return false;
+  if (prevSignificant === '/') return false;
+  if (!IDENT_CHAR_REGEX.test(prevSignificant)) return true;
+  let k = out.length - 1;
+  while (k >= 0 && IDENT_CHAR_REGEX.test(out[k])) k--;
+  return VALUE_EXPECTING_KEYWORDS.has(out.slice(k + 1));
+};
+
+const matchesRunRequestCallStart = (code, i) => {
+  if (i > 0 && IDENT_CHAR_REGEX.test(code[i - 1])) return false;
+  for (let k = 0; k < RUN_REQUEST_CALL_TOKEN.length; k++) {
+    if (code[i + k] !== RUN_REQUEST_CALL_TOKEN[k]) return false;
+  }
+  const after = code[i + RUN_REQUEST_CALL_TOKEN.length];
+  return after === '(' || (after !== undefined && isWhitespaceChar(after));
+};
+
+// Attempts to rewrite a single `bru.runRequest(<string-literal>)` call starting at
+// `start`. Returns `{ text, next }` only when the argument is exactly one quoted
+// literal whose content ends in `.bru`; otherwise returns null and the caller falls
+// through to per-char scanning (which safely skips embedded string content).
+const tryRewriteRunRequestCall = (code, start) => {
+  const n = code.length;
+  let j = start + RUN_REQUEST_CALL_TOKEN.length;
+  while (j < n && isWhitespaceChar(code[j])) j++;
+  if (code[j] !== '(') return null;
+  j++;
+  while (j < n && isWhitespaceChar(code[j])) j++;
+  const quote = code[j];
+  if (quote !== '"' && quote !== '\'' && quote !== '`') return null;
+  // For a runRequest arg we never expect `${...}` substitutions, so plain string
+  // scanning is sufficient — treating backticks as opaque here is intentional.
+  const strEnd = findTemplateOrStringEnd(code, j, quote);
+  if (strEnd > n || code[strEnd - 1] !== quote) return null;
+  let k = strEnd;
+  while (k < n && isWhitespaceChar(code[k])) k++;
+  if (code[k] !== ')') return null;
+  const contentStart = j + 1;
+  const contentEnd = strEnd - 1;
+  const content = code.slice(contentStart, contentEnd);
+  if (!content.endsWith(BRU_EXTENSION)) return null;
+  const stripped = content.slice(0, -BRU_EXTENSION.length);
+  const text = code.slice(start, contentStart) + stripped + code.slice(contentEnd, k + 1);
+  return { text, next: k + 1 };
+};
+
+// Like findStringLiteralEnd but tolerates backticks. Newlines inside a template
+// literal are legal, so only terminate at the matching closing quote.
+const findTemplateOrStringEnd = (code, start, quote) => {
+  if (quote !== '`') return findStringLiteralEnd(code, start, quote);
+  const n = code.length;
+  let j = start + 1;
+  while (j < n) {
+    const ch = code[j];
+    if (ch === '\\') {
+      j += 2;
+      continue;
+    }
+    if (ch === '`') return j + 1;
+    j++;
+  }
+  return n;
+};
 
 const stripBruExtInRunRequest = (code) => {
   if (typeof code !== 'string' || code.length === 0) return code;
-  // Cheap prefix filter: skip the regex engine entirely when the token isn't present.
   if (code.indexOf('runRequest') === -1) return code;
-  return code.replace(RUN_REQUEST_BRU_EXT_REGEX, '$1$3$2');
+
+  const n = code.length;
+  let out = '';
+  let i = 0;
+  // A stack of frames lets `${...}` re-enter code mode while an outer template
+  // waits for its closing backtick. The root frame is code with braceDepth 0;
+  // each template pushes a template frame; each `${` inside a template pushes a
+  // code frame with braceDepth 1 so its matching `}` returns to the template.
+  const frames = [{ kind: 'code', braceDepth: 0 }];
+  let prevSignificant = '';
+
+  while (i < n) {
+    const frame = frames[frames.length - 1];
+
+    if (frame.kind === 'template') {
+      const c = code[i];
+      if (c === '\\') {
+        out += code.slice(i, i + 2);
+        i += 2;
+        continue;
+      }
+      if (c === '`') {
+        out += c;
+        i++;
+        frames.pop();
+        prevSignificant = '`';
+        continue;
+      }
+      if (c === '$' && code[i + 1] === '{') {
+        out += '${';
+        i += 2;
+        frames.push({ kind: 'code', braceDepth: 1 });
+        prevSignificant = '';
+        continue;
+      }
+      out += c;
+      i++;
+      continue;
+    }
+
+    const c = code[i];
+    const next = code[i + 1];
+
+    if (c === '/' && next === '/') {
+      const nl = code.indexOf('\n', i + 2);
+      const end = nl === -1 ? n : nl;
+      out += code.slice(i, end);
+      i = end;
+      continue;
+    }
+
+    if (c === '/' && next === '*') {
+      const close = code.indexOf('*/', i + 2);
+      const end = close === -1 ? n : close + 2;
+      out += code.slice(i, end);
+      i = end;
+      continue;
+    }
+
+    if (c === '/' && startsRegexLiteral(out, prevSignificant)) {
+      const end = findRegexLiteralEnd(code, i);
+      if (end > 0) {
+        out += code.slice(i, end);
+        i = end;
+        prevSignificant = '/';
+        continue;
+      }
+    }
+
+    if (c === '"' || c === '\'') {
+      const end = findStringLiteralEnd(code, i, c);
+      out += code.slice(i, end);
+      i = end;
+      prevSignificant = c;
+      continue;
+    }
+
+    if (c === '`') {
+      out += c;
+      i++;
+      frames.push({ kind: 'template' });
+      continue;
+    }
+
+    if (c === '{') {
+      out += c;
+      i++;
+      if (frame.braceDepth > 0) frame.braceDepth++;
+      prevSignificant = '{';
+      continue;
+    }
+
+    if (c === '}') {
+      if (frame.braceDepth > 0) {
+        frame.braceDepth--;
+        if (frame.braceDepth === 0) {
+          out += c;
+          i++;
+          frames.pop();
+          prevSignificant = '}';
+          continue;
+        }
+      }
+      out += c;
+      i++;
+      prevSignificant = '}';
+      continue;
+    }
+
+    if (c === 'b' && matchesRunRequestCallStart(code, i)) {
+      const rewrite = tryRewriteRunRequestCall(code, i);
+      if (rewrite) {
+        out += rewrite.text;
+        i = rewrite.next;
+        prevSignificant = ')';
+        continue;
+      }
+    }
+
+    out += c;
+    i++;
+    if (!isWhitespaceChar(c)) prevSignificant = c;
+  }
+
+  return out;
 };
 
 const stripBruExtInParsedScripts = (parsed) => {
@@ -400,5 +667,6 @@ module.exports = {
   registerYmlMigrationIpc,
   migrateCollectionOnDisk,
   migrateCollectionToYml,
+  stripBruExtInRunRequest,
   MIGRATION_CANCELLED_MESSAGE
 };

--- a/packages/bruno-electron/src/ipc/yml-migration.js
+++ b/packages/bruno-electron/src/ipc/yml-migration.js
@@ -27,6 +27,37 @@ const MIGRATION_IGNORED_DIRS = new Set(['node_modules', '.git']);
 // so a cancel takes effect at the next file boundary — never mid-write.
 const migrationCancellations = new Set();
 
+// Rewrites the string literal argument of `bru.runRequest("path.bru")` to drop the
+// trailing `.bru`. The network handler (ipc/network/index.js — `runRequestByItemPathname`)
+// appends the collection's current format extension when the pathname has none, so an
+// extensionless path resolves correctly in both bru and yml collections — a migrated
+// script that still says `"foo.bru"` would otherwise try to load a file that no longer
+// exists. Emitting extensionless paths also keeps the script portable across any future
+// format change without another script rewrite.
+//
+// Matches `bru.runRequest(` (with optional whitespace) followed by a matching quoted
+// path ending in `.bru`. The path content excludes the opening quote and newlines,
+// covering every realistic callsite while keeping the pattern linear-time on script
+// length.
+const RUN_REQUEST_BRU_EXT_REGEX = /(\bbru\.runRequest\s*\(\s*(['"`]))([^'"`\r\n]*?)\.bru\2/g;
+
+const stripBruExtInRunRequest = (code) => {
+  if (typeof code !== 'string' || code.length === 0) return code;
+  // Cheap prefix filter: skip the regex engine entirely when the token isn't present.
+  if (code.indexOf('runRequest') === -1) return code;
+  return code.replace(RUN_REQUEST_BRU_EXT_REGEX, '$1$3$2');
+};
+
+const stripBruExtInParsedScripts = (parsed) => {
+  const request = parsed?.request;
+  if (!request) return;
+  if (request.script) {
+    request.script.req = stripBruExtInRunRequest(request.script.req);
+    request.script.res = stripBruExtInRunRequest(request.script.res);
+  }
+  request.tests = stripBruExtInRunRequest(request.tests);
+};
+
 const collectBruFilesForMigration = (root, extraIgnored = []) => {
   const ignoredNames = new Set([...MIGRATION_IGNORED_DIRS, ...extraIgnored]);
   const results = [];
@@ -92,6 +123,7 @@ const migrateCollectionOnDisk = async ({
     let collectionRoot = {};
     if (fs.existsSync(collectionBruPath)) {
       collectionRoot = parseCollection(fs.readFileSync(collectionBruPath, 'utf8'), { format: 'bru' });
+      stripBruExtInParsedScripts(collectionRoot);
     }
 
     const ymlBrunoConfig = { ...brunoConfig };
@@ -151,10 +183,12 @@ const migrateCollectionOnDisk = async ({
           ymlContent = await stringifyEnvironmentViaWorker(envData, { format: 'yml' });
         } else if (basename === 'folder.bru') {
           const folderData = await parseFolderViaWorker(bruContent, { format: 'bru' });
+          stripBruExtInParsedScripts(folderData);
           ymlPath = path.join(dirname, 'folder.yml');
           ymlContent = await stringifyFolderViaWorker(folderData, { format: 'yml' });
         } else {
           const requestData = await parseRequestViaWorker(bruContent, { format: 'bru' });
+          stripBruExtInParsedScripts(requestData);
           ymlPath = bruFilePath.replace(/\.bru$/, '.yml');
           ymlContent = await stringifyRequestViaWorker(requestData, { format: 'yml' });
         }

--- a/packages/bruno-electron/src/ipc/yml-migration.spec.js
+++ b/packages/bruno-electron/src/ipc/yml-migration.spec.js
@@ -39,7 +39,12 @@ jest.mock('@usebruno/filestore', () => {
   };
 });
 
-const { migrateCollectionOnDisk, migrateCollectionToYml, MIGRATION_CANCELLED_MESSAGE } = require('./yml-migration');
+const {
+  migrateCollectionOnDisk,
+  migrateCollectionToYml,
+  stripBruExtInRunRequest,
+  MIGRATION_CANCELLED_MESSAGE
+} = require('./yml-migration');
 const { openCollection } = require('../app/collections');
 const snapshotManager = require('../services/snapshot');
 
@@ -364,7 +369,7 @@ describe('migrateCollectionOnDisk', () => {
 
     const chainYml = fs.readFileSync(filePath('chain.yml'), 'utf8');
     expect(chainYml).toContain('bru.runRequest("newFolder/SecondReq")');
-    expect(chainYml).toContain("bru.runRequest('single/quoted')");
+    expect(chainYml).toContain('bru.runRequest(\'single/quoted\')');
     expect(chainYml).toContain('bru.runRequest(`template/literal`)');
     expect(chainYml).toContain('bru.runRequest("tests/only")');
     // Untouched: extensionless call and a look-alike extension.
@@ -406,6 +411,138 @@ describe('migrateCollectionOnDisk', () => {
     expect(reportError).toHaveBeenCalledWith(expect.stringContaining('could not be restored'));
     // the backup directory with the originals must survive for manual recovery
     expect(fs.readdirSync(backupRootDir)).toHaveLength(1);
+  });
+});
+
+describe('stripBruExtInRunRequest', () => {
+  it('rewrites standalone string-literal arguments in every quote style', () => {
+    const input = [
+      'await bru.runRequest("folder/one.bru");',
+      'await bru.runRequest(\'folder/two.bru\');',
+      'await bru.runRequest(`folder/three.bru`);'
+    ].join('\n');
+    const output = stripBruExtInRunRequest(input);
+    expect(output).toBe([
+      'await bru.runRequest("folder/one");',
+      'await bru.runRequest(\'folder/two\');',
+      'await bru.runRequest(`folder/three`);'
+    ].join('\n'));
+  });
+
+  it('rewrites every eligible call on the same line', () => {
+    const input = 'bru.runRequest("a.bru"); bru.runRequest("b.bru");';
+    expect(stripBruExtInRunRequest(input)).toBe('bru.runRequest("a"); bru.runRequest("b");');
+  });
+
+  it('leaves calls inside line comments untouched', () => {
+    const input = [
+      '// bru.runRequest("commented.bru")',
+      'bru.runRequest("real.bru");'
+    ].join('\n');
+    const output = stripBruExtInRunRequest(input);
+    expect(output).toContain('// bru.runRequest("commented.bru")');
+    expect(output).toContain('bru.runRequest("real")');
+    expect(output).not.toContain('real.bru');
+  });
+
+  it('leaves calls inside block comments untouched', () => {
+    const input = '/* bru.runRequest("block.bru") */ bru.runRequest("real.bru");';
+    const output = stripBruExtInRunRequest(input);
+    expect(output).toContain('/* bru.runRequest("block.bru") */');
+    expect(output).toContain('bru.runRequest("real")');
+  });
+
+  it('leaves lookalike text inside an unrelated outer string literal untouched', () => {
+    const single = 'const s = \'bru.runRequest("outer.bru")\';';
+    const double = 'const s = "bru.runRequest(\'outer.bru\')";';
+    expect(stripBruExtInRunRequest(single)).toBe(single);
+    expect(stripBruExtInRunRequest(double)).toBe(double);
+  });
+
+  it('does not rewrite when the argument is a compound expression', () => {
+    const cases = [
+      'bru.runRequest("first.bru" + suffix)',
+      'bru.runRequest("first.bru", { retries: 1 })',
+      'bru.runRequest(getPath("first.bru"))',
+      'bru.runRequest(`${prefix}` + ".bru")'
+    ];
+    for (const input of cases) {
+      expect(stripBruExtInRunRequest(input)).toBe(input);
+    }
+  });
+
+  it('does not rewrite calls whose argument does not end in .bru', () => {
+    const cases = [
+      'bru.runRequest("no-ext")',
+      'bru.runRequest("looks/like.bruv")',
+      'bru.runRequest("")'
+    ];
+    for (const input of cases) {
+      expect(stripBruExtInRunRequest(input)).toBe(input);
+    }
+  });
+
+  it('ignores identifiers that only end in "bru"', () => {
+    const input = 'notbru.runRequest("foo.bru"); mybru.runRequest("bar.bru");';
+    expect(stripBruExtInRunRequest(input)).toBe(input);
+  });
+
+  it('tolerates whitespace around the call punctuation', () => {
+    const input = 'bru.runRequest\n(\n  "spaced/out.bru"\n)';
+    expect(stripBruExtInRunRequest(input)).toBe('bru.runRequest\n(\n  "spaced/out"\n)');
+  });
+
+  it('is a no-op when the input never references runRequest', () => {
+    const input = 'const x = 1;\nfunction f() { return x + 2; }';
+    expect(stripBruExtInRunRequest(input)).toBe(input);
+  });
+
+  it('returns the input unchanged for empty or non-string values', () => {
+    expect(stripBruExtInRunRequest('')).toBe('');
+    expect(stripBruExtInRunRequest(null)).toBe(null);
+    expect(stripBruExtInRunRequest(undefined)).toBe(undefined);
+  });
+
+  it('rewrites calls nested inside a template literal substitution', () => {
+    const input = 'const msg = `Result: ${await bru.runRequest("nested/one.bru")}`;';
+    expect(stripBruExtInRunRequest(input)).toBe(
+      'const msg = `Result: ${await bru.runRequest("nested/one")}`;'
+    );
+  });
+
+  it('descends into nested template substitutions', () => {
+    const input = 'const s = `${`inner ${bru.runRequest("deep.bru")}`}`;';
+    expect(stripBruExtInRunRequest(input)).toBe(
+      'const s = `${`inner ${bru.runRequest("deep")}`}`;'
+    );
+  });
+
+  it('leaves template literal text (outside substitutions) untouched', () => {
+    const input = 'const s = `text bru.runRequest("outer.bru") text`;';
+    expect(stripBruExtInRunRequest(input)).toBe(input);
+  });
+
+  it('leaves calls that appear inside a regex literal untouched', () => {
+    const cases = [
+      'const re = /bru\\.runRequest\\("foo\\.bru"\\)/;',
+      'if (source.match(/bru\\.runRequest\\("bar.bru"\\)/)) {}',
+      'const re = /[a-z]bru\\.runRequest\\("baz.bru"\\)/g;'
+    ];
+    for (const input of cases) {
+      expect(stripBruExtInRunRequest(input)).toBe(input);
+    }
+  });
+
+  it('rewrites a call that follows an unrelated division', () => {
+    const input = 'const half = total / 2; bru.runRequest("real.bru");';
+    expect(stripBruExtInRunRequest(input)).toBe(
+      'const half = total / 2; bru.runRequest("real");'
+    );
+  });
+
+  it('treats `/` after a value-expecting keyword as a regex, not division', () => {
+    const input = 'function f() { return /bru\\.runRequest\\("kw.bru"\\)/; }';
+    expect(stripBruExtInRunRequest(input)).toBe(input);
   });
 });
 

--- a/packages/bruno-electron/src/ipc/yml-migration.spec.js
+++ b/packages/bruno-electron/src/ipc/yml-migration.spec.js
@@ -76,6 +76,46 @@ const COLLECTION_BRU = `docs {
 }
 `;
 
+const REQUEST_BRU_WITH_RUN_REQUEST = `meta {
+  name: chain
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:3000/chain
+}
+
+script:pre-request {
+  await bru.runRequest("newFolder/SecondReq.bru");
+  await bru.runRequest('single/quoted.bru');
+}
+
+script:post-response {
+  await bru.runRequest(\`template/literal.bru\`);
+  await bru.runRequest("no-ext");
+  await bru.runRequest("keeper.bruv");
+}
+
+tests {
+  await bru.runRequest("tests/only.bru");
+}
+`;
+
+const FOLDER_BRU_WITH_RUN_REQUEST = `meta {
+  name: chained
+}
+
+script:pre-request {
+  await bru.runRequest("folder-scoped/first.bru");
+}
+`;
+
+const COLLECTION_BRU_WITH_RUN_REQUEST = `script:pre-request {
+  await bru.runRequest("collection-scoped/first.bru");
+}
+`;
+
 describe('migrateCollectionOnDisk', () => {
   let collectionDir;
   let backupRootDir;
@@ -313,6 +353,33 @@ describe('migrateCollectionOnDisk', () => {
 
     const ocYml = fs.readFileSync(filePath('opencollection.yml'), 'utf8');
     expect(ocYml).toContain('proxy.example.com');
+  });
+
+  it('strips the .bru extension from bru.runRequest calls across request, folder and collection scripts', async () => {
+    fs.writeFileSync(filePath('collection.bru'), COLLECTION_BRU_WITH_RUN_REQUEST);
+    fs.writeFileSync(filePath('chain.bru'), REQUEST_BRU_WITH_RUN_REQUEST);
+    fs.writeFileSync(filePath('api', 'folder.bru'), FOLDER_BRU_WITH_RUN_REQUEST);
+
+    await runMigration();
+
+    const chainYml = fs.readFileSync(filePath('chain.yml'), 'utf8');
+    expect(chainYml).toContain('bru.runRequest("newFolder/SecondReq")');
+    expect(chainYml).toContain("bru.runRequest('single/quoted')");
+    expect(chainYml).toContain('bru.runRequest(`template/literal`)');
+    expect(chainYml).toContain('bru.runRequest("tests/only")');
+    // Untouched: extensionless call and a look-alike extension.
+    expect(chainYml).toContain('bru.runRequest("no-ext")');
+    expect(chainYml).toContain('bru.runRequest("keeper.bruv")');
+    // No stray literal ".bru" survived any of the rewritten calls.
+    expect(chainYml).not.toMatch(/bru\.runRequest\([^)]*\.bru['"`]\)/);
+
+    const folderYml = fs.readFileSync(filePath('api', 'folder.yml'), 'utf8');
+    expect(folderYml).toContain('bru.runRequest("folder-scoped/first")');
+    expect(folderYml).not.toContain('folder-scoped/first.bru');
+
+    const ocYml = fs.readFileSync(filePath('opencollection.yml'), 'utf8');
+    expect(ocYml).toContain('bru.runRequest("collection-scoped/first")');
+    expect(ocYml).not.toContain('collection-scoped/first.bru');
   });
 
   it('keeps the backup and reports when a source cannot be restored', async () => {


### PR DESCRIPTION
### Description

BRU-4224

Users who migrate a bru collection to yml still have bru.runRequest("newFolder/SecondReq.bru") left unchanged

### Problem

bru.runRequest("newFolder/SecondReq.bru") is not converted to bru.runRequest("newFolder/SecondReq") when the collection is migrated from bru to yml.

### Fix

bru.runRequest("newFolder/SecondReq.bru") is converted to bru.runRequest("newFolder/SecondReq") during migration from bru to yml.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration handling to remove `.bru` extensions from valid `bru.runRequest` script references.
  - Applies consistently to collection, folder, and request scripts.
  - Preserves comments, strings, compound expressions, quote styles, extensionless paths, and similar-looking extensions.
  - Avoids changing invalid, ambiguous, or unrelated script content.

- **Tests**
  - Added coverage for supported script locations, quote styles, and migration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->