### PR TITLE
fix (mock server): adding request log in case of express failure because of response header too

### DIFF
--- a/packages/bruno-app/src/components/MockServer/MockServerDashboard/RequestLog/StyledWrapper.js
+++ b/packages/bruno-app/src/components/MockServer/MockServerDashboard/RequestLog/StyledWrapper.js
@@ -229,6 +229,13 @@ const Wrapper = styled.div`
   .match-trace-actual,
   .match-trace-fallback-note,
   .match-trace-operator,
+  .match-trace-error {
+    margin-top: 8px;
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.colors.text.danger};
+    word-break: break-word;
+  }
+
   .match-trace-empty {
     font-size: ${(props) => props.theme.font.size.xs};
     color: ${(props) => props.theme.colors.text.muted};

--- a/packages/bruno-app/src/components/MockServer/MockServerDashboard/RequestLog/index.js
+++ b/packages/bruno-app/src/components/MockServer/MockServerDashboard/RequestLog/index.js
@@ -85,7 +85,11 @@ const MatchTracePanel = ({ entry }) => {
   if (!trace) {
     return (
       <div className="match-trace-panel" data-testid="mock-server-match-trace">
-        <div className="match-trace-empty">No match trace for this entry.</div>
+        {entry?.error ? (
+          <div className="match-trace-error" data-testid="mock-server-log-error">{entry.error}</div>
+        ) : (
+          <div className="match-trace-empty">No match trace for this entry.</div>
+        )}
       </div>
     );
   }
@@ -106,6 +110,10 @@ const MatchTracePanel = ({ entry }) => {
             )
           : <span className="match-trace-result match-trace-result-fail">{failureLabel || 'No match'}</span>}
       </div>
+
+      {entry.error ? (
+        <div className="match-trace-error" data-testid="mock-server-log-error">{entry.error}</div>
+      ) : null}
 
       {trace.availableRoutes?.length ? (
         <div className="match-trace-section">

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -31,7 +31,7 @@ export const copyExampleToMockResponse = (example, parentRequest) => ({
   },
   response: {
     status: Number(example.response?.status) || 200,
-    statusText: example.response?.statusText || 'OK',
+    statusText: example.response?.statusText || '',
     headers: example.response?.headers || [],
     body: {
       type: example.response?.body?.type || 'json',

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.js
@@ -23,7 +23,7 @@ export const copyExampleToMockResponse = (example, parentRequest) => ({
     requestPathname: parentRequest?.pathname || null
   },
   request: {
-    url: extractMockRoutePath(example.request?.url || parentRequest?.request?.url || '/', { preserveTemplateVars: true }),
+    url: extractMockRoutePath(example.request?.url || parentRequest?.request?.url || '/'),
     method: (example.request?.method || parentRequest?.request?.method || 'GET').toUpperCase(),
     headers: example.request?.headers || [],
     params: example.request?.params || [],
@@ -31,7 +31,7 @@ export const copyExampleToMockResponse = (example, parentRequest) => ({
   },
   response: {
     status: Number(example.response?.status) || 200,
-    statusText: example.response?.statusText || '',
+    statusText: example.response?.statusText || 'OK',
     headers: example.response?.headers || [],
     body: {
       type: example.response?.body?.type || 'json',
@@ -458,7 +458,7 @@ export const countMatchedRouteHits = (entries = []) => {
   const hitCounts = {};
 
   for (const entry of entries) {
-    if (!entry?.matched) {
+    if (!entry?.matched || entry.error) {
       continue;
     }
 

--- a/packages/bruno-app/src/utils/mock-server/mock-responses.sync.spec.js
+++ b/packages/bruno-app/src/utils/mock-server/mock-responses.sync.spec.js
@@ -159,4 +159,12 @@ describe('countMatchedRouteHits', () => {
       'POST /users': 1
     });
   });
+  it('does not count a matched response that failed to send', () => {
+    expect(countMatchedRouteHits([
+      { matched: true, method: 'POST', path: '/orders' },
+      { matched: true, method: 'POST', path: '/orders', error: 'Header name must be a valid HTTP token' }
+    ])).toEqual({
+      'POST /orders': 1
+    });
+  });
 });

--- a/packages/bruno-electron/src/app/mock-server/mock-server.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server.js
@@ -373,9 +373,10 @@ const handleRequest = (mockServerUid, req, res) => {
       delay
     };
 
-    // A saved mock response can hold a header node refuses to write - an invalid
-    // HTTP token in the name, a newline in the value. Log the failure so the
-    // request still shows up in the request log with the status we actually sent.
+    // A saved mock response can hold values node refuses to write - an invalid
+    // HTTP token in a header name, a newline in a value, a status code outside
+    // 100-999. Log the failure so the request log shows the status we actually
+    // sent, not the one the mock response asked for.
     try {
       for (const header of selected.response.headers) {
         if (!header.name || !header.value) continue;
@@ -400,6 +401,12 @@ const handleRequest = (mockServerUid, req, res) => {
         };
         res.setHeader('content-type', contentTypeMap[selected.response.body.type] || 'text/plain');
       }
+
+      if (statusCode === 204) {
+        res.status(204).end();
+      } else {
+        res.status(statusCode).send(selected.response.body.content || '');
+      }
     } catch (err) {
       const message = err.message || 'Mock response failed';
 
@@ -422,12 +429,6 @@ const handleRequest = (mockServerUid, req, res) => {
       statusCode,
       duration: Date.now() - startTime
     });
-
-    if (statusCode === 204) {
-      res.status(204).end();
-    } else {
-      res.status(statusCode).send(selected.response.body.content || '');
-    }
   };
 
   if (delay > 0) {

--- a/packages/bruno-electron/src/app/mock-server/mock-server.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server.js
@@ -373,10 +373,6 @@ const handleRequest = (mockServerUid, req, res) => {
       delay
     };
 
-    // A saved mock response can hold values node refuses to write - an invalid
-    // HTTP token in a header name, a newline in a value, a status code outside
-    // 100-999. Log the failure so the request log shows the status we actually
-    // sent, not the one the mock response asked for.
     try {
       for (const header of selected.response.headers) {
         if (!header.name || !header.value) continue;

--- a/packages/bruno-electron/src/app/mock-server/mock-server.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server.js
@@ -428,9 +428,6 @@ const handleRequest = (mockServerUid, req, res) => {
   };
 
   if (delay > 0) {
-    // A throw inside the timer callback has no express frame to land in, so it
-    // would take down the main process. Keep the net even though header failures
-    // are already handled above.
     setTimeout(() => {
       try {
         sendResponse();

--- a/packages/bruno-electron/src/app/mock-server/mock-server.js
+++ b/packages/bruno-electron/src/app/mock-server/mock-server.js
@@ -277,6 +277,7 @@ const logRequest = (collection, mockServerUid, data) => {
     matchedResponseUid: data.matchedResponseUid || null,
     matchTrace: data.matchTrace || null,
     statusCode: data.statusCode,
+    error: data.error || null,
     delay: data.delay || 0,
     duration: data.duration || 0
   };
@@ -361,32 +362,7 @@ const handleRequest = (mockServerUid, req, res) => {
 
   const sendResponse = () => {
     const statusCode = selected.response.status || 200;
-
-    for (const header of selected.response.headers) {
-      if (!header.name || !header.value) continue;
-
-      const name = header.name.toLowerCase();
-      if (
-        name === 'transfer-encoding'
-        || name === 'content-length'
-        || name === 'content-encoding'
-        || name === 'connection'
-      ) continue;
-
-      res.setHeader(header.name, header.value);
-    }
-
-    if (!res.getHeader('content-type')) {
-      const contentTypeMap = {
-        json: 'application/json',
-        xml: 'application/xml',
-        text: 'text/plain',
-        html: 'text/html'
-      };
-      res.setHeader('content-type', contentTypeMap[selected.response.body.type] || 'text/plain');
-    }
-
-    logRequest(collection, mockServerUid, {
+    const logEntry = {
       method: req.method,
       path: reqPath,
       matched: true,
@@ -394,8 +370,56 @@ const handleRequest = (mockServerUid, req, res) => {
       matchedSourceFile: selected.sourceFile,
       matchedResponseUid: selected.responseUid || null,
       matchTrace,
+      delay
+    };
+
+    // A saved mock response can hold a header node refuses to write - an invalid
+    // HTTP token in the name, a newline in the value. Log the failure so the
+    // request still shows up in the request log with the status we actually sent.
+    try {
+      for (const header of selected.response.headers) {
+        if (!header.name || !header.value) continue;
+
+        const name = header.name.toLowerCase();
+        if (
+          name === 'transfer-encoding'
+          || name === 'content-length'
+          || name === 'content-encoding'
+          || name === 'connection'
+        ) continue;
+
+        res.setHeader(header.name, header.value);
+      }
+
+      if (!res.getHeader('content-type')) {
+        const contentTypeMap = {
+          json: 'application/json',
+          xml: 'application/xml',
+          text: 'text/plain',
+          html: 'text/html'
+        };
+        res.setHeader('content-type', contentTypeMap[selected.response.body.type] || 'text/plain');
+      }
+    } catch (err) {
+      const message = err.message || 'Mock response failed';
+
+      logRequest(collection, mockServerUid, {
+        ...logEntry,
+        statusCode: 500,
+        error: message,
+        duration: Date.now() - startTime
+      });
+
+      if (!res.headersSent) {
+        res.status(500).json({ error: message });
+      }
+
+      return;
+    }
+
+    logRequest(collection, mockServerUid, {
+      ...logEntry,
       statusCode,
-      delay,
       duration: Date.now() - startTime
     });
 
@@ -406,8 +430,10 @@ const handleRequest = (mockServerUid, req, res) => {
     }
   };
 
-  // adding a try-catch block to handle any errors that may occur during the response
   if (delay > 0) {
+    // A throw inside the timer callback has no express frame to land in, so it
+    // would take down the main process. Keep the net even though header failures
+    // are already handled above.
     setTimeout(() => {
       try {
         sendResponse();


### PR DESCRIPTION


### Description

JIRA: 4358 

Failing mock response returns 500 but is never recorded in the Request Log and does not increment route hits. 

### Problem

A mock response header node refuses to write (invalid HTTP token, newline in value) throws in sendResponse before logRequest runs, so the request never reaches the Request Log and the route's Hits stay flat even though the client gets a 500.
 
### Fix

Wrap the header-writing block in try/catch and log the entry there with statusCode: 500 plus the error message,

### Screenshots

Before


https://github.com/user-attachments/assets/a5d0b4cd-630e-4a3a-aa54-7d06b1b5785c

After


https://github.com/user-attachments/assets/694d8231-362f-4340-bfb2-dae625991823



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mock server request logs now display response and matching errors clearly.
  * Failed responses return HTTP 500 details and a JSON error when possible.
  * Route match counts exclude requests that encountered errors.
  * Example mock responses handle route templates correctly and preserve empty status text when unavailable.

* **Improvements**
  * Improved error formatting and readability in request logs.
  * Mock server response processing is more resilient to header and delayed-execution failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->