### PR TITLE
feat(ResponseHeaders): add link rendering for URL header values and implement tests

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/StyledWrapper.js
@@ -36,6 +36,16 @@ const Wrapper = styled.div`
 
       &.value {
         word-break: break-all;
+
+        a {
+          color: ${(props) => props.theme.colors.text.link};
+          text-decoration: none;
+          cursor: pointer;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
       }
     }
 

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import StyledWrapper from './StyledWrapper';
+import { isValidUrl } from 'utils/url';
 import { usePersistedState } from 'hooks/usePersistedState';
 import { useTrackScroll } from 'hooks/useTrackScroll';
 
@@ -8,6 +9,23 @@ const ResponseHeaders = ({ headers, item }) => {
   const wrapperRef = useRef(null);
   const [scroll, setScroll] = usePersistedState({ key: `response-headers-scroll-${item?.uid}`, default: 0 });
   useTrackScroll({ ref: wrapperRef, selector: '.response-tab-content', onChange: setScroll, initialValue: scroll });
+
+  const renderValue = (value) => {
+    if (typeof value === 'string' && isValidUrl(value)) {
+      return (
+        <a
+          href={value}
+          onClick={(e) => {
+            e.preventDefault();
+            window?.ipcRenderer?.openExternal(value);
+          }}
+        >
+          {value}
+        </a>
+      );
+    }
+    return value;
+  };
 
   return (
     <StyledWrapper className="w-full" ref={wrapperRef}>
@@ -25,7 +43,7 @@ const ResponseHeaders = ({ headers, item }) => {
                   return (
                     <tr key={index}>
                       <td className="key">{header[0]}</td>
-                      <td className="value">{header[1]}</td>
+                      <td className="value">{renderValue(header[1])}</td>
                     </tr>
                   );
                 })

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
@@ -11,19 +11,30 @@ const ResponseHeaders = ({ headers, item }) => {
   useTrackScroll({ ref: wrapperRef, selector: '.response-tab-content', onChange: setScroll, initialValue: scroll });
 
   const renderValue = (value) => {
-    if (typeof value === 'string' && isValidUrl(value)) {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+
+    // Only allow http(s) links from response headers.
+    if (/^https?:\/\//i.test(trimmed) && isValidUrl(trimmed)) {
       return (
         <a
-          href={value}
+          href={trimmed}
           onClick={(e) => {
-            e.preventDefault();
-            window?.ipcRenderer?.openExternal(value);
+            const openExternal = window?.ipcRenderer?.openExternal;
+            if (typeof openExternal === 'function') {
+              e.preventDefault();
+              openExternal(trimmed);
+            }
           }}
         >
           {value}
         </a>
       );
     }
+
     return value;
   };
 

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.spec.js
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import ResponseHeaders from './index';
+
+const theme = {
+  font: { size: { sm: '0.8125rem' } },
+  table: {
+    border: '#e0e0e0',
+    striped: '#f5f5f5',
+    thead: { color: '#333' }
+  },
+  colors: { text: { link: '#1663bb' } }
+};
+
+const renderWithTheme = (component) => render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+
+describe('ResponseHeaders', () => {
+  const item = { uid: 'req-1' };
+
+  beforeEach(() => {
+    global.window.ipcRenderer = { openExternal: jest.fn() };
+  });
+
+  it('should render header names and values', () => {
+    const headers = { 'content-type': 'application/json' };
+    renderWithTheme(<ResponseHeaders headers={headers} item={item} />);
+    expect(screen.getByText('content-type')).toBeInTheDocument();
+    expect(screen.getByText('application/json')).toBeInTheDocument();
+  });
+
+  it('should render a URL header value as a link', () => {
+    const headers = { location: 'https://example.com/next' };
+    renderWithTheme(<ResponseHeaders headers={headers} item={item} />);
+    const link = screen.getByRole('link', { name: 'https://example.com/next' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com/next');
+  });
+
+  it('should open the URL externally on click instead of navigating', () => {
+    const headers = { location: 'https://example.com/next' };
+    renderWithTheme(<ResponseHeaders headers={headers} item={item} />);
+    const link = screen.getByRole('link', { name: 'https://example.com/next' });
+    fireEvent.click(link);
+    expect(global.window.ipcRenderer.openExternal).toHaveBeenCalledWith('https://example.com/next');
+  });
+
+  it('should render non-URL header values as plain text', () => {
+    const headers = { 'cache-control': 'max-age=3600' };
+    renderWithTheme(<ResponseHeaders headers={headers} item={item} />);
+    expect(screen.getByText('max-age=3600')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should render nothing in the body when there are no headers', () => {
+    const { container } = renderWithTheme(<ResponseHeaders headers={{}} item={item} />);
+    expect(container.querySelector('tbody').children.length).toBe(0);
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.spec.js
@@ -57,4 +57,32 @@ describe('ResponseHeaders', () => {
     const { container } = renderWithTheme(<ResponseHeaders headers={{}} item={item} />);
     expect(container.querySelector('tbody').children.length).toBe(0);
   });
+
+  it.each([
+    ['javascript', 'javascript:alert(1)'],
+    ['file', 'file:///etc/passwd'],
+    ['ftp', 'ftp://example.com/file.txt'],
+    ['mailto', 'mailto:user@example.com'],
+    ['custom scheme', 'myapp://open/thing']
+  ])('should not render a link for a non-http(s) %s value', (_label, value) => {
+    const headers = { 'x-custom': value };
+    renderWithTheme(<ResponseHeaders headers={headers} item={item} />);
+    expect(screen.getByText(value)).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should not open externally when clicking a rejected-protocol value', () => {
+    const headers = { 'x-custom': 'javascript:alert(1)' };
+    renderWithTheme(<ResponseHeaders headers={headers} item={item} />);
+    expect(global.window.ipcRenderer.openExternal).not.toHaveBeenCalled();
+  });
+
+  it('should link an http(s) value that has surrounding whitespace', () => {
+    const headers = { location: '  https://example.com/next  ' };
+    renderWithTheme(<ResponseHeaders headers={headers} item={item} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://example.com/next');
+    fireEvent.click(link);
+    expect(global.window.ipcRenderer.openExternal).toHaveBeenCalledWith('https://example.com/next');
+  });
 });


### PR DESCRIPTION
### Description

Currently, the Response Headers panel (ResponsePane/ResponseHeaders) displays all header values as plain text. When a header value is a URL (e.g. Location), users cannot click it to open it - they have to manually copy and paste it into a browser.

### Problem

[Render URL values in Response Headers as clickable links](https://github.com/usebruno/bruno/issues/9060)

### Fix

With this pull request, I'm proposing that when a header value is a valid URL, render it as a clickable link. This allows faster navigation from response headers (e.g. following a Location redirect).

### Screenshots

| Before | After |
| --- | --- |
|  <img width="566" height="29" alt="image" src="https://github.com/user-attachments/assets/2beaf930-2961-47be-85de-468a206fd98f" /> | <img width="563" height="33" alt="image" src="https://github.com/user-attachments/assets/9d51d73c-028d-4a68-85bf-61b50fb6c99f" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP(S) links in response header values are now clickable.
  * Links open externally when supported and include clear hover styling.

* **Bug Fixes**
  * Non-string and plain-text header values continue to display correctly.
  * Surrounding whitespace is trimmed when opening URLs.
  * Unsupported protocols are not treated as links.

* **Tests**
  * Added coverage for link rendering, external navigation, plain text, empty headers, and whitespace-trimmed URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->