### PR TITLE
fix(theme): added missing border for light and dark theme

### DIFF
--- a/packages/bruno-app/src/themes/dark/dark.js
+++ b/packages/bruno-app/src/themes/dark/dark.js
@@ -46,6 +46,7 @@ export const palette = {
     OVERLAY0: '#444444'
   },
   border: {
+    BORDER3: '#555555',
     BORDER2: '#444444',
     BORDER1: '#333333',
     BORDER0: '#2a2a2a'
@@ -180,6 +181,7 @@ const darkTheme = {
       lg: '10px',
       xl: '12px'
     },
+    border3: palette.border.BORDER3,
     border2: palette.border.BORDER2,
     border1: palette.border.BORDER1,
     border0: palette.border.BORDER0

--- a/packages/bruno-app/src/themes/light/light.js
+++ b/packages/bruno-app/src/themes/light/light.js
@@ -45,6 +45,7 @@ export const palette = {
     OVERLAY0: '#C0C0C0'
   },
   border: {
+    BORDER3: '#b3b3b3',
     BORDER2: '#cccccc',
     BORDER1: '#e5e5e5',
     BORDER0: '#efefef'
@@ -166,6 +167,7 @@ const lightTheme = {
       lg: '10px',
       xl: '12px'
     },
+    border3: palette.border.BORDER3,
     border2: palette.border.BORDER2,
     border1: palette.border.BORDER1,
     border0: palette.border.BORDER0


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Light and dark theme don't have border 3 which is required

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
Border 3 is required and added in all themes here (https://github.com/usebruno/bruno/pull/8965) expect for light and dark.


### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
Added border 3 color in dark and one light



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
