### PR TITLE
chore(bruno-to-postman): update comments to match current apis in bruno

### DIFF
--- a/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
+++ b/packages/bruno-converters/src/utils/bruno-to-postman-translator.js
@@ -178,8 +178,9 @@ const simpleTranslations = {
  * - req.getTags() - Postman doesn't have tags
  * - req.setMaxRedirects() - Postman doesn't expose redirect settings
  * - req.getTimeout() / req.setTimeout() - Postman doesn't expose timeout settings
- * - req.getExecutionMode() / req.getExecutionPlatform() - Bruno-specific
+ * - req.getExecutionMode() - Bruno-specific
  * - req.onFail() - Postman doesn't support error handlers
+ * - req.disableParsingResponseJson() - Bruno-specific
  *
  * Response APIs:
  * - res.setBody() - Postman response is read-only
@@ -190,7 +191,6 @@ const simpleTranslations = {
  * - bru.getProcessEnv() - Postman doesn't expose process env vars
  * - bru.getOauth2CredentialVar() - Bruno-specific
  * - bru.getCollectionName() - pm.info doesn't expose collection name
- * - bru.disableParsingResponseJson() - Bruno-specific
  * - bru.cwd() - Bruno-specific
  * - bru.getAssertionResults() / bru.getTestResults() - Bruno-specific
  */


### PR DESCRIPTION
### Description

remove comments within converters package that incorrectly communicate the presence of certain apis, that bruno doesn't support currently


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
