### PR TITLE
fix(app): scoped mock server API spec options to the active workspace

### DIFF
--- a/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
@@ -43,18 +43,12 @@ const toSpecOption = (spec, fallbackName = null) => ({
   pathname: spec.pathname
 });
 
-const buildSpecSelectOptions = (workspaceSpecs, apiSpecs, editingInstance = null) => {
+const buildSpecSelectOptions = (workspaceSpecs, editingInstance = null) => {
   const optionsByUid = new Map(
     workspaceSpecs.map((spec) => [spec.uid, toSpecOption(spec)])
   );
 
-  apiSpecs.forEach((spec) => {
-    if (!optionsByUid.has(spec.uid)) {
-      optionsByUid.set(spec.uid, toSpecOption(spec));
-    }
-  });
-
-  const selectedSpecUid = resolveSelectedSpecUid(editingInstance, apiSpecs);
+  const selectedSpecUid = resolveSelectedSpecUid(editingInstance, workspaceSpecs);
   if (!selectedSpecUid && editingInstance?.specPath) {
     optionsByUid.set(editingInstance.specPath, {
       uid: editingInstance.specPath,
@@ -147,8 +141,8 @@ const CreateMockServerModal = ({
   }, [activeWorkspace, apiSpecs]);
 
   const specSelectOptions = useMemo(() => (
-    buildSpecSelectOptions(workspaceApiSpecs, apiSpecs, editingInstance)
-  ), [workspaceApiSpecs, apiSpecs, editingInstance]);
+    buildSpecSelectOptions(workspaceApiSpecs, editingInstance)
+  ), [workspaceApiSpecs, editingInstance]);
 
   const collectionSelectOptions = useMemo(() => (
     buildCollectionSelectOptions(workspaceCollections, collections, editingInstance)
@@ -157,7 +151,7 @@ const CreateMockServerModal = ({
   const defaultCollection = workspaceCollections.find((collection) => collection.uid === defaultCollectionUid)
     || workspaceCollections[0]
     || null;
-  const defaultSpec = specSelectOptions.find((spec) => spec.uid === resolveSelectedSpecUid(editingInstance, apiSpecs))
+  const defaultSpec = specSelectOptions.find((spec) => spec.uid === resolveSelectedSpecUid(editingInstance, workspaceApiSpecs))
     || specSelectOptions[0]
     || null;
 
@@ -169,7 +163,7 @@ const CreateMockServerModal = ({
   const hasSpecOptions = specSelectOptions.length > 0;
   const canLinkSource = hasCollectionOptions || hasSpecOptions;
   const initialSpecUid = editingInstance
-    ? resolveSelectedSpecUid(editingInstance, apiSpecs)
+    ? (resolveSelectedSpecUid(editingInstance, workspaceApiSpecs) || editingInstance.specPath || '')
     : (defaultSpec?.uid || '');
 
   const formik = useFormik({

--- a/tests/mock-server/spec-workspace-isolation.spec.ts
+++ b/tests/mock-server/spec-workspace-isolation.spec.ts
@@ -1,0 +1,151 @@
+import path from 'path';
+import fs from 'fs';
+import { test, expect, closeElectronApp } from '../../playwright';
+import { waitForReadyPage, openWorkspaceFromDialog } from '../utils/page';
+import { buildCommonLocators } from '../utils/page/locators';
+import { buildTitleBarLocators } from '../utils/page/title-bar';
+import { buildMockServerLocators, openCreateMockServerModal, openMockServerSettings } from '../utils/page/mock-server';
+import { buildApiSpecPanelLocators, openApiSpecFromDialog } from '../utils/page/openapi/render-spec';
+
+const EMPTY_WORKSPACE_YML = [
+  'opencollection: 1.0.0',
+  'info:',
+  '  name: EmptyWorkspace',
+  '  type: workspace',
+  'collections:',
+  'specs: []',
+  'docs: \'\'',
+  ''
+].join('\n');
+
+// The Mock Servers sidebar section is behind a beta flag, so it has to be enabled for the
+// create-mock-server button and the mock server rows to exist at all.
+const PREFERENCES = JSON.stringify({
+  preferences: {
+    onboarding: {
+      hasLaunchedBefore: true,
+      hasSeenWelcomeModal: true
+    },
+    beta: {
+      'mock-server': true
+    }
+  }
+}, null, 2);
+
+const SPEC_FIXTURE = path.resolve(__dirname, '..', 'import', 'openapi', 'fixtures', 'openapi-comprehensive.yaml');
+const SPEC_TITLE = 'Comprehensive API Test Collection';
+const SPEC_FILENAME = 'openapi-comprehensive.yaml';
+const STALE_SPEC_SERVER = 'Stale Spec Mock';
+
+const buildStaleSpecMockYml = (specPath: string) => [
+  'info:',
+  `  name: ${STALE_SPEC_SERVER}`,
+  'mock:',
+  '  port: 4599',
+  '  delay: 0',
+  '  source:',
+  '    type: spec',
+  `    path: "${specPath.replace(/\\/g, '\\\\')}"`,
+  'routes: []',
+  ''
+].join('\n');
+
+const seedWorkspace = async (
+  createTmpDir: (tag?: string) => Promise<string>,
+  { staleSpecMock = false } = {}
+) => {
+  const userDataPath = await createTmpDir('mock-server-spec-isolation');
+  fs.writeFileSync(path.join(userDataPath, 'preferences.json'), PREFERENCES);
+
+  const workspacePath = await createTmpDir('empty-workspace');
+  fs.writeFileSync(path.join(workspacePath, 'workspace.yml'), EMPTY_WORKSPACE_YML);
+
+  if (staleSpecMock) {
+    const mocksDir = path.join(workspacePath, 'mocks');
+    fs.mkdirSync(mocksDir, { recursive: true });
+    fs.writeFileSync(path.join(mocksDir, 'stale-spec-mock.yml'), buildStaleSpecMockYml(SPEC_FIXTURE));
+  }
+
+  return { userDataPath, workspacePath };
+};
+
+test.describe('Mock server API spec source is scoped to the active workspace', () => {
+  test('a spec opened in another workspace is never offered in an empty workspace', async ({
+    launchElectronApp,
+    createTmpDir
+  }) => {
+    test.setTimeout(60000);
+
+    const { userDataPath, workspacePath } = await seedWorkspace(createTmpDir);
+    const app = await launchElectronApp({ userDataPath });
+
+    try {
+      const page = await waitForReadyPage(app);
+      const titleBar = buildTitleBarLocators(page);
+      const apiSpecPanel = buildApiSpecPanelLocators(page);
+      const ms = buildMockServerLocators(page);
+
+      await test.step('Open an API spec in the starting workspace', async () => {
+        await openApiSpecFromDialog(page, app, SPEC_FIXTURE);
+        await expect(apiSpecPanel.sidebarItem(SPEC_TITLE)).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('Switch to a workspace that has no collections and no specs', async () => {
+        await openWorkspaceFromDialog(app, page, workspacePath);
+        await expect(titleBar.activeWorkspaceName()).toHaveText('EmptyWorkspace', { timeout: 10000 });
+      });
+
+      await test.step('The API Specs sidebar section is empty here', async () => {
+        await expect(apiSpecPanel.sidebarItem(SPEC_TITLE)).toHaveCount(0);
+      });
+
+      await openCreateMockServerModal(page);
+
+      await test.step('Linking a source is off by default because nothing here can be linked', async () => {
+        await expect(ms.linkSourceCheckbox()).not.toBeChecked();
+      });
+
+      await test.step('The API Spec source stays unavailable', async () => {
+        await ms.linkSourceCheckbox().check();
+        await expect(ms.sourceSpecRadio()).toBeDisabled();
+      });
+    } finally {
+      await closeElectronApp(app);
+    }
+  });
+
+  test('editing a mock server whose spec is not in this workspace does not offer that spec by name', async ({
+    launchElectronApp,
+    createTmpDir
+  }) => {
+    test.setTimeout(60000);
+
+    const { userDataPath, workspacePath } = await seedWorkspace(createTmpDir, { staleSpecMock: true });
+    const app = await launchElectronApp({ userDataPath });
+
+    try {
+      const page = await waitForReadyPage(app);
+      const titleBar = buildTitleBarLocators(page);
+      const ms = buildMockServerLocators(page);
+
+      await test.step('Open the workspace holding a mock server linked to an unregistered spec', async () => {
+        await openWorkspaceFromDialog(app, page, workspacePath);
+        await expect(titleBar.activeWorkspaceName()).toHaveText('EmptyWorkspace', { timeout: 10000 });
+      });
+
+      await openMockServerSettings(page, STALE_SPEC_SERVER);
+
+      await test.step('The stale spec keeps the selection filled instead of blanking the field', async () => {
+        await expect(ms.specSelect()).toBeVisible();
+        await expect(ms.specSelect()).not.toHaveValue('');
+        await expect(ms.specSelectedOption()).toHaveText(SPEC_FILENAME);
+      });
+
+      await test.step('The unregistered spec is never offered under its own name', async () => {
+        await expect(ms.specOption(SPEC_TITLE)).toHaveCount(0);
+      });
+    } finally {
+      await closeElectronApp(app);
+    }
+  });
+});

--- a/tests/utils/page/mock-server.ts
+++ b/tests/utils/page/mock-server.ts
@@ -35,6 +35,15 @@ export const buildMockServerLocators = (page: Page) => ({
   createModal: () => page.locator('.bruno-modal-card'),
   nameInput: () => page.getByTestId('mock-server-name-input'),
   modalSubmit: () => page.getByTestId('modal-submit-btn'),
+  sidebarCreateBtn: () => page.getByTestId('mock-servers-create-btn'),
+  linkSourceCheckbox: () => page.getByTestId('mock-server-link-source-checkbox'),
+  sourceSpecRadio: () => page.getByTestId('mock-server-source-spec'),
+  specSelect: () => page.getByTestId('mock-server-spec-select'),
+  specSelectedOption: () => page.getByTestId('mock-server-spec-select').locator('option:checked'),
+  specOption: (name: string) => page.getByTestId('mock-server-spec-select').locator('option').filter({ hasText: name }),
+  settingsBtn: () => page.getByTestId('mock-server-settings-btn'),
+  sidebarItem: (name: string) => page.locator('.mock-server-item').filter({ hasText: name }),
+  sidebarSection: () => page.locator('.sidebar-section').filter({ hasText: 'Mock Servers' }),
 
   routeSearch: () => page.getByTestId('mock-server-route-search'),
   methodFilter: () => page.getByTestId('mock-server-method-filter'),
@@ -104,6 +113,16 @@ export const stopMockServer = async (page: Page) => {
   });
 };
 
+// Open the create-mock-server modal from the Mock Servers sidebar section. Unlike the
+// collection flow, this needs no collection, so it works in an empty workspace.
+export const openCreateMockServerModal = async (page: Page) => {
+  await test.step('Open the create mock server modal from the sidebar', async () => {
+    const ms = buildMockServerLocators(page);
+    await ms.sidebarCreateBtn().click();
+    await ms.nameInput().waitFor({ state: 'visible', timeout: 10000 });
+  });
+};
+
 // Open the create-mock-server flow from a collection's actions menu and submit a name.
 export const createMockServerFromCollection = async (page: Page, collectionName: string, serverName: string) => {
   await test.step(`Create mock server "${serverName}" for "${collectionName}"`, async () => {
@@ -117,5 +136,21 @@ export const createMockServerFromCollection = async (page: Page, collectionName:
     await ms.nameInput().fill(serverName);
     await ms.modalSubmit().click();
     await ms.dashboard().waitFor({ state: 'visible', timeout: 10000 });
+  });
+};
+
+// Open an existing mock server's Settings modal via its sidebar row and the dashboard.
+export const openMockServerSettings = async (page: Page, serverName: string) => {
+  await test.step(`Open settings for mock server "${serverName}"`, async () => {
+    const ms = buildMockServerLocators(page);
+    const section = ms.sidebarSection();
+    if (!(await section.evaluate((el) => el.classList.contains('expanded')))) {
+      await section.locator('.section-header-left').click();
+    }
+    await section.locator('.section-content').waitFor({ state: 'visible', timeout: 10000 });
+    await ms.sidebarItem(serverName).click();
+    await ms.dashboard().waitFor({ state: 'visible', timeout: 10000 });
+    await ms.settingsBtn().click();
+    await ms.nameInput().waitFor({ state: 'visible', timeout: 10000 });
   });
 };


### PR DESCRIPTION
### Description
**BRU-4366**
The API Spec dropdown listed every spec loaded in the session, from any workspace.

### Problem
An empty workspace still offered other workspaces specs, creating a mock server from them is failing.

### Fix
Options now come only from specs registered in the active workspace; editing still shows its current spec.

### Screenshots

**Before**
<img width="1467" height="694" alt="Screenshot 2026-08-25 at 12 46 06 PM" src="https://github.com/user-attachments/assets/ad0ed7f4-f1cd-4058-a8ee-4834c208d0f8" />

**After**
<img width="648" height="496" alt="Screenshot 2026-08-25 at 12 43 21 PM" src="https://github.com/user-attachments/assets/8ffbc7ef-0817-4d53-bf18-4c2c3297c494" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mock server specification selection now shows only API specifications available in the active workspace.
  * Existing mock servers retain their configured specification path when the matching workspace specification cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->