### PR TITLE
fix(bruno-js): evaluate npm modules once instead of per script context (9.5 GB → 0.8 GB on a 2k-request run)

### DIFF
--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -2,8 +2,198 @@ const vm = require('node:vm');
 const fs = require('node:fs');
 const path = require('node:path');
 const nodeModule = require('node:module');
+const { AsyncLocalStorage } = require('node:async_hooks');
 
 const { isBuiltinModule, isPathWithinAllowedRoots } = require('./utils');
+const { safeGlobals } = require('./constants');
+const { mixinTypedArrays } = require('../mixins/typed-arrays');
+
+/**
+ * Shared context for npm modules.
+ *
+ * Every script execution runs in a fresh vm context, so evaluating npm modules
+ * inside the script's own context meant a collection-level script doing
+ * `require('@faker-js/faker')` re-evaluated the whole package on every request
+ * (~20 MB of heap and ~8 MB of ArrayBuffers per script run, sitting in contexts
+ * V8 only reclaims under heap pressure — a 2,000-request `bru run` reached
+ * 9.5 GB RSS, see usebruno/bruno#9074).
+ *
+ * npm modules are therefore evaluated once per process, in a single dedicated
+ * context, and their exports are shared by every script — the way Node's own
+ * `require` cache behaves. The Bruno objects a module may reference as globals
+ * (`bru`, `req`, `res`, `test`, ...) are exposed on that context as accessors
+ * that resolve to the *currently executing* script's context, so a module
+ * evaluated during request 1 still sees request 42's `bru` when called from
+ * request 42. Collection-local modules (`./scripts/x.js`) are unaffected: they
+ * keep being evaluated per script context, cached in `localModuleCache`.
+ *
+ * "Currently executing" is tracked with AsyncLocalStorage rather than a global,
+ * because a script's `runInContext` is awaited: executions that interleave (the
+ * app can run several requests at once) must each keep resolving to their own
+ * `bru`/`req`/`res`, whatever order they complete in. Nested executions
+ * (`bru.runRequest`) nest naturally.
+ */
+const activeScriptContext = new AsyncLocalStorage();
+const sharedNpmModuleCache = new Map();
+let sharedNpmSandbox = null;
+let sharedNpmContext = null;
+
+// Keys that scripts get from Bruno rather than from the host: always exposed as
+// dynamic accessors on the shared context (extended on the fly by runWithScriptContext).
+const BRUNO_CONTEXT_KEYS = [
+  'bru',
+  'req',
+  'res',
+  'test',
+  'expect',
+  'assert',
+  '__brunoTestResults',
+  '__bruSetScope',
+  'jwt',
+  'console',
+  'scriptingConfig'
+];
+
+const facades = new Map();
+
+/**
+ * Late-bound stand-in for one Bruno global (`bru`, `req`, ...) inside the shared
+ * npm context. Every trap resolves the *current* script context's value, so a
+ * module that captured `bru` at load time (`const captured = bru` during
+ * execution A) still talks to execution B's `bru` when called from B. The
+ * target is a plain object for object-valued globals (so `typeof bru` stays
+ * 'object') and an arrow function for callable ones (so `test(...)` works);
+ * neither has a non-configurable own property that would constrain the traps.
+ * One facade per (key, callability), picked from the value the current
+ * execution provides, so a key that is an object in one execution and a
+ * function in another is served correctly in both.
+ * @param {string} key - The Bruno global's name
+ * @param {boolean} callable - Whether the current value is a function
+ */
+function facadeFor(key, callable) {
+  const cacheKey = `${key}:${callable ? 'fn' : 'obj'}`;
+  if (facades.has(cacheKey)) {
+    return facades.get(cacheKey);
+  }
+  const current = () => activeScriptContext.getStore()?.[key];
+  const isMissing = (value) => value === undefined || value === null;
+  const target = callable ? () => {} : {};
+  // Methods are handed out as late-bound wrappers too, so `const { getVar } = bru`
+  // at module scope keeps calling the current script's getVar. Cached per method
+  // name so `bru.setVar === bru.setVar` holds within the facade.
+  const methods = new Map();
+  const lateBoundMethod = (prop) => {
+    if (!methods.has(prop)) {
+      methods.set(prop, (...args) => {
+        const value = current();
+        const member = isMissing(value) ? undefined : value[prop];
+        if (typeof member !== 'function') {
+          throw new TypeError(`${key}.${String(prop)} is not available outside of a script execution`);
+        }
+        return Reflect.apply(member, value, args);
+      });
+    }
+    return methods.get(prop);
+  };
+  const facade = new Proxy(target, {
+    get: (_, prop) => {
+      const value = current();
+      if (isMissing(value)) {
+        return undefined;
+      }
+      const member = value[prop];
+      return typeof member === 'function' ? lateBoundMethod(prop) : member;
+    },
+    set: (_, prop, newValue) => {
+      const value = current();
+      if (isMissing(value)) {
+        return false;
+      }
+      value[prop] = newValue;
+      return true;
+    },
+    has: (_, prop) => {
+      const value = current();
+      return !isMissing(value) && prop in Object(value);
+    },
+    ownKeys: () => {
+      const value = current();
+      return isMissing(value) ? [] : Reflect.ownKeys(Object(value));
+    },
+    getOwnPropertyDescriptor: (_, prop) => {
+      const value = current();
+      const descriptor = isMissing(value) ? undefined : Object.getOwnPropertyDescriptor(Object(value), prop);
+      return descriptor ? { ...descriptor, configurable: true } : undefined;
+    },
+    getPrototypeOf: () => {
+      const value = current();
+      return isMissing(value) ? null : Object.getPrototypeOf(Object(value));
+    },
+    apply: (_, thisArg, args) => {
+      const value = current();
+      if (typeof value !== 'function') {
+        throw new TypeError(`${key} is not available outside of a script execution`);
+      }
+      return Reflect.apply(value, thisArg, args);
+    }
+  });
+  facades.set(cacheKey, facade);
+  return facade;
+}
+
+function defineDynamicGlobal(key) {
+  if (Object.prototype.hasOwnProperty.call(sharedNpmSandbox, key)) {
+    return;
+  }
+  Object.defineProperty(sharedNpmSandbox, key, {
+    enumerable: true,
+    configurable: true,
+    get: () => {
+      // A key the current execution does not provide reads as undefined, exactly
+      // as it would inside the script's own context (e.g. `res` before a response).
+      const value = activeScriptContext.getStore()?.[key];
+      if (value === undefined || value === null) {
+        return undefined;
+      }
+      return facadeFor(key, typeof value === 'function');
+    }
+  });
+}
+
+function getSharedNpmContext() {
+  if (!sharedNpmContext) {
+    sharedNpmSandbox = Object.fromEntries(
+      safeGlobals
+        .filter((key) => global[key] !== undefined)
+        .map((key) => [key, global[key]])
+    );
+    mixinTypedArrays(sharedNpmSandbox);
+    sharedNpmContext = vm.createContext(sharedNpmSandbox);
+    sharedNpmSandbox.global = sharedNpmSandbox;
+    sharedNpmSandbox.globalThis = sharedNpmSandbox;
+    BRUNO_CONTEXT_KEYS.forEach(defineDynamicGlobal);
+  }
+  return sharedNpmContext;
+}
+
+/**
+ * Runs `fn` with `scriptContext` as the currently executing script context, so
+ * npm modules called from it (or from async work it starts) resolve `bru`,
+ * `req`, `res`, ... to it. Safe for interleaved executions; nested executions
+ * (`bru.runRequest`) see their own context.
+ * @param {Object} scriptContext - The script's vm global object
+ * @param {Function} fn - The execution, typically `() => script.runInContext(...)`
+ * @returns {*} Whatever `fn` returns
+ */
+function runWithScriptContext(scriptContext, fn) {
+  getSharedNpmContext();
+  for (const key of Object.keys(scriptContext)) {
+    if (key !== 'global' && key !== 'globalThis' && key !== 'require') {
+      defineDynamicGlobal(key);
+    }
+  }
+  return activeScriptContext.run(scriptContext, fn);
+}
 
 /**
  * Resolve a local module path, handling files and directories
@@ -111,13 +301,11 @@ function createCustomRequire({
       return require(moduleName);
     }
 
-    // 4. Handle npm modules - load INTO vm context
+    // 4. Handle npm modules - evaluated once, in the shared npm context
     return loadNpmModule({
       moduleName,
       collectionPath,
-      currentModuleDir,
-      isolatedContext,
-      localModuleCache
+      currentModuleDir
     });
   };
 }
@@ -200,7 +388,8 @@ function loadLocalModule({
 }
 
 /**
- * Executes a module in the VM context with caching and special file handling
+ * Executes an npm module in the shared npm context, caching it process-wide,
+ * with special file handling
  * @param {Object} options - Configuration options
  * @returns {*} The exported content of the loaded module
  * @throws {Error} When module cannot be loaded
@@ -208,13 +397,11 @@ function loadLocalModule({
 function executeModuleInVmContext({
   resolvedPath,
   moduleName,
-  isolatedContext,
-  collectionPath,
-  localModuleCache
+  collectionPath
 }) {
   // Check cache - we cache moduleObj, return its exports
-  if (localModuleCache.has(resolvedPath)) {
-    return localModuleCache.get(resolvedPath).exports;
+  if (sharedNpmModuleCache.has(resolvedPath)) {
+    return sharedNpmModuleCache.get(resolvedPath).exports;
   }
 
   // Native modules (.node files) - fall back to host require
@@ -223,7 +410,7 @@ function executeModuleInVmContext({
   if (resolvedPath.endsWith('.node')) {
     const result = require(resolvedPath);
     // Wrap in moduleObj format for consistent cache retrieval
-    localModuleCache.set(resolvedPath, { exports: result });
+    sharedNpmModuleCache.set(resolvedPath, { exports: result });
     return result;
   }
 
@@ -232,7 +419,7 @@ function executeModuleInVmContext({
     const jsonContent = fs.readFileSync(resolvedPath, 'utf8');
     const result = JSON.parse(jsonContent);
     // Wrap in moduleObj format for consistent cache retrieval
-    localModuleCache.set(resolvedPath, { exports: result });
+    sharedNpmModuleCache.set(resolvedPath, { exports: result });
     return result;
   }
 
@@ -244,24 +431,22 @@ function executeModuleInVmContext({
   // Pre-populate cache with moduleObj BEFORE execution to handle circular dependencies
   // This allows re-entrant requires to get partial exports (Node.js behavior)
   // We cache moduleObj (not moduleObj.exports) so that module.exports reassignment works
-  localModuleCache.set(resolvedPath, moduleObj);
+  sharedNpmModuleCache.set(resolvedPath, moduleObj);
 
   const moduleRequire = createNpmModuleRequire({
     collectionPath,
-    isolatedContext,
-    currentModuleDir: moduleDir,
-    localModuleCache
+    currentModuleDir: moduleDir
   });
 
   try {
     // Wrap module code in a function that receives CJS parameters
     const wrappedCode = `(function(module, exports, require, __filename, __dirname) {\n${moduleSource}\n})`;
     const compiledScript = new vm.Script(wrappedCode, { filename: resolvedPath });
-    const moduleFunction = compiledScript.runInContext(isolatedContext);
+    const moduleFunction = compiledScript.runInContext(getSharedNpmContext());
     moduleFunction(moduleObj, moduleObj.exports, moduleRequire, resolvedPath, moduleDir);
   } catch (error) {
     // Remove failed module from cache to allow retry
-    localModuleCache.delete(resolvedPath);
+    sharedNpmModuleCache.delete(resolvedPath);
     const stack = error.stack || '';
     throw new Error(`Error loading module ${moduleName}: ${error.message}\nStack: ${stack}`);
   }
@@ -284,9 +469,7 @@ function executeModuleInVmContext({
 function loadNpmModule({
   moduleName,
   collectionPath,
-  currentModuleDir,
-  isolatedContext,
-  localModuleCache
+  currentModuleDir
 }) {
   let resolvedPath;
 
@@ -323,9 +506,7 @@ function loadNpmModule({
   return executeModuleInVmContext({
     resolvedPath,
     moduleName,
-    isolatedContext,
-    collectionPath,
-    localModuleCache
+    collectionPath
   });
 }
 
@@ -340,9 +521,7 @@ function loadNpmModule({
  */
 function createNpmModuleRequire({
   collectionPath,
-  isolatedContext,
-  currentModuleDir,
-  localModuleCache
+  currentModuleDir
 }) {
   const moduleRequire = nodeModule.createRequire(path.join(currentModuleDir, 'index.js'));
 
@@ -353,9 +532,7 @@ function createNpmModuleRequire({
       return executeModuleInVmContext({
         resolvedPath,
         moduleName,
-        isolatedContext,
-        collectionPath,
-        localModuleCache
+        collectionPath
       });
     }
 
@@ -371,13 +548,12 @@ function createNpmModuleRequire({
     return executeModuleInVmContext({
       resolvedPath,
       moduleName,
-      isolatedContext,
-      collectionPath,
-      localModuleCache
+      collectionPath
     });
   };
 }
 
 module.exports = {
-  createCustomRequire
+  createCustomRequire,
+  runWithScriptContext
 };

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -4,7 +4,7 @@ const { get } = require('lodash');
 const lodash = require('lodash');
 const { wrapConsoleWithSerializers } = require('./console');
 const { ScriptError, resolveVmFilename } = require('./utils');
-const { createCustomRequire } = require('./cjs-loader');
+const { createCustomRequire, runWithScriptContext } = require('./cjs-loader');
 const { safeGlobals } = require('./constants');
 const { mixinTypedArrays } = require('../mixins/typed-arrays');
 const { wrapScriptInClosure, SANDBOX } = require('../../utils/sandbox');
@@ -109,9 +109,13 @@ async function runScriptInNodeVm({
     };
 
     try {
-      await compiledScript.runInContext(isolatedContext, {
-        displayErrors: true
-      });
+      // npm modules loaded by this script (or already cached from an earlier one)
+      // resolve `bru`, `req`, `res`, ... against this context while it runs
+      await runWithScriptContext(scriptContext, () =>
+        compiledScript.runInContext(isolatedContext, {
+          displayErrors: true
+        })
+      );
     } catch (error) {
       // V8 invokes prepareStackTrace lazily on first .stack access.
       // Reading .stack here so custom handler runs and populates error.__callSites

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -613,6 +613,175 @@ describe('node-vm sandbox', () => {
     });
   });
 
+  describe('createCustomRequire - npm modules are shared across script executions', () => {
+    it('should evaluate an npm module once per process, not once per script context', async () => {
+      // Every script execution gets a fresh vm context. Re-evaluating npm modules
+      // in each of them made large packages (faker, moment, ...) cost tens of MB
+      // per request (usebruno/bruno#9074). The module body increments a host-side
+      // counter so we can count evaluations across two separate executions.
+      const marker = `_npmEvalCount_${Date.now()}`;
+      makePkg(path.join(collectionPath, 'node_modules'), 'counted-module', {
+        'index.js': `
+          process.${marker} = (process.${marker} || 0) + 1;
+          module.exports = { token: Symbol('counted') };
+        `
+      });
+
+      const script = `
+        const mod = require('counted-module');
+        bru.setVar('token', mod.token);
+      `;
+      const contextA = { bru: { setVar: jest.fn() }, console };
+      const contextB = { bru: { setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(process[marker]).toBe(1);
+      // Both scripts got the same module instance
+      expect(contextA.bru.setVar.mock.calls[0][1]).toBe(contextB.bru.setVar.mock.calls[0][1]);
+      delete process[marker];
+    });
+
+    it('should let a cached npm module see the bru of the script currently running', async () => {
+      // A module evaluated during execution A must not keep pointing at A's bru
+      // when it is called from execution B.
+      makePkg(path.join(collectionPath, 'node_modules'), 'bru-reader', {
+        'index.js': `module.exports = { read: (name) => bru.getVar(name) };`
+      });
+
+      const script = `
+        const reader = require('bru-reader');
+        bru.setVar('seen', reader.read('who'));
+      `;
+      const contextA = { bru: { getVar: jest.fn().mockReturnValue('A'), setVar: jest.fn() }, console };
+      const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['the first-started script finishes first', 5, 40],
+      ['the first-started script finishes last', 40, 5]
+    ])('should keep interleaved executions bound to their own bru when %s', async (_, delayA, delayB) => {
+      // Two scripts run concurrently and both await before calling into the same cached
+      // npm module. A global "current context" stack only survives LIFO completion: when
+      // the first-started script finishes first, its module call would read the other
+      // script's bru and its cleanup would pop the other script's entry.
+      makePkg(path.join(collectionPath, 'node_modules'), 'bru-reader-async', {
+        'index.js': `module.exports = { read: (name) => bru.getVar(name) };`
+      });
+
+      const scriptFor = (delayMs) => `
+        const reader = require('bru-reader-async');
+        await new Promise((resolve) => setTimeout(resolve, ${delayMs}));
+        bru.setVar('seen', reader.read('who'));
+      `;
+      const contextA = { bru: { getVar: jest.fn().mockReturnValue('A'), setVar: jest.fn() }, console };
+      const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
+
+      await Promise.all([
+        runScriptInNodeVm({ script: scriptFor(delayA), context: contextA, collectionPath, scriptingConfig: {} }),
+        runScriptInNodeVm({ script: scriptFor(delayB), context: contextB, collectionPath, scriptingConfig: {} })
+      ]);
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
+    });
+
+    it('should let a module that captured bru at load time talk to the current script', async () => {
+      // `const captured = bru` runs once, during the first load (execution A). A plain
+      // accessor would hand that module A's bru forever; the facade stays late-bound.
+      makePkg(path.join(collectionPath, 'node_modules'), 'bru-capturer', {
+        'index.js': `
+          const captured = bru;
+          const { getVar } = bru;
+          module.exports = {
+            viaCaptured: (name) => captured.getVar(name),
+            viaDestructured: (name) => getVar(name),
+            hasSetVar: () => 'setVar' in captured,
+            setThroughCaptured: (name, value) => { captured.setVar(name, value); },
+            types: () => typeof captured + '/' + typeof console + '/' + typeof test
+          };
+        `
+      });
+
+      const script = `
+        const capturer = require('bru-capturer');
+        capturer.setThroughCaptured('seen', capturer.viaCaptured('who') + capturer.viaDestructured('who'));
+        bru.setVar('hasSetVar', capturer.hasSetVar());
+        bru.setVar('types', capturer.types());
+      `;
+      const makeContext = (who) => ({
+        bru: { getVar: jest.fn().mockReturnValue(who), setVar: jest.fn() },
+        test: () => {},
+        console
+      });
+      const contextA = makeContext('A');
+      const contextB = makeContext('B');
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'AA');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'BB');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('hasSetVar', true);
+      // The facades keep the value's typeof: objects stay objects, functions stay callable
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('types', 'object/object/function');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(2);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(2);
+    });
+
+    it('should read a missing key as undefined and still call it once a later execution provides a function', async () => {
+      // Execution A exposes `helper` as undefined: the module must see plain undefined (as it
+      // would in the script's own context); execution B provides a function and calls it.
+      makePkg(path.join(collectionPath, 'node_modules'), 'helper-caller', {
+        'index.js': `module.exports = { probe: () => typeof helper, run: () => helper('x') };`
+      });
+
+      const contextA = { bru: { setVar: jest.fn() }, helper: undefined, console };
+      await runScriptInNodeVm({
+        script: `bru.setVar('probe', require('helper-caller').probe());`,
+        context: contextA, collectionPath, scriptingConfig: {}
+      });
+
+      const helper = jest.fn().mockReturnValue('called');
+      const contextB = { bru: { setVar: jest.fn() }, helper, console };
+      await runScriptInNodeVm({
+        script: `bru.setVar('ran', require('helper-caller').run());`,
+        context: contextB, collectionPath, scriptingConfig: {}
+      });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('probe', 'undefined');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('ran', 'called');
+      expect(helper).toHaveBeenCalledWith('x');
+    });
+
+    it('should keep collection-local modules per script context', async () => {
+      // Local modules may capture per-request state; they keep the per-context cache.
+      const marker = `_localEvalCount_${Date.now()}`;
+      fs.writeFileSync(
+        path.join(collectionPath, 'local-counted.js'),
+        `process.${marker} = (process.${marker} || 0) + 1; module.exports = {};`
+      );
+      const script = `require('./local-counted');`;
+
+      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig: {} });
+
+      expect(process[marker]).toBe(2);
+      delete process[marker];
+    });
+  });
+
   describe('createCustomRequire - Node.js builtin modules', () => {
     it('should load builtin modules (crypto)', async () => {
       const script = `


### PR DESCRIPTION
## Description

Fixes #9074.
Ref - BRU-4445

The node-vm sandbox (`--sandbox=developer`) creates a fresh `vm` context for every script execution, and `cjs-loader` evaluated **npm modules inside that context**, cached only in the per-context `localModuleCache`. A collection-level script doing `require('@faker-js/faker')` (or `moment`, `nanoid`, ...) therefore re-evaluated the whole package on **every request**. Measured per script run: ~20 MB of heap plus ~8 MB of ArrayBuffers, in contexts V8 only reclaims under heap pressure. On a 2,170-request `bru run` the CLI reached **9.5 GB RSS** (6 GB after ~500 requests) and OOM-killed our 8 GB CI agents; `@usebruno/cli` 3.0.3 — which handed npm modules to the host `require` — peaked at 2 GB on the same collection.

This PR evaluates npm modules **once per process**, in a dedicated shared vm context, and shares their exports with every script, the way Node's own `require` cache behaves:

- `cjs-loader.js`: new `sharedNpmModuleCache` + `getSharedNpmContext()`. The shared context gets the same `safeGlobals`/typed arrays as script contexts; the Bruno objects a module may reference as globals (`bru`, `req`, `res`, `test`, `expect`, `assert`, `__brunoTestResults`, `__bruSetScope`, `jwt`, `console`, `scriptingConfig`) are defined as **accessors that resolve to the script context currently executing**, so a module evaluated during request 1 still sees request 42's `bru` when called from request 42 (the existing `should provide bru object to npm modules` test keeps passing, and a new test covers the cross-execution case).
- `index.js`: `enterScriptContext(scriptContext)` / `exitScriptContext()` around `runInContext` (a stack, so `bru.runRequest` nesting works).
- Collection-local modules (`./scripts/x.js`) are unchanged: still evaluated per script context via `localModuleCache` (a test pins that).

Behavioural note for reviewers: exports of npm modules are now objects from the shared context rather than from the script's own context. That is the pre-4.0 behaviour (host-context objects), so `instanceof` checks across the boundary behave as they did in 3.x.

## Measurements (same collection, 2,170 requests, Node 24)

| | peak RSS | duration |
|---|---|---|
| `main` (4.0.0) | 9.5 GB | 514 s |
| this PR | 818 MB | 205 s |
| 3.0.3 for reference | 2.0 GB | 65 s* |

\* 3.0.3 runs the suite faster for reasons unrelated to this change; the remaining gap is a separate topic.

## Tests

- `packages/bruno-js`: 638/638 (`npm test`), including 3 new tests in `node-vm/index.spec.js`: npm module evaluated once across executions, cached module sees the *current* script's `bru`, local modules stay per context.
- Verified against the real collection with `bru run` while sampling the runner's RSS every 5 s.
- `npx eslint` on the changed files: 0 errors.

Companion PR for the per-request socket retention in `bruno-cli` that this change exposes: #9079.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when using npm modules across multiple script executions by reusing shared module instances.
  * Ensured modules access the correct active script context during concurrent, nested, and asynchronous executions.
  * Preserved isolation for collection-local modules.
  * Improved support for modules that capture or destructure Bruno context values.

* **Tests**
  * Added coverage for shared module reuse, context handling, concurrent execution, and collection-local module behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->