### PR TITLE
fix(bruno-cli): close throwaway keep-alive agents after each request (one leaked socket per request)

### DIFF
--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -402,6 +402,21 @@ const runSingleRequest = async function (
     // when every leg reuses one socket.
     const httpsAgentRequestFields = request.ntlmConfig ? { keepAlive: true } : {};
 
+    // Without `--cache-ssl-session` every request gets its own keep-alive agent. When the
+    // response completes that agent parks its socket in its free pool, and since the agent
+    // is never used again nothing closes the socket: one open fd per request for the rest
+    // of the run (a 2,000-request run held 2,000 sockets). Tear the agents down as soon as
+    // the response is in. Cached agents are shared across requests and must stay alive.
+    const destroyThrowawayAgents = (...configs) => {
+      if (!disableCache) {
+        return;
+      }
+      for (const config of configs) {
+        config?.httpAgent?.destroy?.();
+        config?.httpsAgent?.destroy?.();
+      }
+    };
+
     if (insecure) {
       httpsAgentRequestFields['rejectUnauthorized'] = false;
     } else {
@@ -645,7 +660,12 @@ const runSingleRequest = async function (
             httpsAgent: oauth2HttpsAgent
           });
 
-          token = await getOAuth2Token(request.oauth2, oauth2AxiosInstance);
+          try {
+            token = await getOAuth2Token(request.oauth2, oauth2AxiosInstance);
+          } finally {
+            // The token request's agents are throwaway too (unless cached): close their sockets
+            destroyThrowawayAgents({ httpAgent: oauth2HttpAgent, httpsAgent: oauth2HttpsAgent });
+          }
         }
 
         if (token) {
@@ -738,6 +758,7 @@ const runSingleRequest = async function (
 
       /** @type {import('axios').AxiosResponse} */
       response = await axiosInstance(refreshExplicitHeaderNames(request));
+      destroyThrowawayAgents(request, response?.config);
 
       const { data, dataBuffer } = parseDataFromResponse(response, request.__brunoDisableParsingResponseJson);
       response.data = data;
@@ -752,6 +773,7 @@ const runSingleRequest = async function (
         saveCookies(request.url, response.headers);
       }
     } catch (err) {
+      destroyThrowawayAgents(request, err?.config, err?.response?.config);
       if (err?.response) {
         const { data, dataBuffer } = parseDataFromResponse(err?.response);
         err.response.data = data;

--- a/packages/bruno-cli/src/utils/axios-instance.js
+++ b/packages/bruno-cli/src/utils/axios-instance.js
@@ -214,6 +214,13 @@ function makeAxiosInstance({
             explicitHeaderNames: requestConfig.__explicitHeaderNames
           });
 
+          // The hop that just answered is done with its throwaway agents; close their
+          // sockets before fresh agents are created for the redirect target.
+          if (disableCache) {
+            error.config?.httpAgent?.destroy?.();
+            error.config?.httpsAgent?.destroy?.();
+          }
+
           await setupProxyAgents({
             requestConfig,
             proxyMode,

--- a/packages/bruno-cli/tests/integration/run-agent-teardown.spec.js
+++ b/packages/bruno-cli/tests/integration/run-agent-teardown.spec.js
@@ -1,0 +1,97 @@
+const { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const { runCli } = require('./helpers/run-cli');
+
+const writeFixtureFile = (filePath, content) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+};
+
+/**
+ * Without `--cache-ssl-session` every request gets its own keep-alive agent. Once the
+ * response is in, that agent parks its socket in its free pool and is never used again,
+ * so nothing closes the socket: a run used to hold one open connection per executed
+ * request until the process exited (2,000 requests -> 2,000 fds). The runner now tears
+ * throwaway agents down as soon as the response completes, so the server never sees
+ * more than the connection of the request in flight.
+ */
+describe('CLI run — throwaway agents are torn down after each request', () => {
+  const REQUEST_COUNT = 6;
+  let server;
+  let openSockets;
+  let openAtRequest;
+  let port;
+  let tmpDir;
+
+  beforeAll(async () => {
+    openSockets = new Set();
+    openAtRequest = [];
+    server = http.createServer((req, res) => {
+      openAtRequest.push(openSockets.size);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    server.on('connection', (socket) => {
+      openSockets.add(socket);
+      socket.on('close', () => openSockets.delete(socket));
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = server.address().port;
+  });
+
+  afterAll(async () => {
+    for (const socket of openSockets) {
+      socket.destroy();
+    }
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-cli-agent-teardown-'));
+    openAtRequest.length = 0;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const stageCollection = () => {
+    writeFixtureFile(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'agent-teardown', type: 'collection' }, null, 2) + '\n'
+    );
+    writeFixtureFile(path.join(tmpDir, 'collection.bru'), 'meta {\n  name: agent-teardown\n  seq: 1\n}\n');
+    for (let i = 1; i <= REQUEST_COUNT; i++) {
+      writeFixtureFile(
+        path.join(tmpDir, `req-${i}.bru`),
+        `meta {
+  name: req-${i}
+  type: http
+  seq: ${i}
+}
+
+get {
+  url: http://127.0.0.1:${port}/ping/${i}
+  body: none
+  auth: none
+}
+`
+      );
+    }
+  };
+
+  it('closes each request\'s connection before the next request is sent', async () => {
+    stageCollection();
+
+    const { code } = await runCli(['run', '--noproxy'], tmpDir);
+    expect(code).toBe(0);
+
+    expect(openAtRequest).toHaveLength(REQUEST_COUNT);
+    // Only the in-flight connection may be open; one extra is tolerated for the
+    // previous socket's FIN still being in transit when the next request lands.
+    expect(Math.max(...openAtRequest)).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Description

Related to #9074 — companion of #9078 (the `bruno-js` npm-module memory fix).

Without `--cache-ssl-session`, `setupProxyAgents()` creates a new agent for every request with `{ keepAlive: true }`. When the response completes, that agent parks the socket in its free pool — and since the agent is never used again, nothing ever closes the socket. A `bru run` therefore held **one open connection per executed request** until the process exited: 2,170 requests → 2,170 fds (`@usebruno/cli` 3.0.3 reused a single connection). On a CI agent with the default 1024 fd limit that is a hard failure once a run gets past ~1,000 requests.

The fix keeps the per-request agents and the `Connection: keep-alive` on the wire (the existing `run-sent-headers` test pins that), and simply **destroys throwaway agents once the response is in**:

- `run-single-request.js`: `destroyThrowawayAgents(...)` after `axiosInstance(request)` resolves, and at the top of the `catch` (covers 4xx/5xx and network errors). No-op when `--cache-ssl-session` is set, because cached agents are shared across requests.
- `axios-instance.js`: before a redirect hop creates fresh agents, the previous hop's throwaway agents are destroyed too.

## Measurements

Same 2,170-request collection, sampling the runner every 5 s: open sockets stay at **1** and fds at **22** for the whole run (previously sockets == requests executed so far).

## Tests

- New integration test `tests/integration/run-agent-teardown.spec.js`: a local server tracks open connections; with 6 sequential requests it asserts no more than the in-flight connection (+1 slack) is open when a request arrives. Fails on `main` (6 open at the 6th request), passes with this change.
- `packages/bruno-cli`: 197/197.
- `npx eslint` on the changed files: 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of temporary network connections when SSL session caching is disabled.
  - Prevented idle connections from accumulating during requests, redirects, and OAuth2 authentication.
  - Improved reliability for NTLM-authenticated requests and redirects.
  - Enhanced CLI stability when running workflows containing multiple requests.

- **Tests**
  - Added integration coverage confirming that temporary connections are properly closed and do not accumulate during CLI request execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->