### PR TITLE
fix(CLI): fixed junit reporters omit iterations and requests skipped due to bail

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -834,13 +834,13 @@ const handler = async function (argv) {
                 filename: relativePath
               },
               request: {
-                method: null,
-                url: null,
+                method: ri.request?.method || null,
+                url: ri.request?.url || null,
                 headers: null,
                 data: null
               },
               response: {
-                status: 'skipped',
+                status: '-',
                 statusText: null,
                 data: null,
                 responseTime: 0

--- a/packages/bruno-cli/src/reporters/junit.js
+++ b/packages/bruno-cli/src/reporters/junit.js
@@ -105,6 +105,7 @@ const makeJUnitOutput = async (results, outputPath) => {
 
     if (result?.skipped) {
       suite['@skipped'] = 1;
+      suite.skipped = [{ '@message': result.skipReason === 'bail' ? 'Request skipped due to bail' : 'Request Skipped' }];
     } else if (result.error) {
       suite['@errors'] = 1;
       suite['@tests'] = 1;

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -198,7 +198,7 @@ const runSingleRequest = async function (
           data: request.data
         },
         response: {
-          status: 'skipped',
+          status: '-',
           statusText: errorMsg,
           data: null,
           responseTime: 0,
@@ -296,7 +296,7 @@ const runSingleRequest = async function (
               data: request.data
             },
             response: {
-              status: 'skipped',
+              status: '-',
               statusText: 'request skipped via pre-request script',
               data: null,
               responseTime: 0,

--- a/packages/bruno-cli/src/utils/run.js
+++ b/packages/bruno-cli/src/utils/run.js
@@ -15,7 +15,7 @@ const createSkippedFileResults = (skippedFiles, collectionPath) => {
         data: null
       },
       response: {
-        status: 'skipped',
+        status: '-',
         statusText: skippedFile.error,
         data: null,
         responseTime: 0

--- a/packages/bruno-cli/tests/reporters/junit.spec.js
+++ b/packages/bruno-cli/tests/reporters/junit.spec.js
@@ -11,7 +11,7 @@ describe('makeJUnitOutput', () => {
     jest.spyOn(xmlbuilder, 'create').mockImplementation(() => {
       return { end: createStub };
     });
-    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => { });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -277,7 +277,10 @@ describe('makeJUnitOutput', () => {
 
     makeJUnitOutput(results, '/tmp/testfile.xml');
 
-    const suites = xmlbuilder.create.mock.calls[0][0].testsuites.testsuite;
+    expect(createStub).toHaveBeenCalled();
+
+    const junit = xmlbuilder.create.mock.calls[0][0];
+    const suites = junit.testsuites.testsuite;
 
     expect(suites.length).toBe(4);
 

--- a/packages/bruno-cli/tests/reporters/junit.spec.js
+++ b/packages/bruno-cli/tests/reporters/junit.spec.js
@@ -11,7 +11,7 @@ describe('makeJUnitOutput', () => {
     jest.spyOn(xmlbuilder, 'create').mockImplementation(() => {
       return { end: createStub };
     });
-    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => { });
   });
 
   afterEach(() => {
@@ -243,5 +243,57 @@ describe('makeJUnitOutput', () => {
     expect(failcase.failure).toBeDefined;
     expect(failcase.failure[0]['@type']).toBe('failure');
     expect(failcase.failure[0]['@message']).toBe('expected 200 to equal 404');
+  });
+
+  it('should report every request of a single iteration, naming bail only when it is the skip reason', () => {
+    const buildExecutedResult = (name, status, error) => ({
+      name,
+      path: `${name}.yml`,
+      test: { filename: `${name}.yml` },
+      request: { method: 'GET', url: 'https://api.example.com/users' },
+      testResults: [{ description: 'Status is 200', status, error }],
+      runDuration: 1.2345678
+    });
+
+    const buildSkippedResult = (name, skipReason) => ({
+      name,
+      path: `${name}.yml`,
+      test: { filename: `${name}.yml` },
+      request: { method: 'GET', url: 'https://api.example.com/users' },
+      status: 'skipped',
+      skipped: true,
+      ...(skipReason ? { skipReason } : {}),
+      assertionResults: [],
+      testResults: [],
+      runDuration: 0
+    });
+
+    const results = [
+      buildSkippedResult('1st API'),
+      buildExecutedResult('2nd API', 'pass'),
+      buildExecutedResult('3rd API', 'fail', 'expected 200 to equal 500'),
+      buildSkippedResult('4th API', 'bail')
+    ];
+
+    makeJUnitOutput(results, '/tmp/testfile.xml');
+
+    const suites = xmlbuilder.create.mock.calls[0][0].testsuites.testsuite;
+
+    expect(suites.length).toBe(4);
+
+    expect(suites[0]).toMatchObject({ '@name': '1st API', '@failures': 0, '@skipped': 1, '@tests': 0 });
+    expect(suites[0].skipped[0]['@message']).toBe('Request Skipped');
+    expect(suites[0].testcase.length).toBe(0);
+
+    expect(suites[1]).toMatchObject({ '@name': '2nd API', '@failures': 0, '@skipped': 0, '@tests': 1 });
+    expect(suites[1].skipped).toBeUndefined();
+    expect(suites[1].testcase.length).toBe(1);
+
+    expect(suites[2]).toMatchObject({ '@name': '3rd API', '@failures': 1, '@skipped': 0, '@tests': 1 });
+    expect(suites[2].skipped).toBeUndefined();
+
+    expect(suites[3]).toMatchObject({ '@name': '4th API', '@failures': 0, '@skipped': 1, '@tests': 0 });
+    expect(suites[3].skipped[0]['@message']).toBe('Request skipped due to bail');
+    expect(suites[3].testcase.length).toBe(0);
   });
 });

--- a/packages/bruno-cli/tests/runner/report-metadata.spec.js
+++ b/packages/bruno-cli/tests/runner/report-metadata.spec.js
@@ -66,7 +66,7 @@ describe('HTML Report Generation', () => {
               data: null
             },
             response: {
-              status: 'skipped',
+              status: '-',
               statusText: 'Unexpected token',
               data: null,
               responseTime: 0
@@ -108,6 +108,6 @@ describe('HTML Report Generation', () => {
 
     expect(htmlString).toContain('Request Skipped');
     expect(htmlString).toContain('summarySkippedRequests');
-    expect(htmlString).toContain('result.response.status === \'skipped\'');
+    expect(htmlString).toContain('result.status === \'skipped\'');
   });
 });

--- a/packages/bruno-cli/tests/runner/response-fields.spec.js
+++ b/packages/bruno-cli/tests/runner/response-fields.spec.js
@@ -82,8 +82,9 @@ jest.mock('@usebruno/common', () => {
   };
 });
 
-const prepareRequest = require('../../src/runner/prepare-request');
+const { ScriptRuntime } = require('@usebruno/js');
 const { makeAxiosInstance } = require('../../src/utils/axios-instance');
+const prepareRequest = require('../../src/runner/prepare-request');
 const { runSingleRequest } = require('../../src/runner/run-single-request');
 
 const baseItem = {
@@ -132,11 +133,32 @@ describe('runSingleRequest: duration and size fields (issue #7352)', () => {
     const result = await runSingleRequest(...baseArgs);
 
     expect(result.status).toBe('skipped');
+    expect(result.response.status).toBe('-');
     expect(result.response.duration).toBe(0);
     expect(result.response.size).toBe(0);
     expect(result.response.responseTime).toBe(0);
     expect(typeof result.response.duration).toBe('number');
     expect(typeof result.response.size).toBe('number');
+  });
+
+  it('should return "-" as the response status when a pre-request script skips the request', async () => {
+    prepareRequest.mockResolvedValue({
+      method: 'GET',
+      url: 'http://example.com/api/test',
+      headers: {},
+      data: null,
+      script: { req: 'bru.runner.skipRequest();' }
+    });
+    ScriptRuntime.mockImplementation(() => ({
+      runRequestScript: jest.fn().mockResolvedValue({ skipRequest: true, results: [] })
+    }));
+
+    const result = await runSingleRequest(...baseArgs);
+
+    expect(result.status).toBe('skipped');
+    expect(result.skipped).toBe(true);
+    expect(result.response.status).toBe('-');
+    expect(result.response.statusText).toBe('request skipped via pre-request script');
   });
 
   it('should return numeric duration and size on successful request', async () => {

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -1,4 +1,5 @@
-import { getFilteredRequestResults } from './template';
+import { generateHtmlReport } from './generate-report';
+import htmlTemplateString, { getFilteredRequestResults } from './template';
 import vm from 'vm';
 
 describe('getFilteredRequestResults', () => {
@@ -28,5 +29,42 @@ describe('getFilteredRequestResults', () => {
         index: 1
       }
     ]);
+  });
+});
+
+describe('htmlTemplateString', () => {
+  it('renders skipped requests off the request status, naming bail as the reason', () => {
+    const template = htmlTemplateString('');
+
+    expect(template).toContain('result.status === \'skipped\'');
+    expect(template).not.toContain('result.response.status === \'skipped\'');
+    expect(template).toContain('result.skipReason === \'bail\' ? \'Request skipped due to bail\'');
+  });
+});
+
+describe('generateHtmlReport', () => {
+  it('keeps the skip reason, method and url of bail-skipped requests', () => {
+    const bailSkippedResult = {
+      path: 'Create User.yml',
+      status: 'skipped',
+      skipped: true,
+      skipReason: 'bail',
+      request: { method: 'POST', url: 'https://api.example.com/users' },
+      response: { status: '-', responseTime: 0 },
+      runDuration: 0
+    };
+
+    const html = generateHtmlReport({
+      runnerResults: [{ iterationIndex: 0, results: [bailSkippedResult], summary: { totalRequests: 1 } }] as any
+    });
+    const encodedResults = html.match(/decodeBase64\('([^']*)'\)/)?.[1] || '';
+    const [iteration] = JSON.parse(Buffer.from(encodedResults, 'base64').toString()).results;
+
+    expect(iteration.results[0]).toMatchObject({
+      status: 'skipped',
+      skipReason: 'bail',
+      request: { method: 'POST', url: 'https://api.example.com/users' },
+      response: { status: '-' }
+    });
   });
 });

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -42,6 +42,11 @@ describe('htmlTemplateString', () => {
   });
 });
 
+const readEmbeddedIterations = (html: string) => {
+  const base64 = html.split('decodeBase64(\'')[1].split('\'')[0];
+  return JSON.parse(Buffer.from(base64, 'base64').toString()).results;
+};
+
 describe('generateHtmlReport', () => {
   it('keeps the skip reason, method and url of bail-skipped requests', () => {
     const bailSkippedResult = {
@@ -57,8 +62,7 @@ describe('generateHtmlReport', () => {
     const html = generateHtmlReport({
       runnerResults: [{ iterationIndex: 0, results: [bailSkippedResult], summary: { totalRequests: 1 } }] as any
     });
-    const encodedResults = html.match(/decodeBase64\('([^']*)'\)/)?.[1] || '';
-    const [iteration] = JSON.parse(Buffer.from(encodedResults, 'base64').toString()).results;
+    const [iteration] = readEmbeddedIterations(html);
 
     expect(iteration.results[0]).toMatchObject({
       status: 'skipped',

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -37,7 +37,6 @@ describe('htmlTemplateString', () => {
     const template = htmlTemplateString('');
 
     expect(template).toContain('result.status === \'skipped\'');
-    expect(template).not.toContain('result.response.status === \'skipped\'');
     expect(template).toContain('result.skipReason === \'bail\' ? \'Request skipped due to bail\'');
   });
 });

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -2,6 +2,14 @@ import { generateHtmlReport } from './generate-report';
 import htmlTemplateString, { getFilteredRequestResults } from './template';
 import vm from 'vm';
 
+const readEmbeddedIterations = (html: string) => {
+  const base64 = html.match(/decodeBase64\('([^']*)'\)/)?.[1];
+  if (!base64) {
+    throw new Error('The report did not embed its results as a base64 payload');
+  }
+  return JSON.parse(Buffer.from(base64, 'base64').toString()).results;
+};
+
 describe('getFilteredRequestResults', () => {
   it('preserves original request indexes when filtering failed results', () => {
     const results = [
@@ -40,11 +48,6 @@ describe('htmlTemplateString', () => {
     expect(template).toContain('result.skipReason === \'bail\' ? \'Request skipped due to bail\'');
   });
 });
-
-const readEmbeddedIterations = (html: string) => {
-  const base64 = html.split('decodeBase64(\'')[1].split('\'')[0];
-  return JSON.parse(Buffer.from(base64, 'base64').toString()).results;
-};
 
 describe('generateHtmlReport', () => {
   it('keeps the skip reason, method and url of bail-skipped requests', () => {

--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -327,7 +327,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             :bordered="false"
           >
             <template #header>
-              {{result.path}} - {{result.response.status === 'skipped' ? 'Request Skipped' : (totalPassed + '/' + total + ' Passed')}} {{hasError && result.response.status !== 'skipped' ? " - (request failed)" : "" }}
+              {{result.path}} - {{result.status === 'skipped' ? (result.skipReason === 'bail' ? 'Request skipped due to bail' : 'Request Skipped') : (totalPassed + '/' + total + ' Passed')}} {{hasError && result.status !== 'skipped' ? " - (request failed)" : "" }}
             </template>
           </n-alert>
         </template>
@@ -382,7 +382,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
               </n-card>
             </n-gi>
           </n-grid>
-          <n-alert v-if="hasError || (result.response.status === 'skipped' && result.error)" title="Error" type="error">
+          <n-alert v-if="hasError || (result.status === 'skipped' && result.error)" title="Error" type="error">
             {{result.error}}
           </n-alert>
           <n-card title="REQUEST HEADERS">
@@ -768,12 +768,12 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             return (props?.result?.testResults?.length || 0) + (props?.result?.assertionResults?.length || 0);
           });
 
-          const hasError = computed(() => !!props?.result?.error || props?.result?.status === 'error' || (props?.result?.response?.status === 'skipped' && props?.result?.error));
+          const hasError = computed(() => !!props?.result?.error || props?.result?.status === 'error' || (props?.result?.status === 'skipped' && props?.result?.error));
           const hasFailure = computed(() => total.value !== totalPassed.value);
           const testDuration = computed(() => Math.round(props?.result?.runDuration * 1000) + ' ms');
           const resultTitle = computed(() => props?.result?.path + ' ' + props?.result?.response?.status + ' ' + props?.result?.response?.statusText + ' ' + props?.index);
           const getAlertType = computed(() => {
-            if (props.result.response.status === 'skipped') {
+            if (props.result.status === 'skipped') {
               return 'warning';
             }
             return hasError.value || hasFailure.value ? 'error' : 'success';

--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -327,7 +327,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             :bordered="false"
           >
             <template #header>
-              {{result.path}} - {{result.status === 'skipped' ? (result.skipReason === 'bail' ? 'Request skipped due to bail' : 'Request Skipped') : (totalPassed + '/' + total + ' Passed')}} {{hasError && result.status !== 'skipped' ? " - (request failed)" : "" }}
+              {{result.path}} - {{resultSummary}} {{hasError && result.status !== 'skipped' ? " - (request failed)" : "" }}
             </template>
           </n-alert>
         </template>
@@ -772,6 +772,12 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
           const hasFailure = computed(() => total.value !== totalPassed.value);
           const testDuration = computed(() => Math.round(props?.result?.runDuration * 1000) + ' ms');
           const resultTitle = computed(() => props?.result?.path + ' ' + props?.result?.response?.status + ' ' + props?.result?.response?.statusText + ' ' + props?.index);
+          const resultSummary = computed(() => {
+            if (props.result.status === 'skipped') {
+              return props.result.skipReason === 'bail' ? 'Request skipped due to bail' : 'Request Skipped';
+            }
+            return totalPassed.value + '/' + total.value + ' Passed';
+          });
           const getAlertType = computed(() => {
             if (props.result.status === 'skipped') {
               return 'warning';
@@ -793,6 +799,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             result: props.result,
             testDuration,
             resultTitle,
+            resultSummary,
             getAlertType,
             iterationIndex: props?.result?.iterationIndex
           };

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1760,7 +1760,6 @@ const registerNetworkIpc = (mainWindow) => {
               stopRunnerExecution = true;
             }
 
-            // sasa
             if (preRequestScriptResult?.skipRequest) {
               mainWindow.webContents.send('main:run-folder-event', {
                 type: 'runner-request-skipped',

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1760,6 +1760,7 @@ const registerNetworkIpc = (mainWindow) => {
               stopRunnerExecution = true;
             }
 
+            // sasa
             if (preRequestScriptResult?.skipRequest) {
               mainWindow.webContents.send('main:run-folder-event', {
                 type: 'runner-request-skipped',


### PR DESCRIPTION
BRU-3508

### Description

When --bail stopped a run, the JUnit report did not clearly show which requests were skipped. Requests that never started were missing from the report, and bail-skipped requests appeared as empty suites, which could make CI tools treat them as passing.
The HTML report also showed skipped requests without the method, URL, or reason for the skip.


### Problem

- JUnit only used the requests that the runner actually processed.
- Iterations that never started because of bail were missing.
- Skipped suites had skipped="1" but no <skipped> element.
- HTML was checking response.status, which did not work correctly for bail-skipped requests.
- Skipped requests were missing their method and UR


### Fix

- All planned requests and iterations are now included in the reports.
- A common helper creates the bail-skipped result.
- JUnit now adds <skipped message="Request Skipped due to bail"/>.
- Bail-skipped requests keep their actual method and URL.
- Skipped requests show - as the response status.
- HTML now checks result.status correctly.
- HTML shows "Request skipped due to bail" and highlights it correctly.
- bru.runner.skipRequest() also returns - as the response status.

Here is the CSV file I used for testing:
[test.csv](https://github.com/user-attachments/files/31220972/test.csv)

Here is the sample collection:
[CLI-skipped-request-due-to-bail.yml](https://github.com/user-attachments/files/31221144/CLI-skipped-request-due-to-bail.yml)

Commands to run
for Html  -----   `bru run --csv-file-path test.csv --bail --reporter-html results.html`
for Junit -----  `bru run --csv-file-path test.csv --bail --reporter-junit results.xml`
for json -----   `bru run --csv-file-path test.csv --bail --reporter-json results.json`

Here are the before and after generated report files for the reference

Before:
[before-results.html](https://github.com/user-attachments/files/31366554/before-results.html)
[before-results.json](https://github.com/user-attachments/files/31366555/before-results.json)
[before-results.xml](https://github.com/user-attachments/files/31366557/before-results.xml)

After:
[after-results.html](https://github.com/user-attachments/files/31366536/after-results.html)
[after-results.json](https://github.com/user-attachments/files/31366543/after-results.json)
[after-results.xml](https://github.com/user-attachments/files/31366544/after-results.xml)

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

HTML Report
| Before | After |
| --- | --- |
| <img width="1920" height="849" alt="image" src="https://github.com/user-attachments/assets/f7c6e9a4-895d-45f3-b3bc-04e68a8e67da" /> | <img width="1920" height="846" alt="image" src="https://github.com/user-attachments/assets/b9e64d4c-44a7-4208-b079-322929440791" /> |

JUnit Report
| Before | After |
| --- | --- |
| <img width="1920" height="846" alt="image" src="https://github.com/user-attachments/assets/ad4693e1-a05f-4308-9b6e-f62e4aeda719" /> | <img width="1920" height="850" alt="image" src="https://github.com/user-attachments/assets/e5f4dc86-d5de-49f1-9a71-3c50eb0a7536" /> |

JSON Report
| Before | After |
| --- | --- |
| <img width="965" height="649" alt="image" src="https://github.com/user-attachments/assets/9e17ff8a-2e60-4ba0-a1ca-b312f7cb4156" /> | <img width="996" height="647" alt="image" src="https://github.com/user-attachments/assets/30db5981-a38c-4ccb-b969-4ad863dcea9b" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved skipped-request reporting across CLI, JUnit, and HTML reports.
  - Skipped requests now retain method and URL details and display a consistent `-` response status.
  - Reports distinguish requests skipped due to bail from other skipped requests.
  - JUnit reports now include explicit skipped entries with appropriate messages.
  - HTML reports show accurate skip messaging, status, and embedded request details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->