### PR TITLE
fix: create example modal shows status text and body type

### DIFF
--- a/packages/bruno-app/src/components/ResponseExample/CreateExampleModal/index.js
+++ b/packages/bruno-app/src/components/ResponseExample/CreateExampleModal/index.js
@@ -1,21 +1,11 @@
 import { useState, useEffect } from 'react';
 import Modal from 'components/Modal';
 import Portal from 'components/Portal';
-import statusCodePhraseMap from 'components/ResponsePane/StatusCode/get-status-code-phrase';
 
-const BODY_TYPES = [
-  { value: 'json', label: 'JSON' },
-  { value: 'text', label: 'Text' },
-  { value: 'xml', label: 'XML' },
-  { value: 'html', label: 'HTML' }
-];
-
-const CreateExampleModal = ({ isOpen, onClose, onSave, title = 'Create Response Example', initialName = '', showMockFields = false, confirmText = 'Create Example' }) => {
+const CreateExampleModal = ({ isOpen, onClose, onSave, title = 'Create Response Example', initialName = '', confirmText = 'Create Example' }) => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [nameError, setNameError] = useState('');
-  const [statusCode, setStatusCode] = useState(200);
-  const [bodyType, setBodyType] = useState('json');
 
   const handleNameChange = (e) => {
     setName(e.target.value);
@@ -27,17 +17,11 @@ const CreateExampleModal = ({ isOpen, onClose, onSave, title = 'Create Response 
 
   const handleConfirm = () => {
     if (name.trim()) {
-      if (showMockFields) {
-        onSave(name.trim(), description.trim(), { statusCode: Number(statusCode) || 200, bodyType });
-      } else {
-        onSave(name.trim(), description.trim());
-      }
+      onSave(name.trim(), description.trim());
       // Reset form
       setName('');
       setDescription('');
       setNameError('');
-      setStatusCode(200);
-      setBodyType('json');
     } else {
       setNameError('Example name is required');
     }
@@ -48,8 +32,6 @@ const CreateExampleModal = ({ isOpen, onClose, onSave, title = 'Create Response 
     setName('');
     setDescription('');
     setNameError('');
-    setStatusCode(200);
-    setBodyType('json');
     onClose();
   };
 
@@ -58,8 +40,6 @@ const CreateExampleModal = ({ isOpen, onClose, onSave, title = 'Create Response 
       setName(initialName);
       setDescription('');
       setNameError('');
-      setStatusCode(200);
-      setBodyType('json');
     }
   }, [isOpen, initialName]);
 
@@ -113,44 +93,6 @@ const CreateExampleModal = ({ isOpen, onClose, onSave, title = 'Create Response 
               data-testid="create-example-description-input"
             />
           </div>
-
-          {showMockFields && (
-            <>
-              <div>
-                <label htmlFor="statusCode" className="block font-medium">
-                  Status Code
-                </label>
-                <select
-                  id="statusCode"
-                  className="textbox mt-2 w-full"
-                  value={statusCode}
-                  onChange={(e) => setStatusCode(Number(e.target.value))}
-                  data-testid="status-code-select"
-                >
-                  {Object.entries(statusCodePhraseMap).map(([code, phrase]) => (
-                    <option key={code} value={code}>{code} {phrase}</option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label htmlFor="bodyType" className="block font-medium">
-                  Body Type
-                </label>
-                <select
-                  id="bodyType"
-                  className="textbox mt-2 w-full"
-                  value={bodyType}
-                  onChange={(e) => setBodyType(e.target.value)}
-                  data-testid="body-type-select"
-                >
-                  {BODY_TYPES.map((type) => (
-                    <option key={type.value} value={type.value}>{type.label}</option>
-                  ))}
-                </select>
-              </div>
-            </>
-          )}
         </div>
       </Modal>
     </Portal>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -697,7 +697,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
         onSave={handleCreateExample}
         title="Create Response Example"
         initialName={getInitialExampleName(item)}
-        showMockFields={isMockServerEnabled}
+        showMockFields={false}
       />
       <div
         className={itemRowClassName}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -26,9 +26,8 @@ import { useSelector, useDispatch } from 'react-redux';
 import { addTab, focusTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import { handleCollectionItemDrop, sendRequest, showInFolder, pasteItem, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { toggleCollectionItem, addResponseExample } from 'providers/ReduxStore/slices/collections';
-import { insertTaskIntoQueue } from 'providers/ReduxStore/slices/app';
 import { uuid } from 'utils/common';
-import { copyRequest, setFocusedSidebarPath } from 'providers/ReduxStore/slices/app';
+import { copyRequest, setFocusedSidebarPath, insertTaskIntoQueue } from 'providers/ReduxStore/slices/app';
 import NewRequest from 'components/Sidebar/NewRequest';
 import NewFolder from 'components/Sidebar/NewFolder';
 import NewApp from 'components/Sidebar/NewApp';
@@ -38,7 +37,7 @@ import DeleteCollectionItem from './DeleteCollectionItem';
 import IgnoreCollectionItem from './IgnoreCollectionItem';
 import RunCollectionItem from './RunCollectionItem';
 import GenerateCodeItem from './GenerateCodeItem';
-import { isItemARequest, isItemAFolder } from 'utils/tabs';
+import { isItemARequest, isItemAFolder, scrollToTheActiveTab } from 'utils/tabs';
 import { doesRequestMatchSearchText, doesFolderHaveItemsMatchSearchText } from 'utils/collections/search';
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import toast from 'react-hot-toast';
@@ -48,8 +47,6 @@ import CollectionItemInfo from './CollectionItemInfo/index';
 import CollectionItemIcon from './CollectionItemIcon';
 import ExampleItem from './ExampleItem';
 import ExampleIcon from 'components/Icons/ExampleIcon';
-import { scrollToTheActiveTab } from 'utils/tabs';
-import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import {
   getTabUidForItem as getTabUidForItemSelector,
   isTabForItemActive as isTabForItemActiveSelector,
@@ -73,7 +70,6 @@ import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext'
 import useKeybinding from 'hooks/useKeybinding';
 
 const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }) => {
-  const isMockServerEnabled = useBetaFeature(BETA_FEATURES.MOCK_SERVER);
   const { dropdownContainerRef } = useSidebarAccordion();
   const selectorInput = {
     itemUid: item.uid,
@@ -540,20 +536,16 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     });
   };
 
-  const handleCreateExample = async (name, description = '', mockFields) => {
-    const statusCode = mockFields?.statusCode || 200;
-    const bodyType = mockFields?.bodyType || 'text';
-    const defaultContent = bodyType === 'json' ? '{}' : '';
-
+  const handleCreateExample = async (name, description = '') => {
     const exampleData = {
       name: name,
       description: description,
-      status: statusCode,
+      status: 200,
       statusText: 'OK',
       headers: [],
       body: {
-        type: bodyType,
-        content: defaultContent
+        type: 'text',
+        content: ''
       }
     };
 
@@ -697,7 +689,6 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
         onSave={handleCreateExample}
         title="Create Response Example"
         initialName={getInitialExampleName(item)}
-        showMockFields={false}
       />
       <div
         className={itemRowClassName}


### PR DESCRIPTION
### Description

Create example modal shows status text and body type.

### Problem

In the first implementation, when we didn't decouple mock response and examples, the same component was being used to create mock responses. With the decoupling, this piece of code now is a dead code. 

### Fix

Removed all the code that was added for the mock example response which is not needed anymore and reverted it back to the original example code. 

### Screenshots

Before

<img width="452" height="426" alt="image" src="https://github.com/user-attachments/assets/59dff30d-3a21-465d-9aeb-dfd2683d2828" />

After

<img width="451" height="287" alt="image" src="https://github.com/user-attachments/assets/c211e77e-8d4f-4931-ba55-b2c9c9a088fd" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified response example creation by removing mock status code and body type selections.
  * New response examples now use standard default settings: HTTP 200, text content, and an empty body.
  * Removed mock-server options from collection response example workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->