### PR TITLE
feat(translator): add global variable translation methods for Postman to bruno conversion

### DIFF
--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -150,6 +150,10 @@ const simpleTranslations = {
   'pm.setEnvironmentVariable': 'bru.setEnvVar',
   'pm.getEnvironmentVariable': 'bru.getEnvVar',
   'pm.clearEnvironmentVariable': 'bru.deleteEnvVar',
+  'pm.setGlobalVariable': 'bru.setGlobalEnvVar',
+  'pm.getGlobalVariable': 'bru.getGlobalEnvVar',
+  'pm.clearGlobalVariable': 'bru.deleteGlobalEnvVar',
+  'pm.clearGlobalVariables': 'bru.deleteAllGlobalEnvVars',
 
   // Legacy response properties
   'responseCode.code': 'res.getStatus()',

--- a/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
+++ b/packages/bruno-converters/src/utils/postman-to-bruno-translator.js
@@ -150,6 +150,7 @@ const simpleTranslations = {
   'pm.setEnvironmentVariable': 'bru.setEnvVar',
   'pm.getEnvironmentVariable': 'bru.getEnvVar',
   'pm.clearEnvironmentVariable': 'bru.deleteEnvVar',
+  'pm.clearEnvironmentVariables': 'bru.deleteAllEnvVars',
   'pm.setGlobalVariable': 'bru.setGlobalEnvVar',
   'pm.getGlobalVariable': 'bru.getGlobalEnvVar',
   'pm.clearGlobalVariable': 'bru.deleteGlobalEnvVar',

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/environment.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/environment.test.js
@@ -102,6 +102,12 @@ describe('Environment Variable Translation', () => {
     expect(translatedCode).toBe('bru.deleteEnvVar("tempToken");');
   });
 
+  it('should translate postman.clearEnvironmentVariables', () => {
+    const code = 'postman.clearEnvironmentVariables();';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.deleteAllEnvVars();');
+  });
+
   it('should translate postman.setGlobalVariable', () => {
     const code = 'postman.setGlobalVariable("timeStamp", now);';
     const translatedCode = translateCode(code);

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/environment.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/environment.test.js
@@ -102,6 +102,30 @@ describe('Environment Variable Translation', () => {
     expect(translatedCode).toBe('bru.deleteEnvVar("tempToken");');
   });
 
+  it('should translate postman.setGlobalVariable', () => {
+    const code = 'postman.setGlobalVariable("timeStamp", now);';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.setGlobalEnvVar("timeStamp", now);');
+  });
+
+  it('should translate postman.getGlobalVariable', () => {
+    const code = 'const ts = postman.getGlobalVariable("timeStamp");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('const ts = bru.getGlobalEnvVar("timeStamp");');
+  });
+
+  it('should translate postman.clearGlobalVariable', () => {
+    const code = 'postman.clearGlobalVariable("timeStamp");';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.deleteGlobalEnvVar("timeStamp");');
+  });
+
+  it('should translate postman.clearGlobalVariables', () => {
+    const code = 'postman.clearGlobalVariables();';
+    const translatedCode = translateCode(code);
+    expect(translatedCode).toBe('bru.deleteAllGlobalEnvVars();');
+  });
+
   it('should handle all environment variable methods together', () => {
     const code = `
         // All environment variable methods


### PR DESCRIPTION
Jira BRU-4397

### Description

Adds the missing legacy Postman globals, env  APIs to postman to bruno translator

Legacy translations covered by this PR:

| Postman (legacy)                            | Bruno                              |
| ------------------------------------------- | ---------------------------------- |
| `postman.setGlobalVariable(key, value)`     | `bru.setGlobalEnvVar(key, value)`  |
| `postman.getGlobalVariable(key)`            | `bru.getGlobalEnvVar(key)`         |
| `postman.clearGlobalVariable(key)`          | `bru.deleteGlobalEnvVar(key)`      |
| `postman.clearGlobalVariables()`            | `bru.deleteAllGlobalEnvVars()`     |
| `postman.clearEnvironmentVariables()`       | `bru.deleteAllEnvVars()`           |

### Fix

Added the five missing entries to the `simpleTranslations` map in `postman-to-bruno-translator.js`

### Screenshots

N/A — translator-only change, no UI.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for translating five legacy Postman environment and global-variable APIs to their Bruno equivalents.
  - Supported operations include clearing, setting, and retrieving environment and global variables.

- **Tests**
  - Added coverage confirming correct translation for all newly supported legacy APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->