### PR TITLE
fix(unit-test): timeout for seeding 200 files on windows

### DIFF
--- a/packages/bruno-electron/src/utils/tests/filesystem/index.spec.js
+++ b/packages/bruno-electron/src/utils/tests/filesystem/index.spec.js
@@ -103,19 +103,17 @@ describe('File System Operations', () => {
   });
 
   describe('MAX_DUPLICATE_NAMES cap', () => {
-    it('caps at 200: creates req.bru, req 1.bru … req 199.bru, then the 201st rejects', async () => {
+    it('rejects once every candidate name (base + 199 suffixes) is taken', async () => {
       const dir = path.join(tempDir, 'cap');
       await fs.mkdir(dir, { recursive: true });
 
-      for (let i = 0; i < 200; i++) {
-        const { filename } = await writeFileUnique(dir, 'req', 'bru', 'x');
-        expect(filename).toBe(i === 0 ? 'req.bru' : `req ${i}.bru`);
-      }
+      const names = ['req.bru', ...Array.from({ length: 199 }, (_, i) => `req ${i + 1}.bru`)];
+      await Promise.all(names.map((name) => fs.writeFile(path.join(dir, name), 'x')));
 
       await expect(writeFileUnique(dir, 'req', 'bru', 'x')).rejects.toThrow(
         /Too many items named "req" \(limit 200\)/
       );
-    });
+    }, 30000);
   });
 });
 


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Max naming collisions unit tests failed for windows giving timeout while creating the files,

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
the cap test called writeFileUnique 200× in a loop, and each call the suffix to add causing times out on Windows CI's slower filesystem.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
seed the 200 colliding names in parallel with Promise.all(fs.writeFile) and make a single writeFileUnique call to assert the cap (O(n), ~30ms), plus a 30s timeout.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated duplicate filename limit coverage to verify the expected error when 200 matching names already exist.
  * Improved test execution by creating setup files in parallel and allowing additional time for completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->