### PR TITLE
Feat/grpc message hooks

### DIFF
--- a/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcBody/index.js
@@ -99,9 +99,13 @@ const SingleGrpcMessage = ({ message, item, collection, index, methodType, handl
 
   const onSend = async () => {
     try {
-      await sendGrpcMessage(item, collection.uid, content);
+      const { success, error } = await sendGrpcMessage(item, collection.uid, content);
+      if (!success) {
+        toastError(new Error(error), 'Message not sent');
+      }
     } catch (error) {
       console.error('Error sending message:', error);
+      toastError(error, 'Message not sent');
     }
   };
 

--- a/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/index.js
@@ -65,7 +65,12 @@ const GrpcRequestPane = ({ item, collection, handleRun }) => {
   const docs = getPropertyFromDraftOrRequest(item, 'request.docs');
   const script = getPropertyFromDraftOrRequest(item, 'request.script');
   const hasScript = GRPC_SCRIPT_KEYS.some((hook) => script?.[hook]?.trim().length > 0);
-  const hasScriptError = item.beforeCallStartScriptErrorMessage || item.afterCallEndScriptErrorMessage;
+  // keys spelled out so they stay greppable
+  const hasScriptError
+    = item.beforeCallStartScriptErrorMessage
+      || item.afterCallEndScriptErrorMessage
+      || item.beforeMessageSendScriptErrorMessage
+      || item.afterMessageReceiveScriptErrorMessage;
   const itemAuthMode = item.draft?.request?.auth?.mode ?? item.request?.auth?.mode ?? item.root?.request?.auth?.mode;
   const hasAuth = useMemo(
     () => hasEffectiveAuth(collection, item, AUTH_MODES_GRPC),

--- a/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcRequestPane/index.js
@@ -68,9 +68,9 @@ const GrpcRequestPane = ({ item, collection, handleRun }) => {
   // keys spelled out so they stay greppable
   const hasScriptError
     = item.beforeCallStartScriptErrorMessage
-      || item.afterCallEndScriptErrorMessage
       || item.beforeMessageSendScriptErrorMessage
-      || item.afterMessageReceiveScriptErrorMessage;
+      || item.afterMessageReceiveScriptErrorMessage
+      || item.afterCallEndScriptErrorMessage;
   const itemAuthMode = item.draft?.request?.auth?.mode ?? item.request?.auth?.mode ?? item.root?.request?.auth?.mode;
   const hasAuth = useMemo(
     () => hasEffectiveAuth(collection, item, AUTH_MODES_GRPC),

--- a/packages/bruno-app/src/components/RequestPane/GrpcScript/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GrpcScript/index.js
@@ -18,6 +18,18 @@ const HOOKS = {
     showHintsFor: ['req', 'bru'],
     errorMessageKey: 'beforeCallStartScriptErrorMessage'
   },
+  beforeMessageSend: {
+    label: 'Before Message Send',
+    scriptType: SCRIPT_TYPES.BEFORE_MESSAGE_SEND,
+    showHintsFor: ['req', 'bru'],
+    errorMessageKey: 'beforeMessageSendScriptErrorMessage'
+  },
+  afterMessageReceive: {
+    label: 'After Message Receive',
+    scriptType: SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE,
+    showHintsFor: ['req', 'res', 'bru'],
+    errorMessageKey: 'afterMessageReceiveScriptErrorMessage'
+  },
   afterCallEnd: {
     label: 'After Call End',
     scriptType: SCRIPT_TYPES.AFTER_CALL_END,

--- a/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/StyledWrapper.js
@@ -24,6 +24,12 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.colors.text.muted};
   }
 
+  .message-group-label {
+    color: ${(props) => props.theme.colors.text.muted};
+    font-size: 0.75rem;
+    padding-top: 0.5rem;
+  }
+
   .dropdown-icon {
     color: ${(props) => props.theme.sidebar.dropdownIcon.color};
   }

--- a/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import StyledWrapper from './StyledWrapper';
 import { usePersistedState } from 'hooks/usePersistedState';
 import { useTrackScroll } from 'hooks/useTrackScroll';
@@ -112,20 +112,14 @@ const GrpcTestResults = ({ item, sections }) => {
   const [scroll, setScroll] = usePersistedState({ key: `grpc-response-tests-scroll-${item?.uid}`, default: 0 });
   useTrackScroll({ ref: wrapperRef, selector: '.response-tab-content', onChange: setScroll, initialValue: scroll });
 
-  const expandFilledSections = () =>
-    Object.fromEntries(sections.map((section) => [section.key, section.results.length > 0]));
+  const [userToggledSections, setUserToggledSections] = useState({});
 
-  const [expandedSections, setExpandedSections] = useState(expandFilledSections);
+  const isSectionExpanded = (section) => userToggledSections[section.key] ?? section.results.length > 0;
 
-  const resultCounts = sections.map((section) => section.results.length).join(',');
-  useEffect(() => {
-    setExpandedSections(expandFilledSections());
-  }, [resultCounts]);
-
-  const toggleSection = (key) => {
-    setExpandedSections({
-      ...expandedSections,
-      [key]: !expandedSections[key]
+  const toggleSection = (section) => {
+    setUserToggledSections({
+      ...userToggledSections,
+      [section.key]: !isSectionExpanded(section)
     });
   };
 
@@ -141,8 +135,8 @@ const GrpcTestResults = ({ item, sections }) => {
           sectionKey={section.key}
           title={section.title}
           results={section.results}
-          isExpanded={expandedSections[section.key]}
-          onToggle={() => toggleSection(section.key)}
+          isExpanded={isSectionExpanded(section)}
+          onToggle={() => toggleSection(section)}
         />
       ))}
     </StyledWrapper>

--- a/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/index.js
@@ -11,8 +11,25 @@ import {
 
 export const buildGrpcTestSections = (item) => [
   { key: 'beforeCallStart', title: 'Before Call Start Tests', results: item.beforeCallStartTestResults || [] },
+  { key: 'beforeMessageSend', title: 'Before Message Send Tests', results: item.beforeMessageSendTestResults || [] },
+  { key: 'afterMessageReceive', title: 'After Message Receive Tests', results: item.afterMessageReceiveTestResults || [] },
   { key: 'afterCallEnd', title: 'After Call End Tests', results: item.afterCallEndTestResults || [] }
 ];
+
+const groupResultsByMessage = (results) => {
+  const groups = [];
+
+  for (const result of results) {
+    const last = groups[groups.length - 1];
+    if (last && last.messageIndex === result.messageIndex) {
+      last.results.push(result);
+      continue;
+    }
+    groups.push({ messageIndex: result.messageIndex, results: [result] });
+  }
+
+  return groups;
+};
 
 const ResultIcon = ({ status }) => (
   <span
@@ -67,15 +84,22 @@ const GrpcTestSection = ({ sectionKey, title, results, isExpanded, onToggle }) =
           {title} ({results.length}), Passed: {passedCount}, Failed: {failedCount}
         </span>
       </div>
-      {isExpanded && (
-        <ul className="ml-5">
-          {results.map((result) => (
-            <li key={result.uid} className="py-1">
-              <ResultItem result={result} />
-            </li>
-          ))}
-        </ul>
-      )}
+      {isExpanded && groupResultsByMessage(results).map((group) => (
+        <div key={group.messageIndex ?? 'call'}>
+          {group.messageIndex !== undefined && (
+            <div className="message-group-label ml-5" data-testid={`grpc-test-message-group-${group.messageIndex}`}>
+              Message {group.messageIndex + 1}
+            </div>
+          )}
+          <ul className="ml-5">
+            {group.results.map((result) => (
+              <li key={result.uid} className="py-1">
+                <ResultItem result={result} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 };

--- a/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/GrpcTestResults/index.spec.js
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import GrpcTestResults, { buildGrpcTestSections, countGrpcTestResults } from './index';
+
+const theme = {
+  text: '#333',
+  colors: { text: { green: '#16a34a', danger: '#ef4444', muted: '#999' } },
+  sidebar: { collection: { item: { hoverBg: '#eee' } }, dropdownIcon: { color: '#666' } }
+};
+
+const renderResults = (item) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <GrpcTestResults item={item} sections={buildGrpcTestSections(item)} />
+    </ThemeProvider>
+  );
+
+const pass = (uid, description, messageIndex) => ({ uid, description, status: 'pass', messageIndex });
+
+describe('buildGrpcTestSections', () => {
+  it('covers all four hooks, in the order they run', () => {
+    expect(buildGrpcTestSections({}).map(({ key }) => key)).toEqual([
+      'beforeCallStart',
+      'beforeMessageSend',
+      'afterMessageReceive',
+      'afterCallEnd'
+    ]);
+  });
+
+  it('counts the results of every hook', () => {
+    const sections = buildGrpcTestSections({
+      beforeCallStartTestResults: [pass('r1', 'call opens')],
+      afterMessageReceiveTestResults: [pass('r2', 'reply ok', 0), pass('r3', 'reply ok', 1)]
+    });
+
+    expect(countGrpcTestResults(sections)).toBe(3);
+  });
+});
+
+describe('GrpcTestResults', () => {
+  it('groups the accumulated message-hook results under the message each came from', () => {
+    renderResults({
+      uid: 'item-1',
+      afterMessageReceiveTestResults: [
+        pass('r1', 'first reply is ok', 0),
+        pass('r2', 'first reply has an id', 0),
+        pass('r3', 'second reply is ok', 1)
+      ]
+    });
+
+    expect(screen.getByTestId('grpc-test-message-group-0')).toHaveTextContent('Message 1');
+    expect(screen.getByTestId('grpc-test-message-group-1')).toHaveTextContent('Message 2');
+    expect(screen.getByText('second reply is ok')).toBeInTheDocument();
+  });
+
+  it('leaves the call-hook results ungrouped, since they carry no message index', () => {
+    renderResults({
+      uid: 'item-1',
+      afterCallEndTestResults: [pass('r1', 'status is OK'), pass('r2', 'trailer is present')]
+    });
+
+    expect(screen.queryByTestId('grpc-test-message-group-0')).not.toBeInTheDocument();
+    expect(screen.getByText('status is OK')).toBeInTheDocument();
+  });
+
+  it('renders nothing but a placeholder when no hook produced a result', () => {
+    renderResults({ uid: 'item-1' });
+
+    expect(screen.getByText('No tests found')).toBeInTheDocument();
+  });
+});

--- a/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/GrpcResponsePane/index.js
@@ -106,7 +106,7 @@ const GrpcResponsePane = ({ item, collection }) => {
         return <Timeline collection={collection} item={item} activeTabUid={activeTabUid} />;
       }
       case 'tests': {
-        return <GrpcTestResults item={item} sections={testSections} />;
+        return <GrpcTestResults key={item.uid} item={item} sections={testSections} />;
       }
       default: {
         return <div>404 | Not found</div>;
@@ -198,7 +198,7 @@ const GrpcResponsePane = ({ item, collection }) => {
             focusedTab?.responsePaneTab === 'timeline' && requestTimeline?.length ? (
               <Timeline collection={collection} item={item} activeTabUid={activeTabUid} />
             ) : focusedTab?.responsePaneTab === 'tests' ? (
-              <GrpcTestResults item={item} sections={testSections} />
+              <GrpcTestResults key={item.uid} item={item} sections={testSections} />
             ) : null
           ) : (
             <>{getTabPanel(focusedTab.responsePaneTab)}</>

--- a/packages/bruno-app/src/components/ResponsePane/ScriptError/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ScriptError/index.js
@@ -216,6 +216,8 @@ const SCRIPT_PHASES = [
   { phase: SCRIPT_TYPES.POST_RESPONSE, title: 'Post-Response Script Error', messageKey: 'postResponseScriptErrorMessage', contextKey: 'postResponseScriptErrorContext' },
   { phase: SCRIPT_TYPES.TEST, title: 'Test Script Error', messageKey: 'testScriptErrorMessage', contextKey: 'testScriptErrorContext' },
   { phase: SCRIPT_TYPES.BEFORE_CALL_START, title: 'Before Call Start Script Error', messageKey: 'beforeCallStartScriptErrorMessage', contextKey: 'beforeCallStartScriptErrorContext' },
+  { phase: SCRIPT_TYPES.BEFORE_MESSAGE_SEND, title: 'Before Message Send Script Error', messageKey: 'beforeMessageSendScriptErrorMessage', contextKey: 'beforeMessageSendScriptErrorContext' },
+  { phase: SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE, title: 'After Message Receive Script Error', messageKey: 'afterMessageReceiveScriptErrorMessage', contextKey: 'afterMessageReceiveScriptErrorContext' },
   { phase: SCRIPT_TYPES.AFTER_CALL_END, title: 'After Call End Script Error', messageKey: 'afterCallEndScriptErrorMessage', contextKey: 'afterCallEndScriptErrorContext' }
 ];
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1600,7 +1600,9 @@ export const newGrpcRequest = (params) => (dispatch, getState) => {
         },
         script: {
           beforeCallStart: null,
-          afterCallEnd: null
+          afterCallEnd: null,
+          beforeMessageSend: null,
+          afterMessageReceive: null
         },
         assertions: [],
         tests: null

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1600,9 +1600,9 @@ export const newGrpcRequest = (params) => (dispatch, getState) => {
         },
         script: {
           beforeCallStart: null,
-          afterCallEnd: null,
           beforeMessageSend: null,
-          afterMessageReceive: null
+          afterMessageReceive: null,
+          afterCallEnd: null
         },
         assertions: [],
         tests: null

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/grpc-script.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/grpc-script.spec.js
@@ -77,6 +77,20 @@ describe('updateGrpcScript', () => {
     expect(itemFrom(next).draft.request.script.beforeCallStart).toBeNull();
   });
 
+  it.each([
+    ['beforeMessageSend', 'bru.setVar("sent", bru.grpc.request.message.timestamp);'],
+    ['afterMessageReceive', 'bru.setVar("received", bru.grpc.response.message.timestamp);']
+  ])('writes the %s message hook into the draft request script', (hook, script) => {
+    const state = makeState();
+
+    const next = reducer(
+      state,
+      updateGrpcScript({ collectionUid: COLLECTION_UID, itemUid: ITEM_UID, hook, script })
+    );
+
+    expect(itemFrom(next).draft.request.script[hook]).toBe(script);
+  });
+
   it('leaves the saved request untouched when creating the draft', () => {
     const state = makeState();
 
@@ -168,7 +182,7 @@ describe('updateGrpcScript', () => {
   // The hook allowlist is the only thing stopping an arbitrary key from being written into
   // request.script, which the filestore would then try to serialize.
   describe('hook allowlist', () => {
-    it.each(['req', 'res', 'tests', 'proto', '__proto__', 'BeforeCallStart', '', undefined, null])(
+    it.each(['req', 'res', 'tests', 'proto', '__proto__', 'BeforeCallStart', 'beforemessagesend', 'onMessage', '', undefined, null])(
       'ignores the disallowed hook %p',
       (hook) => {
         const state = makeState();

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/grpc-script.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/grpc-script.spec.js
@@ -182,6 +182,7 @@ describe('updateGrpcScript', () => {
 
   // The hook allowlist is the only thing stopping an arbitrary key from being written into
   // request.script, which the filestore would then try to serialize.
+  // The below items are not in allow-list, hence the state remains the same after the reducer call.
   describe('hook allowlist', () => {
     it.each(['req', 'res', 'tests', 'proto', '__proto__', 'BeforeCallStart', 'beforemessagesend', 'onMessage', '', undefined, null])(
       'ignores the disallowed hook %p',

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/grpc-script.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/grpc-script.spec.js
@@ -2,7 +2,8 @@ import reducer, {
   updateGrpcScript,
   grpcScriptError,
   grpcTestResults,
-  initRunRequestEvent
+  initRunRequestEvent,
+  responseCleared
 } from 'providers/ReduxStore/slices/collections';
 
 const COLLECTION_UID = 'col-1';
@@ -288,6 +289,54 @@ describe('grpcScriptError', () => {
     expect(itemFrom(next).afterCallEndScriptErrorContext).toEqual(errorContext);
   });
 
+  it.each([
+    ['before-message-send', 'beforeMessageSendScriptErrorMessage', 'beforeMessageSendScriptErrorContext'],
+    ['after-message-receive', 'afterMessageReceiveScriptErrorMessage', 'afterMessageReceiveScriptErrorContext']
+  ])('records a %s failure with its context', (scriptType, messageKey, contextKey) => {
+    const state = makeState();
+
+    const next = reducer(
+      state,
+      grpcScriptError({
+        itemUid: ITEM_UID,
+        collectionUid: COLLECTION_UID,
+        scriptType,
+        // The main process folds the message index into the text, since only the last error is kept.
+        errorMessage: 'Message 3: boom',
+        errorContext
+      })
+    );
+
+    expect(itemFrom(next)[messageKey]).toBe('Message 3: boom');
+    expect(itemFrom(next)[contextKey]).toEqual(errorContext);
+  });
+
+  it('keeps only the last failure of a message hook, since it runs once per message', () => {
+    const first = reducer(
+      makeState(),
+      grpcScriptError({
+        itemUid: ITEM_UID,
+        collectionUid: COLLECTION_UID,
+        scriptType: 'after-message-receive',
+        errorMessage: 'Message 1: boom',
+        errorContext
+      })
+    );
+
+    const next = reducer(
+      first,
+      grpcScriptError({
+        itemUid: ITEM_UID,
+        collectionUid: COLLECTION_UID,
+        scriptType: 'after-message-receive',
+        errorMessage: 'Message 2: bang',
+        errorContext
+      })
+    );
+
+    expect(itemFrom(next).afterMessageReceiveScriptErrorMessage).toBe('Message 2: bang');
+  });
+
   // ScriptError picks the code-snippet card over the plain banner on the truthiness of the
   // context, so a missing context has to land as null rather than undefined.
   it('normalizes a missing error context to null', () => {
@@ -428,6 +477,52 @@ describe('grpcTestResults', () => {
     }
   );
 
+  it.each([
+    ['before-message-send', 'beforeMessageSendTestResults'],
+    ['after-message-receive', 'afterMessageReceiveTestResults']
+  ])('accumulates the %s results, tagging each with the message it came from', (scriptType, field) => {
+    const first = reducer(
+      makeState(),
+      grpcTestResults({ itemUid: ITEM_UID, collectionUid: COLLECTION_UID, scriptType, results, messageIndex: 0 })
+    );
+
+    const next = reducer(
+      first,
+      grpcTestResults({ itemUid: ITEM_UID, collectionUid: COLLECTION_UID, scriptType, results, messageIndex: 1 })
+    );
+
+    expect(itemFrom(next)[field]).toEqual([
+      ...results.map((result) => ({ ...result, messageIndex: 0 })),
+      ...results.map((result) => ({ ...result, messageIndex: 1 }))
+    ]);
+  });
+
+  it('keeps the call hooks replacing while the message hooks accumulate', () => {
+    const withMessages = reducer(
+      makeState(),
+      grpcTestResults({
+        itemUid: ITEM_UID,
+        collectionUid: COLLECTION_UID,
+        scriptType: 'after-message-receive',
+        results,
+        messageIndex: 0
+      })
+    );
+
+    const next = reducer(
+      withMessages,
+      grpcTestResults({
+        itemUid: ITEM_UID,
+        collectionUid: COLLECTION_UID,
+        scriptType: 'after-call-end',
+        results
+      })
+    );
+
+    expect(itemFrom(next).afterCallEndTestResults).toEqual(results);
+    expect(itemFrom(next).afterMessageReceiveTestResults).toHaveLength(results.length);
+  });
+
   it('ignores an unknown collection or item', () => {
     const state = makeState();
 
@@ -469,34 +564,47 @@ describe('initRunRequestEvent', () => {
   const previousRun = {
     beforeCallStartScriptErrorMessage: 'undefinedVar is not defined',
     afterCallEndScriptErrorMessage: 'boom',
+    beforeMessageSendScriptErrorMessage: 'Message 1: no send',
+    afterMessageReceiveScriptErrorMessage: 'Message 1: bang',
     beforeCallStartScriptErrorContext: errorContext,
     afterCallEndScriptErrorContext: errorContext,
+    beforeMessageSendScriptErrorContext: errorContext,
+    afterMessageReceiveScriptErrorContext: errorContext,
     beforeCallStartTestResults: [{ uid: 'r1', description: 'responds with OK', status: 'pass' }],
-    afterCallEndTestResults: [{ uid: 'r2', description: 'carries a trailer', status: 'fail' }]
+    afterCallEndTestResults: [{ uid: 'r2', description: 'carries a trailer', status: 'fail' }],
+    beforeMessageSendTestResults: [{ uid: 'r3', description: 'message 1 is valid', status: 'pass', messageIndex: 0 }],
+    afterMessageReceiveTestResults: [{ uid: 'r4', description: 'reply 1 is ok', status: 'pass', messageIndex: 0 }]
   };
 
   const rerun = (state) =>
     reducer(state, initRunRequestEvent({ requestUid: 'req-2', itemUid: ITEM_UID, collectionUid: COLLECTION_UID }));
 
-  it('clears both hook test results', () => {
+  it('clears every hook test result', () => {
     const next = rerun(makeState({ item: previousRun }));
 
     expect(itemFrom(next).beforeCallStartTestResults).toEqual([]);
     expect(itemFrom(next).afterCallEndTestResults).toEqual([]);
+    // These accumulate, so a stale list would keep growing run over run.
+    expect(itemFrom(next).beforeMessageSendTestResults).toEqual([]);
+    expect(itemFrom(next).afterMessageReceiveTestResults).toEqual([]);
   });
 
-  it('clears both hook error messages', () => {
+  it('clears every hook error message', () => {
     const next = rerun(makeState({ item: previousRun }));
 
     expect(itemFrom(next).beforeCallStartScriptErrorMessage).toBeNull();
     expect(itemFrom(next).afterCallEndScriptErrorMessage).toBeNull();
+    expect(itemFrom(next).beforeMessageSendScriptErrorMessage).toBeNull();
+    expect(itemFrom(next).afterMessageReceiveScriptErrorMessage).toBeNull();
   });
 
-  it('clears both hook error contexts', () => {
+  it('clears every hook error context', () => {
     const next = rerun(makeState({ item: previousRun }));
 
     expect(itemFrom(next).beforeCallStartScriptErrorContext).toBeNull();
     expect(itemFrom(next).afterCallEndScriptErrorContext).toBeNull();
+    expect(itemFrom(next).beforeMessageSendScriptErrorContext).toBeNull();
+    expect(itemFrom(next).afterMessageReceiveScriptErrorContext).toBeNull();
   });
 
   it('leaves the hook scripts on the request alone', () => {
@@ -510,5 +618,26 @@ describe('initRunRequestEvent', () => {
     const next = rerun(state);
 
     expect(itemFrom(next).request.script.beforeCallStart).toBe('req.setMetadata("x", "1");');
+  });
+});
+
+describe('responseCleared', () => {
+  it('clears every hook test result, including the accumulating message ones', () => {
+    const state = makeState({
+      item: {
+        response: { statusCode: 0 },
+        beforeCallStartTestResults: [{ uid: 'r1', description: 'responds with OK', status: 'pass' }],
+        afterCallEndTestResults: [{ uid: 'r2', description: 'carries a trailer', status: 'fail' }],
+        beforeMessageSendTestResults: [{ uid: 'r3', description: 'message 1 is valid', status: 'pass', messageIndex: 0 }],
+        afterMessageReceiveTestResults: [{ uid: 'r4', description: 'reply 1 is ok', status: 'pass', messageIndex: 0 }]
+      }
+    });
+
+    const next = reducer(state, responseCleared({ itemUid: ITEM_UID, collectionUid: COLLECTION_UID }));
+
+    expect(itemFrom(next).beforeCallStartTestResults).toEqual([]);
+    expect(itemFrom(next).afterCallEndTestResults).toEqual([]);
+    expect(itemFrom(next).beforeMessageSendTestResults).toEqual([]);
+    expect(itemFrom(next).afterMessageReceiveTestResults).toEqual([]);
   });
 });

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -843,9 +843,19 @@ export const collectionsSlice = createSlice({
         item.afterCallEndScriptErrorMessage = errorMessage;
         item.afterCallEndScriptErrorContext = errorContext || null;
       }
+
+      if (scriptType === SCRIPT_TYPES.BEFORE_MESSAGE_SEND) {
+        item.beforeMessageSendScriptErrorMessage = errorMessage;
+        item.beforeMessageSendScriptErrorContext = errorContext || null;
+      }
+
+      if (scriptType === SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE) {
+        item.afterMessageReceiveScriptErrorMessage = errorMessage;
+        item.afterMessageReceiveScriptErrorContext = errorContext || null;
+      }
     },
     grpcTestResults: (state, action) => {
-      const { itemUid, collectionUid, scriptType, results } = action.payload;
+      const { itemUid, collectionUid, scriptType, results, messageIndex } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
       if (!collection) return;
 
@@ -858,6 +868,16 @@ export const collectionsSlice = createSlice({
 
       if (scriptType === SCRIPT_TYPES.AFTER_CALL_END) {
         item.afterCallEndTestResults = results;
+      }
+
+      const taggedResults = () => results.map((result) => ({ ...result, messageIndex }));
+
+      if (scriptType === SCRIPT_TYPES.BEFORE_MESSAGE_SEND) {
+        item.beforeMessageSendTestResults = [...(item.beforeMessageSendTestResults || []), ...taggedResults()];
+      }
+
+      if (scriptType === SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE) {
+        item.afterMessageReceiveTestResults = [...(item.afterMessageReceiveTestResults || []), ...taggedResults()];
       }
     },
     responseCleared: (state, action) => {
@@ -878,6 +898,8 @@ export const collectionsSlice = createSlice({
           item.testResults = [];
           item.beforeCallStartTestResults = [];
           item.afterCallEndTestResults = [];
+          item.beforeMessageSendTestResults = [];
+          item.afterMessageReceiveTestResults = [];
         }
       }
     },
@@ -3295,10 +3317,16 @@ export const collectionsSlice = createSlice({
       item.testScriptErrorContext = null;
       item.beforeCallStartScriptErrorMessage = null;
       item.afterCallEndScriptErrorMessage = null;
+      item.beforeMessageSendScriptErrorMessage = null;
+      item.afterMessageReceiveScriptErrorMessage = null;
       item.beforeCallStartScriptErrorContext = null;
       item.afterCallEndScriptErrorContext = null;
+      item.beforeMessageSendScriptErrorContext = null;
+      item.afterMessageReceiveScriptErrorContext = null;
       item.beforeCallStartTestResults = [];
       item.afterCallEndTestResults = [];
+      item.beforeMessageSendTestResults = [];
+      item.afterMessageReceiveTestResults = [];
     },
     runRequestEvent: (state, action) => {
       const { itemUid, collectionUid, type, requestUid } = action.payload;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -870,14 +870,14 @@ export const collectionsSlice = createSlice({
         item.afterCallEndTestResults = results;
       }
 
-      const taggedResults = () => results.map((result) => ({ ...result, messageIndex }));
+      if (scriptType === SCRIPT_TYPES.BEFORE_MESSAGE_SEND || scriptType === SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE) {
+        const isBeforeSend = scriptType === SCRIPT_TYPES.BEFORE_MESSAGE_SEND;
+        const resultsKey = isBeforeSend ? 'beforeMessageSendTestResults' : 'afterMessageReceiveTestResults';
 
-      if (scriptType === SCRIPT_TYPES.BEFORE_MESSAGE_SEND) {
-        item.beforeMessageSendTestResults = [...(item.beforeMessageSendTestResults || []), ...taggedResults()];
-      }
-
-      if (scriptType === SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE) {
-        item.afterMessageReceiveTestResults = [...(item.afterMessageReceiveTestResults || []), ...taggedResults()];
+        if (!item[resultsKey]) {
+          item[resultsKey] = [];
+        }
+        item[resultsKey].push(...results.map((result) => ({ ...result, messageIndex })));
       }
     },
     responseCleared: (state, action) => {

--- a/packages/bruno-common/src/scripts/index.ts
+++ b/packages/bruno-common/src/scripts/index.ts
@@ -7,7 +7,7 @@ export const SCRIPT_TYPES = Object.freeze({
   POST_RESPONSE: 'post-response',
   TEST: 'test',
   BEFORE_CALL_START: 'before-call-start',
-  AFTER_CALL_END: 'after-call-end',
   BEFORE_MESSAGE_SEND: 'before-message-send',
-  AFTER_MESSAGE_RECEIVE: 'after-message-receive'
+  AFTER_MESSAGE_RECEIVE: 'after-message-receive',
+  AFTER_CALL_END: 'after-call-end'
 } as const);

--- a/packages/bruno-common/src/scripts/index.ts
+++ b/packages/bruno-common/src/scripts/index.ts
@@ -1,11 +1,13 @@
 export const HTTP_SCRIPT_KEYS = ['req', 'res'];
 
-export const GRPC_SCRIPT_KEYS = ['beforeCallStart', 'afterCallEnd'];
+export const GRPC_SCRIPT_KEYS = ['beforeCallStart', 'beforeMessageSend', 'afterMessageReceive', 'afterCallEnd'];
 
 export const SCRIPT_TYPES = Object.freeze({
   PRE_REQUEST: 'pre-request',
   POST_RESPONSE: 'post-response',
   TEST: 'test',
   BEFORE_CALL_START: 'before-call-start',
-  AFTER_CALL_END: 'after-call-end'
+  AFTER_CALL_END: 'after-call-end',
+  BEFORE_MESSAGE_SEND: 'before-message-send',
+  AFTER_MESSAGE_RECEIVE: 'after-message-receive'
 } as const);

--- a/packages/bruno-converters/src/opencollection/common/scripts.ts
+++ b/packages/bruno-converters/src/opencollection/common/scripts.ts
@@ -23,6 +23,8 @@ export const toOpenCollectionScripts = (request: BrunoFolderRequest | BrunoHttpR
   pushScript('res', 'after-response', script?.res);
   pushScript('beforeCallStart', 'grpc:before-call-start', script?.beforeCallStart);
   pushScript('afterCallEnd', 'grpc:after-call-end', script?.afterCallEnd);
+  pushScript('beforeMessageSend', 'grpc:before-message-send', script?.beforeMessageSend);
+  pushScript('afterMessageReceive', 'grpc:after-message-receive', script?.afterMessageReceive);
 
   if (request?.tests?.trim().length) {
     ocScripts.push({
@@ -74,6 +76,12 @@ export const fromOpenCollectionScripts = (scripts: Scripts | null | undefined, a
         break;
       case 'grpc:after-call-end':
         setScript('afterCallEnd', script.code);
+        break;
+      case 'grpc:before-message-send':
+        setScript('beforeMessageSend', script.code);
+        break;
+      case 'grpc:after-message-receive':
+        setScript('afterMessageReceive', script.code);
         break;
       case 'tests':
         brunoScripts.tests = script.code;

--- a/packages/bruno-converters/src/opencollection/common/scripts.ts
+++ b/packages/bruno-converters/src/opencollection/common/scripts.ts
@@ -22,9 +22,9 @@ export const toOpenCollectionScripts = (request: BrunoFolderRequest | BrunoHttpR
   pushScript('req', 'before-request', script?.req);
   pushScript('res', 'after-response', script?.res);
   pushScript('beforeCallStart', 'grpc:before-call-start', script?.beforeCallStart);
-  pushScript('afterCallEnd', 'grpc:after-call-end', script?.afterCallEnd);
   pushScript('beforeMessageSend', 'grpc:before-message-send', script?.beforeMessageSend);
   pushScript('afterMessageReceive', 'grpc:after-message-receive', script?.afterMessageReceive);
+  pushScript('afterCallEnd', 'grpc:after-call-end', script?.afterCallEnd);
 
   if (request?.tests?.trim().length) {
     ocScripts.push({
@@ -74,14 +74,14 @@ export const fromOpenCollectionScripts = (scripts: Scripts | null | undefined, a
       case 'grpc:before-call-start':
         setScript('beforeCallStart', script.code);
         break;
-      case 'grpc:after-call-end':
-        setScript('afterCallEnd', script.code);
-        break;
       case 'grpc:before-message-send':
         setScript('beforeMessageSend', script.code);
         break;
       case 'grpc:after-message-receive':
         setScript('afterMessageReceive', script.code);
+        break;
+      case 'grpc:after-call-end':
+        setScript('afterCallEnd', script.code);
         break;
       case 'tests':
         brunoScripts.tests = script.code;

--- a/packages/bruno-converters/tests/opencollection/grpc-scripts.spec.js
+++ b/packages/bruno-converters/tests/opencollection/grpc-scripts.spec.js
@@ -85,17 +85,17 @@ describe('brunoToOpenCollection (export): grpc lifecycle scripts', () => {
     const oc = exportItems([
       grpcItem({
         beforeCallStart: 'before()',
-        afterCallEnd: 'after()',
         beforeMessageSend: 'beforeSend()',
-        afterMessageReceive: 'afterReceive()'
+        afterMessageReceive: 'afterReceive()',
+        afterCallEnd: 'after()'
       })
     ]);
 
     expect(oc.items[0].runtime.scripts).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' },
       { type: 'grpc:before-message-send', code: 'beforeSend()' },
-      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' },
+      { type: 'grpc:after-call-end', code: 'after()' }
     ]);
   });
 
@@ -112,23 +112,23 @@ describe('brunoToOpenCollection (export): grpc lifecycle scripts', () => {
     const oc = exportItems([
       grpcItem({
         beforeCallStart: '  before()\n',
-        afterCallEnd: '\n\tafter()  ',
         beforeMessageSend: ' beforeSend() ',
-        afterMessageReceive: '\n afterReceive() \n'
+        afterMessageReceive: '\n afterReceive() \n',
+        afterCallEnd: '\n\tafter()  '
       })
     ]);
 
     expect(oc.items[0].runtime.scripts).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' },
       { type: 'grpc:before-message-send', code: 'beforeSend()' },
-      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' },
+      { type: 'grpc:after-call-end', code: 'after()' }
     ]);
   });
 
   it('drops hooks whose code is only whitespace', () => {
     const oc = exportItems([
-      grpcItem({ beforeCallStart: '   ', afterCallEnd: '\n\t\n', beforeMessageSend: ' ', afterMessageReceive: '\t' })
+      grpcItem({ beforeCallStart: '   ', beforeMessageSend: ' ', afterMessageReceive: '\t', afterCallEnd: '\n\t\n' })
     ]);
 
     expect(oc.items[0].runtime?.scripts).toBeUndefined();
@@ -136,12 +136,12 @@ describe('brunoToOpenCollection (export): grpc lifecycle scripts', () => {
 
   it('drops a blank hook while keeping its populated sibling', () => {
     const oc = exportItems([
-      grpcItem({ beforeCallStart: '   ', afterCallEnd: 'after()', beforeMessageSend: '  ', afterMessageReceive: 'afterReceive()' })
+      grpcItem({ beforeCallStart: '   ', beforeMessageSend: '  ', afterMessageReceive: 'afterReceive()', afterCallEnd: 'after()' })
     ]);
 
     expect(oc.items[0].runtime.scripts).toEqual([
-      { type: 'grpc:after-call-end', code: 'after()' },
-      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' },
+      { type: 'grpc:after-call-end', code: 'after()' }
     ]);
   });
 
@@ -193,9 +193,9 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
       items: [
         ocGrpcItem([
           { type: 'grpc:before-call-start', code: 'before()' },
-          { type: 'grpc:after-call-end', code: 'after()' },
           { type: 'grpc:before-message-send', code: 'beforeSend()' },
           { type: 'grpc:after-message-receive', code: 'afterReceive()' },
+          { type: 'grpc:after-call-end', code: 'after()' },
           { type: 'tests', code: 'test()' }
         ])
       ]
@@ -203,9 +203,9 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
 
     expect(collection.items[0].request.script).toEqual({
       beforeCallStart: 'before()',
-      afterCallEnd: 'after()',
       beforeMessageSend: 'beforeSend()',
-      afterMessageReceive: 'afterReceive()'
+      afterMessageReceive: 'afterReceive()',
+      afterCallEnd: 'after()'
     });
     expect(collection.items[0].request.tests).toBe('test()');
   });
@@ -248,16 +248,16 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
       items: [
         ocGrpcItem([
           { type: 'grpc:before-call-start', code: '' },
-          { type: 'grpc:after-call-end', code: 'after()' },
           { type: 'grpc:before-message-send', code: '' },
-          { type: 'grpc:after-message-receive', code: 'afterReceive()' }
+          { type: 'grpc:after-message-receive', code: 'afterReceive()' },
+          { type: 'grpc:after-call-end', code: 'after()' }
         ])
       ]
     });
 
     expect(collection.items[0].request.script).toEqual({
-      afterCallEnd: 'after()',
-      afterMessageReceive: 'afterReceive()'
+      afterMessageReceive: 'afterReceive()',
+      afterCallEnd: 'after()'
     });
   });
 
@@ -268,9 +268,9 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
       items: [
         ocGrpcItem([
           { type: 'grpc:before-call-start', code: '' },
-          { type: 'grpc:after-call-end', code: '' },
           { type: 'grpc:before-message-send', code: '' },
-          { type: 'grpc:after-message-receive', code: '' }
+          { type: 'grpc:after-message-receive', code: '' },
+          { type: 'grpc:after-call-end', code: '' }
         ])
       ]
     });
@@ -391,9 +391,9 @@ describe('grpc lifecycle scripts: export then import keeps them the same', () =>
       grpcItem(
         {
           beforeCallStart: 'before()',
-          afterCallEnd: 'after()',
           beforeMessageSend: 'beforeSend()',
-          afterMessageReceive: 'afterReceive()'
+          afterMessageReceive: 'afterReceive()',
+          afterCallEnd: 'after()'
         },
         'test()'
       )
@@ -402,9 +402,9 @@ describe('grpc lifecycle scripts: export then import keeps them the same', () =>
 
     expect(collection.items[0].request.script).toEqual({
       beforeCallStart: 'before()',
-      afterCallEnd: 'after()',
       beforeMessageSend: 'beforeSend()',
-      afterMessageReceive: 'afterReceive()'
+      afterMessageReceive: 'afterReceive()',
+      afterCallEnd: 'after()'
     });
     expect(collection.items[0].request.tests).toBe('test()');
   });

--- a/packages/bruno-converters/tests/opencollection/grpc-scripts.spec.js
+++ b/packages/bruno-converters/tests/opencollection/grpc-scripts.spec.js
@@ -82,11 +82,20 @@ const exportItems = (items) => brunoToOpenCollection({ name: 'API', brunoConfig:
 
 describe('brunoToOpenCollection (export): grpc lifecycle scripts', () => {
   it('writes the lifecycle hooks as grpc-prefixed script types', () => {
-    const oc = exportItems([grpcItem({ beforeCallStart: 'before()', afterCallEnd: 'after()' })]);
+    const oc = exportItems([
+      grpcItem({
+        beforeCallStart: 'before()',
+        afterCallEnd: 'after()',
+        beforeMessageSend: 'beforeSend()',
+        afterMessageReceive: 'afterReceive()'
+      })
+    ]);
 
     expect(oc.items[0].runtime.scripts).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' }
+      { type: 'grpc:after-call-end', code: 'after()' },
+      { type: 'grpc:before-message-send', code: 'beforeSend()' },
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
     ]);
   });
 
@@ -100,24 +109,40 @@ describe('brunoToOpenCollection (export): grpc lifecycle scripts', () => {
   });
 
   it('trims the whitespace around the hooks', () => {
-    const oc = exportItems([grpcItem({ beforeCallStart: '  before()\n', afterCallEnd: '\n\tafter()  ' })]);
+    const oc = exportItems([
+      grpcItem({
+        beforeCallStart: '  before()\n',
+        afterCallEnd: '\n\tafter()  ',
+        beforeMessageSend: ' beforeSend() ',
+        afterMessageReceive: '\n afterReceive() \n'
+      })
+    ]);
 
     expect(oc.items[0].runtime.scripts).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' }
+      { type: 'grpc:after-call-end', code: 'after()' },
+      { type: 'grpc:before-message-send', code: 'beforeSend()' },
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
     ]);
   });
 
   it('drops hooks whose code is only whitespace', () => {
-    const oc = exportItems([grpcItem({ beforeCallStart: '   ', afterCallEnd: '\n\t\n' })]);
+    const oc = exportItems([
+      grpcItem({ beforeCallStart: '   ', afterCallEnd: '\n\t\n', beforeMessageSend: ' ', afterMessageReceive: '\t' })
+    ]);
 
     expect(oc.items[0].runtime?.scripts).toBeUndefined();
   });
 
   it('drops a blank hook while keeping its populated sibling', () => {
-    const oc = exportItems([grpcItem({ beforeCallStart: '   ', afterCallEnd: 'after()' })]);
+    const oc = exportItems([
+      grpcItem({ beforeCallStart: '   ', afterCallEnd: 'after()', beforeMessageSend: '  ', afterMessageReceive: 'afterReceive()' })
+    ]);
 
-    expect(oc.items[0].runtime.scripts).toEqual([{ type: 'grpc:after-call-end', code: 'after()' }]);
+    expect(oc.items[0].runtime.scripts).toEqual([
+      { type: 'grpc:after-call-end', code: 'after()' },
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
+    ]);
   });
 
   it('drops req/res carried by a grpc request', () => {
@@ -127,7 +152,7 @@ describe('brunoToOpenCollection (export): grpc lifecycle scripts', () => {
   });
 
   it('drops grpc hooks carried by an http request', () => {
-    const oc = exportItems([httpItem({ req: 'pre()', beforeCallStart: 'before()' })]);
+    const oc = exportItems([httpItem({ req: 'pre()', beforeCallStart: 'before()', afterMessageReceive: 'afterReceive()' })]);
 
     expect(oc.items[0].runtime.scripts).toEqual([{ type: 'before-request', code: 'pre()' }]);
   });
@@ -169,6 +194,8 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
         ocGrpcItem([
           { type: 'grpc:before-call-start', code: 'before()' },
           { type: 'grpc:after-call-end', code: 'after()' },
+          { type: 'grpc:before-message-send', code: 'beforeSend()' },
+          { type: 'grpc:after-message-receive', code: 'afterReceive()' },
           { type: 'tests', code: 'test()' }
         ])
       ]
@@ -176,7 +203,9 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
 
     expect(collection.items[0].request.script).toEqual({
       beforeCallStart: 'before()',
-      afterCallEnd: 'after()'
+      afterCallEnd: 'after()',
+      beforeMessageSend: 'beforeSend()',
+      afterMessageReceive: 'afterReceive()'
     });
     expect(collection.items[0].request.tests).toBe('test()');
   });
@@ -219,12 +248,17 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
       items: [
         ocGrpcItem([
           { type: 'grpc:before-call-start', code: '' },
-          { type: 'grpc:after-call-end', code: 'after()' }
+          { type: 'grpc:after-call-end', code: 'after()' },
+          { type: 'grpc:before-message-send', code: '' },
+          { type: 'grpc:after-message-receive', code: 'afterReceive()' }
         ])
       ]
     });
 
-    expect(collection.items[0].request.script).toEqual({ afterCallEnd: 'after()' });
+    expect(collection.items[0].request.script).toEqual({
+      afterCallEnd: 'after()',
+      afterMessageReceive: 'afterReceive()'
+    });
   });
 
   it('leaves the hooks unset when every hook has empty code', () => {
@@ -234,7 +268,9 @@ describe('openCollectionToBruno (import): grpc lifecycle scripts', () => {
       items: [
         ocGrpcItem([
           { type: 'grpc:before-call-start', code: '' },
-          { type: 'grpc:after-call-end', code: '' }
+          { type: 'grpc:after-call-end', code: '' },
+          { type: 'grpc:before-message-send', code: '' },
+          { type: 'grpc:after-message-receive', code: '' }
         ])
       ]
     });
@@ -350,13 +386,25 @@ describe('graphql and websocket requests: grpc lifecycle scripts', () => {
 });
 
 describe('grpc lifecycle scripts: export then import keeps them the same', () => {
-  it('preserves both hooks across a round trip', () => {
-    const oc = exportItems([grpcItem({ beforeCallStart: 'before()', afterCallEnd: 'after()' }, 'test()')]);
+  it('preserves every hook across a round trip', () => {
+    const oc = exportItems([
+      grpcItem(
+        {
+          beforeCallStart: 'before()',
+          afterCallEnd: 'after()',
+          beforeMessageSend: 'beforeSend()',
+          afterMessageReceive: 'afterReceive()'
+        },
+        'test()'
+      )
+    ]);
     const collection = openCollectionToBruno(oc);
 
     expect(collection.items[0].request.script).toEqual({
       beforeCallStart: 'before()',
-      afterCallEnd: 'after()'
+      afterCallEnd: 'after()',
+      beforeMessageSend: 'beforeSend()',
+      afterMessageReceive: 'afterReceive()'
     });
     expect(collection.items[0].request.tests).toBe('test()');
   });

--- a/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
@@ -334,8 +334,20 @@ const registerGrpcEventHandlers = (window) => {
 
   // Send a message to an existing stream
   ipcMain.handle('grpc:send-message', async (event, requestId, collectionUid, message) => {
+    let data;
     try {
-      await grpcScriptOrchestration.runBeforeMessageSend({ requestId, data: safeParseJSON(message) });
+      // Parsed up front so a malformed message fails here.
+      data = typeof message === 'string' ? JSON.parse(message) : message;
+    } catch (error) {
+      return { success: false, error: `Failed to parse request body: ${error.message}` };
+    }
+
+    if (!grpcClient.isConnectionActive(requestId)) {
+      return { success: false, error: 'Cannot send message: the gRPC stream is not open' };
+    }
+
+    try {
+      await grpcScriptOrchestration.runBeforeMessageSend({ requestId, data });
     } catch (error) {
       // The hook aborted this one message; the stream stays open for the next.
       return { success: false, error: error.message };

--- a/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-event-handlers.js
@@ -282,11 +282,17 @@ const registerGrpcEventHandlers = (window) => {
           pfx,
           verifyOptions,
           includeDirs,
-          proxyConfig: grpcProxyConfig
+          proxyConfig: grpcProxyConfig,
+          onBeforeMessageSend: ({ data }) =>
+            grpcScriptOrchestration.runBeforeMessageSend({ requestId: preparedRequest.uid, data })
         });
       } catch (error) {
         // The call never opened, so no terminal event will arrive to retire the session it armed.
         grpcScriptOrchestration.closeCallSession(request.uid);
+        // A `beforeMessageSend` that threw aborted the call
+        if (error.isGrpcScriptError) {
+          return { success: false, error: error.message };
+        }
         throw error;
       }
 
@@ -327,7 +333,14 @@ const registerGrpcEventHandlers = (window) => {
   });
 
   // Send a message to an existing stream
-  ipcMain.handle('grpc:send-message', (event, requestId, collectionUid, message) => {
+  ipcMain.handle('grpc:send-message', async (event, requestId, collectionUid, message) => {
+    try {
+      await grpcScriptOrchestration.runBeforeMessageSend({ requestId, data: safeParseJSON(message) });
+    } catch (error) {
+      // The hook aborted this one message; the stream stays open for the next.
+      return { success: false, error: error.message };
+    }
+
     try {
       grpcClient.sendMessage(requestId, collectionUid, message);
       grpcScriptOrchestration.interceptGrpcEvent('grpc:message', requestId, collectionUid, message);

--- a/packages/bruno-electron/src/ipc/network/grpc-script-orchestration.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-script-orchestration.js
@@ -378,6 +378,9 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
     });
   };
 
+  // Unlike `beforeMessageSend`, this one does not rethrow: the message has already been delivered
+  // and forwarded to the renderer, so there is nothing left to abort. Errors are surfaced through
+  // `grpc:script-error` and the call carries on with the remaining messages.
   const runAfterMessageReceive = (session, message) => {
     const messageIndex = session.receivedCount++;
     const { request, collection, collectionUid } = session;

--- a/packages/bruno-electron/src/ipc/network/grpc-script-orchestration.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-script-orchestration.js
@@ -64,17 +64,38 @@ const buildSentMessages = (session) => {
   return firstAuthored ? [{ data: safeParseJSON(firstAuthored.content), timestamp: session.startedAt }] : [];
 };
 
-const buildCallResult = (session) => ({
+// partial results for message hooks
+const buildPartialCallResult = (session) => ({
   messages: session.messages,
   metadata: session.metadata,
   trailers: session.trailers,
-  statusCode: session.statusCode ?? UNKNOWN_STATUS_CODE,
+  statusCode: session.statusCode,
   statusText: session.statusText,
-  duration: Date.now() - session.startedAt,
+  duration: undefined,
   url: session.request.url,
   method: session.request.method,
   methodType: session.request.methodType
 });
+
+const buildCallResult = (session) => ({
+  ...buildPartialCallResult(session),
+  statusCode: session.statusCode ?? UNKNOWN_STATUS_CODE,
+  duration: Date.now() - session.startedAt
+});
+
+// hooks that need session information. BeforeCallStart is excluded since session is not armed at that point
+const SESSION_HOOK_KEYS = ['afterCallEnd', 'beforeMessageSend', 'afterMessageReceive'];
+
+const hasSessionHook = (request) =>
+  SESSION_HOOK_KEYS.some((key) => get(request, `script.${key}`)?.trim().length);
+
+// Runs the hooks in a queue for a session/request so messages and timeline are in received order.
+const enqueueHook = (session, run) => {
+  // Both handlers are `run` so a rejection cannot poison the chain for later messages.
+  session.hookQueue = session.hookQueue.then(run, run);
+
+  return session.hookQueue;
+};
 
 const createGrpcScriptOrchestration = ({ sendEvent }) => {
   const callSessions = new Map();
@@ -143,15 +164,25 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
     }
   };
 
-  const emitScriptError = ({ requestId, collectionUid, scriptType, error, scriptMetadata, collectionPath }) => {
+  const emitScriptError = ({
+    requestId,
+    collectionUid,
+    scriptType,
+    error,
+    scriptMetadata,
+    collectionPath,
+    messageIndex
+  }) => {
+    const errorMessage = error.message || `An error occurred in ${scriptType.replaceAll('-', ' ')} script`;
+
     sendEvent('grpc:script-error', requestId, collectionUid, {
       scriptType,
-      errorMessage: error.message || `An error occurred in ${scriptType.replace('-', ' ')} script`,
+      errorMessage: messageIndex === undefined ? errorMessage : `Message ${messageIndex + 1}: ${errorMessage}`,
       errorContext: formatErrorWithContextV2(error, scriptType, scriptMetadata, collectionPath)
     });
   };
 
-  const applyScriptResult = ({ scriptResult, request, collection, collectionUid, scriptType }) => {
+  const applyScriptResult = ({ scriptResult, request, collection, collectionUid, scriptType, messageIndex }) => {
     sendVariableUpdates(scriptResult, { collectionUid, requestUid: request.uid, collection });
     resetOauth2Credentials({
       oauth2CredentialsToReset: scriptResult.oauth2CredentialsToReset,
@@ -162,7 +193,8 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
     if (scriptResult.results) {
       sendEvent('grpc:test-results', request.uid, collectionUid, {
         scriptType,
-        results: scriptResult.results
+        results: scriptResult.results,
+        messageIndex
       });
     }
   };
@@ -178,17 +210,17 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
     let scriptError = null;
 
     try {
-      scriptResult = await scriptRuntime.runGrpcRequestScript(
-        decomment(hookScript, { space: true }),
+      scriptResult = await scriptRuntime.runGrpcRequestScript({
+        script: decomment(hookScript, { space: true }),
         request,
-        envVars,
+        envVariables: envVars,
         runtimeVariables,
-        collection.pathname,
+        collectionPath: collection.pathname,
         onConsoleLog,
         processEnvVars,
         scriptingConfig,
-        collection.name
-      );
+        collectionName: collection.name
+      });
     } catch (error) {
       scriptError = error;
       // Variables the hook set before throwing still have to reach the app.
@@ -231,25 +263,28 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
 
   const runAfterCallEnd = async (session) => {
     const { request, collection, collectionUid } = session;
+
+    if (!request.script?.afterCallEnd?.trim().length) return;
+
     const scriptRuntime = new GrpcScriptRuntime({ runtime: session.scriptingConfig?.runtime });
 
     let scriptResult = null;
     let scriptError = null;
 
     try {
-      scriptResult = await scriptRuntime.runGrpcResponseScript(
-        decomment(request.script.afterCallEnd, { space: true }),
+      scriptResult = await scriptRuntime.runGrpcResponseScript({
+        script: decomment(request.script.afterCallEnd, { space: true }),
         request,
-        buildCallResult(session),
-        session.envVars,
-        session.runtimeVariables,
-        collection.pathname,
+        response: buildCallResult(session),
+        envVariables: session.envVars,
+        runtimeVariables: session.runtimeVariables,
+        collectionPath: collection.pathname,
         onConsoleLog,
-        session.processEnvVars,
-        session.scriptingConfig,
-        collection.name,
-        { sentMessages: buildSentMessages(session) }
-      );
+        processEnvVars: session.processEnvVars,
+        scriptingConfig: session.scriptingConfig,
+        collectionName: collection.name,
+        sentMessages: buildSentMessages(session)
+      });
     } catch (error) {
       scriptError = error;
       scriptResult = error.partialResults ?? null;
@@ -275,14 +310,131 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
         collectionPath: collection.pathname
       });
     }
+  };
 
-    closeSessionIfCurrent(session);
+  /**
+   * @param {object} params
+   * @param {string} params.requestId
+   * @param {*} params.data - The message payload about to be transmitted
+   */
+  const runBeforeMessageSend = ({ requestId, data }) => {
+    const session = callSessions.get(requestId);
+    const hookScript = get(session, 'request.script.beforeMessageSend');
+    if (!hookScript?.trim().length) return Promise.resolve();
+
+    return enqueueHook(session, async () => {
+      const { request, collection, collectionUid } = session;
+      const messageIndex = session.sentCount++;
+      const scriptRuntime = new GrpcScriptRuntime({ runtime: session.scriptingConfig?.runtime });
+
+      let scriptResult = null;
+      let scriptError = null;
+
+      try {
+        scriptResult = await scriptRuntime.runGrpcBeforeMessageSendScript({
+          script: decomment(hookScript, { space: true }),
+          request,
+          message: { data, timestamp: Date.now() },
+          envVariables: session.envVars,
+          runtimeVariables: session.runtimeVariables,
+          collectionPath: collection.pathname,
+          onConsoleLog,
+          processEnvVars: session.processEnvVars,
+          scriptingConfig: session.scriptingConfig,
+          collectionName: collection.name,
+          sentMessages: session.sentMessages
+        });
+      } catch (error) {
+        scriptError = error;
+        scriptResult = error.partialResults ?? null;
+      }
+
+      if (scriptResult) {
+        applyScriptResult({
+          scriptResult,
+          request,
+          collection,
+          collectionUid,
+          scriptType: SCRIPT_TYPES.BEFORE_MESSAGE_SEND,
+          messageIndex
+        });
+      }
+
+      if (scriptError) {
+        emitScriptError({
+          requestId: session.requestId,
+          collectionUid,
+          scriptType: SCRIPT_TYPES.BEFORE_MESSAGE_SEND,
+          error: scriptError,
+          scriptMetadata: request.script?.beforeMessageSendMetadata,
+          collectionPath: collection.pathname,
+          messageIndex
+        });
+        // Marked so the IPC handlers can answer `{ success: false }`
+        scriptError.isGrpcScriptError = true;
+        throw scriptError;
+      }
+    });
+  };
+
+  const runAfterMessageReceive = (session, message) => {
+    const messageIndex = session.receivedCount++;
+    const { request, collection, collectionUid } = session;
+    const scriptRuntime = new GrpcScriptRuntime({ runtime: session.scriptingConfig?.runtime });
+
+    return (async () => {
+      let scriptResult = null;
+      let scriptError = null;
+
+      try {
+        scriptResult = await scriptRuntime.runGrpcAfterMessageReceiveScript({
+          script: decomment(request.script.afterMessageReceive, { space: true }),
+          request,
+          response: buildPartialCallResult(session),
+          message,
+          envVariables: session.envVars,
+          runtimeVariables: session.runtimeVariables,
+          collectionPath: collection.pathname,
+          onConsoleLog,
+          processEnvVars: session.processEnvVars,
+          scriptingConfig: session.scriptingConfig,
+          collectionName: collection.name,
+          sentMessages: buildSentMessages(session)
+        });
+      } catch (error) {
+        scriptError = error;
+        scriptResult = error.partialResults ?? null;
+      }
+
+      if (scriptResult) {
+        applyScriptResult({
+          scriptResult,
+          request,
+          collection,
+          collectionUid,
+          scriptType: SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE,
+          messageIndex
+        });
+      }
+
+      if (scriptError) {
+        emitScriptError({
+          requestId: session.requestId,
+          collectionUid,
+          scriptType: SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE,
+          error: scriptError,
+          scriptMetadata: request.script?.afterMessageReceiveMetadata,
+          collectionPath: collection.pathname,
+          messageIndex
+        });
+      }
+    })();
   };
 
   // Arms the aggregator for a call. Must run before the connection opens.
   const openCallSession = ({ request, collection, envVars, runtimeVariables, processEnvVars, scriptingConfig }) => {
-    // A request with no `afterCallEnd` gets no session
-    if (!get(request, 'script.afterCallEnd')?.trim().length) return;
+    // A request with none of the hooks that read from the session gets no session
+    if (!hasSessionHook(request)) return;
 
     callSessions.set(request.uid, {
       requestId: request.uid,
@@ -300,12 +452,17 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
       trailers: undefined,
       statusCode: undefined,
       statusText: undefined,
-      terminated: false
+      terminated: false,
+      hookQueue: Promise.resolve(),
+      sentCount: 0,
+      receivedCount: 0
     });
   };
 
   // Wraps the GrpcClient event callback. Forwards to the renderer first
   const interceptGrpcEvent = (eventName, ...args) => {
+    // If AfterMessageReceive transforms the received message then the ordering has to change,
+    // since a message is already transferred to response pane before transformation
     sendEvent(eventName, ...args);
 
     if (!CALL_EVENTS.has(eventName)) return;
@@ -316,21 +473,39 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
 
     applyEventToSession(session, eventName, payload);
 
+    if (
+      eventName === 'grpc:response'
+      && payload?.res !== undefined
+      && !payload?.error
+      && session.request.script?.afterMessageReceive?.trim().length
+    ) {
+      const received = session.messages[session.messages.length - 1];
+      enqueueHook(session, () => runAfterMessageReceive(session, received));
+    }
+
     if (!TERMINAL_EVENTS.includes(eventName) || session.terminated) return;
 
     session.terminated = true;
     // A server stream emits both `end` and `status`. Hence running 'afterCallEnd' after a tick to get trailers and status code.
     setImmediate(() => {
-      runAfterCallEnd(session).catch((error) => {
-        console.error('Error running gRPC afterCallEnd hook:', error);
-        closeSessionIfCurrent(session);
-      });
+      enqueueHook(session, () => runAfterCallEnd(session))
+        .catch((error) => {
+          console.error('Error running gRPC afterCallEnd hook:', error);
+        })
+        .finally(() => closeSessionIfCurrent(session));
     });
   };
 
   const closeAllCallSessions = () => callSessions.clear();
 
-  return { runBeforeCallStart, openCallSession, closeCallSession, interceptGrpcEvent, closeAllCallSessions };
+  return {
+    runBeforeCallStart,
+    runBeforeMessageSend,
+    openCallSession,
+    closeCallSession,
+    interceptGrpcEvent,
+    closeAllCallSessions
+  };
 };
 
 module.exports = { createGrpcScriptOrchestration };

--- a/packages/bruno-electron/src/ipc/network/grpc-script-orchestration.js
+++ b/packages/bruno-electron/src/ipc/network/grpc-script-orchestration.js
@@ -178,7 +178,8 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
     sendEvent('grpc:script-error', requestId, collectionUid, {
       scriptType,
       errorMessage: messageIndex === undefined ? errorMessage : `Message ${messageIndex + 1}: ${errorMessage}`,
-      errorContext: formatErrorWithContextV2(error, scriptType, scriptMetadata, collectionPath)
+      errorContext: formatErrorWithContextV2(error, scriptType, scriptMetadata, collectionPath),
+      messageIndex
     });
   };
 
@@ -480,7 +481,10 @@ const createGrpcScriptOrchestration = ({ sendEvent }) => {
       && session.request.script?.afterMessageReceive?.trim().length
     ) {
       const received = session.messages[session.messages.length - 1];
-      enqueueHook(session, () => runAfterMessageReceive(session, received));
+      enqueueHook(session, () => runAfterMessageReceive(session, received))
+        .catch((error) => {
+          console.error('Error running gRPC afterMessageReceive hook:', error);
+        });
     }
 
     if (!TERMINAL_EVENTS.includes(eventName) || session.terminated) return;

--- a/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
+++ b/packages/bruno-filestore/src/formats/bru/tests/redact-large-text-blocks.spec.js
@@ -124,6 +124,14 @@ script:grpc:after-call-end {
   bru.setVar("endedAt", 2);
 }
 
+script:grpc:before-message-send {
+  bru.setVar("sentAt", bru.grpc.request.message.timestamp);
+}
+
+script:grpc:after-message-receive {
+  bru.setVar("receivedAt", bru.grpc.response.message.timestamp);
+}
+
 tests {
   test("hook ran", function() {
     expect(bru.getVar("startedAt")).to.equal(1);
@@ -376,8 +384,8 @@ describe('redactLargeBruTextBlocks', () => {
 
   it('extracts the grpc lifecycle hooks and leaves the dictionary message block in place', () => {
     const { skeleton, blocks } = redactLargeBruTextBlocks(grpcBru);
-    // both lifecycle hooks + tests; `body:grpc` is a dictionary and stays in the skeleton
-    expect(blocks.length).toBe(3);
+    // all four lifecycle hooks + tests; `body:grpc` is a dictionary and stays in the skeleton
+    expect(blocks.length).toBe(5);
     expect(skeleton.length).toBeLessThan(grpcBru.length);
     blocks.forEach((block) => {
       expect(skeleton).toContain(block.token);

--- a/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
+++ b/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
@@ -21,9 +21,9 @@ const BLOCK_TAGS = [
   'script:pre-request',
   'script:post-response',
   'script:grpc:before-call-start',
-  'script:grpc:after-call-end',
   'script:grpc:before-message-send',
   'script:grpc:after-message-receive',
+  'script:grpc:after-call-end',
   'tests',
   'docs',
   'body'

--- a/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
+++ b/packages/bruno-filestore/src/formats/bru/utils/redact-large-text-blocks.ts
@@ -22,6 +22,8 @@ const BLOCK_TAGS = [
   'script:post-response',
   'script:grpc:before-call-start',
   'script:grpc:after-call-end',
+  'script:grpc:before-message-send',
+  'script:grpc:after-message-receive',
   'tests',
   'docs',
   'body'

--- a/packages/bruno-filestore/src/formats/yml/common/scripts.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/scripts.spec.ts
@@ -23,18 +23,34 @@ describe('toOpenCollectionScripts', () => {
 
   it('writes the grpc lifecycle hooks for the grpc keys', () => {
     const out = toOpenCollectionScripts(
-      { script: { beforeCallStart: 'before()', afterCallEnd: 'after()' } } as any,
+      {
+        script: {
+          beforeCallStart: 'before()',
+          afterCallEnd: 'after()',
+          beforeMessageSend: 'beforeSend()',
+          afterMessageReceive: 'afterReceive()'
+        }
+      } as any,
       GRPC_SCRIPT_KEYS
     );
 
     expect(out).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' }
+      { type: 'grpc:after-call-end', code: 'after()' },
+      { type: 'grpc:before-message-send', code: 'beforeSend()' },
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
     ]);
   });
 
   it('drops script slots outside the allowed keys', () => {
-    const script = { req: 'pre()', res: 'post()', beforeCallStart: 'before()', afterCallEnd: 'after()' };
+    const script = {
+      req: 'pre()',
+      res: 'post()',
+      beforeCallStart: 'before()',
+      afterCallEnd: 'after()',
+      beforeMessageSend: 'beforeSend()',
+      afterMessageReceive: 'afterReceive()'
+    };
 
     expect(toOpenCollectionScripts({ script } as any, HTTP_SCRIPT_KEYS)).toEqual([
       { type: 'before-request', code: 'pre()' },
@@ -42,12 +58,15 @@ describe('toOpenCollectionScripts', () => {
     ]);
     expect(toOpenCollectionScripts({ script } as any, GRPC_SCRIPT_KEYS)).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' }
+      { type: 'grpc:after-call-end', code: 'after()' },
+      { type: 'grpc:before-message-send', code: 'beforeSend()' },
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
     ]);
   });
 
   it('returns undefined when every populated slot is gated out', () => {
     expect(toOpenCollectionScripts({ script: { beforeCallStart: 'before()' } } as any, HTTP_SCRIPT_KEYS)).toBeUndefined();
+    expect(toOpenCollectionScripts({ script: { beforeMessageSend: 'beforeSend()' } } as any, HTTP_SCRIPT_KEYS)).toBeUndefined();
     expect(toOpenCollectionScripts({ script: { req: 'pre()' } } as any, GRPC_SCRIPT_KEYS)).toBeUndefined();
   });
 
@@ -87,6 +106,8 @@ describe('toBrunoScripts', () => {
         { type: 'after-response', code: 'post()' },
         { type: 'grpc:before-call-start', code: 'before()' },
         { type: 'grpc:after-call-end', code: 'after()' },
+        { type: 'grpc:before-message-send', code: 'beforeSend()' },
+        { type: 'grpc:after-message-receive', code: 'afterReceive()' },
         { type: 'tests', code: 'test()' }
       ])
     ).toEqual({
@@ -94,7 +115,9 @@ describe('toBrunoScripts', () => {
         req: 'pre()',
         res: 'post()',
         beforeCallStart: 'before()',
-        afterCallEnd: 'after()'
+        afterCallEnd: 'after()',
+        beforeMessageSend: 'beforeSend()',
+        afterMessageReceive: 'afterReceive()'
       },
       tests: 'test()'
     });

--- a/packages/bruno-filestore/src/formats/yml/common/scripts.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/scripts.spec.ts
@@ -26,9 +26,9 @@ describe('toOpenCollectionScripts', () => {
       {
         script: {
           beforeCallStart: 'before()',
-          afterCallEnd: 'after()',
           beforeMessageSend: 'beforeSend()',
-          afterMessageReceive: 'afterReceive()'
+          afterMessageReceive: 'afterReceive()',
+          afterCallEnd: 'after()'
         }
       } as any,
       GRPC_SCRIPT_KEYS
@@ -36,9 +36,9 @@ describe('toOpenCollectionScripts', () => {
 
     expect(out).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' },
       { type: 'grpc:before-message-send', code: 'beforeSend()' },
-      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' },
+      { type: 'grpc:after-call-end', code: 'after()' }
     ]);
   });
 
@@ -47,9 +47,9 @@ describe('toOpenCollectionScripts', () => {
       req: 'pre()',
       res: 'post()',
       beforeCallStart: 'before()',
-      afterCallEnd: 'after()',
       beforeMessageSend: 'beforeSend()',
-      afterMessageReceive: 'afterReceive()'
+      afterMessageReceive: 'afterReceive()',
+      afterCallEnd: 'after()'
     };
 
     expect(toOpenCollectionScripts({ script } as any, HTTP_SCRIPT_KEYS)).toEqual([
@@ -58,9 +58,9 @@ describe('toOpenCollectionScripts', () => {
     ]);
     expect(toOpenCollectionScripts({ script } as any, GRPC_SCRIPT_KEYS)).toEqual([
       { type: 'grpc:before-call-start', code: 'before()' },
-      { type: 'grpc:after-call-end', code: 'after()' },
       { type: 'grpc:before-message-send', code: 'beforeSend()' },
-      { type: 'grpc:after-message-receive', code: 'afterReceive()' }
+      { type: 'grpc:after-message-receive', code: 'afterReceive()' },
+      { type: 'grpc:after-call-end', code: 'after()' }
     ]);
   });
 

--- a/packages/bruno-filestore/src/formats/yml/common/scripts.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/scripts.ts
@@ -22,9 +22,9 @@ export const toOpenCollectionScripts = (request: BrunoFolderRequest | BrunoHttpR
   pushScript('req', 'before-request', script?.req);
   pushScript('res', 'after-response', script?.res);
   pushScript('beforeCallStart', 'grpc:before-call-start', script?.beforeCallStart);
-  pushScript('afterCallEnd', 'grpc:after-call-end', script?.afterCallEnd);
   pushScript('beforeMessageSend', 'grpc:before-message-send', script?.beforeMessageSend);
   pushScript('afterMessageReceive', 'grpc:after-message-receive', script?.afterMessageReceive);
+  pushScript('afterCallEnd', 'grpc:after-call-end', script?.afterCallEnd);
 
   if (request?.tests?.trim().length) {
     ocScripts.push({
@@ -71,14 +71,14 @@ export const toBrunoScripts = (scripts: Scripts | null | undefined): {
       case 'grpc:before-call-start':
         setScript('beforeCallStart', script.code);
         break;
-      case 'grpc:after-call-end':
-        setScript('afterCallEnd', script.code);
-        break;
       case 'grpc:before-message-send':
         setScript('beforeMessageSend', script.code);
         break;
       case 'grpc:after-message-receive':
         setScript('afterMessageReceive', script.code);
+        break;
+      case 'grpc:after-call-end':
+        setScript('afterCallEnd', script.code);
         break;
       case 'tests':
         brunoScripts.tests = script.code;

--- a/packages/bruno-filestore/src/formats/yml/common/scripts.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/scripts.ts
@@ -23,6 +23,8 @@ export const toOpenCollectionScripts = (request: BrunoFolderRequest | BrunoHttpR
   pushScript('res', 'after-response', script?.res);
   pushScript('beforeCallStart', 'grpc:before-call-start', script?.beforeCallStart);
   pushScript('afterCallEnd', 'grpc:after-call-end', script?.afterCallEnd);
+  pushScript('beforeMessageSend', 'grpc:before-message-send', script?.beforeMessageSend);
+  pushScript('afterMessageReceive', 'grpc:after-message-receive', script?.afterMessageReceive);
 
   if (request?.tests?.trim().length) {
     ocScripts.push({
@@ -71,6 +73,12 @@ export const toBrunoScripts = (scripts: Scripts | null | undefined): {
         break;
       case 'grpc:after-call-end':
         setScript('afterCallEnd', script.code);
+        break;
+      case 'grpc:before-message-send':
+        setScript('beforeMessageSend', script.code);
+        break;
+      case 'grpc:after-message-receive':
+        setScript('afterMessageReceive', script.code);
         break;
       case 'tests':
         brunoScripts.tests = script.code;

--- a/packages/bruno-filestore/src/formats/yml/grpc-round-trip.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/grpc-round-trip.spec.ts
@@ -24,15 +24,24 @@ const grpcItem = (script: Record<string, string | null>, tests: string | null = 
 }) as any;
 
 describe('grpc lifecycle hooks — stringify/parse round trip', () => {
-  it('writes both hooks as grpc-prefixed script types and reads them back', () => {
-    const yml = stringifyItem(grpcItem({ beforeCallStart: 'bru.setVar("a", 1);', afterCallEnd: 'bru.setVar("b", 2);' }));
+  it('writes every hook as a grpc-prefixed script type and reads them back', () => {
+    const yml = stringifyItem(grpcItem({
+      beforeCallStart: 'bru.setVar("a", 1);',
+      afterCallEnd: 'bru.setVar("b", 2);',
+      beforeMessageSend: 'bru.setVar("c", 3);',
+      afterMessageReceive: 'bru.setVar("d", 4);'
+    }));
 
     expect(yml).toContain('grpc:before-call-start');
     expect(yml).toContain('grpc:after-call-end');
+    expect(yml).toContain('grpc:before-message-send');
+    expect(yml).toContain('grpc:after-message-receive');
 
     const { script } = parseGrpcItem(yml);
     expect(script!.beforeCallStart).toBe('bru.setVar("a", 1);');
     expect(script!.afterCallEnd).toBe('bru.setVar("b", 2);');
+    expect(script!.beforeMessageSend).toBe('bru.setVar("c", 3);');
+    expect(script!.afterMessageReceive).toBe('bru.setVar("d", 4);');
   });
 
   it('preserves a multiline hook verbatim', () => {
@@ -44,24 +53,35 @@ describe('grpc lifecycle hooks — stringify/parse round trip', () => {
     expect(script!.beforeCallStart).toBe(beforeCallStart);
   });
 
-  it('round-trips one hook without inventing the other', () => {
+  it('round-trips one hook without inventing the others', () => {
     const yml = stringifyItem(grpcItem({ beforeCallStart: null, afterCallEnd: 'bru.setVar("b", 2);' }));
 
     expect(yml).not.toContain('grpc:before-call-start');
+    expect(yml).not.toContain('grpc:before-message-send');
+    expect(yml).not.toContain('grpc:after-message-receive');
 
     const { script } = parseGrpcItem(yml);
     expect(script!.beforeCallStart).toBeNull();
     expect(script!.afterCallEnd).toBe('bru.setVar("b", 2);');
+    expect(script!.beforeMessageSend).toBeNull();
+    expect(script!.afterMessageReceive).toBeNull();
   });
 
-  it('writes no scripts block when both hooks are empty', () => {
-    const yml = stringifyItem(grpcItem({ beforeCallStart: null, afterCallEnd: '   ' }));
+  it('writes no scripts block when every hook is empty', () => {
+    const yml = stringifyItem(grpcItem({
+      beforeCallStart: null,
+      afterCallEnd: '   ',
+      beforeMessageSend: null,
+      afterMessageReceive: '   '
+    }));
 
     expect(yml).not.toContain('scripts:');
 
     const { script } = parseGrpcItem(yml);
     expect(script!.beforeCallStart).toBeNull();
     expect(script!.afterCallEnd).toBeNull();
+    expect(script!.beforeMessageSend).toBeNull();
+    expect(script!.afterMessageReceive).toBeNull();
   });
 
   it('keeps tests alongside the hooks', () => {
@@ -75,7 +95,12 @@ describe('grpc lifecycle hooks — stringify/parse round trip', () => {
   });
 
   it('survives a second round trip unchanged', () => {
-    const item = grpcItem({ beforeCallStart: 'bru.setVar("a", 1);', afterCallEnd: 'bru.setVar("b", 2);' });
+    const item = grpcItem({
+      beforeCallStart: 'bru.setVar("a", 1);',
+      afterCallEnd: 'bru.setVar("b", 2);',
+      beforeMessageSend: 'bru.setVar("c", 3);',
+      afterMessageReceive: 'bru.setVar("d", 4);'
+    });
 
     const firstPass = stringifyItem(item);
     const secondPass = stringifyItem(parseItem(firstPass));

--- a/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
@@ -52,7 +52,9 @@ const parseGrpcRequest = (ocRequest: GrpcRequest): BrunoItem => {
     },
     script: {
       beforeCallStart: null,
-      afterCallEnd: null
+      afterCallEnd: null,
+      beforeMessageSend: null,
+      afterMessageReceive: null
     },
     vars: {
       req: [],
@@ -85,6 +87,12 @@ const parseGrpcRequest = (ocRequest: GrpcRequest): BrunoItem => {
     }
     if (scripts.script.afterCallEnd) {
       brunoRequest.script.afterCallEnd = scripts.script.afterCallEnd;
+    }
+    if (scripts.script.beforeMessageSend) {
+      brunoRequest.script.beforeMessageSend = scripts.script.beforeMessageSend;
+    }
+    if (scripts.script.afterMessageReceive) {
+      brunoRequest.script.afterMessageReceive = scripts.script.afterMessageReceive;
     }
   }
   if (scripts?.tests) {

--- a/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
+++ b/packages/bruno-filestore/src/formats/yml/items/parseGrpcRequest.ts
@@ -52,9 +52,9 @@ const parseGrpcRequest = (ocRequest: GrpcRequest): BrunoItem => {
     },
     script: {
       beforeCallStart: null,
-      afterCallEnd: null,
       beforeMessageSend: null,
-      afterMessageReceive: null
+      afterMessageReceive: null,
+      afterCallEnd: null
     },
     vars: {
       req: [],
@@ -85,14 +85,14 @@ const parseGrpcRequest = (ocRequest: GrpcRequest): BrunoItem => {
     if (scripts.script.beforeCallStart) {
       brunoRequest.script.beforeCallStart = scripts.script.beforeCallStart;
     }
-    if (scripts.script.afterCallEnd) {
-      brunoRequest.script.afterCallEnd = scripts.script.afterCallEnd;
-    }
     if (scripts.script.beforeMessageSend) {
       brunoRequest.script.beforeMessageSend = scripts.script.beforeMessageSend;
     }
     if (scripts.script.afterMessageReceive) {
       brunoRequest.script.afterMessageReceive = scripts.script.afterMessageReceive;
+    }
+    if (scripts.script.afterCallEnd) {
+      brunoRequest.script.afterCallEnd = scripts.script.afterCallEnd;
     }
   }
   if (scripts?.tests) {

--- a/packages/bruno-filestore/src/formats/yml/script.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/script.spec.ts
@@ -5,15 +5,26 @@ import parseCollection from './parseCollection';
 import stringifyFolder from './stringifyFolder';
 import parseFolder from './parseFolder';
 
+const GRPC_SLOTS = {
+  beforeCallStart: 'before()',
+  afterCallEnd: 'after()',
+  beforeMessageSend: 'beforeSend()',
+  afterMessageReceive: 'afterReceive()'
+};
+
 const ALL_SLOTS = {
   req: 'pre()',
   res: 'post()',
-  beforeCallStart: 'before()',
-  afterCallEnd: 'after()'
+  ...GRPC_SLOTS
 };
 
 const HTTP_TYPES = ['before-request', 'after-response'];
-const GRPC_TYPES = ['grpc:before-call-start', 'grpc:after-call-end'];
+const GRPC_TYPES = [
+  'grpc:before-call-start',
+  'grpc:after-call-end',
+  'grpc:before-message-send',
+  'grpc:after-message-receive'
+];
 
 const expectScriptTypes = (yml: string, written: string[], dropped: string[]) => {
   written.forEach((type) => expect(yml).toContain(`type: ${type}`));
@@ -83,6 +94,8 @@ describe('script — request items', () => {
     expectScriptTypes(yml, HTTP_TYPES, GRPC_TYPES);
     expect(yml).not.toContain('before()');
     expect(yml).not.toContain('after()');
+    expect(yml).not.toContain('beforeSend()');
+    expect(yml).not.toContain('afterReceive()');
 
     expect(parseItem(yml).request!.script).toEqual({ req: 'pre()', res: 'post()' });
   });
@@ -102,7 +115,12 @@ describe('script — request items', () => {
     expect(yml).not.toContain('pre()');
     expect(yml).not.toContain('post()');
 
-    expect(parseItem(yml).request!.script).toEqual({ beforeCallStart: 'before()', afterCallEnd: 'after()' });
+    expect(parseItem(yml).request!.script).toEqual({
+      beforeCallStart: 'before()',
+      afterCallEnd: 'after()',
+      beforeMessageSend: 'beforeSend()',
+      afterMessageReceive: 'afterReceive()'
+    });
   });
 });
 
@@ -124,9 +142,7 @@ describe('script — collection and folder roots', () => {
   });
 
   it('a collection root carrying only grpc hooks writes no scripts at all', () => {
-    const yml = stringifyCollection(rootWithScript({ beforeCallStart: 'before()', afterCallEnd: 'after()' }), {
-      name: 'c'
-    });
+    const yml = stringifyCollection(rootWithScript({ ...GRPC_SLOTS }), { name: 'c' });
 
     expect(yml).not.toContain('scripts:');
 
@@ -134,7 +150,7 @@ describe('script — collection and folder roots', () => {
   });
 
   it('a folder root carrying only grpc hooks writes no scripts at all', () => {
-    const yml = stringifyFolder(rootWithScript({ beforeCallStart: 'before()', afterCallEnd: 'after()' }));
+    const yml = stringifyFolder(rootWithScript({ ...GRPC_SLOTS }));
 
     expect(yml).not.toContain('scripts:');
 

--- a/packages/bruno-js/src/grpc/bruno-grpc-request.js
+++ b/packages/bruno-js/src/grpc/bruno-grpc-request.js
@@ -1,6 +1,7 @@
 const { cloneDeep } = require('lodash');
 const GrpcMetadataList = require('./grpc-metadata-list');
 const GrpcMessageList = require('./grpc-message-list');
+const GrpcMessage = require('./grpc-message');
 
 /**
  * Reached from a hook as `bru.grpc.request`.
@@ -21,8 +22,11 @@ class BrunoGrpcRequest {
    *   `messages` always answers with these, never with the messages authored in the UI — the two
    *   differ whenever the user streams a subset of the authored messages, or none. It is therefore
    *   empty in `beforeCallStart`, where the call has yet to send anything.
+   * @param {object} [options.message] - The single message about to be sent, as `{ data, timestamp }`.
+   *   Supplied only by `beforeMessageSend`; in the call hooks the `message` property is absent from
+   *   the model entirely, so `'message' in bru.grpc.request` is `false` there.
    */
-  constructor(request, { metadataWritable = false, sentMessages = [] } = {}) {
+  constructor(request, { metadataWritable = false, sentMessages = [], message } = {}) {
     this.#request = request;
     this.url = request.url;
     this.method = request.method;
@@ -34,6 +38,9 @@ class BrunoGrpcRequest {
     // Cloned on every read, as `response.messages` is, so a hook editing a message cannot reach
     // what the call actually sent.
     this.messages = new GrpcMessageList(() => cloneDeep(sentMessages));
+    if (message) {
+      this.message = new GrpcMessage(message);
+    }
   }
 
   // Provides reference for in-memory edits on setters

--- a/packages/bruno-js/src/grpc/bruno-grpc-response.js
+++ b/packages/bruno-js/src/grpc/bruno-grpc-response.js
@@ -2,6 +2,7 @@ const { cloneDeep } = require('lodash');
 const { toMetadataObject } = require('./grpc-metadata');
 const GrpcMetadataList = require('./grpc-metadata-list');
 const GrpcMessageList = require('./grpc-message-list');
+const GrpcMessage = require('./grpc-message');
 
 /**
  * Reached from hooks as `bru.grpc.response`.
@@ -16,9 +17,12 @@ class BrunoGrpcResponse {
   #response;
 
   /**
-   * @param {object} response - The completed call
+   * @param {object} response - The call so far; complete in `afterCallEnd`, partial in `afterMessageReceive`
+   * @param {object} [options]
+   * @param {object} [options.message] - The single message just received, as `{ data, timestamp }`.
+   *   Supplied only by `afterMessageReceive`;
    */
-  constructor(response) {
+  constructor(response, { message } = {}) {
     this.#response = response;
     this.statusCode = response.statusCode;
     this.statusText = response.statusText;
@@ -26,6 +30,11 @@ class BrunoGrpcResponse {
     this.metadata = new GrpcMetadataList(() => toMetadataObject(this.#response.metadata), { writable: false });
     this.trailers = new GrpcMetadataList(() => toMetadataObject(this.#response.trailers), { writable: false });
     this.duration = response.duration;
+
+    // Assigned conditionally, as on the request, so `afterCallEnd` has no such property at all.
+    if (message) {
+      this.message = new GrpcMessage(message);
+    }
 
     // Deliberately a plain object, where HTTP's `BrunoResponse` returns a callable so `res('user.id')`
     // queries the body. gRPC body (messages) will vary based on method type, so skipping here.

--- a/packages/bruno-js/src/grpc/bruno-grpc-response.js
+++ b/packages/bruno-js/src/grpc/bruno-grpc-response.js
@@ -8,7 +8,7 @@ const GrpcMessage = require('./grpc-message');
  * Reached from hooks as `bru.grpc.response`.
  *
  * `messages`, `metadata` and `trailers` are the same list types `bru.grpc.request` uses, always
- * read-only here, since the connection has already been completed.
+ * read-only here.
  *
  * Scalar values have interpolated values unlike the request counterpart.
  * Keep quickjs shim up to date on any updates to this class
@@ -20,7 +20,7 @@ class BrunoGrpcResponse {
    * @param {object} response - The call so far; complete in `afterCallEnd`, partial in `afterMessageReceive`
    * @param {object} [options]
    * @param {object} [options.message] - The single message just received, as `{ data, timestamp }`.
-   *   Supplied only by `afterMessageReceive`;
+   *   Supplied only by `afterMessageReceive`
    */
   constructor(response, { message } = {}) {
     this.#response = response;

--- a/packages/bruno-js/src/grpc/grpc-message.js
+++ b/packages/bruno-js/src/grpc/grpc-message.js
@@ -3,8 +3,6 @@ const { cloneDeep } = require('lodash');
 /**
  * `bru.grpc.request.message` / `bru.grpc.response.message` in the message hooks — the single message
  * being sent or received, as opposed to the `GrpcMessageList` of all of them.
- *
- * Keep quickjs shim up to date on any updates to this class
  */
 class GrpcMessage {
   /**

--- a/packages/bruno-js/src/grpc/grpc-message.js
+++ b/packages/bruno-js/src/grpc/grpc-message.js
@@ -1,0 +1,22 @@
+const { cloneDeep } = require('lodash');
+
+/**
+ * `bru.grpc.request.message` / `bru.grpc.response.message` in the message hooks — the single message
+ * being sent or received, as opposed to the `GrpcMessageList` of all of them.
+ *
+ * Keep quickjs shim up to date on any updates to this class
+ */
+class GrpcMessage {
+  /**
+   * @param {object} [message]
+   * @param {*} [message.data] - The parsed message payload
+   * @param {number} [message.timestamp] - Epoch ms
+   */
+  constructor({ data, timestamp } = {}) {
+    // Cloned for immutability during script execution
+    this.data = cloneDeep(data);
+    this.timestamp = timestamp;
+  }
+}
+
+module.exports = GrpcMessage;

--- a/packages/bruno-js/src/grpc/grpc-script-runtime.js
+++ b/packages/bruno-js/src/grpc/grpc-script-runtime.js
@@ -202,7 +202,7 @@ class GrpcScriptRuntime {
       request,
       // Passing sentMessages so only messages sent by client is accessible
       buildGrpc: () => ({
-        request: new BrunoGrpcRequest(request, { sentMessages }),
+        request: new BrunoGrpcRequest(request, { sentMessages, metadataWritable: false }),
         response: new BrunoGrpcResponse(response)
       }),
       extraResult: { response },
@@ -258,7 +258,7 @@ class GrpcScriptRuntime {
    * `after-message-receive`. `message` is the message just received, and is also the last entry of
    * `response.messages` — the call folds it in before the hook runs.
    *
-   * The `response` here is *partial*: the call is still open, so `statusCode`, `statusMessage`,
+   * The `response` here is *partial*: the call is still open, so `statusCode`, `statusText`,
    * `duration` and `trailers` are not yet known and read as `undefined` / empty. `metadata` is
    * usually populated, since headers precede the first message.
    */

--- a/packages/bruno-js/src/grpc/grpc-script-runtime.js
+++ b/packages/bruno-js/src/grpc/grpc-script-runtime.js
@@ -13,7 +13,7 @@ const { createScopeSetter } = require('../runtime/scripted-entries');
  * Runs the gRPC lifecycle hooks
  *
  * All four hooks share one body (`#runHook`) and differ only in what they put on `bru.grpc` and
- * what their result object carries — `buildGrpc` and `extraResult` below.
+ * what their result object carries — `buildGrpc` and `baseResult` below.
  *
  * The shared body mirrors `ScriptRuntime`'s `runRequestScript` / `runResponseScript` step for step,
  * substituting the gRPC request/response models. Two intentional differences, not oversights:
@@ -30,13 +30,13 @@ class GrpcScriptRuntime {
    * @param {string} params.script - The hook body, already decommented by the caller
    * @param {object} params.request - The prepared gRPC request
    * @param {Function} params.buildGrpc - Returns the `bru.grpc` object for this hook
-   * @param {object} [params.extraResult] - Merged into the result object this hook returns
+   * @param {object} [params.baseResult] - Hook-specific fields the shared result is built on top of
    */
   async #runHook({
     script,
     request,
     buildGrpc,
-    extraResult = {},
+    baseResult = {},
     envVariables,
     runtimeVariables,
     collectionPath,
@@ -104,7 +104,7 @@ class GrpcScriptRuntime {
     bru.runRequest = () => Promise.reject(new Error('bru.runRequest is not supported in gRPC scripts'));
 
     const buildScriptResult = () => ({
-      ...extraResult,
+      ...baseResult,
       envVariables: bru._envDirty ? cleanJson(envVariables) : null,
       runtimeVariables: bru._runtimeVarsDirty ? cleanJson(runtimeVariables) : null,
       collectionVariables: bru._collVarsDirty ? cleanJson(collectionVariables) : null,
@@ -167,7 +167,7 @@ class GrpcScriptRuntime {
       request,
       // Initial scope - `request.messages` reports what the call sent, so it is still empty here.
       buildGrpc: () => ({ request: new BrunoGrpcRequest(request, { metadataWritable: true }) }),
-      extraResult: { request },
+      baseResult: { request },
       envVariables,
       runtimeVariables,
       collectionPath,
@@ -199,7 +199,7 @@ class GrpcScriptRuntime {
         request: new BrunoGrpcRequest(request, { sentMessages, metadataWritable: false }),
         response: new BrunoGrpcResponse(response)
       }),
-      extraResult: { response },
+      baseResult: { response },
       envVariables,
       runtimeVariables,
       collectionPath,
@@ -237,7 +237,7 @@ class GrpcScriptRuntime {
         request: new BrunoGrpcRequest(request, { metadataWritable: false, sentMessages, message })
       }),
       // `message` is carried on the result for the planned `message.set`; discarded by callers today.
-      extraResult: { request, message },
+      baseResult: { request, message },
       envVariables,
       runtimeVariables,
       collectionPath,
@@ -277,7 +277,7 @@ class GrpcScriptRuntime {
         request: new BrunoGrpcRequest(request, { metadataWritable: false, sentMessages }),
         response: new BrunoGrpcResponse(response, { message })
       }),
-      extraResult: { response, message },
+      baseResult: { response, message },
       envVariables,
       runtimeVariables,
       collectionPath,

--- a/packages/bruno-js/src/grpc/grpc-script-runtime.js
+++ b/packages/bruno-js/src/grpc/grpc-script-runtime.js
@@ -19,10 +19,11 @@ const bindUnsupportedRunRequest = (bru) => {
 /**
  * Runs the gRPC lifecycle hooks
  *
- * The two methods below mirror `ScriptRuntime`'s `runRequestScript` / `runResponseScript` step for
- * step, substituting the gRPC request/response models.
+ * All four hooks share one body (`#runHook`) and differ only in what they put on `bru.grpc` and
+ * what their result object carries — `buildGrpc` and `extraResult` below.
  *
- * Two intentional differences from `ScriptRuntime`, not oversights:
+ * The shared body mirrors `ScriptRuntime`'s `runRequestScript` / `runResponseScript` step for step,
+ * substituting the gRPC request/response models. Two intentional differences, not oversights:
  * - `bru.runRequest` rejects instead of running anything (see `bindUnsupportedRunRequest`).
  * - The models live under `bru.grpc` rather than as the `req` / `res` globals HTTP scripts get.
  */
@@ -31,9 +32,18 @@ class GrpcScriptRuntime {
     this.runtime = props?.runtime || 'quickjs';
   }
 
-  async runGrpcRequestScript(
+  /**
+   * @param {object} params
+   * @param {string} params.script - The hook body, already decommented by the caller
+   * @param {object} params.request - The prepared gRPC request
+   * @param {Function} params.buildGrpc - Returns the `bru.grpc` object for this hook
+   * @param {object} [params.extraResult] - Merged into the result object this hook returns
+   */
+  async #runHook({
     script,
     request,
+    buildGrpc,
+    extraResult = {},
     envVariables,
     runtimeVariables,
     collectionPath,
@@ -41,7 +51,7 @@ class GrpcScriptRuntime {
     processEnvVars,
     scriptingConfig,
     collectionName
-  ) {
+  }) {
     const globalEnvironmentVariables = request?.globalEnvironmentVariables || {};
     const oauth2CredentialVariables = request?.oauth2CredentialVariables || {};
     const collectionVariables = request?.collectionVariables || {};
@@ -68,8 +78,7 @@ class GrpcScriptRuntime {
       requestUrl: request?.url
     });
 
-    // Initial scope - `request.messages` reports what the call sent, so it is still empty here.
-    bru.grpc = { request: new BrunoGrpcRequest(request, { metadataWritable: true }) };
+    bru.grpc = buildGrpc();
 
     // extend bru with result getter methods
     const { __brunoTestResults, test } = createBruTestResultMethods(bru, assertionResults, chai);
@@ -100,8 +109,8 @@ class GrpcScriptRuntime {
 
     bindUnsupportedRunRequest(bru);
 
-    const buildRequestScriptResult = () => ({
-      request,
+    const buildScriptResult = () => ({
+      ...extraResult,
       envVariables: bru._envDirty ? cleanJson(envVariables) : null,
       runtimeVariables: bru._runtimeVarsDirty ? cleanJson(runtimeVariables) : null,
       collectionVariables: bru._collVarsDirty ? cleanJson(collectionVariables) : null,
@@ -118,8 +127,8 @@ class GrpcScriptRuntime {
     // set before it threw still reach the caller
     let scriptError = null;
 
-    if (this.runtime === SANDBOX.NODEVM) {
-      try {
+    try {
+      if (this.runtime === SANDBOX.NODEVM) {
         await runScriptInNodeVm({
           script,
           context,
@@ -127,39 +136,55 @@ class GrpcScriptRuntime {
           scriptingConfig,
           scriptPath
         });
-      } catch (error) {
-        scriptError = error;
+      } else {
+        // default runtime is `quickjs`
+        await executeQuickJsVmAsync({
+          script,
+          context,
+          collectionPath,
+          scriptPath
+        });
       }
-
-      if (scriptError) {
-        scriptError.partialResults = buildRequestScriptResult();
-        throw scriptError;
-      }
-
-      return buildRequestScriptResult();
-    }
-
-    // default runtime is `quickjs`
-    try {
-      await executeQuickJsVmAsync({
-        script: script,
-        context: context,
-        collectionPath,
-        scriptPath
-      });
     } catch (error) {
       scriptError = error;
     }
 
     if (scriptError) {
-      scriptError.partialResults = buildRequestScriptResult();
+      scriptError.partialResults = buildScriptResult();
       throw scriptError;
     }
 
-    return buildRequestScriptResult();
+    return buildScriptResult();
   }
 
-  async runGrpcResponseScript(
+  async runGrpcRequestScript({
+    script,
+    request,
+    envVariables,
+    runtimeVariables,
+    collectionPath,
+    onConsoleLog,
+    processEnvVars,
+    scriptingConfig,
+    collectionName
+  }) {
+    return this.#runHook({
+      script,
+      request,
+      // Initial scope - `request.messages` reports what the call sent, so it is still empty here.
+      buildGrpc: () => ({ request: new BrunoGrpcRequest(request, { metadataWritable: true }) }),
+      extraResult: { request },
+      envVariables,
+      runtimeVariables,
+      collectionPath,
+      onConsoleLog,
+      processEnvVars,
+      scriptingConfig,
+      collectionName
+    });
+  }
+
+  async runGrpcResponseScript({
     script,
     request,
     response,
@@ -170,124 +195,103 @@ class GrpcScriptRuntime {
     processEnvVars,
     scriptingConfig,
     collectionName,
-    { sentMessages = [] } = {}
-  ) {
-    const globalEnvironmentVariables = request?.globalEnvironmentVariables || {};
-    const oauth2CredentialVariables = request?.oauth2CredentialVariables || {};
-    const collectionVariables = request?.collectionVariables || {};
-    const folderVariables = request?.folderVariables || {};
-    const requestVariables = request?.requestVariables || {};
-    const promptVariables = request?.promptVariables || {};
-    const assertionResults = request?.assertionResults || [];
-    const certsAndProxyConfig = request?.certsAndProxyConfig;
-    const scriptPath = request?.pathname;
-    const bru = new Bru({
-      runtime: this.runtime,
+    sentMessages = []
+  }) {
+    return this.#runHook({
+      script,
+      request,
+      // Passing sentMessages so only messages sent by client is accessible
+      buildGrpc: () => ({
+        request: new BrunoGrpcRequest(request, { sentMessages }),
+        response: new BrunoGrpcResponse(response)
+      }),
+      extraResult: { response },
       envVariables,
       runtimeVariables,
-      processEnvVars,
       collectionPath,
-      collectionVariables,
-      folderVariables,
-      requestVariables,
-      globalEnvironmentVariables,
-      oauth2CredentialVariables,
-      collectionName,
-      promptVariables,
-      certsAndProxyConfig,
-      requestUrl: request?.url
+      onConsoleLog,
+      processEnvVars,
+      scriptingConfig,
+      collectionName
     });
+  }
 
-    // Passing sentMessages so only messages sent by client is accessible
-    bru.grpc = {
-      request: new BrunoGrpcRequest(request, { sentMessages }),
-      response: new BrunoGrpcResponse(response)
-    };
-
-    // extend bru with result getter methods
-    const { __brunoTestResults, test } = createBruTestResultMethods(bru, assertionResults, chai);
-
-    const context = {
-      bru,
-      test,
-      expect: chai.expect,
-      assert: chai.assert,
-      __brunoTestResults: __brunoTestResults,
-      __bruSetScope: createScopeSetter(bru)
-    };
-
-    if (onConsoleLog && typeof onConsoleLog === 'function') {
-      const customLogger = (type) => {
-        return (...args) => {
-          onConsoleLog(type, cleanJson(args));
-        };
-      };
-      context.console = {
-        log: customLogger('log'),
-        info: customLogger('info'),
-        warn: customLogger('warn'),
-        error: customLogger('error'),
-        debug: customLogger('debug')
-      };
-    }
-
-    bindUnsupportedRunRequest(bru);
-
-    const buildResponseScriptResult = () => ({
-      response,
-      envVariables: bru._envDirty ? cleanJson(envVariables) : null,
-      runtimeVariables: bru._runtimeVarsDirty ? cleanJson(runtimeVariables) : null,
-      collectionVariables: bru._collVarsDirty ? cleanJson(collectionVariables) : null,
-      globalEnvironmentVariables: bru._globalEnvDirty ? cleanJson(globalEnvironmentVariables) : null,
-      oauth2CredentialsToReset: bru.oauth2CredentialsToReset,
-      results: cleanJson(__brunoTestResults.getResults()),
-      nextRequestName: bru.nextRequest,
-      skipRequest: bru.skipRequest,
-      stopExecution: bru.stopExecution,
-      scriptedRequestEntries: cleanJson(bru.scriptedRequestEntries || [])
+  /**
+   * `before-message-send`. `message` is the message about to be transmitted; it joins
+   * `request.messages` only once the send succeeds, so the two never overlap.
+   *
+   * `bru.grpc.response` is deliberately absent, matching `beforeCallStart` — even on a bidi stream
+   * where messages have already been received.
+   */
+  async runGrpcBeforeMessageSendScript({
+    script,
+    request,
+    message,
+    envVariables,
+    runtimeVariables,
+    collectionPath,
+    onConsoleLog,
+    processEnvVars,
+    scriptingConfig,
+    collectionName,
+    sentMessages = []
+  }) {
+    return this.#runHook({
+      script,
+      request,
+      buildGrpc: () => ({
+        request: new BrunoGrpcRequest(request, { metadataWritable: false, sentMessages, message })
+      }),
+      // `message` is carried on the result for the planned `message.set`; discarded by callers today.
+      extraResult: { request, message },
+      envVariables,
+      runtimeVariables,
+      collectionPath,
+      onConsoleLog,
+      processEnvVars,
+      scriptingConfig,
+      collectionName
     });
+  }
 
-    let scriptError = null;
-
-    if (this.runtime === SANDBOX.NODEVM) {
-      try {
-        await runScriptInNodeVm({
-          script,
-          context,
-          collectionPath,
-          scriptingConfig,
-          scriptPath
-        });
-      } catch (error) {
-        scriptError = error;
-      }
-
-      if (scriptError) {
-        scriptError.partialResults = buildResponseScriptResult();
-        throw scriptError;
-      }
-
-      return buildResponseScriptResult();
-    }
-
-    // default runtime is `quickjs`
-    try {
-      await executeQuickJsVmAsync({
-        script: script,
-        context: context,
-        collectionPath,
-        scriptPath
-      });
-    } catch (error) {
-      scriptError = error;
-    }
-
-    if (scriptError) {
-      scriptError.partialResults = buildResponseScriptResult();
-      throw scriptError;
-    }
-
-    return buildResponseScriptResult();
+  /**
+   * `after-message-receive`. `message` is the message just received, and is also the last entry of
+   * `response.messages` — the call folds it in before the hook runs.
+   *
+   * The `response` here is *partial*: the call is still open, so `statusCode`, `statusMessage`,
+   * `duration` and `trailers` are not yet known and read as `undefined` / empty. `metadata` is
+   * usually populated, since headers precede the first message.
+   */
+  async runGrpcAfterMessageReceiveScript({
+    script,
+    request,
+    response,
+    message,
+    envVariables,
+    runtimeVariables,
+    collectionPath,
+    onConsoleLog,
+    processEnvVars,
+    scriptingConfig,
+    collectionName,
+    sentMessages = []
+  }) {
+    return this.#runHook({
+      script,
+      request,
+      buildGrpc: () => ({
+        request: new BrunoGrpcRequest(request, { metadataWritable: false, sentMessages }),
+        response: new BrunoGrpcResponse(response, { message })
+      }),
+      extraResult: { response, message },
+      envVariables,
+      runtimeVariables,
+      collectionPath,
+      onConsoleLog,
+      processEnvVars,
+      scriptingConfig,
+      collectionName
+    });
   }
 }
 

--- a/packages/bruno-js/src/grpc/grpc-script-runtime.js
+++ b/packages/bruno-js/src/grpc/grpc-script-runtime.js
@@ -9,13 +9,6 @@ const { executeQuickJsVmAsync } = require('../sandbox/quickjs');
 const { SANDBOX } = require('../utils/sandbox');
 const { createScopeSetter } = require('../runtime/scripted-entries');
 
-const RUN_REQUEST_UNSUPPORTED = 'bru.runRequest is not supported in gRPC scripts';
-
-// A gRPC request can't run another request yet, so there is no `runRequestByItemPathname` to bind.
-const bindUnsupportedRunRequest = (bru) => {
-  bru.runRequest = () => Promise.reject(new Error(RUN_REQUEST_UNSUPPORTED));
-};
-
 /**
  * Runs the gRPC lifecycle hooks
  *
@@ -24,7 +17,7 @@ const bindUnsupportedRunRequest = (bru) => {
  *
  * The shared body mirrors `ScriptRuntime`'s `runRequestScript` / `runResponseScript` step for step,
  * substituting the gRPC request/response models. Two intentional differences, not oversights:
- * - `bru.runRequest` rejects instead of running anything (see `bindUnsupportedRunRequest`).
+ * - `bru.runRequest` rejects instead of running anything.
  * - The models live under `bru.grpc` rather than as the `req` / `res` globals HTTP scripts get.
  */
 class GrpcScriptRuntime {
@@ -107,7 +100,8 @@ class GrpcScriptRuntime {
       };
     }
 
-    bindUnsupportedRunRequest(bru);
+    // A gRPC request can't run another request yet, so there is no `runRequestByItemPathname` to bind.
+    bru.runRequest = () => Promise.reject(new Error('bru.runRequest is not supported in gRPC scripts'));
 
     const buildScriptResult = () => ({
       ...extraResult,

--- a/packages/bruno-js/src/sandbox/quickjs/shims/bruno-grpc.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/bruno-grpc.js
@@ -1,5 +1,5 @@
-const addBrunoGrpcRequestShimToContext = require('./bruno-grpc-request');
-const addBrunoGrpcResponseShimToContext = require('./bruno-grpc-response');
+const addBrunoGrpcRequestShimToContext = require('./grpc/bruno-grpc-request');
+const addBrunoGrpcResponseShimToContext = require('./grpc/bruno-grpc-response');
 
 /**
  * Installs `bru.grpc` onto the `bru` object the bru shim has already put on the global, so it has

--- a/packages/bruno-js/src/sandbox/quickjs/shims/grpc/bruno-grpc-request.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/grpc/bruno-grpc-request.js
@@ -1,4 +1,4 @@
-const { marshallToVm } = require('../utils');
+const { marshallToVm } = require('../../utils');
 const addGrpcMetadataListShimToContext = require('./grpc-metadata-list');
 const addGrpcMessageListShimToContext = require('./grpc-message-list');
 
@@ -30,6 +30,13 @@ const addBrunoGrpcRequestShimToContext = (vm, request, grpcObject) => {
     requestObject,
     'globalThis.bru.grpc.request'
   );
+
+  // request.message — present only in `beforeMessageSend`.
+  if (request.message) {
+    const message = marshallToVm(request.message, vm);
+    vm.setProp(requestObject, 'message', message);
+    message.dispose();
+  }
 
   vm.setProp(grpcObject, 'request', requestObject);
   requestObject.dispose();

--- a/packages/bruno-js/src/sandbox/quickjs/shims/grpc/bruno-grpc-response.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/grpc/bruno-grpc-response.js
@@ -24,7 +24,7 @@ const addBrunoGrpcResponseShimToContext = (vm, response, grpcObject) => {
     addGrpcMessageListShimToContext(vm, response.messages, responseObject, 'globalThis.bru.grpc.response')
   );
 
-  // response.message — present only in `afterMessageReceive`;
+  // response.message — present only in `afterMessageReceive`
   if (response.message) {
     const message = marshallToVm(response.message, vm);
     vm.setProp(responseObject, 'message', message);

--- a/packages/bruno-js/src/sandbox/quickjs/shims/grpc/bruno-grpc-response.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/grpc/bruno-grpc-response.js
@@ -1,4 +1,4 @@
-const { marshallToVm } = require('../utils');
+const { marshallToVm } = require('../../utils');
 const addGrpcMetadataListShimToContext = require('./grpc-metadata-list');
 const addGrpcMessageListShimToContext = require('./grpc-message-list');
 
@@ -23,6 +23,13 @@ const addBrunoGrpcResponseShimToContext = (vm, response, grpcObject) => {
   listEvalCode.push(
     addGrpcMessageListShimToContext(vm, response.messages, responseObject, 'globalThis.bru.grpc.response')
   );
+
+  // response.message — present only in `afterMessageReceive`;
+  if (response.message) {
+    const message = marshallToVm(response.message, vm);
+    vm.setProp(responseObject, 'message', message);
+    message.dispose();
+  }
 
   vm.setProp(grpcObject, 'response', responseObject);
   responseObject.dispose();

--- a/packages/bruno-js/src/sandbox/quickjs/shims/grpc/grpc-message-list.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/grpc/grpc-message-list.js
@@ -1,4 +1,4 @@
-const { createPropertyListBridge } = require('../utils/property-list-bridge');
+const { createPropertyListBridge } = require('../../utils/property-list-bridge');
 
 /**
  * Bridges a GrpcMessageList — `bru.grpc.request.messages`, `bru.grpc.response.messages`

--- a/packages/bruno-js/src/sandbox/quickjs/shims/grpc/grpc-metadata-list.js
+++ b/packages/bruno-js/src/sandbox/quickjs/shims/grpc/grpc-metadata-list.js
@@ -1,4 +1,4 @@
-const { createPropertyListBridge } = require('../utils/property-list-bridge');
+const { createPropertyListBridge } = require('../../utils/property-list-bridge');
 
 /**
  * Bridges a GrpcMetadataList — `bru.grpc.request.metadata`, `bru.grpc.response.metadata`,

--- a/packages/bruno-js/src/utils/error-formatter.js
+++ b/packages/bruno-js/src/utils/error-formatter.js
@@ -18,6 +18,8 @@ const SCRIPT_TYPE_TO_YML = {
   [SCRIPT_TYPES.POST_RESPONSE]: 'after-response',
   [SCRIPT_TYPES.TEST]: 'tests',
   [SCRIPT_TYPES.BEFORE_CALL_START]: 'grpc:before-call-start',
+  [SCRIPT_TYPES.BEFORE_MESSAGE_SEND]: 'grpc:before-message-send',
+  [SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE]: 'grpc:after-message-receive',
   [SCRIPT_TYPES.AFTER_CALL_END]: 'grpc:after-call-end'
 };
 
@@ -37,6 +39,8 @@ const BLOCK_PATTERNS = {
   [SCRIPT_TYPES.POST_RESPONSE]: /^script:post-response\s*\{/,
   [SCRIPT_TYPES.TEST]: /^tests\s*\{/,
   [SCRIPT_TYPES.BEFORE_CALL_START]: /^script:grpc:before-call-start\s*\{/,
+  [SCRIPT_TYPES.BEFORE_MESSAGE_SEND]: /^script:grpc:before-message-send\s*\{/,
+  [SCRIPT_TYPES.AFTER_MESSAGE_RECEIVE]: /^script:grpc:after-message-receive\s*\{/,
   [SCRIPT_TYPES.AFTER_CALL_END]: /^script:grpc:after-call-end\s*\{/
 };
 

--- a/packages/bruno-js/src/utils/error-formatter.spec.js
+++ b/packages/bruno-js/src/utils/error-formatter.spec.js
@@ -143,9 +143,19 @@ script:grpc:after-call-end {
   const data = response.data;
   bru.setVar('userId', data.id);
   console.log(data);
+}
+
+script:grpc:before-message-send {
+  bru.setVar('outbound', bru.grpc.request.message.data.greeting);
+}
+
+script:grpc:after-message-receive {
+  const message = bru.grpc.response.message;
+  bru.setVar('inbound', message.data.reply);
 }`;
 
-// gRPC yml fixture: blockStartLine = 8 (before-call-start), 12 (after-call-end)
+// gRPC yml fixture: blockStartLine = 8 (before-call-start), 12 (after-call-end),
+// 16 (before-message-send), 19 (after-message-receive)
 const GRPC_YML = [
   'info:',
   '  name: grpc-yaml-test',
@@ -159,7 +169,14 @@ const GRPC_YML = [
   '    - type: grpc:after-call-end',
   '      code: |-',
   '        const data = response.data;',
-  '        bru.setVar(\'userId\', data.id);'
+  '        bru.setVar(\'userId\', data.id);',
+  '    - type: grpc:before-message-send',
+  '      code: |-',
+  '        bru.setVar(\'outbound\', bru.grpc.request.message.data.greeting);',
+  '    - type: grpc:after-message-receive',
+  '      code: |-',
+  '        const message = bru.grpc.response.message;',
+  '        bru.setVar(\'inbound\', message.data.reply);'
 ].join('\n');
 
 // Wrapper offsets: QuickJS = 9 (script line 1 = VM line 10), NodeVM = 2 (script line 1 = VM line 3)
@@ -203,6 +220,8 @@ describe('Error Formatter', () => {
     it('should find gRPC lifecycle hook blocks in .bru files', () => {
       expect(findScriptBlockStartLine(grpcBruPath, 'before-call-start')).toBe(12);
       expect(findScriptBlockStartLine(grpcBruPath, 'after-call-end')).toBe(17);
+      expect(findScriptBlockStartLine(grpcBruPath, 'before-message-send')).toBe(23);
+      expect(findScriptBlockStartLine(grpcBruPath, 'after-message-receive')).toBe(27);
     });
 
     it('should return null for missing block or non-.bru files', () => {
@@ -223,6 +242,8 @@ describe('Error Formatter', () => {
     it('should find last content line for gRPC lifecycle hook blocks', () => {
       expect(findScriptBlockEndLine(grpcBruPath, 'before-call-start')).toBe(13);
       expect(findScriptBlockEndLine(grpcBruPath, 'after-call-end')).toBe(19);
+      expect(findScriptBlockEndLine(grpcBruPath, 'before-message-send')).toBe(23);
+      expect(findScriptBlockEndLine(grpcBruPath, 'after-message-receive')).toBe(28);
     });
 
     it('should return null for empty block', () => {
@@ -258,6 +279,8 @@ describe('Error Formatter', () => {
     it('should find gRPC lifecycle hook blocks in .yml files', () => {
       expect(findYmlScriptBlockStartLine(grpcYmlPath, 'before-call-start')).toBe(8);
       expect(findYmlScriptBlockStartLine(grpcYmlPath, 'after-call-end')).toBe(12);
+      expect(findYmlScriptBlockStartLine(grpcYmlPath, 'before-message-send')).toBe(16);
+      expect(findYmlScriptBlockStartLine(grpcYmlPath, 'after-message-receive')).toBe(19);
     });
 
     it('should return null for missing block or non-.yml files', () => {
@@ -282,6 +305,8 @@ describe('Error Formatter', () => {
     it('should find last content line for gRPC lifecycle hook blocks', () => {
       expect(findYmlScriptBlockEndLine(grpcYmlPath, 'before-call-start')).toBe(9);
       expect(findYmlScriptBlockEndLine(grpcYmlPath, 'after-call-end')).toBe(13);
+      expect(findYmlScriptBlockEndLine(grpcYmlPath, 'before-message-send')).toBe(16);
+      expect(findYmlScriptBlockEndLine(grpcYmlPath, 'after-message-receive')).toBe(20);
     });
 
     it('should return null for missing block', () => {

--- a/packages/bruno-js/tests/bruno-grpc-request.spec.js
+++ b/packages/bruno-js/tests/bruno-grpc-request.spec.js
@@ -1,4 +1,5 @@
 const BrunoGrpcRequest = require('../src/grpc/bruno-grpc-request');
+const GrpcMessage = require('../src/grpc/grpc-message');
 
 const makeReq = (overrides = {}) => ({
   url: 'grpcb.in:9000',
@@ -80,6 +81,35 @@ describe('BrunoGrpcRequest', () => {
 
       expect(req.messages.count()).toBe(0);
       expect(req.messages.get()).toBeUndefined();
+    });
+  });
+
+  describe('message', () => {
+    test('the message option becomes a GrpcMessage carrying data and timestamp', () => {
+      const req = new BrunoGrpcRequest(makeReq(), {
+        message: { data: { greeting: 'outbound' }, timestamp: 1700000001 }
+      });
+
+      expect(req.message).toBeInstanceOf(GrpcMessage);
+      expect(req.message.data).toEqual({ greeting: 'outbound' });
+      expect(req.message.timestamp).toBe(1700000001);
+    });
+
+    test('without the option the property is absent, not undefined, so the call hooks cannot see it', () => {
+      const req = new BrunoGrpcRequest(makeReq());
+
+      expect('message' in req).toBe(false);
+    });
+
+    test('the message being sent is not yet in messages, which holds only what has been transmitted', () => {
+      const req = new BrunoGrpcRequest(makeReq(), {
+        sentMessages: [{ data: { greeting: 'first' }, timestamp: 1700000000 }],
+        message: { data: { greeting: 'second' }, timestamp: 1700000001 }
+      });
+
+      expect(req.messages.count()).toBe(1);
+      expect(req.messages.get().data).toEqual({ greeting: 'first' });
+      expect(req.message.data).toEqual({ greeting: 'second' });
     });
   });
 });

--- a/packages/bruno-js/tests/bruno-grpc-response.spec.js
+++ b/packages/bruno-js/tests/bruno-grpc-response.spec.js
@@ -83,7 +83,7 @@ describe('BrunoGrpcResponse', () => {
       metadata: [{ name: 'content-type', value: 'application/grpc' }],
       trailers: undefined,
       statusCode: undefined,
-      statusMessage: undefined,
+      statusText: undefined,
       duration: undefined,
       methodType: 'server-streaming'
     };
@@ -91,7 +91,7 @@ describe('BrunoGrpcResponse', () => {
     const res = new BrunoGrpcResponse(partial, { message: partial.messages[0] });
 
     expect(res.statusCode).toBeUndefined();
-    expect(res.statusMessage).toBeUndefined();
+    expect(res.statusText).toBeUndefined();
     expect(res.duration).toBeUndefined();
     expect(res.trailers.count()).toBe(0);
     expect(res.metadata.get('content-type')).toBe('application/grpc');

--- a/packages/bruno-js/tests/bruno-grpc-response.spec.js
+++ b/packages/bruno-js/tests/bruno-grpc-response.spec.js
@@ -1,4 +1,5 @@
 const BrunoGrpcResponse = require('../src/grpc/bruno-grpc-response');
+const GrpcMessage = require('../src/grpc/grpc-message');
 
 const makeRes = (overrides = {}) => ({
   statusCode: 0,
@@ -55,5 +56,47 @@ describe('BrunoGrpcResponse', () => {
 
     expect(() => res.metadata.set('content-type', 'text/plain')).toThrow(/beforeCallStart/);
     expect(() => res.trailers.delete('grpc-status')).toThrow(/beforeCallStart/);
+  });
+
+  describe('message', () => {
+    test('the message option becomes a GrpcMessage carrying data and timestamp', () => {
+      const res = new BrunoGrpcResponse(makeRes(), {
+        message: { data: { id: 1 }, timestamp: 1700000000 }
+      });
+
+      expect(res.message).toBeInstanceOf(GrpcMessage);
+      expect(res.message.data).toEqual({ id: 1 });
+      expect(res.message.timestamp).toBe(1700000000);
+    });
+
+    test('without the option the property is absent, not undefined, so afterCallEnd cannot see it', () => {
+      const res = new BrunoGrpcResponse(makeRes());
+
+      expect('message' in res).toBe(false);
+    });
+  });
+
+  // What `afterMessageReceive` sees: the call is still open, so only what has arrived is known.
+  test('a mid-call response reports no status, trailers or duration', () => {
+    const partial = {
+      messages: [{ data: { id: 1 }, timestamp: 1700000000 }],
+      metadata: [{ name: 'content-type', value: 'application/grpc' }],
+      trailers: undefined,
+      statusCode: undefined,
+      statusMessage: undefined,
+      duration: undefined,
+      methodType: 'server-streaming'
+    };
+
+    const res = new BrunoGrpcResponse(partial, { message: partial.messages[0] });
+
+    expect(res.statusCode).toBeUndefined();
+    expect(res.statusMessage).toBeUndefined();
+    expect(res.duration).toBeUndefined();
+    expect(res.trailers.count()).toBe(0);
+    expect(res.metadata.get('content-type')).toBe('application/grpc');
+    expect(res.message.data).toEqual({ id: 1 });
+    // The received message is already the last entry of `messages` — the call folds it in first.
+    expect(res.messages.get(res.messages.count() - 1).data).toEqual({ id: 1 });
   });
 });

--- a/packages/bruno-js/tests/grpc-message.spec.js
+++ b/packages/bruno-js/tests/grpc-message.spec.js
@@ -1,0 +1,35 @@
+const GrpcMessage = require('../src/grpc/grpc-message');
+
+describe('GrpcMessage', () => {
+  test('exposes the payload and the timestamp it was stamped with', () => {
+    const message = new GrpcMessage({ data: { greeting: 'hi' }, timestamp: 1700000000 });
+
+    expect(message.data).toEqual({ greeting: 'hi' });
+    expect(message.timestamp).toBe(1700000000);
+  });
+
+  test('data is a clone, so editing it cannot reach what the call sends', () => {
+    const source = { data: { greeting: 'hi' }, timestamp: 1700000000 };
+    const message = new GrpcMessage(source);
+
+    message.data.greeting = 'tampered';
+
+    expect(source.data).toEqual({ greeting: 'hi' });
+  });
+
+  test('data and timestamp are own enumerable fields, which is what makes them survive QuickJS marshalling', () => {
+    // `marshallToVm` copies properties with `for...in`, so a getter on the prototype would be
+    // invisible inside the sandbox while working fine in node-vm. This assertion is the only one
+    // a getter-based refactor would fail.
+    const message = new GrpcMessage({ data: { greeting: 'hi' }, timestamp: 1700000000 });
+
+    expect(Object.keys(message)).toEqual(['data', 'timestamp']);
+  });
+
+  test('an empty message yields undefined fields rather than throwing', () => {
+    const message = new GrpcMessage();
+
+    expect(message.data).toBeUndefined();
+    expect(message.timestamp).toBeUndefined();
+  });
+});

--- a/packages/bruno-js/tests/grpc-script-runtime.spec.js
+++ b/packages/bruno-js/tests/grpc-script-runtime.spec.js
@@ -388,7 +388,7 @@ describe('GrpcScriptRuntime', () => {
       metadata: [{ name: 'content-type', value: 'application/grpc' }],
       trailers: undefined,
       statusCode: undefined,
-      statusMessage: undefined,
+      statusText: undefined,
       duration: undefined,
       methodType: 'server-streaming',
       ...overrides

--- a/packages/bruno-js/tests/grpc-script-runtime.spec.js
+++ b/packages/bruno-js/tests/grpc-script-runtime.spec.js
@@ -26,22 +26,28 @@ const makeResponse = (overrides = {}) => ({
 const onConsoleLog = () => {};
 
 const runBeforeCallStart = (script, request, runtime = 'nodevm') =>
-  new GrpcScriptRuntime({ runtime }).runGrpcRequestScript(script, request, {}, {}, '.', onConsoleLog, process.env);
+  new GrpcScriptRuntime({ runtime }).runGrpcRequestScript({
+    script,
+    request,
+    envVariables: {},
+    runtimeVariables: {},
+    collectionPath: '.',
+    onConsoleLog,
+    processEnvVars: process.env
+  });
 
 const runAfterCallEnd = (script, request, response, { sentMessages = [], runtime = 'nodevm' } = {}) =>
-  new GrpcScriptRuntime({ runtime }).runGrpcResponseScript(
+  new GrpcScriptRuntime({ runtime }).runGrpcResponseScript({
     script,
     request,
     response,
-    {},
-    {},
-    '.',
+    envVariables: {},
+    runtimeVariables: {},
+    collectionPath: '.',
     onConsoleLog,
-    process.env,
-    undefined,
-    undefined,
-    { sentMessages }
-  );
+    processEnvVars: process.env,
+    sentMessages
+  });
 
 describe('GrpcScriptRuntime', () => {
   describe('beforeCallStart (runGrpcRequestScript)', () => {

--- a/packages/bruno-js/tests/grpc-script-runtime.spec.js
+++ b/packages/bruno-js/tests/grpc-script-runtime.spec.js
@@ -36,7 +36,50 @@ const runBeforeCallStart = (script, request, runtime = 'nodevm') =>
     processEnvVars: process.env
   });
 
-const runAfterCallEnd = (script, request, response, { sentMessages = [], runtime = 'nodevm' } = {}) =>
+const runBeforeMessageSend = (
+  script,
+  request,
+  message,
+  { sentMessages = [], runtime = 'nodevm' } = {}
+) =>
+  new GrpcScriptRuntime({ runtime }).runGrpcBeforeMessageSendScript({
+    script,
+    request,
+    message,
+    envVariables: {},
+    runtimeVariables: {},
+    collectionPath: '.',
+    onConsoleLog,
+    processEnvVars: process.env,
+    sentMessages
+  });
+
+const runAfterMessageReceive = (
+  script,
+  request,
+  response,
+  message,
+  { sentMessages = [], runtime = 'nodevm' } = {}
+) =>
+  new GrpcScriptRuntime({ runtime }).runGrpcAfterMessageReceiveScript({
+    script,
+    request,
+    response,
+    message,
+    envVariables: {},
+    runtimeVariables: {},
+    collectionPath: '.',
+    onConsoleLog,
+    processEnvVars: process.env,
+    sentMessages
+  });
+
+const runAfterCallEnd = (
+  script,
+  request,
+  response,
+  { sentMessages = [], runtime = 'nodevm' } = {}
+) =>
   new GrpcScriptRuntime({ runtime }).runGrpcResponseScript({
     script,
     request,
@@ -51,35 +94,55 @@ const runAfterCallEnd = (script, request, response, { sentMessages = [], runtime
 
 describe('GrpcScriptRuntime', () => {
   describe('beforeCallStart (runGrpcRequestScript)', () => {
-    it('applies metadata writes to the request that will be sent', async () => {
-      const request = makeRequest();
+    it.each(['nodevm', 'quickjs'])(
+      'applies metadata writes to the request that will be sent (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
+        bru.grpc.request.metadata.set('x-token', 'from-hook');
+        bru.setVar('metadataCount', bru.grpc.request.metadata.count());
+      `;
 
-      const result = await runBeforeCallStart(`bru.grpc.request.metadata.set('x-token', 'from-hook');`, request);
+        const result = await runBeforeCallStart(script, makeRequest(), runtime);
 
-      expect(result.request.headers).toEqual({ 'x-token': 'from-hook' });
-    });
+        expect(result.request.headers).toEqual({ 'x-token': 'from-hook' });
+        expect(result.runtimeVariables.metadataCount).toBe(1);
+      }
+    );
 
-    it('exposes the request scalars, with no messages sent yet', async () => {
-      const script = `
+    it.each(['nodevm', 'quickjs'])(
+      'exposes the request scalars, with no messages sent yet (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
         bru.setVar('method', bru.grpc.request.method);
         bru.setVar('methodType', bru.grpc.request.methodType);
         bru.setVar('sentCount', bru.grpc.request.messages.count());
       `;
 
-      const result = await runBeforeCallStart(script, makeRequest());
+        const result = await runBeforeCallStart(script, makeRequest(), runtime);
 
-      expect(result.runtimeVariables).toEqual({
-        method: '/hello.HelloService/SayHello',
-        methodType: 'unary',
-        sentCount: 0
-      });
-    });
+        expect(result.runtimeVariables).toEqual({
+          method: '/hello.HelloService/SayHello',
+          methodType: 'unary',
+          sentCount: 0
+        });
+      }
+    );
 
-    it('has no bru.grpc.response, since the call has not run yet', async () => {
-      const result = await runBeforeCallStart(`bru.setVar('hasResponse', Boolean(bru.grpc.response));`, makeRequest());
+    it.each(['nodevm', 'quickjs'])(
+      'has no bru.grpc.response, since the call has not run yet (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const result = await runBeforeCallStart(
+          `bru.setVar('hasResponse', Boolean(bru.grpc.response));`,
+          makeRequest(),
+          runtime
+        );
 
-      expect(result.runtimeVariables.hasResponse).toBe(false);
-    });
+        expect(result.runtimeVariables.hasResponse).toBe(false);
+      }
+    );
 
     it('rejects bru.runRequest, which gRPC scripts cannot use', async () => {
       const script = `
@@ -92,7 +155,9 @@ describe('GrpcScriptRuntime', () => {
 
       const result = await runBeforeCallStart(script, makeRequest());
 
-      expect(result.runtimeVariables.error).toBe('bru.runRequest is not supported in gRPC scripts');
+      expect(result.runtimeVariables.error).toBe(
+        'bru.runRequest is not supported in gRPC scripts'
+      );
     });
 
     it('attaches what the hook set before it threw to the error it re-throws', async () => {
@@ -101,40 +166,35 @@ describe('GrpcScriptRuntime', () => {
         throw new Error('hook exploded');
       `;
 
-      const error = await runBeforeCallStart(script, makeRequest()).catch((e) => e);
+      const error = await runBeforeCallStart(script, makeRequest()).catch(
+        (e) => e
+      );
 
       expect(error.message).toContain('hook exploded');
-      expect(error.partialResults.runtimeVariables).toEqual({ ranBefore: true });
+      expect(error.partialResults.runtimeVariables).toEqual({
+        ranBefore: true
+      });
     });
 
     it('returns null for the variable scopes the hook did not touch', async () => {
-      const result = await runBeforeCallStart(`bru.setEnvVar('token', 'abc');`, makeRequest());
+      const result = await runBeforeCallStart(
+        `bru.setEnvVar('token', 'abc');`,
+        makeRequest()
+      );
 
       expect(result.envVariables).toEqual({ token: 'abc' });
       expect(result.runtimeVariables).toBeNull();
       expect(result.collectionVariables).toBeNull();
       expect(result.globalEnvironmentVariables).toBeNull();
     });
-
-    it('reads and writes the request through the QuickJS shim', async () => {
-      await quickJsLoader();
-      const script = `
-        bru.grpc.request.metadata.set('x-token', 'from-hook');
-        bru.setVar('metadataCount', bru.grpc.request.metadata.count());
-        bru.setVar('sentCount', bru.grpc.request.messages.count());
-      `;
-      const request = makeRequest();
-
-      const result = await runBeforeCallStart(script, request, 'quickjs');
-
-      expect(result.request.headers).toEqual({ 'x-token': 'from-hook' });
-      expect(result.runtimeVariables).toEqual({ metadataCount: 1, sentCount: 0 });
-    });
   });
 
   describe('afterCallEnd (runGrpcResponseScript)', () => {
-    it('exposes the completed call', async () => {
-      const script = `
+    it.each(['nodevm', 'quickjs'])(
+      'exposes the completed call (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
         bru.setVar('statusCode', bru.grpc.response.statusCode);
         bru.setVar('duration', bru.grpc.response.duration);
         bru.setVar('reply', bru.grpc.response.messages.get(0).data.reply);
@@ -142,72 +202,358 @@ describe('GrpcScriptRuntime', () => {
         bru.setVar('grpcStatus', bru.grpc.response.trailers.get('grpc-status'));
       `;
 
-      const result = await runAfterCallEnd(script, makeRequest(), makeResponse());
+        const result = await runAfterCallEnd(
+          script,
+          makeRequest(),
+          makeResponse(),
+          { runtime }
+        );
 
-      expect(result.runtimeVariables).toEqual({
-        statusCode: 0,
-        duration: 12,
-        reply: 'hello',
-        contentType: 'application/grpc',
-        grpcStatus: '0'
-      });
-    });
+        expect(result.runtimeVariables).toEqual({
+          statusCode: 0,
+          duration: 12,
+          reply: 'hello',
+          contentType: 'application/grpc',
+          grpcStatus: '0'
+        });
+      }
+    );
 
-    it('reports the messages that were sent, not the ones that were authored', async () => {
-      const request = makeRequest({
-        body: {
-          grpc: [
-            { name: 'message 1', content: '{"greeting":"hi"}' },
-            { name: 'message 2', content: '{"greeting":"unsent"}' }
-          ]
-        }
-      });
-      const script = `
+    it.each(['nodevm', 'quickjs'])(
+      'reports the messages that were sent, not the ones that were authored (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const request = makeRequest({
+          body: {
+            grpc: [
+              { name: 'message 1', content: '{"greeting":"hi"}' },
+              { name: 'message 2', content: '{"greeting":"unsent"}' }
+            ]
+          }
+        });
+        const script = `
         bru.setVar('count', bru.grpc.request.messages.count());
         bru.setVar('greeting', bru.grpc.request.messages.get(0).data.greeting);
       `;
 
-      const result = await runAfterCallEnd(script, request, makeResponse(), {
-        sentMessages: [{ data: { greeting: 'hi' }, timestamp: 1700000000 }]
-      });
+        const result = await runAfterCallEnd(script, request, makeResponse(), {
+          sentMessages: [{ data: { greeting: 'hi' }, timestamp: 1700000000 }],
+          runtime
+        });
 
-      expect(result.runtimeVariables).toEqual({ count: 1, greeting: 'hi' });
-    });
+        expect(result.runtimeVariables).toEqual({ count: 1, greeting: 'hi' });
+      }
+    );
 
-    it('rejects every metadata write once the call has ended', async () => {
-      const script = `
+    it.each(['nodevm', 'quickjs'])(
+      'rejects every metadata write once the call has ended (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
         try { bru.grpc.request.metadata.set('x-token', 'too-late'); } catch (e) { bru.setVar('requestMetadata', e.message); }
         try { bru.grpc.response.trailers.delete('grpc-status'); } catch (e) { bru.setVar('responseTrailers', e.message); }
       `;
-      const request = makeRequest();
+        const request = makeRequest();
 
-      const result = await runAfterCallEnd(script, request, makeResponse());
+        const result = await runAfterCallEnd(script, request, makeResponse(), {
+          runtime
+        });
 
-      expect(result.runtimeVariables.requestMetadata).toContain('metadata.set() is not available');
-      expect(result.runtimeVariables.responseTrailers).toContain('metadata.delete() is not available');
-      expect(request.headers).toEqual({ 'X-Token': 'authored' });
-    });
+        expect(result.runtimeVariables.requestMetadata).toContain(
+          'metadata.set() is not available'
+        );
+        expect(result.runtimeVariables.responseTrailers).toContain(
+          'metadata.delete() is not available'
+        );
+        expect(request.headers).toEqual({ 'X-Token': 'authored' });
+      }
+    );
+  });
 
-    it('reads the completed call through the QuickJS shim', async () => {
-      await quickJsLoader();
-      const script = `
-        bru.setVar('statusCode', bru.grpc.response.statusCode);
-        bru.setVar('reply', bru.grpc.response.messages.get(0).data.reply);
-        bru.setVar('contentType', bru.grpc.response.metadata.get('content-type'));
-        bru.setVar('sentCount', bru.grpc.request.messages.count());
+  describe('beforeMessageSend (runGrpcBeforeMessageSendScript)', () => {
+    const outbound = { data: { greeting: 'outbound' }, timestamp: 1700000005 };
+
+    it.each(['nodevm', 'quickjs'])(
+      'exposes the message about to be sent (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
+        bru.setVar('greeting', bru.grpc.request.message.data.greeting);
+        bru.setVar('timestamp', bru.grpc.request.message.timestamp);
+        bru.setVar('methodType', bru.grpc.request.methodType);
       `;
 
-      const result = await runAfterCallEnd(script, makeRequest(), makeResponse(), {
-        sentMessages: [{ data: { greeting: 'hi' }, timestamp: 1700000000 }],
-        runtime: 'quickjs'
-      });
+        const result = await runBeforeMessageSend(
+          script,
+          makeRequest(),
+          outbound,
+          { runtime }
+        );
 
-      expect(result.runtimeVariables).toEqual({
-        statusCode: 0,
-        reply: 'hello',
-        contentType: 'application/grpc',
-        sentCount: 1
+        expect(result.runtimeVariables).toEqual({
+          greeting: 'outbound',
+          timestamp: 1700000005,
+          methodType: 'unary'
+        });
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'messages holds only what was already transmitted (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
+        bru.setVar('sentCount', bru.grpc.request.messages.count());
+        bru.setVar('lastSent', bru.grpc.request.messages.get(0).data.greeting);
+        bru.setVar('pending', bru.grpc.request.message.data.greeting);
+      `;
+
+        const result = await runBeforeMessageSend(
+          script,
+          makeRequest({ methodType: 'bidi-streaming' }),
+          outbound,
+          {
+            sentMessages: [
+              { data: { greeting: 'first' }, timestamp: 1700000000 }
+            ],
+            runtime
+          }
+        );
+
+        expect(result.runtimeVariables).toEqual({
+          sentCount: 1,
+          lastSent: 'first',
+          pending: 'outbound'
+        });
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'has no bru.grpc.response, even mid-stream (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+
+        const result = await runBeforeMessageSend(
+          `bru.setVar('hasResponse', Boolean(bru.grpc.response));`,
+          makeRequest({ methodType: 'bidi-streaming' }),
+          outbound,
+          { runtime }
+        );
+
+        expect(result.runtimeVariables.hasResponse).toBe(false);
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'rejects metadata writes — the headers are already on the wire (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const request = makeRequest();
+
+        const result = await runBeforeMessageSend(
+          `try { bru.grpc.request.metadata.set('x-token', 'too-late'); } catch (e) { bru.setVar('err', e.message); }`,
+          request,
+          outbound,
+          { runtime }
+        );
+
+        expect(result.runtimeVariables.err).toContain(
+          'metadata.set() is not available'
+        );
+        expect(request.headers).toEqual({ 'X-Token': 'authored' });
+      }
+    );
+
+    it('attaches the variables set before a throw, so an aborted send still reports them', async () => {
+      const script = `
+        bru.setVar('reached', true);
+        throw new Error('no send');
+      `;
+
+      await expect(
+        runBeforeMessageSend(script, makeRequest(), outbound)
+      ).rejects.toMatchObject({
+        message: 'no send',
+        partialResults: { runtimeVariables: { reached: true } }
       });
     });
+  });
+
+  describe('afterMessageReceive (runGrpcAfterMessageReceiveScript)', () => {
+    const inbound = { data: { reply: 'hello' }, timestamp: 1700000009 };
+
+    // What the orchestration hands over mid-call: no status, no trailers, no duration.
+    const makePartialResponse = (overrides = {}) => ({
+      messages: [inbound],
+      metadata: [{ name: 'content-type', value: 'application/grpc' }],
+      trailers: undefined,
+      statusCode: undefined,
+      statusMessage: undefined,
+      duration: undefined,
+      methodType: 'server-streaming',
+      ...overrides
+    });
+
+    it.each(['nodevm', 'quickjs'])(
+      'exposes the message just received (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
+        bru.setVar('reply', bru.grpc.response.message.data.reply);
+        bru.setVar('timestamp', bru.grpc.response.message.timestamp);
+        bru.setVar('contentType', bru.grpc.response.metadata.get('content-type'));
+      `;
+
+        const result = await runAfterMessageReceive(
+          script,
+          makeRequest(),
+          makePartialResponse(),
+          inbound,
+          { runtime }
+        );
+
+        expect(result.runtimeVariables).toEqual({
+          reply: 'hello',
+          timestamp: 1700000009,
+          contentType: 'application/grpc'
+        });
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'the received message is already the last of response.messages (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const second = { data: { reply: 'world' }, timestamp: 1700000010 };
+        const script = `
+        bru.setVar('count', bru.grpc.response.messages.count());
+        bru.setVar('last', bru.grpc.response.messages.get(bru.grpc.response.messages.count() - 1).data.reply);
+        bru.setVar('current', bru.grpc.response.message.data.reply);
+      `;
+
+        const result = await runAfterMessageReceive(
+          script,
+          makeRequest(),
+          makePartialResponse({ messages: [inbound, second] }),
+          second,
+          { runtime }
+        );
+
+        expect(result.runtimeVariables).toEqual({
+          count: 2,
+          last: 'world',
+          current: 'world'
+        });
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'reports no status, trailers or duration while the call is open (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
+        bru.setVar('hasStatusCode', bru.grpc.response.statusCode !== undefined);
+        bru.setVar('hasDuration', bru.grpc.response.duration !== undefined);
+        bru.setVar('trailerCount', bru.grpc.response.trailers.count());
+      `;
+
+        const result = await runAfterMessageReceive(
+          script,
+          makeRequest(),
+          makePartialResponse(),
+          inbound,
+          { runtime }
+        );
+
+        expect(result.runtimeVariables).toEqual({
+          hasStatusCode: false,
+          hasDuration: false,
+          trailerCount: 0
+        });
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'rejects metadata writes on both models (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
+        try { bru.grpc.request.metadata.set('x-token', 'too-late'); } catch (e) { bru.setVar('request', e.message); }
+        try { bru.grpc.response.metadata.set('content-type', 'text/plain'); } catch (e) { bru.setVar('response', e.message); }
+      `;
+
+        const result = await runAfterMessageReceive(
+          script,
+          makeRequest(),
+          makePartialResponse(),
+          inbound,
+          { runtime }
+        );
+
+        expect(result.runtimeVariables.request).toContain(
+          'metadata.set() is not available'
+        );
+        expect(result.runtimeVariables.response).toContain(
+          'metadata.set() is not available'
+        );
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'has no request.message — nothing is being sent (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+
+        const result = await runAfterMessageReceive(
+          `bru.setVar('hasRequestMessage', 'message' in bru.grpc.request);`,
+          makeRequest(),
+          makePartialResponse(),
+          inbound,
+          { runtime }
+        );
+
+        expect(result.runtimeVariables.hasRequestMessage).toBe(false);
+      }
+    );
+  });
+
+  describe('the call hooks never see a single message', () => {
+    it.each(['nodevm', 'quickjs'])(
+      'beforeCallStart has no request.message (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+
+        const result = await runBeforeCallStart(
+          `bru.setVar('hasMessage', 'message' in bru.grpc.request);`,
+          makeRequest(),
+          runtime
+        );
+
+        expect(result.runtimeVariables.hasMessage).toBe(false);
+      }
+    );
+
+    it.each(['nodevm', 'quickjs'])(
+      'afterCallEnd has no message on either model (%s)',
+      async (runtime) => {
+        if (runtime === 'quickjs') await quickJsLoader();
+        const script = `
+        bru.setVar('onRequest', 'message' in bru.grpc.request);
+        bru.setVar('onResponse', 'message' in bru.grpc.response);
+      `;
+
+        const result = await runAfterCallEnd(
+          script,
+          makeRequest(),
+          makeResponse(),
+          { runtime }
+        );
+
+        expect(result.runtimeVariables).toEqual({
+          onRequest: false,
+          onResponse: false
+        });
+      }
+    );
   });
 });

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -186,11 +186,13 @@ const grammar = ohm.grammar(`Bru {
   example = "example" st* "{" nl* examplecontent tagend
   examplecontent = (~tagend any)*
 
-  script = scriptreq | scriptres | scriptbeforecallstart | scriptaftercallend
+  script = scriptreq | scriptres | scriptbeforecallstart | scriptaftercallend | scriptbeforemessagesend | scriptaftermessagereceive
   scriptreq = "script:pre-request" st* "{" nl* textblock tagend
   scriptres = "script:post-response" st* "{" nl* textblock tagend
   scriptbeforecallstart = "script:grpc:before-call-start" st* "{" nl* textblock tagend
   scriptaftercallend = "script:grpc:after-call-end" st* "{" nl* textblock tagend
+  scriptbeforemessagesend = "script:grpc:before-message-send" st* "{" nl* textblock tagend
+  scriptaftermessagereceive = "script:grpc:after-message-receive" st* "{" nl* textblock tagend
   tests = "tests" st* "{" nl* textblock tagend
   docs = "docs" st* "{" nl* textblock tagend
 }`);
@@ -1213,6 +1215,20 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     return {
       script: {
         afterCallEnd: outdentString(textblock.sourceString)
+      }
+    };
+  },
+  scriptbeforemessagesend(_1, _2, _3, _4, textblock, _5) {
+    return {
+      script: {
+        beforeMessageSend: outdentString(textblock.sourceString)
+      }
+    };
+  },
+  scriptaftermessagereceive(_1, _2, _3, _4, textblock, _5) {
+    return {
+      script: {
+        afterMessageReceive: outdentString(textblock.sourceString)
       }
     };
   },

--- a/packages/bruno-lang/v2/src/bruToJson.js
+++ b/packages/bruno-lang/v2/src/bruToJson.js
@@ -186,13 +186,13 @@ const grammar = ohm.grammar(`Bru {
   example = "example" st* "{" nl* examplecontent tagend
   examplecontent = (~tagend any)*
 
-  script = scriptreq | scriptres | scriptbeforecallstart | scriptaftercallend | scriptbeforemessagesend | scriptaftermessagereceive
+  script = scriptreq | scriptres | scriptbeforecallstart | scriptbeforemessagesend | scriptaftermessagereceive | scriptaftercallend
   scriptreq = "script:pre-request" st* "{" nl* textblock tagend
   scriptres = "script:post-response" st* "{" nl* textblock tagend
   scriptbeforecallstart = "script:grpc:before-call-start" st* "{" nl* textblock tagend
-  scriptaftercallend = "script:grpc:after-call-end" st* "{" nl* textblock tagend
   scriptbeforemessagesend = "script:grpc:before-message-send" st* "{" nl* textblock tagend
   scriptaftermessagereceive = "script:grpc:after-message-receive" st* "{" nl* textblock tagend
+  scriptaftercallend = "script:grpc:after-call-end" st* "{" nl* textblock tagend
   tests = "tests" st* "{" nl* textblock tagend
   docs = "docs" st* "{" nl* textblock tagend
 }`);
@@ -1211,13 +1211,6 @@ const sem = grammar.createSemantics().addAttribute('ast', {
       }
     };
   },
-  scriptaftercallend(_1, _2, _3, _4, textblock, _5) {
-    return {
-      script: {
-        afterCallEnd: outdentString(textblock.sourceString)
-      }
-    };
-  },
   scriptbeforemessagesend(_1, _2, _3, _4, textblock, _5) {
     return {
       script: {
@@ -1229,6 +1222,13 @@ const sem = grammar.createSemantics().addAttribute('ast', {
     return {
       script: {
         afterMessageReceive: outdentString(textblock.sourceString)
+      }
+    };
+  },
+  scriptaftercallend(_1, _2, _3, _4, textblock, _5) {
+    return {
+      script: {
+        afterCallEnd: outdentString(textblock.sourceString)
       }
     };
   },

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -770,14 +770,6 @@ ${indentString(script.beforeCallStart)}
 `;
   }
 
-  if (script && script.afterCallEnd && script.afterCallEnd.length) {
-    bru += `script:grpc:after-call-end {
-${indentString(script.afterCallEnd)}
-}
-
-`;
-  }
-
   if (script && script.beforeMessageSend && script.beforeMessageSend.length) {
     bru += `script:grpc:before-message-send {
 ${indentString(script.beforeMessageSend)}
@@ -789,6 +781,14 @@ ${indentString(script.beforeMessageSend)}
   if (script && script.afterMessageReceive && script.afterMessageReceive.length) {
     bru += `script:grpc:after-message-receive {
 ${indentString(script.afterMessageReceive)}
+}
+
+`;
+  }
+
+  if (script && script.afterCallEnd && script.afterCallEnd.length) {
+    bru += `script:grpc:after-call-end {
+${indentString(script.afterCallEnd)}
 }
 
 `;

--- a/packages/bruno-lang/v2/src/jsonToBru.js
+++ b/packages/bruno-lang/v2/src/jsonToBru.js
@@ -778,6 +778,22 @@ ${indentString(script.afterCallEnd)}
 `;
   }
 
+  if (script && script.beforeMessageSend && script.beforeMessageSend.length) {
+    bru += `script:grpc:before-message-send {
+${indentString(script.beforeMessageSend)}
+}
+
+`;
+  }
+
+  if (script && script.afterMessageReceive && script.afterMessageReceive.length) {
+    bru += `script:grpc:after-message-receive {
+${indentString(script.afterMessageReceive)}
+}
+
+`;
+  }
+
   if (tests && tests.length) {
     bru += `tests {
 ${indentString(tests)}

--- a/packages/bruno-lang/v2/tests/index.spec.js
+++ b/packages/bruno-lang/v2/tests/index.spec.js
@@ -24,13 +24,15 @@ describe('jsonToBru', () => {
 });
 
 describe('round-trip', () => {
-  it('should preserve all four script blocks through jsonToBru and back', () => {
+  it('should preserve all six script blocks through jsonToBru and back', () => {
     const json = {
       script: {
         req: 'req.setHeader(\'Content-Type\', \'application/json\');',
         res: 'expect(res.status).to.equal(200);',
         beforeCallStart: 'req.setMetadata(\'authorization\', \'Bearer token\');',
-        afterCallEnd: 'if (res.getStatusCode() === 0) {\n  bru.setVar(\'ok\', true);\n}'
+        afterCallEnd: 'if (res.getStatusCode() === 0) {\n  bru.setVar(\'ok\', true);\n}',
+        beforeMessageSend: 'bru.setVar(\'sent\', bru.grpc.request.message.timestamp);',
+        afterMessageReceive: 'if (bru.grpc.response.message.data) {\n  bru.setVar(\'received\', true);\n}'
       }
     };
 

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -466,9 +466,9 @@ describe('jsonToBru stringify', () => {
           req: 'req.setHeader(\'Content-Type\', \'application/json\');',
           res: 'expect(res.status).to.equal(200);',
           beforeCallStart: 'req.setMetadata(\'authorization\', \'Bearer token\');',
-          afterCallEnd: 'expect(res.getStatusCode()).to.equal(0);',
           beforeMessageSend: 'bru.setVar(\'sent\', bru.grpc.request.message.timestamp);',
-          afterMessageReceive: 'expect(bru.grpc.response.message.data).to.be.an(\'object\');'
+          afterMessageReceive: 'expect(bru.grpc.response.message.data).to.be.an(\'object\');',
+          afterCallEnd: 'expect(res.getStatusCode()).to.equal(0);'
         }
       });
 
@@ -484,16 +484,16 @@ script:grpc:before-call-start {
   req.setMetadata('authorization', 'Bearer token');
 }
 
-script:grpc:after-call-end {
-  expect(res.getStatusCode()).to.equal(0);
-}
-
 script:grpc:before-message-send {
   bru.setVar('sent', bru.grpc.request.message.timestamp);
 }
 
 script:grpc:after-message-receive {
   expect(bru.grpc.response.message.data).to.be.an('object');
+}
+
+script:grpc:after-call-end {
+  expect(res.getStatusCode()).to.equal(0);
 }
 `);
     });

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -466,7 +466,9 @@ describe('jsonToBru stringify', () => {
           req: 'req.setHeader(\'Content-Type\', \'application/json\');',
           res: 'expect(res.status).to.equal(200);',
           beforeCallStart: 'req.setMetadata(\'authorization\', \'Bearer token\');',
-          afterCallEnd: 'expect(res.getStatusCode()).to.equal(0);'
+          afterCallEnd: 'expect(res.getStatusCode()).to.equal(0);',
+          beforeMessageSend: 'bru.setVar(\'sent\', bru.grpc.request.message.timestamp);',
+          afterMessageReceive: 'expect(bru.grpc.response.message.data).to.be.an(\'object\');'
         }
       });
 
@@ -484,6 +486,14 @@ script:grpc:before-call-start {
 
 script:grpc:after-call-end {
   expect(res.getStatusCode()).to.equal(0);
+}
+
+script:grpc:before-message-send {
+  bru.setVar('sent', bru.grpc.request.message.timestamp);
+}
+
+script:grpc:after-message-receive {
+  expect(bru.grpc.response.message.data).to.be.an('object');
 }
 `);
     });

--- a/packages/bruno-lang/v2/tests/script.spec.js
+++ b/packages/bruno-lang/v2/tests/script.spec.js
@@ -68,7 +68,39 @@ script:grpc:after-call-end {
     expect(output).toEqual(expected);
   });
 
-  it('should merge all four script blocks present in a single file', () => {
+  it('should parse grpc before-message-send script', () => {
+    const input = `
+script:grpc:before-message-send {
+  expect(bru.grpc.request.message.data).to.be.an('object');
+}
+`;
+
+    const output = parser(input);
+    const expected = {
+      script: {
+        beforeMessageSend: 'expect(bru.grpc.request.message.data).to.be.an(\'object\');'
+      }
+    };
+    expect(output).toEqual(expected);
+  });
+
+  it('should parse grpc after-message-receive script', () => {
+    const input = `
+script:grpc:after-message-receive {
+  expect(bru.grpc.response.message.data).to.be.an('object');
+}
+`;
+
+    const output = parser(input);
+    const expected = {
+      script: {
+        afterMessageReceive: 'expect(bru.grpc.response.message.data).to.be.an(\'object\');'
+      }
+    };
+    expect(output).toEqual(expected);
+  });
+
+  it('should merge all six script blocks present in a single file', () => {
     const input = `
 script:pre-request {
   req.setHeader('Content-Type', 'application/json');
@@ -85,6 +117,14 @@ script:grpc:before-call-start {
 script:grpc:after-call-end {
   expect(res.getStatusCode()).to.equal(0);
 }
+
+script:grpc:before-message-send {
+  bru.setVar('sent', bru.grpc.request.message.timestamp);
+}
+
+script:grpc:after-message-receive {
+  bru.setVar('received', bru.grpc.response.message.timestamp);
+}
 `;
 
     const output = parser(input);
@@ -93,7 +133,9 @@ script:grpc:after-call-end {
         req: 'req.setHeader(\'Content-Type\', \'application/json\');',
         res: 'expect(res.status).to.equal(200);',
         beforeCallStart: 'req.setMetadata(\'authorization\', \'Bearer token\');',
-        afterCallEnd: 'expect(res.getStatusCode()).to.equal(0);'
+        afterCallEnd: 'expect(res.getStatusCode()).to.equal(0);',
+        beforeMessageSend: 'bru.setVar(\'sent\', bru.grpc.request.message.timestamp);',
+        afterMessageReceive: 'bru.setVar(\'received\', bru.grpc.response.message.timestamp);'
       }
     };
     expect(output).toEqual(expected);

--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -580,6 +580,9 @@ class GrpcClient {
    * @param {string[]} [params.includeDirs] - Include directories for proto file resolution
    * @param {Object} [params.proxyConfig] - HTTP proxy configuration
    * @param {string} params.proxyConfig.proxyUrl - The HTTP proxy URL
+   * @param {Function} [params.onBeforeMessageSend] - Awaited once, immediately before a unary or
+   *   server-streaming call puts its message on the wire, with `{ data, methodType, messageIndex }`.
+   *   Throwing aborts the call before anything is dispatched.
    */
   async startConnection({
     request,
@@ -592,7 +595,8 @@ class GrpcClient {
     verifyOptions,
     channelOptions = {},
     includeDirs = [],
-    proxyConfig
+    proxyConfig,
+    onBeforeMessageSend
   }) {
     const credentials = this.#getChannelCredentials({
       url: request.url,
@@ -685,6 +689,19 @@ class GrpcClient {
     Object.entries(request.headers).forEach(([name, value]) => {
       metadata.add(name, value);
     });
+
+    // Runs before the message is dispatched, so a hook that throws
+    // means the call never opens.
+    const methodType = this.#getMethodType(method);
+    if (methodType === 'unary' || methodType === 'server-streaming') {
+      try {
+        // Apply the result messages[0] when setter is added.
+        await onBeforeMessageSend?.({ data: messages[0], methodType, messageIndex: 0 });
+      } catch (error) {
+        client.close();
+        throw error;
+      }
+    }
 
     this.#handleConnection({
       client,

--- a/packages/bruno-requests/src/grpc/grpc-client.js
+++ b/packages/bruno-requests/src/grpc/grpc-client.js
@@ -581,7 +581,7 @@ class GrpcClient {
    * @param {Object} [params.proxyConfig] - HTTP proxy configuration
    * @param {string} params.proxyConfig.proxyUrl - The HTTP proxy URL
    * @param {Function} [params.onBeforeMessageSend] - Awaited once, immediately before a unary or
-   *   server-streaming call puts its message on the wire, with `{ data, methodType, messageIndex }`.
+   *   server-streaming call puts its message on the wire, with `{ data }`.
    *   Throwing aborts the call before anything is dispatched.
    */
   async startConnection({
@@ -695,8 +695,7 @@ class GrpcClient {
     const methodType = this.#getMethodType(method);
     if (methodType === 'unary' || methodType === 'server-streaming') {
       try {
-        // Apply the result messages[0] when setter is added.
-        await onBeforeMessageSend?.({ data: messages[0], methodType, messageIndex: 0 });
+        await onBeforeMessageSend?.({ data: messages[0] });
       } catch (error) {
         client.close();
         throw error;

--- a/packages/bruno-schema-types/src/common/scripts.ts
+++ b/packages/bruno-schema-types/src/common/scripts.ts
@@ -5,9 +5,9 @@ export interface HTTPScripts {
 
 export interface GrpcScripts {
   beforeCallStart?: string | null;
-  afterCallEnd?: string | null;
   beforeMessageSend?: string | null;
   afterMessageReceive?: string | null;
+  afterCallEnd?: string | null;
 }
 
 export interface Script extends HTTPScripts, GrpcScripts {}

--- a/packages/bruno-schema-types/src/common/scripts.ts
+++ b/packages/bruno-schema-types/src/common/scripts.ts
@@ -6,6 +6,8 @@ export interface HTTPScripts {
 export interface GrpcScripts {
   beforeCallStart?: string | null;
   afterCallEnd?: string | null;
+  beforeMessageSend?: string | null;
+  afterMessageReceive?: string | null;
 }
 
 export interface Script extends HTTPScripts, GrpcScripts {}

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -549,7 +549,9 @@ const grpcRequestSchema = Yup.object({
     .required('body is required'),
   script: Yup.object({
     beforeCallStart: Yup.string().nullable(),
-    afterCallEnd: Yup.string().nullable()
+    afterCallEnd: Yup.string().nullable(),
+    beforeMessageSend: Yup.string().nullable(),
+    afterMessageReceive: Yup.string().nullable()
   })
     .noUnknown(true)
     .strict(),

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -549,9 +549,9 @@ const grpcRequestSchema = Yup.object({
     .required('body is required'),
   script: Yup.object({
     beforeCallStart: Yup.string().nullable(),
-    afterCallEnd: Yup.string().nullable(),
     beforeMessageSend: Yup.string().nullable(),
-    afterMessageReceive: Yup.string().nullable()
+    afterMessageReceive: Yup.string().nullable(),
+    afterCallEnd: Yup.string().nullable()
   })
     .noUnknown(true)
     .strict(),

--- a/tests/grpc/lifecycle-hooks-persistence/lifecycle-hooks-persistence.spec.ts
+++ b/tests/grpc/lifecycle-hooks-persistence/lifecycle-hooks-persistence.spec.ts
@@ -15,8 +15,11 @@ import {
 
 const REQUEST_NAME = 'grpc-lifecycle-hooks';
 const GRPC_URL = 'localhost:50051';
+
 const BEFORE_CALL_START_SCRIPT = 'bru.setVar(\'startedAt\', 1);';
 const AFTER_CALL_END_SCRIPT = 'bru.setVar(\'endedAt\', 2);';
+const BEFORE_MESSAGE_SEND_SCRIPT = 'bru.setVar(\'sentAt\', bru.grpc.request.message.timestamp);';
+const AFTER_MESSAGE_RECEIVE_SCRIPT = 'bru.setVar(\'receivedAt\', bru.grpc.response.message.timestamp);';
 
 type GrpcRequestYml = {
   runtime?: {
@@ -33,7 +36,7 @@ for (const { format, collectionName, tmpDirPrefix } of FORMATS) {
   test.describe.serial(`grpc lifecycle hooks (${format} format)`, () => {
     let collectionPath: string;
 
-    test('authors both hooks on a gRPC request and saves them', async ({ page, createTmpDir }) => {
+    test('authors every hook on a gRPC request and saves them', async ({ page, createTmpDir }) => {
       collectionPath = await createTmpDir(tmpDirPrefix);
 
       await createCollection(page, collectionName, collectionPath, format);
@@ -41,18 +44,22 @@ for (const { format, collectionName, tmpDirPrefix } of FORMATS) {
 
       await writeScriptContent(page, 'before-call-start', BEFORE_CALL_START_SCRIPT);
       await writeScriptContent(page, 'after-call-end', AFTER_CALL_END_SCRIPT);
+      await writeScriptContent(page, 'before-message-send', BEFORE_MESSAGE_SEND_SCRIPT);
+      await writeScriptContent(page, 'after-message-receive', AFTER_MESSAGE_RECEIVE_SCRIPT);
       await saveRequest(page);
 
-      await test.step('reopening the request shows both hooks', async () => {
+      await test.step('reopening the request shows every hook', async () => {
         await closeAllTabs(page);
         await openRequest(page, collectionName, REQUEST_NAME);
 
         expect(await readScriptContent(page, 'before-call-start')).toBe(BEFORE_CALL_START_SCRIPT);
         expect(await readScriptContent(page, 'after-call-end')).toBe(AFTER_CALL_END_SCRIPT);
+        expect(await readScriptContent(page, 'before-message-send')).toBe(BEFORE_MESSAGE_SEND_SCRIPT);
+        expect(await readScriptContent(page, 'after-message-receive')).toBe(AFTER_MESSAGE_RECEIVE_SCRIPT);
       });
     });
 
-    test(`writes both hooks to the request .${format} file`, async () => {
+    test(`writes every hook to the request .${format} file`, async () => {
       const requestFilePath = path.join(collectionPath, collectionName, `${REQUEST_NAME}.${format}`);
       expect(fs.existsSync(requestFilePath)).toBe(true);
 
@@ -61,16 +68,23 @@ for (const { format, collectionName, tmpDirPrefix } of FORMATS) {
       if (format === 'bru') {
         expect(fileContent).toContain('script:grpc:before-call-start {');
         expect(fileContent).toContain('script:grpc:after-call-end {');
+        expect(fileContent).toContain('script:grpc:before-message-send {');
+        expect(fileContent).toContain('script:grpc:after-message-receive {');
 
         const parsed = bruToJsonV2(fileContent) as { script?: Record<string, string> };
         expect(parsed.script?.beforeCallStart).toBe(BEFORE_CALL_START_SCRIPT);
         expect(parsed.script?.afterCallEnd).toBe(AFTER_CALL_END_SCRIPT);
+        expect(parsed.script?.beforeMessageSend).toBe(BEFORE_MESSAGE_SEND_SCRIPT);
+        expect(parsed.script?.afterMessageReceive).toBe(AFTER_MESSAGE_RECEIVE_SCRIPT);
       } else {
         const scripts = (yaml.load(fileContent) as GrpcRequestYml).runtime?.scripts ?? [];
+        expect(scripts).toHaveLength(4);
         expect(scripts).toEqual(
           expect.arrayContaining([
             { type: 'grpc:before-call-start', code: BEFORE_CALL_START_SCRIPT },
-            { type: 'grpc:after-call-end', code: AFTER_CALL_END_SCRIPT }
+            { type: 'grpc:after-call-end', code: AFTER_CALL_END_SCRIPT },
+            { type: 'grpc:before-message-send', code: BEFORE_MESSAGE_SEND_SCRIPT },
+            { type: 'grpc:after-message-receive', code: AFTER_MESSAGE_RECEIVE_SCRIPT }
           ])
         );
       }

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/BrokenAfterMessageReceive.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/BrokenAfterMessageReceive.yml
@@ -1,0 +1,29 @@
+info:
+  name: BrokenAfterMessageReceive
+  type: grpc
+  seq: 19
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/LotsOfReplies
+  methodType: server-streaming
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "receive-hook-throws"
+        }
+
+runtime:
+  scripts:
+    - type: grpc:after-message-receive
+      code: |-
+        // the throw sits off line 1 so the flashed line number the spec asserts is discriminating
+        throw new Error('afterMessageReceive exploded');
+    - type: grpc:after-call-end
+      code: |-
+        // Queued behind ten rejected message hooks, so a poisoned queue would skip this entirely.
+        test('afterCallEnd still runs once every message hook has thrown', () => {
+          expect(bru.grpc.response.messages.count()).to.equal(10);
+          expect(bru.grpc.response.statusCode).to.equal(0);
+        });

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/BrokenBeforeMessageSend.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/BrokenBeforeMessageSend.yml
@@ -1,0 +1,22 @@
+info:
+  name: BrokenBeforeMessageSend
+  type: grpc
+  seq: 16
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/SayHello
+  methodType: unary
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "never sent"
+        }
+
+runtime:
+  scripts:
+    - type: grpc:before-message-send
+      code: |-
+        bru.setVar('sendReached', 'yes');
+        throw new Error('beforeMessageSend exploded');

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/BrokenSendOnBidiStream.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/BrokenSendOnBidiStream.yml
@@ -1,0 +1,41 @@
+info:
+  name: BrokenSendOnBidiStream
+  type: grpc
+  seq: 18
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/BidiHello
+  methodType: bidi-streaming
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "reject-me"
+        }
+    - title: message 2
+      message: |-
+        {
+          "greeting": "let-me-through"
+        }
+
+runtime:
+  scripts:
+    - type: grpc:before-message-send
+      code: |-
+        if (bru.grpc.request.message.data.greeting === 'reject-me') {
+          throw new Error('this message is not going out');
+        }
+
+        // The stream survives the rejected message, so the next one still reaches the hook.
+        test('the message that follows the rejected one is still streamed', () => {
+          expect(bru.grpc.request.message.data.greeting).to.equal('let-me-through');
+          expect(bru.grpc.request.messages.count()).to.equal(0);
+        });
+    - type: grpc:after-call-end
+      code: |-
+        test('only the message the hook let through was streamed', () => {
+          expect(bru.grpc.request.messages.count()).to.equal(1);
+          expect(bru.grpc.request.messages.get(0).data.greeting).to.equal('let-me-through');
+          expect(bru.grpc.response.messages.count()).to.equal(1);
+        });

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/EchoLastReply.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/EchoLastReply.yml
@@ -1,0 +1,15 @@
+info:
+  name: EchoLastReply
+  type: grpc
+  seq: 12
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/SayHello
+  methodType: unary
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "{{lastReply}}"
+        }

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/EchoReceivedCount.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/EchoReceivedCount.yml
@@ -1,0 +1,15 @@
+info:
+  name: EchoReceivedCount
+  type: grpc
+  seq: 14
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/SayHello
+  methodType: unary
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "received-{{receivedCount}}"
+        }

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/EchoSendReached.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/EchoSendReached.yml
@@ -1,0 +1,15 @@
+info:
+  name: EchoSendReached
+  type: grpc
+  seq: 17
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/SayHello
+  methodType: unary
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "send-{{sendReached}}"
+        }

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/HookTests.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/HookTests.yml
@@ -65,7 +65,7 @@ runtime:
 
         // Same request object as `beforeCallStart` saw, interpolated by now.
         test('request scalars are interpolated by the time the call is over', () => {
-          expect(bru.grpc.request.url).to.equal('grpc://grpcb.in:9000');
+          expect(bru.grpc.request.url).to.equal('grpc://localhost:50051');
           expect(bru.grpc.request.method).to.equal('/hello.HelloService/SayHello');
           expect(bru.grpc.request.methodType).to.equal('unary');
           expect(bru.grpc.request.name).to.equal('HookTests');

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/MessageHooksBidi.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/MessageHooksBidi.yml
@@ -1,0 +1,49 @@
+info:
+  name: MessageHooksBidi
+  type: grpc
+  seq: 15
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/BidiHello
+  methodType: bidi-streaming
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "bidi-hook-1"
+        }
+    - title: message 2
+      message: |-
+        {
+          "greeting": "bidi-hook-2"
+        }
+
+runtime:
+  scripts:
+    - type: grpc:before-message-send
+      code: |-
+        // `messages` holds what has already gone out, so it lags this message by one.
+        const alreadySent = bru.grpc.request.messages.count();
+
+        test('outgoing message ' + (alreadySent + 1) + ' reaches the hook before it is streamed', () => {
+          expect(bru.grpc.request.message.data.greeting).to.equal('bidi-hook-' + (alreadySent + 1));
+        });
+    - type: grpc:after-message-receive
+      code: |-
+        test('a reply is handed to the hook as it arrives', () => {
+          expect(bru.grpc.response.message.data.reply).to.match(/^hello bidi-hook-[12]$/);
+        });
+
+        // The call only ends when the user ends it, so the terminal fields cannot be known here.
+        test('the response is partial while the stream is still open', () => {
+          expect(bru.grpc.response.statusCode).to.be.undefined;
+          expect(bru.grpc.response.duration).to.be.undefined;
+          expect(bru.grpc.response.trailers.count()).to.equal(0);
+        });
+    - type: grpc:after-call-end
+      code: |-
+        test('both messages were streamed and both replies came back', () => {
+          expect(bru.grpc.request.messages.count()).to.equal(2);
+          expect(bru.grpc.response.messages.count()).to.equal(2);
+        });

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/MessageHooksServerStream.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/MessageHooksServerStream.yml
@@ -1,0 +1,42 @@
+info:
+  name: MessageHooksServerStream
+  type: grpc
+  seq: 13
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/LotsOfReplies
+  methodType: server-streaming
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "stream-hooks"
+        }
+
+runtime:
+  scripts:
+    - type: grpc:before-call-start
+      code: bru.setVar('receivedCount', '');
+    - type: grpc:before-message-send
+      code: |-
+        // A server stream sends exactly one message, so this hook runs once however many replies come back.
+        test('the one outgoing message reaches the hook', () => {
+          expect(bru.grpc.request.message.data.greeting).to.equal('stream-hooks');
+          expect(bru.grpc.request.messages.count()).to.equal(0);
+        });
+    - type: grpc:after-message-receive
+      code: |-
+        // The hook runs once per reply, and the runs are queued, so this counts them in order.
+        const seen = Number(bru.getVar('receivedCount') || 0) + 1;
+        bru.setVar('receivedCount', String(seen));
+
+        test('reply ' + seen + ' is handed to its own run of the hook', () => {
+          expect(bru.grpc.response.message.data.reply).to.equal('hello stream-hooks #' + seen);
+        });
+    - type: grpc:after-call-end
+      code: |-
+        test('the hook ran once for each of the ten replies', () => {
+          expect(bru.getVar('receivedCount')).to.equal('10');
+          expect(bru.grpc.response.messages.count()).to.equal(10);
+        });

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/MessageHooksUnary.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/MessageHooksUnary.yml
@@ -1,0 +1,82 @@
+info:
+  name: MessageHooksUnary
+  type: grpc
+  seq: 11
+
+grpc:
+  url: "{{host}}"
+  method: /hello.HelloService/SayHello
+  methodType: unary
+  metadata:
+    - name: x-keep
+      value: kept-value
+  message:
+    - title: message 1
+      message: |-
+        {
+          "greeting": "{{unaryGreeting}}"
+        }
+
+runtime:
+  scripts:
+    - type: grpc:before-call-start
+      code: |-
+        bru.setVar('unaryGreeting', 'unary-hooks');
+        bru.setVar('lastReply', '');
+    - type: grpc:before-message-send
+      code: |-
+        // Interpolation has already run by the time the message is handed to this hook.
+        test('the hook is handed the message about to go out', () => {
+          expect(bru.grpc.request.message.data.greeting).to.equal('unary-hooks');
+          expect(bru.grpc.request.message.timestamp).to.be.a('number');
+        });
+
+        // `messages` reports what the call has sent, and this one has yet to send anything.
+        test('the message has not joined request.messages yet', () => {
+          expect(bru.grpc.request.messages.count()).to.equal(0);
+        });
+
+        // Same scope as beforeCallStart — there is nothing to respond with yet.
+        test('no response is in scope before the message is sent', () => {
+          expect(bru.grpc.response).to.be.undefined;
+        });
+
+        test('metadata is read-only once the call is under way', () => {
+          expect(bru.grpc.request.metadata.get('x-keep')).to.equal('kept-value');
+          expect(() => bru.grpc.request.metadata.set('x-late', '1')).to.throw();
+        });
+    - type: grpc:after-message-receive
+      code: |-
+        test('the hook is handed the reply that just arrived', () => {
+          expect(bru.grpc.response.message.data.reply).to.equal('hello unary-hooks');
+          expect(bru.grpc.response.message.timestamp).to.be.a('number');
+        });
+
+        test('the reply is also folded into response.messages', () => {
+          expect(bru.grpc.response.messages.count()).to.equal(1);
+          expect(bru.grpc.response.messages.get(0).data.reply).to.equal('hello unary-hooks');
+        });
+
+        // A unary call never streams, so the sent message is rebuilt from the authored body.
+        test('the sent message is visible from here', () => {
+          expect(bru.grpc.request.messages.count()).to.equal(1);
+          expect(bru.grpc.request.messages.get(0).data.greeting).to.equal('unary-hooks');
+        });
+
+        // `message` belongs to the request in the send hook and to the response in this one.
+        test('the request carries no message in this hook', () => {
+          expect(bru.grpc.request.message).to.be.undefined;
+        });
+
+        bru.setVar('lastReply', bru.grpc.response.message.data.reply);
+    - type: grpc:after-call-end
+      code: |-
+        // The call is over here, so the fields afterMessageReceive saw as unknown are filled in.
+        test('the completed call reports its status and duration', () => {
+          expect(bru.grpc.response.statusCode).to.equal(0);
+          expect(bru.grpc.response.duration).to.be.a('number').and.to.be.above(0);
+        });
+
+        test('afterCallEnd carries no single message', () => {
+          expect(bru.grpc.response.message).to.be.undefined;
+        });

--- a/tests/grpc/run-lifecycle-hooks/fixtures/collection/environments/Env.yml
+++ b/tests/grpc/run-lifecycle-hooks/fixtures/collection/environments/Env.yml
@@ -1,4 +1,4 @@
 name: Env
 variables:
   - name: host
-    value: grpc://grpcb.in:9000
+    value: grpc://localhost:50051

--- a/tests/grpc/run-lifecycle-hooks/run-lifecycle-hooks.spec.ts
+++ b/tests/grpc/run-lifecycle-hooks/run-lifecycle-hooks.spec.ts
@@ -186,6 +186,238 @@ for (const mode of SANDBOX_MODES) {
       });
     });
 
+    test('both message hooks run on a unary call, each handed the message it is about', async ({ pageWithUserData: page }) => {
+      const locators = await openCollection(page);
+      const tests = locators.response.tests;
+
+      await test.step('the call completes', async () => {
+        await sendGrpcRequest(page, 'MessageHooksUnary', 'HelloService/SayHello');
+
+        await expect(locators.response.statusCode()).toHaveText(/0/, { timeout: 30000 });
+        await expect(locators.response.content()).toContainText('hello unary-hooks');
+      });
+
+      await test.step('each message hook gets its own section, and every assertion passed', async () => {
+        await selectResponsePaneTab(page, 'Tests');
+
+        await expect(tests.passedCount()).toHaveText('10');
+        await expect(tests.summary('beforeMessageSend')).toContainText('Before Message Send Tests (4), Passed: 4, Failed: 0');
+        await expect(tests.summary('afterMessageReceive')).toContainText('After Message Receive Tests (4), Passed: 4, Failed: 0');
+        await expect(tests.summary('afterCallEnd')).toContainText('After Call End Tests (2), Passed: 2, Failed: 0');
+        await expect(tests.failedRows('beforeMessageSend')).toHaveCount(0);
+        await expect(tests.failedRows('afterMessageReceive')).toHaveCount(0);
+      });
+
+      // One message went out and one came back, so each message hook ran exactly once.
+      await test.step('the results of both hooks sit under the one message the call carried', async () => {
+        await expect(tests.messageGroups('beforeMessageSend')).toHaveCount(1);
+        await expect(tests.messageGroup('beforeMessageSend', 0)).toHaveText('Message 1');
+        await expect(tests.messageGroups('afterMessageReceive')).toHaveCount(1);
+        await expect(tests.messageGroup('afterMessageReceive', 0)).toHaveText('Message 1');
+      });
+
+      // afterCallEnd runs once per call, not once per message, so its results carry no index.
+      await test.step('the call hook results stay ungrouped', async () => {
+        await expect(tests.messageGroups('afterCallEnd')).toHaveCount(0);
+      });
+
+      await test.step('a following request sees the variable afterMessageReceive wrote', async () => {
+        await sendGrpcRequest(page, 'EchoLastReply', 'HelloService/SayHello');
+
+        await expect(locators.response.statusCode()).toHaveText(/0/, { timeout: 30000 });
+        await expect(locators.response.content()).toContainText('hello hello unary-hooks');
+      });
+    });
+
+    test('afterMessageReceive runs once per reply of a server stream, beforeMessageSend once', async ({ pageWithUserData: page }) => {
+      const locators = await openCollection(page);
+      const tests = locators.response.tests;
+
+      await test.step('receive the whole stream', async () => {
+        await sendGrpcRequest(page, 'MessageHooksServerStream', 'HelloService/LotsOfReplies');
+
+        await expect(locators.response.statusCode()).toHaveText(/0/, { timeout: 30000 });
+        await expect(locators.response.responseItems()).toHaveCount(10);
+      });
+
+      // Ten replies came back over one outgoing message, so the two hooks run a different number of times.
+      await test.step('the send hook ran once and the receive hook ten times', async () => {
+        await selectResponsePaneTab(page, 'Tests');
+
+        await expect(tests.summary('beforeMessageSend')).toContainText('Before Message Send Tests (1), Passed: 1, Failed: 0');
+        await expect(tests.summary('afterMessageReceive')).toContainText('After Message Receive Tests (10), Passed: 10, Failed: 0');
+        await expect(tests.failedRows('afterMessageReceive')).toHaveCount(0);
+      });
+
+      await test.step('every run is grouped under the reply it handled, in order', async () => {
+        await expect(tests.messageGroups('afterMessageReceive')).toHaveCount(10);
+        await expect(tests.messageGroup('afterMessageReceive', 0)).toHaveText('Message 1');
+        await expect(tests.messageGroup('afterMessageReceive', 9)).toHaveText('Message 10');
+        await expect(tests.rows('afterMessageReceive').first()).toContainText('reply 1 is handed to its own run of the hook');
+        await expect(tests.rows('afterMessageReceive').last()).toContainText('reply 10 is handed to its own run of the hook');
+      });
+
+      await test.step('a following request sees the count the receive hook accumulated', async () => {
+        await sendGrpcRequest(page, 'EchoReceivedCount', 'HelloService/SayHello');
+
+        await expect(locators.response.statusCode()).toHaveText(/0/, { timeout: 30000 });
+        await expect(locators.response.content()).toContainText('received-10');
+      });
+    });
+
+    test('both hooks run per message on a bidi stream, and a rerun does not double the results', async ({ pageWithUserData: page }) => {
+      const locators = await openCollection(page);
+      const tests = locators.response.tests;
+
+      await test.step('stream both messages, then end the call', async () => {
+        await streamGrpcMessagesAndEndCall(page, 'MessageHooksBidi', 'HelloService/BidiHello', [0, 1]);
+      });
+
+      await test.step('each hook ran once per message', async () => {
+        await selectResponsePaneTab(page, 'Tests');
+
+        await expect(tests.summary('beforeMessageSend')).toContainText('Before Message Send Tests (2), Passed: 2, Failed: 0');
+        await expect(tests.summary('afterMessageReceive')).toContainText('After Message Receive Tests (4), Passed: 4, Failed: 0');
+        await expect(tests.summary('afterCallEnd')).toContainText('After Call End Tests (1), Passed: 1, Failed: 0');
+      });
+
+      await test.step('the send hook results name the message each run saw', async () => {
+        await expect(tests.messageGroups('beforeMessageSend')).toHaveCount(2);
+        await expect(tests.messageGroup('beforeMessageSend', 0)).toHaveText('Message 1');
+        await expect(tests.messageGroup('beforeMessageSend', 1)).toHaveText('Message 2');
+        await expect(tests.rows('beforeMessageSend').first()).toContainText('outgoing message 1 reaches the hook before it is streamed');
+        await expect(tests.rows('beforeMessageSend').last()).toContainText('outgoing message 2 reaches the hook before it is streamed');
+      });
+
+      // Message hook results accumulate as the call runs, so a rerun has to clear them first.
+      await test.step('rerunning the request replaces the accumulated results rather than adding to them', async () => {
+        await streamGrpcMessagesAndEndCall(page, 'MessageHooksBidi', 'HelloService/BidiHello', [0, 1]);
+        await selectResponsePaneTab(page, 'Tests');
+
+        await expect(tests.summary('beforeMessageSend')).toContainText('Before Message Send Tests (2), Passed: 2, Failed: 0');
+        await expect(tests.summary('afterMessageReceive')).toContainText('After Message Receive Tests (4), Passed: 4, Failed: 0');
+        await expect(tests.messageGroups('beforeMessageSend')).toHaveCount(2);
+      });
+    });
+
+    test('a throwing beforeMessageSend aborts the unary call before it opens', async ({ pageWithUserData: page }) => {
+      const locators = await openCollection(page);
+      const scriptError = buildScriptErrorLocators(page);
+
+      await test.step('the card names the hook that failed and the message it failed on', async () => {
+        await sendGrpcRequest(page, 'BrokenBeforeMessageSend', 'HelloService/SayHello');
+
+        await expect(scriptError.card()).toBeVisible({ timeout: 30000 });
+        await expect(scriptError.title()).toHaveText('Before Message Send Script Error');
+        await expect(scriptError.message()).toContainText('Message 1: beforeMessageSend exploded');
+        await expect(scriptError.filePath()).toHaveText('BrokenBeforeMessageSend.yml');
+      });
+
+      await test.step('nothing was put on the wire', async () => {
+        await expect(locators.response.statusCode()).toHaveCount(0);
+      });
+
+      await test.step('clicking the file path opens the failing hook editor at the failing line', async () => {
+        await scriptError.filePath().click();
+
+        const editor = page.getByTestId('before-message-send-script-editor');
+        await expect(editor).toBeVisible();
+        await expect(editor.locator(FLASHED_LINE_NUMBER)).toHaveText('2');
+        await expect(editor.locator(FLASHED_LINE)).toContainText('throw new Error(\'beforeMessageSend exploded\');');
+      });
+
+      await test.step('a following request sees the variable the hook set before it threw', async () => {
+        await sendGrpcRequest(page, 'EchoSendReached', 'HelloService/SayHello');
+
+        await expect(locators.response.statusCode()).toHaveText(/0/, { timeout: 30000 });
+        await expect(locators.response.content()).toContainText('send-yes');
+      });
+    });
+
+    test('a throwing beforeMessageSend drops one streamed message and leaves the stream open', async ({ pageWithUserData: page }) => {
+      const locators = await openCollection(page);
+      const scriptError = buildScriptErrorLocators(page);
+      const tests = locators.response.tests;
+
+      await test.step('open the stream', async () => {
+        await sendGrpcRequest(page, 'BrokenSendOnBidiStream', 'HelloService/BidiHello');
+        await expect(locators.request.endConnectionButton()).toBeVisible({ timeout: 30000 });
+      });
+
+      await test.step('the first message is refused, so nothing comes back for it', async () => {
+        await locators.request.sendMessage(0).click();
+
+        await expect(locators.response.content()).toHaveCount(0);
+      });
+
+      await test.step('the stream survived, so the next message still goes out and is replied to', async () => {
+        await locators.request.sendMessage(1).click();
+
+        await expect(locators.response.singleResponse()).toBeVisible();
+        await expect(locators.response.content()).toContainText('hello let-me-through');
+        await expect(locators.request.endConnectionButton()).toBeVisible();
+      });
+
+      await test.step('ending the call still reports OK', async () => {
+        await locators.request.endConnectionButton().click();
+
+        await expect(locators.response.statusCode()).toHaveText(/0/, { timeout: 30000 });
+      });
+
+      await test.step('the card names the message the hook refused', async () => {
+        await expect(scriptError.card()).toBeVisible();
+        await expect(scriptError.title()).toHaveText('Before Message Send Script Error');
+        await expect(scriptError.message()).toContainText('Message 1: this message is not going out');
+      });
+
+      // The refused run still consumed an index, so the run that passed is the second one.
+      await test.step('the surviving run is grouped under the second message', async () => {
+        await selectResponsePaneTab(page, 'Tests');
+
+        await expect(tests.summary('beforeMessageSend')).toContainText('Before Message Send Tests (1), Passed: 1, Failed: 0');
+        await expect(tests.messageGroups('beforeMessageSend')).toHaveCount(1);
+        await expect(tests.messageGroup('beforeMessageSend', 1)).toHaveText('Message 2');
+        await expect(tests.summary('afterCallEnd')).toContainText('After Call End Tests (1), Passed: 1, Failed: 0');
+      });
+    });
+
+    test('a throwing afterMessageReceive keeps the stream and afterCallEnd alive', async ({ pageWithUserData: page }) => {
+      const locators = await openCollection(page);
+      const scriptError = buildScriptErrorLocators(page);
+      const tests = locators.response.tests;
+
+      await test.step('every reply still arrives', async () => {
+        await sendGrpcRequest(page, 'BrokenAfterMessageReceive', 'HelloService/LotsOfReplies');
+
+        await expect(locators.response.statusCode()).toHaveText(/0/, { timeout: 30000 });
+        await expect(locators.response.responseItems()).toHaveCount(10);
+      });
+
+      // Only the last failure is kept, and the hook ran once per reply, so it is the tenth.
+      await test.step('the card reports the last of the ten failures', async () => {
+        await expect(scriptError.card()).toBeVisible();
+        await expect(scriptError.title()).toHaveText('After Message Receive Script Error');
+        await expect(scriptError.message()).toContainText('Message 10: afterMessageReceive exploded');
+        await expect(scriptError.filePath()).toHaveText('BrokenAfterMessageReceive.yml');
+      });
+
+      await test.step('afterCallEnd still ran behind the ten failures', async () => {
+        await selectResponsePaneTab(page, 'Tests');
+
+        await expect(tests.summary('afterCallEnd')).toContainText('After Call End Tests (1), Passed: 1, Failed: 0');
+        await expect(tests.section('afterCallEnd')).toContainText('afterCallEnd still runs once every message hook has thrown');
+      });
+
+      await test.step('clicking the file path opens the failing hook editor at the failing line', async () => {
+        await scriptError.filePath().click();
+
+        const editor = page.getByTestId('after-message-receive-script-editor');
+        await expect(editor).toBeVisible();
+        await expect(editor.locator(FLASHED_LINE_NUMBER)).toHaveText('2');
+        await expect(editor.locator(FLASHED_LINE)).toContainText('throw new Error(\'afterMessageReceive exploded\');');
+      });
+    });
+
     test('a throwing afterCallEnd shows a card without taking the response with it', async ({ pageWithUserData: page }) => {
       const locators = await openCollection(page);
       const scriptError = buildScriptErrorLocators(page);

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1973,7 +1973,7 @@ const switchWorkspace = async (page: Page, workspaceName: string) => {
   });
 };
 
-type ScriptSubTab = 'pre-request' | 'post-response' | 'before-call-start' | 'after-call-end' | 'before-message-send' | 'after-message-receive';
+type ScriptSubTab = 'pre-request' | 'post-response' | 'before-call-start' | 'before-message-send' | 'after-message-receive' | 'after-call-end';
 
 /**
  * Navigate to a Script sub-tab (pre-request / post-response for http & graphql, the lifecycle

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1973,7 +1973,7 @@ const switchWorkspace = async (page: Page, workspaceName: string) => {
   });
 };
 
-type ScriptSubTab = 'pre-request' | 'post-response' | 'before-call-start' | 'after-call-end';
+type ScriptSubTab = 'pre-request' | 'post-response' | 'before-call-start' | 'after-call-end' | 'before-message-send' | 'after-message-receive';
 
 /**
  * Navigate to a Script sub-tab (pre-request / post-response for http & graphql, the lifecycle

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -359,7 +359,7 @@ const buildTimelineHeaderRow = (page: Page, item: Locator, name: string) =>
 
 export const getTableCell = (row: any, index: number) => row.locator('td').nth(index + 1);
 
-type GrpcTestSectionKey = 'beforeCallStart' | 'afterCallEnd';
+type GrpcTestSectionKey = 'beforeCallStart' | 'beforeMessageSend' | 'afterMessageReceive' | 'afterCallEnd';
 
 export const buildGrpcCommonLocators = (page: Page) => ({
   ...buildCommonLocators(page),
@@ -407,7 +407,13 @@ export const buildGrpcCommonLocators = (page: Page) => ({
         page
           .getByTestId(`grpc-test-section-${hook}`)
           .getByTestId('test-result-item')
-          .filter({ has: page.getByTestId('test-result-icon-fail') })
+          .filter({ has: page.getByTestId('test-result-icon-fail') }),
+      /** The "Message N" label a message hook's results are grouped under, 0-based */
+      messageGroup: (hook: GrpcTestSectionKey, messageIndex: number) =>
+        page.getByTestId(`grpc-test-section-${hook}`).getByTestId(`grpc-test-message-group-${messageIndex}`),
+      /** Every "Message N" label in a section, so a per-message hook's run count can be asserted */
+      messageGroups: (hook: GrpcTestSectionKey) =>
+        page.getByTestId(`grpc-test-section-${hook}`).locator('[data-testid^="grpc-test-message-group-"]')
     }
   }
 });


### PR DESCRIPTION
### Description

gRPC requests in the base branch has added support for beforeCallStart and AfterCallEnd. This PR adds support for per message hooks, ie, beforeMessageSend and afterMessageReceive. This PR also refactors the shims files related to GRPC and other refactors that were deferred in the base scripting PR.

### Problem

Bruno didnt support GRPC Scripting per message and users were not able to make automated tests per messages.

### Fix

This PR adds the GRPC message hooks to the existing GRPC scripting pipeline with proper E2E test coverage.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  <img width="400" height="200" alt="GRPC-message-hooks" src="https://github.com/user-attachments/assets/9b33f9ec-9811-432b-8a73-52b215e7ff19" /> | <img width="400" height="200" alt="GRPC-message-hooks" src="https://github.com/user-attachments/assets/a82c902a-007c-4807-a66f-5092599c19e2" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.
