### PR TITLE
feat(input): adds input and field component

### DIFF
--- a/packages/bruno-app/src/ui/Field/StyledWrapper.js
+++ b/packages/bruno-app/src/ui/Field/StyledWrapper.js
@@ -1,0 +1,38 @@
+import styled, { css } from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  .field-label {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    font-size: ${(props) => props.theme.font.size.sm};
+    font-weight: 500;
+    color: ${(props) => props.theme.text};
+  }
+
+
+  .field-label.is-required::after {
+    content: '*';
+    margin-left: 0.125rem;
+    color: ${(props) => props.theme.status.danger.text};
+  }
+
+  .field-helper {
+    margin-top: 0.25rem;
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.colors.text.muted};
+  }
+
+  ${(props) =>
+    props.$error
+    && css`
+      .field-helper {
+        color: ${props.theme.status.danger.text};
+      }
+    `}
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/ui/Field/index.js
+++ b/packages/bruno-app/src/ui/Field/index.js
@@ -1,0 +1,62 @@
+import React, { createContext, useId, useMemo } from 'react';
+import StyledWrapper from './StyledWrapper';
+
+// Carries the generated id, helper-text id, error and required state down to the
+// control. Defaults to null so a control renders fine with no Field around it.
+export const FieldContext = createContext(null);
+
+/**
+ * Label + control + one slot shared by `description` and `error` (the error wins).
+ *
+ * `error` takes the Formik/Yup value, not a boolean: a string renders as the message,
+ */
+const Field = ({
+  label,
+  description,
+  error,
+  required = false,
+  htmlFor,
+  children,
+  className = '',
+  'data-testid': testId = 'field'
+}) => {
+  const generatedId = useId().replace(/:/g, '');
+  const inputId = htmlFor ?? generatedId;
+  const helperId = `${inputId}-helper`;
+
+  const errorMessage = typeof error === 'string' ? error : null;
+  const hasError = Boolean(error);
+  const helper = errorMessage ?? description ?? null;
+
+  const context = useMemo(
+    () => ({
+      inputId,
+      describedBy: helper ? helperId : undefined,
+      hasError,
+      required
+    }),
+    [inputId, helperId, helper, hasError, required]
+  );
+
+  return (
+    <FieldContext.Provider value={context}>
+      <StyledWrapper className={className} $error={hasError} data-testid={testId}>
+        {label ? (
+          <label className={`field-label${required ? ' is-required' : ''}`} htmlFor={inputId}>
+            {label}
+          </label>
+        ) : null}
+
+        {children}
+
+        {helper ? (
+          <div className="field-helper" id={helperId} role={hasError ? 'alert' : undefined}>
+            {helper}
+          </div>
+        ) : null}
+      </StyledWrapper>
+    </FieldContext.Provider>
+  );
+};
+
+export default Field;

--- a/packages/bruno-app/src/ui/Input/Input.spec.jsx
+++ b/packages/bruno-app/src/ui/Input/Input.spec.jsx
@@ -1,0 +1,247 @@
+import '@testing-library/jest-dom';
+import React, { useState, createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import Input from './index';
+import Field from '../Field';
+
+const theme = {
+  mode: 'light',
+  text: '#343434',
+  input: {
+    bg: '#ffffff',
+    border: '#cccccc',
+    focusBorder: '#343434',
+    placeholder: { color: '#b0b0b0', opacity: 0.8 }
+  },
+  background: { mantle: '#f8f8f8', surface0: '#f1f1f1' },
+  status: { danger: { border: '#ce4f3b', text: '#ce4f3b' } },
+  colors: { text: { muted: '#9b9b9b' } },
+  codemirror: { placeholder: { color: '#b0b0b0', opacity: 0.75 } },
+  border: { radius: { sm: '4px', base: '6px' } },
+  font: { size: { xs: '0.6875rem', sm: '0.75rem' } }
+};
+
+const renderWithTheme = (ui) => render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+
+describe('Input', () => {
+  let user;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  it('renders a textbox and reports typing through onChange', async () => {
+    const onChange = jest.fn();
+    renderWithTheme(<Input value="" onChange={onChange} placeholder="Collection name" />);
+
+    const input = screen.getByPlaceholderText('Collection name');
+    await user.type(input, 'a');
+
+    expect(input).toHaveAttribute('type', 'text');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toHaveProperty('target');
+  });
+
+  it('works as a controlled component', async () => {
+    const Controlled = () => {
+      const [value, setValue] = useState('');
+      return <Input value={value} onChange={(e) => setValue(e.target.value)} />;
+    };
+    renderWithTheme(<Controlled />);
+
+    await user.type(screen.getByRole('textbox'), 'orders');
+    expect(screen.getByRole('textbox')).toHaveValue('orders');
+  });
+
+  it('forwards the ref to the underlying input element', () => {
+    const ref = createRef();
+    renderWithTheme(<Input value="" onChange={() => {}} ref={ref} />);
+
+    expect(ref.current).toBe(screen.getByRole('textbox'));
+  });
+
+  it('does not accept input when disabled', async () => {
+    const onChange = jest.fn();
+    renderWithTheme(<Input value="" onChange={onChange} disabled />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+    await user.type(input, 'nope');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('marks itself invalid when error is set, and stays valid otherwise', () => {
+    const { unmount } = renderWithTheme(<Input value="" onChange={() => {}} error />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    unmount();
+
+    renderWithTheme(<Input value="" onChange={() => {}} />);
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('renders leading and trailing sections', () => {
+    renderWithTheme(
+      <Input
+        value=""
+        onChange={() => {}}
+        leftSection={<span data-testid="left">/</span>}
+        rightSection={<span data-testid="right">ms</span>}
+      />
+    );
+
+    expect(screen.getByTestId('left')).toBeInTheDocument();
+    expect(screen.getByTestId('right')).toBeInTheDocument();
+  });
+
+  it('applies a default data-testid that callers can override', () => {
+    const { unmount } = renderWithTheme(<Input value="" onChange={() => {}} />);
+    expect(screen.getByTestId('input')).toBe(screen.getByRole('textbox'));
+    unmount();
+
+    renderWithTheme(<Input value="" onChange={() => {}} data-testid="collection-name" />);
+    expect(screen.getByTestId('collection-name')).toBe(screen.getByRole('textbox'));
+  });
+
+  it('leaves autocomplete to the caller', () => {
+    const { unmount } = renderWithTheme(<Input value="" onChange={() => {}} />);
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('autocomplete');
+    unmount();
+
+    renderWithTheme(<Input value="" onChange={() => {}} autoComplete="username" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('autocomplete', 'username');
+  });
+
+  it('generates an id that is safe to use in a CSS selector', () => {
+    renderWithTheme(<Input value="" onChange={() => {}} />);
+
+    const id = screen.getByRole('textbox').getAttribute('id');
+    expect(() => document.querySelector(`#${id}`)).not.toThrow();
+  });
+
+  it('forwards unknown props to the input', () => {
+    renderWithTheme(<Input value="" onChange={() => {}} maxLength={8} name="port" />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('maxlength', '8');
+    expect(input).toHaveAttribute('name', 'port');
+  });
+
+  describe('visibility toggle', () => {
+    const renderPassword = (props = {}) =>
+      renderWithTheme(<Input type="password" value="hunter2" onChange={() => {}} withVisibilityToggle {...props} />);
+
+    it('reveals and re-hides the value', async () => {
+      renderPassword();
+
+      const toggle = screen.getByRole('button', { name: 'Show value' });
+      expect(screen.getByTestId('input')).toHaveAttribute('type', 'password');
+
+      await user.click(toggle);
+      expect(screen.getByTestId('input')).toHaveAttribute('type', 'text');
+      expect(screen.getByRole('button', { name: 'Hide value' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Hide value' }));
+      expect(screen.getByTestId('input')).toHaveAttribute('type', 'password');
+    });
+
+    it('is reachable and operable by keyboard', async () => {
+      renderPassword();
+
+      await user.tab();
+      expect(screen.getByTestId('input')).toHaveFocus();
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Show value' })).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+      expect(screen.getByTestId('input')).toHaveAttribute('type', 'text');
+    });
+
+    it('is absent unless the type is password', () => {
+      renderWithTheme(<Input value="" onChange={() => {}} withVisibilityToggle />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('inside a Field', () => {
+    it('wires the label, helper text and aria-describedby to the input', () => {
+      renderWithTheme(
+        <Field label="Name" description="Used as the folder name">
+          <Input value="" onChange={() => {}} />
+        </Field>
+      );
+
+      const input = screen.getByLabelText('Name');
+      expect(input).toBe(screen.getByRole('textbox'));
+
+      const helper = screen.getByText('Used as the folder name');
+      expect(input).toHaveAttribute('aria-describedby', helper.getAttribute('id'));
+    });
+
+    it('replaces the description with the error and announces it', () => {
+      renderWithTheme(
+        <Field label="Name" description="Used as the folder name" error="Name is required">
+          <Input value="" onChange={() => {}} />
+        </Field>
+      );
+
+      expect(screen.queryByText('Used as the folder name')).not.toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent('Name is required');
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('lets an explicit error prop on the input win over the Field', () => {
+      renderWithTheme(
+        <Field label="Name" error="Name is required">
+          <Input value="" onChange={() => {}} error={false} />
+        </Field>
+      );
+
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('renders no message when the error is not a string, but still marks the field invalid', () => {
+      // Yup hands back an object for a nested schema.
+      renderWithTheme(
+        <Field label="Auto save" error={{ interval: 'must be a number' }}>
+          <Input value="" onChange={() => {}} />
+        </Field>
+      );
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.queryByText('must be a number')).not.toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('marks the control required without polluting the label name', () => {
+      renderWithTheme(
+        <Field label="Name" required>
+          <Input value="" onChange={() => {}} />
+        </Field>
+      );
+
+      const input = screen.getByLabelText('Name');
+      expect(input).toBeRequired();
+      expect(screen.queryByText('*')).not.toBeInTheDocument();
+    });
+
+    it('honours an explicit htmlFor over the generated id', () => {
+      renderWithTheme(
+        <Field label="Name" htmlFor="collection-name">
+          <Input value="" onChange={() => {}} />
+        </Field>
+      );
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', 'collection-name');
+    });
+  });
+
+  it('renders standalone, with no Field above it', () => {
+    renderWithTheme(<Input variant="ghost" value="Content-Type" onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('Content-Type');
+    expect(input).toHaveAttribute('id');
+  });
+});

--- a/packages/bruno-app/src/ui/Input/Input.stories.jsx
+++ b/packages/bruno-app/src/ui/Input/Input.stories.jsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { IconSearch, IconX } from '@tabler/icons';
+import Input from './index';
+import Field from '../Field';
+
+export default {
+  title: 'Components/Input',
+  component: Input,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A single-line text entry control. Controlled: pass value and onChange. Wrap it in Field for a label, helper text and error wiring, or use it bare inside a table cell. There is deliberately no size prop — the design specifies one height; use variant="ghost" for a borderless cell input.'
+      }
+    }
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'inline-radio',
+      options: ['default', 'ghost'],
+      description: 'ghost is borderless, for table cells that sit beside SingleLineEditor cells.'
+    },
+    type: { control: 'text', description: 'Passed through to the input element.' },
+    error: { control: 'boolean', description: 'Draws the danger border and sets aria-invalid.' },
+    withVisibilityToggle: {
+      control: 'boolean',
+      description: 'Adds a reveal button. Only applies when type is "password".'
+    },
+    fullWidth: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    readOnly: { control: 'boolean' },
+    leftSection: { control: false, description: 'Leading content — an icon or a short prefix.' },
+    rightSection: { control: false, description: 'Trailing content — a unit, an action.' },
+    onChange: { action: 'changed' }
+  }
+};
+
+// Controlled wrapper so the playground args actually type.
+const Playground = ({ value: initial = '', ...args }) => {
+  const [value, setValue] = useState(initial);
+  return <Input {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
+};
+
+export const Default = {
+  args: { placeholder: 'Placeholder', fullWidth: true },
+  render: (args) => <Playground {...args} />
+};
+
+const column = { display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: '320px' };
+
+/** Every state from the design, top to bottom. */
+export const States = {
+  tags: ['!dev'],
+  render: () => (
+    <div style={column}>
+      <Field label="Label" description="Helper text">
+        <Input fullWidth placeholder="Placeholder" rightSection={<IconX />} value="" onChange={() => {}} />
+      </Field>
+      <Field label="Label" description="Helper text">
+        <Input fullWidth placeholder="Placeholder" value="" onChange={() => {}} />
+      </Field>
+      <Field label="Label" description="Helper text">
+        <Input fullWidth autoFocus value="Focused" onChange={() => {}} />
+      </Field>
+      <Field label="Label" description="Helper text">
+        <Input fullWidth value="Filled" onChange={() => {}} />
+      </Field>
+      <Field label="Label" error="Helper text">
+        <Input fullWidth value="Invalid" onChange={() => {}} />
+      </Field>
+      <Field label="Label" description="Helper text">
+        <Input fullWidth disabled placeholder="Placeholder" value="" onChange={() => {}} />
+      </Field>
+    </div>
+  )
+};
+
+const FieldExample = () => {
+  const [name, setName] = useState('');
+  return (
+    <div style={column}>
+      <Field label="Collection name" description="Used as the folder name on disk" required>
+        <Input fullWidth value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. orders-api" />
+      </Field>
+      <Field label="Collection name" error="Collection name is required">
+        <Input fullWidth value="" onChange={() => {}} />
+      </Field>
+    </div>
+  );
+};
+
+/** Field owns the label and the single helper slot; the error replaces the description. */
+export const WithField = {
+  tags: ['!dev'],
+  render: () => <FieldExample />
+};
+
+export const Sections = {
+  tags: ['!dev'],
+  render: () => (
+    <div style={column}>
+      <Input fullWidth placeholder="Search" leftSection={<IconSearch />} value="" onChange={() => {}} />
+      <Input fullWidth value="1500" onChange={() => {}} rightSection={<span>ms</span>} />
+      <Input fullWidth type="password" withVisibilityToggle value="s3cret" onChange={() => {}} />
+    </div>
+  )
+};
+
+/** Borderless, for table cells. Placeholder colours come from the CodeMirror tokens so
+ *  a ghost input is indistinguishable from a SingleLineEditor cell next to it. */
+export const Ghost = {
+  tags: ['!dev'],
+  render: () => (
+    <div style={{ ...column, maxWidth: '420px' }}>
+      <Input variant="ghost" fullWidth placeholder="Key" value="Content-Type" onChange={() => {}} />
+      <Input variant="ghost" fullWidth placeholder="Value" value="" onChange={() => {}} />
+    </div>
+  )
+};
+
+const PortExample = () => {
+  const [port, setPort] = useState('8080');
+  return (
+    <Field label="Port" description="Native spinners are hidden by default">
+      <Input type="number" min={1} max={65535} value={port} onChange={(e) => setPort(e.target.value)} />
+    </Field>
+  );
+};
+
+export const NumberInput = {
+  tags: ['!dev'],
+  render: () => <PortExample />
+};

--- a/packages/bruno-app/src/ui/Input/Input.stories.jsx
+++ b/packages/bruno-app/src/ui/Input/Input.stories.jsx
@@ -9,6 +9,7 @@ export default {
   parameters: {
     layout: 'padded',
     docs: {
+      source: { transform: (code) => code.replace(/\bPlayground\b/g, 'Input') },
       description: {
         component:
           'A single-line text entry control. Controlled: pass value and onChange. Wrap it in Field for a label, helper text and error wiring, or use it bare inside a table cell. There is deliberately no size prop — the design specifies one height; use variant="ghost" for a borderless cell input.'
@@ -33,14 +34,26 @@ export default {
     readOnly: { control: 'boolean' },
     leftSection: { control: false, description: 'Leading content — an icon or a short prefix.' },
     rightSection: { control: false, description: 'Trailing content — a unit, an action.' },
-    onChange: { action: 'changed' }
+    onChange: {
+      action: 'changed',
+      description:
+        'Receives the native DOM event, not the value — read e.target.value. This is what lets {...formik.getFieldProps(name)} work: formik reads name and value off the event.'
+    }
   }
 };
 
-// Controlled wrapper so the playground args actually type.
-const Playground = ({ value: initial = '', ...args }) => {
+const Playground = ({ value: initial = '', onChange, ...args }) => {
   const [value, setValue] = useState(initial);
-  return <Input {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
+  return (
+    <Input
+      {...args}
+      value={value}
+      onChange={(e) => {
+        setValue(e.target.value);
+        onChange?.(e);
+      }}
+    />
+  );
 };
 
 export const Default = {
@@ -94,6 +107,15 @@ const FieldExample = () => {
 /** Field owns the label and the single helper slot; the error replaces the description. */
 export const WithField = {
   tags: ['!dev'],
+  parameters: {
+    docs: {
+      source: {
+        code: `<Field label="Collection name" description="Used as the folder name on disk" required>
+                  <Input fullWidth value={name} onChange={(e) => setName(e.target.value)} />
+                </Field>`
+      }
+    }
+  },
   render: () => <FieldExample />
 };
 
@@ -131,5 +153,14 @@ const PortExample = () => {
 
 export const NumberInput = {
   tags: ['!dev'],
+  parameters: {
+    docs: {
+      source: {
+        code: `<Field label="Port">
+          <Input type="number" min={1} max={65535} value={port} onChange={(e) => setPort(e.target.value)} />
+        </Field>`
+      }
+    }
+  },
   render: () => <PortExample />
 };

--- a/packages/bruno-app/src/ui/Input/StyledWrapper.js
+++ b/packages/bruno-app/src/ui/Input/StyledWrapper.js
@@ -1,0 +1,145 @@
+import styled, { css } from 'styled-components';
+
+const disabledBg = (theme) => (theme.mode === 'dark' ? theme.background.surface0 : theme.background.mantle);
+
+const StyledWrapper = styled.div`
+  display: ${(props) => (props.$fullWidth ? 'flex' : 'inline-flex')};
+  width: ${(props) => (props.$fullWidth ? '100%' : 'auto')};
+  align-items: center;
+  gap: 0.375rem;
+  box-sizing: border-box;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid ${(props) => props.theme.input.border};
+  border-radius: ${(props) => props.theme.border.radius.base};
+  background-color: ${(props) => props.theme.input.bg};
+  color: ${(props) => props.theme.text};
+  font-size: ${(props) => props.theme.font.size.sm};
+  line-height: 1;
+  transition: border-color 0.15s ease;
+
+  &:focus-within {
+    border-color: ${(props) => props.theme.input.focusBorder};
+  }
+
+  /* Ghost comes before error so an errored cell still shows the danger border. */
+  ${(props) =>
+    props.$ghost
+    && css`
+      padding: 0;
+      border-color: transparent;
+      background-color: transparent;
+      border-radius: 0;
+
+      /*
+       * Deliberately no focus border: a ghost input shares a table row with
+       * SingleLineEditor cells, which show no focus ring either. Matching them is the
+       * whole point of the variant — see EditableTable/StyledWrapper.js.
+       */
+      &:focus-within {
+        border-color: transparent;
+      }
+    `}
+
+  ${(props) =>
+    props.$error
+    && css`
+      border-color: ${props.theme.status.danger.border};
+
+      &:focus-within {
+        border-color: ${props.theme.status.danger.border};
+      }
+    `}
+
+  ${(props) =>
+    props.$disabled
+    && css`
+      background-color: ${disabledBg(props.theme)};
+      cursor: not-allowed;
+    `}
+
+  .input-control {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+
+    &::placeholder {
+      color: ${(props) => props.theme.input.placeholder.color};
+      opacity: ${(props) => props.theme.input.placeholder.opacity};
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+
+    &[type='number'] {
+      -moz-appearance: textfield;
+      appearance: textfield;
+
+      &::-webkit-outer-spin-button,
+      &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+    }
+  }
+
+  ${(props) =>
+    props.$ghost
+    && css`
+      .input-control::placeholder {
+        color: ${props.theme.codemirror.placeholder.color};
+        opacity: ${props.theme.codemirror.placeholder.opacity};
+      }
+    `}
+
+  .input-section {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: ${(props) => props.theme.colors.text.muted};
+
+    svg {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+
+  .input-section-left {
+    pointer-events: ${(props) => props.$leftSectionPointerEvents};
+  }
+
+  .input-section-right {
+    pointer-events: ${(props) => props.$rightSectionPointerEvents};
+  }
+
+
+  .input-visibility-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    border-radius: ${(props) => props.theme.border.radius.sm};
+    color: ${(props) => props.theme.colors.text.muted};
+    transition: color 0.15s ease;
+
+    &:hover:not(:disabled) {
+      color: ${(props) => props.theme.text};
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/ui/Input/StyledWrapper.js
+++ b/packages/bruno-app/src/ui/Input/StyledWrapper.js
@@ -30,11 +30,6 @@ const StyledWrapper = styled.div`
       background-color: transparent;
       border-radius: 0;
 
-      /*
-       * Deliberately no focus border: a ghost input shares a table row with
-       * SingleLineEditor cells, which show no focus ring either. Matching them is the
-       * whole point of the variant — see EditableTable/StyledWrapper.js.
-       */
       &:focus-within {
         border-color: transparent;
       }

--- a/packages/bruno-app/src/ui/Input/index.js
+++ b/packages/bruno-app/src/ui/Input/index.js
@@ -1,0 +1,90 @@
+import React, { forwardRef, useContext, useId, useState } from 'react';
+import { IconEye, IconEyeOff } from '@tabler/icons';
+import { FieldContext } from '../Field';
+import StyledWrapper from './StyledWrapper';
+
+const Input = forwardRef(
+  (
+    {
+      variant = 'default',
+      type = 'text',
+      error,
+      leftSection = null,
+      rightSection = null,
+      leftSectionPointerEvents = 'none',
+      rightSectionPointerEvents = 'auto',
+      withVisibilityToggle = false,
+      fullWidth = false,
+      disabled = false,
+      readOnly = false,
+      required,
+      id,
+      className = '',
+      'data-testid': testId = 'input',
+      'aria-describedby': ariaDescribedBy,
+      ...rest
+    },
+    ref
+  ) => {
+    const field = useContext(FieldContext);
+    const [revealed, setRevealed] = useState(false);
+
+    const generatedId = useId().replace(/:/g, '');
+
+    const inputId = id ?? field?.inputId ?? generatedId;
+    const hasError = Boolean(error ?? field?.hasError ?? false);
+    const describedBy = ariaDescribedBy ?? field?.describedBy;
+    const isRequired = required ?? field?.required;
+
+    const canToggleVisibility = withVisibilityToggle && type === 'password';
+    const resolvedType = canToggleVisibility && revealed ? 'text' : type;
+
+    return (
+      <StyledWrapper
+        $ghost={variant === 'ghost'}
+        $error={hasError}
+        $disabled={disabled}
+        $fullWidth={fullWidth}
+        $leftSectionPointerEvents={leftSectionPointerEvents}
+        $rightSectionPointerEvents={rightSectionPointerEvents}
+        className={className}
+      >
+        {leftSection ? <span className="input-section input-section-left">{leftSection}</span> : null}
+
+        <input
+          ref={ref}
+          id={inputId}
+          type={resolvedType}
+          className="input-control"
+          disabled={disabled}
+          readOnly={readOnly}
+          required={isRequired}
+          aria-describedby={describedBy}
+          data-testid={testId}
+          spellCheck="false"
+          {...rest}
+          aria-invalid={hasError || undefined}
+        />
+
+        {rightSection ? <span className="input-section input-section-right">{rightSection}</span> : null}
+
+        {canToggleVisibility ? (
+          <button
+            type="button"
+            className="input-visibility-toggle"
+            onClick={() => setRevealed((current) => !current)}
+            disabled={disabled}
+            aria-label={revealed ? 'Hide value' : 'Show value'}
+            data-testid={`${testId}-visibility-toggle`}
+          >
+            {revealed ? <IconEyeOff size={14} strokeWidth={1.5} /> : <IconEye size={14} strokeWidth={1.5} />}
+          </button>
+        ) : null}
+      </StyledWrapper>
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/packages/bruno-app/src/ui/Introduction.mdx
+++ b/packages/bruno-app/src/ui/Introduction.mdx
@@ -4,36 +4,90 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Bruno UI
 
-The design-system primitives for `bruno-app`, under `src/ui`. Build in isolation
-here, see every state at once, and check appearance across all Bruno themes via the
-**Theme** picker in the toolbar.
+The design-system primitives for `bruno-app`, in `src/ui`. Build them in isolation here,
+see every state at once, and check them against all 13 Bruno themes using the **Theme**
+picker in the toolbar.
+
+```bash
+cd packages/bruno-app && npm run storybook   # http://localhost:6006
+```
+
+## What's here
+
+- `Button` — filled / outline / ghost, five sizes *(88 files)*
+- `MenuDropdown` — dropdown menu with keyboard navigation *(38 files)*
+- `ActionIcon` — icon-only button *(34 files)*
+- `StatusBadge` — themed pill for danger, warning, info, success, muted *(12 files)*
+- `ResponsiveTabs` — tab bar that collapses overflow *(10 files)*
+- `HeightBoundContainer` — bounds a child to the available height *(10 files)*
+- `ErrorBanner` — dismissible list of title/message errors *(6 files)*
+- `MethodBadge` — HTTP method label *(5 files)*
+- `Portal` — renders children outside the DOM hierarchy *(5 files)*
+- `ListGroup` — rows with leading and action slots *(3 files)*
+- `RichTextEditor` — TipTap editor; deep path only, it's heavy *(2 files)*
+- `SegmentedControl` — segmented selector built on radios *(1 file)*
+- `Input` — single-line text control *(new)*
+- `Field` — label, control, and one helper/error line *(new)*
+
+A low count usually means the primitive is new, not that it is unfinished.
 
 ## Using a component
 
-Import from the `ui` barrel:
-
 ```jsx
-import { Button, RadioGroup, SegmentedControl } from 'ui';
+import { Field, Input } from 'ui';
 
-<SegmentedControl
-  value={value}
-  onChange={setValue}
-  ariaLabel="Request type"
-  items={[{ value: 'http', label: 'HTTP' }, { value: 'graphql', label: 'GraphQL' }]}
-/>
+<Field label="Collection name" error={touched.name && errors.name}>
+  <Input value={name} onChange={(e) => setName(e.target.value)} />
+</Field>
 ```
 
-Prefer the barrel over deep paths, and don't reach into a component's internals.
+Prefer the barrel over deep paths, and don't reach into a component's internals. Most
+existing code still imports deep paths (`ui/Button`) — either resolves, so don't churn
+files just to switch.
 
 ## Conventions
 
-- **Controlled** components take `value` + `onChange(value, event)`.
-- Components **forward `ref`** and pass through extra props (`...rest`, `data-*`).
-- Every interactive primitive accepts a `dataTestId`.
-- Group primitives (`RadioGroup`, `SegmentedControl`) always need an accessible name
-  (`label` / `ariaLabel` / `ariaLabelledBy`) — they warn in development otherwise.
-- Colors/spacing come from the **theme** (styled-components `props.theme`), not hardcoded values.
+- **Controlled.** Components own no copy of their value. Wrappers around a native
+  element forward the DOM event (`onChange(event)`); composite controls that have no
+  single native element pass the value first (`onChange(value, event)`).
+- **Refs are forwarded** to the element a caller would expect to focus or measure.
+- **Extra props pass through** via `...rest`, so any native attribute keeps working
+  without a component change.
+- **`data-testid`** is a named prop with a per-component default.
+- **Styling** lives in a sibling `StyledWrapper.js`, driven by `$`-prefixed transient
+  props. Colours come from the theme; Tailwind classes are for layout only, never colour.
+- **Accessible names** are required where they can't be derived — `SegmentedControl`
+  warns in development if it has neither `ariaLabel` nor `ariaLabelledBy`.
 
-See the **Design System** section for the theme's colors, typography, radii, and shadows,
-and each component's **Docs** tab for its full API. More detail lives in
-`packages/bruno-app/storybook/README.md`.
+## Theming
+
+Every colour, radius, spacing and font size comes from `props.theme`. There are 13
+themes (5 light, 8 dark) and a primitive has to hold up in all of them, so check the
+toolbar picker before calling a component done.
+
+Two things worth knowing before you reach for a literal:
+
+- **Never hardcode a colour.** The two monochrome themes have no red at all —
+  `status.danger` is a grey there, deliberately. A hardcoded red breaks their premise.
+- **Adding a token is expensive.** `themes/schema/oss.js` sets
+  `additionalProperties: false`, so a new key must be declared there *and* supplied in
+  every theme that needs it. A theme that fails validation is silently swapped for the
+  default, so prefer an existing token, or branch on `theme.mode`.
+
+## Adding a primitive
+
+1. Build it under `src/ui/<Name>/` as `index.js` plus `StyledWrapper.js`.
+2. Add `<Name>.stories.jsx` — title `Components/<Name>`, `autodocs`, `argTypes`, an
+   explicit `docs.description.component`, and a story per meaningful state. The global
+   decorator already supplies the theme, so don't add a `ThemeProvider`.
+3. Add `<Name>.spec.jsx` with React Testing Library, then export from `src/ui/index.js`.
+
+`SegmentedControl` and `Input` are the closest things to a reference implementation.
+Full detail lives in `packages/bruno-app/storybook/README.md`.
+
+**Testing gotcha:** there is no shared `renderWithTheme`, so a spec builds its own
+minimal theme object. Any token a `StyledWrapper` hands to a `polished` function must be
+a real colour string in that stub, or the test throws rather than rendering oddly.
+
+See the **Design System** section for the theme's colours, typography, radii and
+shadows, and each component's **Docs** tab for its full API.

--- a/packages/bruno-app/src/ui/Introduction.mdx
+++ b/packages/bruno-app/src/ui/Introduction.mdx
@@ -34,6 +34,6 @@ Prefer the barrel over deep paths, and don't reach into a component's internals.
   (`label` / `ariaLabel` / `ariaLabelledBy`) — they warn in development otherwise.
 - Colors/spacing come from the **theme** (styled-components `props.theme`), not hardcoded values.
 
-See **Foundations → Tokens** for the theme's colors, typography, radii, and shadows,
+See the **Design System** section for the theme's colors, typography, radii, and shadows,
 and each component's **Docs** tab for its full API. More detail lives in
 `packages/bruno-app/storybook/README.md`.

--- a/packages/bruno-app/src/ui/Introduction.mdx
+++ b/packages/bruno-app/src/ui/Introduction.mdx
@@ -14,22 +14,12 @@ cd packages/bruno-app && npm run storybook   # http://localhost:6006
 
 ## What's here
 
-- `Button` — filled / outline / ghost, five sizes *(88 files)*
-- `MenuDropdown` — dropdown menu with keyboard navigation *(38 files)*
-- `ActionIcon` — icon-only button *(34 files)*
-- `StatusBadge` — themed pill for danger, warning, info, success, muted *(12 files)*
-- `ResponsiveTabs` — tab bar that collapses overflow *(10 files)*
-- `HeightBoundContainer` — bounds a child to the available height *(10 files)*
-- `ErrorBanner` — dismissible list of title/message errors *(6 files)*
-- `MethodBadge` — HTTP method label *(5 files)*
-- `Portal` — renders children outside the DOM hierarchy *(5 files)*
-- `ListGroup` — rows with leading and action slots *(3 files)*
-- `RichTextEditor` — TipTap editor; deep path only, it's heavy *(2 files)*
-- `SegmentedControl` — segmented selector built on radios *(1 file)*
-- `Input` — single-line text control *(new)*
-- `Field` — label, control, and one helper/error line *(new)*
+- `Button` — filled / outline / ghost, five sizes
+- `Input` — single-line text control, with `Field` for the label and helper line
+- `SegmentedControl` — segmented selector built on radios
 
-A low count usually means the primitive is new, not that it is unfinished.
+Other primitives live in `src/ui` without a story yet — read their source until
+they get one.
 
 ## Using a component
 

--- a/packages/bruno-app/src/ui/index.js
+++ b/packages/bruno-app/src/ui/index.js
@@ -1,13 +1,16 @@
 // Public entry for the design-system primitives. Import from here:
-//   import { Button, RadioGroup, SegmentedControl } from 'ui';
+//   import { Button, Field, Input } from 'ui';
 // Prefer this over deep paths, and don't reach into a component's internals.
 export { default as ActionIcon } from './ActionIcon';
 export { default as Button } from './Button';
 export { default as ErrorBanner } from './ErrorBanner';
+export { default as Field } from './Field';
 export { default as HeightBoundContainer } from './HeightBoundContainer';
+export { default as Input } from './Input';
+export { default as ListGroup } from './ListGroup';
 export { default as MenuDropdown } from './MenuDropdown';
 export { default as MethodBadge } from './MethodBadge';
-export { default as RadioGroup } from './RadioGroup';
+export { default as Portal } from './Portal';
 export { default as ResponsiveTabs } from './ResponsiveTabs';
 export { default as SegmentedControl } from './SegmentedControl';
 export { default as StatusBadge } from './StatusBadge';


### PR DESCRIPTION
### Description

Adds two design-system primitives under `src/ui`: `Input` (single-line text control) and `Field` (label + control + helper/error line), with a Storybook page and unit tests.

### Problem

`bruno-app` has no shared input primitive. A `.textbox` class is redefined from scratch in **11 `StyledWrapper.js` files**, which have drifted into four different paddings, three border radii, two heights, and two hardcoded `#ccc` borders. Only one of the eleven handles `:disabled`.

There is also no error state on any input in the app All 61 form errors render as a sibling `<div className="text-red-500">` across 28 files, in eight different className spelling, the input itself never changes appearance or exposes `aria-invalid`.

### Fix

ui/Input one size per the design, `default` and `ghost` variants, `leftSection`/`rightSection` slots, a built-in password visibility toggle, hidden number spinners, `forwardRef`, controlled. Reads existing theme tokens only, so it renders correctly across all 13 themes (verified).

ui/Field owns the label and a single helper slot that `description` and `error` share, the error winning. It passes `id`, `aria-describedby`, error state and `required` to the control through context, so label association and `aria-invalid` are correct by default rather than something each of the 61 call sites has to remember.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

<img width="1458" height="828" alt="image" src="https://github.com/user-attachments/assets/8c8a1045-974d-4706-a6da-62b73bea5923" />

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable Field and Input components with labels, descriptions, validation states, required indicators, accessibility support, and forwarded references.
  * Added password visibility toggles, input sections, ghost styling, number inputs, disabled/read-only states, and flexible sizing.
  * Exposed additional design-system components through the UI library.

* **Documentation**
  * Updated design-system guidance to reference the appropriate theme documentation.

* **Tests**
  * Added comprehensive Input component coverage, including accessibility, validation, interactions, and Field integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->