### PR TITLE
docs: fix typo commiting -> committing

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,6 +1,6 @@
 # Bruno Coding Standards
 
-- No diffs unless an actual change is made, the code changes need to be as minimal as possible, avoid making un-necessary whitespace diffs. This is already handled by eslint but make sure you check your code changes before commiting and raising a PR.
+- No diffs unless an actual change is made, the code changes need to be as minimal as possible, avoid making un-necessary whitespace diffs. This is already handled by eslint but make sure you check your code changes before committing and raising a PR.
 
 ## General Style Rules
 


### PR DESCRIPTION
Corrects the misspelling `commiting` -> `committing` in `CODING_STANDARDS.md`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the coding standards documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->