### PR TITLE
feat: pretty print JSON in SSE responses

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/QueryResult/index.js
@@ -16,7 +16,7 @@ const RAW_FORMAT_OPTIONS = [
 ];
 
 // Preview format options
-const PREVIEW_FORMAT_OPTIONS = [
+export const PREVIEW_FORMAT_OPTIONS = [
   // Structured formats
   { id: 'json', label: 'JSON', type: 'item', codeMirrorMode: 'application/ld+json' },
   { id: 'html', label: 'HTML', type: 'item', codeMirrorMode: 'xml' },

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/StyledWrapper.js
@@ -70,6 +70,10 @@ const StyledWrapper = styled.div`
       color: ${(props) => props.theme.colors.text.yellow};
     }
   }
+
+  .ws-format-trigger {
+    color: ${(props) => props.theme.colors.text.yellow};
+  }
 `;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
@@ -1,11 +1,29 @@
 import React, { useState, useRef, useEffect, useCallback, memo } from 'react';
 import classnames from 'classnames';
 import StyledWrapper from './StyledWrapper';
-import { IconExclamationCircle, IconChevronRight, IconInfoCircle, IconChevronDown, IconArrowUpRight, IconArrowDownLeft } from '@tabler/icons';
+import { IconExclamationCircle, IconChevronRight, IconInfoCircle, IconChevronDown, IconArrowUpRight, IconArrowDownLeft, IconCaretDown } from '@tabler/icons';
+import MenuDropdown from 'ui/MenuDropdown';
 import CodeEditor from 'components/CodeEditor/index';
 import { useTheme } from 'providers/Theme';
 import { useSelector } from 'react-redux';
 import { Virtuoso } from 'react-virtuoso';
+
+const extractJsonFromSSE = (content) => {
+  if (typeof content !== 'string') return null;
+  const lines = content.split('\n');
+  for (const line of lines) {
+    if (line.startsWith('data:')) {
+      const dataStr = line.slice(5).trim();
+      try {
+        const parsed = JSON.parse(dataStr);
+        return JSON.stringify(parsed, null, 2);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+};
 
 const getContentMeta = (content) => {
   if (typeof content === 'object') {
@@ -35,14 +53,6 @@ const parseContent = (content) => {
   };
 };
 
-const getDataTypeText = (type) => {
-  const textMap = {
-    'text/plain': 'RAW',
-    'application/json': 'JSON'
-  };
-  return textMap[type] ?? 'RAW';
-};
-
 /**
  *
  * @param {"incoming"|"outgoing"|"info"} type
@@ -61,6 +71,7 @@ const TypeIcon = ({ type }) => {
 
 const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => {
   const [showHex, setShowHex] = useState(false);
+  const [showFormattedJson, setShowFormattedJson] = useState(false);
   const preferences = useSelector((state) => state.app.preferences);
   const { displayedTheme } = useTheme();
   const [isNew, setIsNew] = useState(false);
@@ -72,7 +83,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => 
   const isOutgoing = message.type === 'outgoing';
   let contentHexdump = message.messageHexdump;
   let parsedContent = parseContent(message.message);
-  const dataType = getDataTypeText(parsedContent.type);
+  const isSseJson = parsedContent.type === 'text/plain' && extractJsonFromSSE(message.message) !== null;
 
   useEffect(() => {
     if (notified.current === true) return;
@@ -145,28 +156,42 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => 
                 'cursor-pointer': !showHex
               })}
               role="tab"
-              onClick={() => setShowHex(true)}
+              onClick={() => {
+                setShowHex(true); setShowFormattedJson(false);
+              }}
             >
               hexdump
             </div>
-            <div
-              className={classnames('select-none capitalize', {
-                'active': !showHex,
-                'cursor-pointer': showHex
-              })}
-              role="tab"
-              onClick={() => setShowHex(false)}
-            >
-              {dataType.toLowerCase()}
-            </div>
+            {isSseJson ? (
+              <MenuDropdown
+                items={[
+                  { id: 'raw', label: 'Raw', onClick: () => {
+                    setShowHex(false); setShowFormattedJson(false);
+                  } },
+                  { id: 'json', label: 'JSON', onClick: () => {
+                    setShowHex(false); setShowFormattedJson(true);
+                  } }
+                ]}
+                selectedItemId={showFormattedJson ? 'json' : 'raw'}
+                showTickMark={true}
+                placement="bottom-end"
+              >
+                <span className="ws-format-trigger flex items-center gap-1 cursor-pointer select-none">
+                  {showFormattedJson ? 'JSON' : 'Raw'}
+                  <IconCaretDown size={12} strokeWidth={2} />
+                </span>
+              </MenuDropdown>
+            ) : (
+              <span className="select-none capitalize">raw</span>
+            )}
           </div>
           <div className="mt-1 h-[300px] w-full">
             <CodeEditor
-              mode={showHex ? 'text/plain' : parsedContent.type}
+              mode={showHex ? 'text/plain' : (showFormattedJson ? 'application/json' : parsedContent.type)}
               theme={displayedTheme}
-              enableLineWrapping={showHex ? false : true}
+              enableLineWrapping={!showHex}
               font={preferences.codeFont || 'default'}
-              value={showHex ? contentHexdump : parsedContent.content}
+              value={showHex ? contentHexdump : (showFormattedJson ? extractJsonFromSSE(message.message) : parsedContent.content)}
               item={item}
               collection={collection}
               readOnly

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
@@ -1,12 +1,15 @@
-import React, { useState, useRef, useEffect, useCallback, memo } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo, memo } from 'react';
 import classnames from 'classnames';
 import StyledWrapper from './StyledWrapper';
-import { IconExclamationCircle, IconChevronRight, IconInfoCircle, IconChevronDown, IconArrowUpRight, IconArrowDownLeft, IconCaretDown } from '@tabler/icons';
-import MenuDropdown from 'ui/MenuDropdown';
+import { IconExclamationCircle, IconChevronRight, IconInfoCircle, IconChevronDown, IconArrowUpRight, IconArrowDownLeft } from '@tabler/icons';
 import CodeEditor from 'components/CodeEditor/index';
 import { useTheme } from 'providers/Theme';
 import { useSelector } from 'react-redux';
 import { Virtuoso } from 'react-virtuoso';
+import { formatResponse } from 'utils/common';
+import { PREVIEW_FORMAT_OPTIONS } from 'components/ResponsePane/QueryResult/index';
+import QueryResultPreview from 'components/ResponsePane/QueryResult/QueryResultPreview';
+import ErrorBanner from 'ui/ErrorBanner';
 
 const extractJsonFromSSE = (content) => {
   if (typeof content !== 'string') return null;
@@ -23,34 +26,6 @@ const extractJsonFromSSE = (content) => {
     }
   }
   return null;
-};
-
-const getContentMeta = (content) => {
-  if (typeof content === 'object') {
-    return {
-      isJSON: true,
-      content: JSON.stringify(content, null, 0)
-    };
-  }
-  try {
-    return {
-      isJSON: true,
-      content: JSON.stringify(JSON.parse(content), null, 0)
-    };
-  } catch {
-    return {
-      isJSON: false,
-      content: content
-    };
-  }
-};
-
-const parseContent = (content) => {
-  let contentMeta = getContentMeta(content);
-  return {
-    type: contentMeta.isJSON ? 'application/json' : 'text/plain',
-    content: contentMeta.isJSON ? JSON.stringify(JSON.parse(contentMeta.content), null, 2) : contentMeta.content
-  };
 };
 
 /**
@@ -70,11 +45,15 @@ const TypeIcon = ({ type }) => {
 };
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => {
 =======
 const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, onStreamFormatChange }) => {
 >>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
   const [showHex, setShowHex] = useState(false);
+=======
+const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, streamViewTab, item, collection }) => {
+>>>>>>> 8da70704f (feat: align streaming UI with SSE responses.)
   const preferences = useSelector((state) => state.app.preferences);
   const { displayedTheme } = useTheme();
   const [isNew, setIsNew] = useState(false);
@@ -84,10 +63,49 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, onStreamF
   const isInfo = message.type === 'info';
   const isError = message.type === 'error';
   const isOutgoing = message.type === 'outgoing';
-  let contentHexdump = message.messageHexdump;
-  let parsedContent = parseContent(message.message);
-  const isSseJson = parsedContent.type === 'text/plain' && extractJsonFromSSE(message.message) !== null;
-  const showFormattedJson = streamFormat === 'json';
+  const selectedFormat = streamFormat || 'raw';
+  const contentHexdump = message.messageHexdump;
+
+  const rawMessage = typeof message.message === 'string' ? message.message : (message.message != null ? String(message.message) : '');
+
+  // Extract JSON payload from SSE data: prefix for formatResponse
+  const sseJsonPayload = useMemo(() => extractJsonFromSSE(rawMessage), [rawMessage]);
+
+  // Derive the CodeMirror mode from PREVIEW_FORMAT_OPTIONS (same as HTTP response path)
+  const codeMirrorMode = useMemo(() => {
+    return PREVIEW_FORMAT_OPTIONS
+      .filter((option) => option.type === 'item' || !option.type)
+      .find((option) => option.id === selectedFormat)?.codeMirrorMode || 'text/plain';
+  }, [selectedFormat]);
+
+  // Determine display value using formatResponse (same utility as HTTP response path)
+  const displayValue = useMemo(() => {
+    if (selectedFormat === 'hex') return contentHexdump || '';
+    if (selectedFormat === 'json' && sseJsonPayload) return sseJsonPayload;
+    if (selectedFormat === 'base64') return Buffer.from(rawMessage, 'utf-8').toString('base64');
+    const dataBuffer = Buffer.from(rawMessage, 'utf-8').toString('base64');
+    return formatResponse(rawMessage, dataBuffer, selectedFormat) || rawMessage;
+  }, [rawMessage, selectedFormat, contentHexdump, sseJsonPayload]);
+
+  // Compute preview mode for the preview toggle (same logic as QueryResult/index.js)
+  const previewMode = useMemo(() => {
+    if (selectedFormat === 'html') return 'preview-web';
+    if (selectedFormat === 'json') return 'preview-json';
+    if (selectedFormat === 'xml') return 'preview-xml';
+    if (selectedFormat === 'javascript') return 'preview-web';
+    return 'preview-text';
+  }, [selectedFormat]);
+
+  const viewTab = streamViewTab || 'editor';
+
+  // Check format compatibility: structured formats need matching content
+  const isCompatible = useMemo(() => {
+    if (selectedFormat === 'hex' || selectedFormat === 'raw' || selectedFormat === 'base64') return true;
+    if (!rawMessage) return true;
+    if (selectedFormat === 'json') return sseJsonPayload !== null;
+    if (selectedFormat === 'html') return /<[a-zA-Z][\s\S]*>/.test(rawMessage);
+    return false;
+  }, [rawMessage, selectedFormat, sseJsonPayload]);
 
   useEffect(() => {
     if (notified.current === true) return;
@@ -132,7 +150,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, onStreamF
           <span className="message-type-icon">
             <TypeIcon type={message.type} />
           </span>
-          <span data-testid="ws-message-content" className="ml-3 text-ellipsis max-w-full overflow-hidden text-nowrap message-content">{parsedContent.content}</span>
+          <span data-testid="ws-message-content" className="ml-3 text-ellipsis max-w-full overflow-hidden text-nowrap message-content">{rawMessage}</span>
         </div>
         <div className="flex shrink-0 gap-2 items-center">
           {message.timestamp && (
@@ -153,59 +171,50 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, onStreamF
       </div>
       {isOpen && (
         <>
-          <div className="mt-2 flex justify-end gap-2 text-xs ws-message-toolbar" role="tablist">
-            <div
-              className={classnames('select-none capitalize', {
-                'active': showHex,
-                'cursor-pointer': !showHex
-              })}
-              role="tab"
-              onClick={() => { setShowHex(true); }}
-            >
-              hexdump
+          {isCompatible ? (
+            <div className="mt-1 h-[300px] w-full">
+              {viewTab === 'preview' ? (
+                <QueryResultPreview
+                  selectedTab="preview"
+                  data={selectedFormat === 'json' && sseJsonPayload ? JSON.parse(sseJsonPayload) : rawMessage}
+                  dataBuffer={Buffer.from(rawMessage, 'utf-8').toString('base64')}
+                  formattedData={displayValue}
+                  item={item}
+                  collection={collection}
+                  codeMirrorMode={codeMirrorMode}
+                  previewMode={previewMode}
+                  disableRunEventListener={true}
+                  displayedTheme={displayedTheme}
+                />
+              ) : (
+                <CodeEditor
+                  mode={codeMirrorMode}
+                  theme={displayedTheme}
+                  enableLineWrapping={selectedFormat !== 'hex'}
+                  font={preferences.codeFont || 'default'}
+                  value={displayValue}
+                  item={item}
+                  collection={collection}
+                  readOnly
+                />
+              )}
             </div>
-            {isSseJson ? (
-              <MenuDropdown
-                items={[
-                  { id: 'raw', label: 'Raw', onClick: () => {
-                    setShowHex(false); onStreamFormatChange?.('raw');
-                  } },
-                  { id: 'json', label: 'JSON', onClick: () => {
-                    setShowHex(false); onStreamFormatChange?.('json');
-                  } }
-                ]}
-                selectedItemId={showFormattedJson ? 'json' : 'raw'}
-                showTickMark={true}
-                placement="bottom-end"
-              >
-                <span className="ws-format-trigger flex items-center gap-1 cursor-pointer select-none">
-                  {showFormattedJson ? 'JSON' : 'Raw'}
-                  <IconCaretDown size={12} strokeWidth={2} />
-                </span>
-              </MenuDropdown>
-            ) : (
-              <span className="select-none capitalize">raw</span>
-            )}
-          </div>
-          <div className="mt-1 h-[300px] w-full">
-            <CodeEditor
-              mode={showHex ? 'text/plain' : (showFormattedJson ? 'application/json' : parsedContent.type)}
-              theme={displayedTheme}
-              enableLineWrapping={!showHex}
-              font={preferences.codeFont || 'default'}
-              value={showHex ? contentHexdump : (showFormattedJson ? extractJsonFromSSE(message.message) : parsedContent.content)}
-              item={item}
-              collection={collection}
-              readOnly
+          ) : (
+            <ErrorBanner
+              errors={[{
+                title: `Cannot preview as ${PREVIEW_FORMAT_OPTIONS.find((o) => o.id === selectedFormat)?.label || selectedFormat}`,
+                message: `Invalid ${PREVIEW_FORMAT_OPTIONS.find((o) => o.id === selectedFormat)?.label || selectedFormat} format. Try selecting a different format from the dropdown above.`
+              }]}
+              className="mt-2"
             />
-          </div>
+          )}
         </>
       )}
     </div>
   );
 });
 
-const WSMessagesList = ({ messages = [], streamFormat, onStreamFormatChange,  item, collection }) => {
+const WSMessagesList = ({ messages = [], streamFormat, streamFormat, streamViewTab, onStreamFormatChange,  item, collection }) => {
   const virtuosoRef = useRef(null);
   const [scrollerElement, setScrollerElement] = useState(null);
   const [openMessages, setOpenMessages] = useState(new Set());
@@ -271,11 +280,20 @@ const WSMessagesList = ({ messages = [], streamFormat, onStreamFormatChange,  it
         isOpen={isOpen}
         onToggle={handleMessageToggle}
         streamFormat={streamFormat}
+<<<<<<< HEAD
         onStreamFormatChange={onStreamFormatChange}
       />
     );
   }, [openMessages, handleMessageToggle, streamFormat, onStreamFormatChange]);
 >>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
+=======
+        streamViewTab={streamViewTab}
+        item={item}
+        collection={collection}
+      />
+    );
+  }, [openMessages, handleMessageToggle, streamFormat, streamViewTab, item, collection]);
+>>>>>>> 8da70704f (feat: align streaming UI with SSE responses.)
 
   const computeItemKey = useCallback((_, msg) => {
     return msg.seq ?? msg.timestamp;

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
@@ -69,9 +69,12 @@ const TypeIcon = ({ type }) => {
   }[type];
 };
 
+<<<<<<< HEAD
 const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => {
+=======
+const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, onStreamFormatChange }) => {
+>>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
   const [showHex, setShowHex] = useState(false);
-  const [showFormattedJson, setShowFormattedJson] = useState(false);
   const preferences = useSelector((state) => state.app.preferences);
   const { displayedTheme } = useTheme();
   const [isNew, setIsNew] = useState(false);
@@ -84,6 +87,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => 
   let contentHexdump = message.messageHexdump;
   let parsedContent = parseContent(message.message);
   const isSseJson = parsedContent.type === 'text/plain' && extractJsonFromSSE(message.message) !== null;
+  const showFormattedJson = streamFormat === 'json';
 
   useEffect(() => {
     if (notified.current === true) return;
@@ -156,9 +160,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => 
                 'cursor-pointer': !showHex
               })}
               role="tab"
-              onClick={() => {
-                setShowHex(true); setShowFormattedJson(false);
-              }}
+              onClick={() => { setShowHex(true); }}
             >
               hexdump
             </div>
@@ -166,10 +168,10 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => 
               <MenuDropdown
                 items={[
                   { id: 'raw', label: 'Raw', onClick: () => {
-                    setShowHex(false); setShowFormattedJson(false);
+                    setShowHex(false); onStreamFormatChange?.('raw');
                   } },
                   { id: 'json', label: 'JSON', onClick: () => {
-                    setShowHex(false); setShowFormattedJson(true);
+                    setShowHex(false); onStreamFormatChange?.('json');
                   } }
                 ]}
                 selectedItemId={showFormattedJson ? 'json' : 'raw'}
@@ -203,7 +205,7 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => 
   );
 });
 
-const WSMessagesList = ({ messages = [], item, collection }) => {
+const WSMessagesList = ({ messages = [], streamFormat, onStreamFormatChange,  item, collection }) => {
   const virtuosoRef = useRef(null);
   const [scrollerElement, setScrollerElement] = useState(null);
   const [openMessages, setOpenMessages] = useState(new Set());
@@ -259,8 +261,21 @@ const WSMessagesList = ({ messages = [], item, collection }) => {
 
   const renderItem = useCallback((_, msg) => {
     const isOpen = openMessages.has(msg.timestamp);
+<<<<<<< HEAD
     return <WSMessageItem message={msg} isOpen={isOpen} onToggle={handleMessageToggle} item={item} collection={collection} />;
   }, [openMessages, handleMessageToggle, item, collection]);
+=======
+    return (
+      <WSMessageItem
+        message={msg}
+        isOpen={isOpen}
+        onToggle={handleMessageToggle}
+        streamFormat={streamFormat}
+        onStreamFormatChange={onStreamFormatChange}
+      />
+    );
+  }, [openMessages, handleMessageToggle, streamFormat, onStreamFormatChange]);
+>>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
 
   const computeItemKey = useCallback((_, msg) => {
     return msg.seq ?? msg.timestamp;

--- a/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/WsResponsePane/WSMessagesList/index.js
@@ -9,7 +9,6 @@ import { Virtuoso } from 'react-virtuoso';
 import { formatResponse } from 'utils/common';
 import { PREVIEW_FORMAT_OPTIONS } from 'components/ResponsePane/QueryResult/index';
 import QueryResultPreview from 'components/ResponsePane/QueryResult/QueryResultPreview';
-import ErrorBanner from 'ui/ErrorBanner';
 
 const extractJsonFromSSE = (content) => {
   if (typeof content !== 'string') return null;
@@ -44,16 +43,8 @@ const TypeIcon = ({ type }) => {
   }[type];
 };
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-const WSMessageItem = memo(({ message, isOpen, onToggle, item, collection }) => {
-=======
-const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, onStreamFormatChange }) => {
->>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
-  const [showHex, setShowHex] = useState(false);
-=======
 const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, streamViewTab, item, collection }) => {
->>>>>>> 8da70704f (feat: align streaming UI with SSE responses.)
+  const [showHex, setShowHex] = useState(false);
   const preferences = useSelector((state) => state.app.preferences);
   const { displayedTheme } = useTheme();
   const [isNew, setIsNew] = useState(false);
@@ -170,51 +161,39 @@ const WSMessageItem = memo(({ message, isOpen, onToggle, streamFormat, streamVie
         </div>
       </div>
       {isOpen && (
-        <>
-          {isCompatible ? (
-            <div className="mt-1 h-[300px] w-full">
-              {viewTab === 'preview' ? (
-                <QueryResultPreview
-                  selectedTab="preview"
-                  data={selectedFormat === 'json' && sseJsonPayload ? JSON.parse(sseJsonPayload) : rawMessage}
-                  dataBuffer={Buffer.from(rawMessage, 'utf-8').toString('base64')}
-                  formattedData={displayValue}
-                  item={item}
-                  collection={collection}
-                  codeMirrorMode={codeMirrorMode}
-                  previewMode={previewMode}
-                  disableRunEventListener={true}
-                  displayedTheme={displayedTheme}
-                />
-              ) : (
-                <CodeEditor
-                  mode={codeMirrorMode}
-                  theme={displayedTheme}
-                  enableLineWrapping={selectedFormat !== 'hex'}
-                  font={preferences.codeFont || 'default'}
-                  value={displayValue}
-                  item={item}
-                  collection={collection}
-                  readOnly
-                />
-              )}
-            </div>
+        <div className="mt-1 h-[300px] w-full">
+          {viewTab === 'preview' ? (
+            <QueryResultPreview
+              selectedTab="preview"
+              data={isCompatible && selectedFormat === 'json' && sseJsonPayload ? JSON.parse(sseJsonPayload) : rawMessage}
+              dataBuffer={Buffer.from(rawMessage, 'utf-8').toString('base64')}
+              formattedData={isCompatible ? displayValue : rawMessage}
+              item={item}
+              collection={collection}
+              codeMirrorMode={isCompatible ? codeMirrorMode : 'text/plain'}
+              previewMode={isCompatible ? previewMode : 'preview-text'}
+              disableRunEventListener={true}
+              displayedTheme={displayedTheme}
+            />
           ) : (
-            <ErrorBanner
-              errors={[{
-                title: `Cannot preview as ${PREVIEW_FORMAT_OPTIONS.find((o) => o.id === selectedFormat)?.label || selectedFormat}`,
-                message: `Invalid ${PREVIEW_FORMAT_OPTIONS.find((o) => o.id === selectedFormat)?.label || selectedFormat} format. Try selecting a different format from the dropdown above.`
-              }]}
-              className="mt-2"
+            <CodeEditor
+              mode={isCompatible ? codeMirrorMode : 'text/plain'}
+              theme={displayedTheme}
+              enableLineWrapping={selectedFormat !== 'hex'}
+              font={preferences.codeFont || 'default'}
+              value={isCompatible ? displayValue : rawMessage}
+              item={item}
+              collection={collection}
+              readOnly
             />
           )}
-        </>
+        </div>
       )}
     </div>
   );
 });
 
-const WSMessagesList = ({ messages = [], streamFormat, streamFormat, streamViewTab, onStreamFormatChange,  item, collection }) => {
+const WSMessagesList = ({ messages = [], streamFormat, streamViewTab, item, collection }) => {
   const virtuosoRef = useRef(null);
   const [scrollerElement, setScrollerElement] = useState(null);
   const [openMessages, setOpenMessages] = useState(new Set());
@@ -270,30 +249,18 @@ const WSMessagesList = ({ messages = [], streamFormat, streamFormat, streamViewT
 
   const renderItem = useCallback((_, msg) => {
     const isOpen = openMessages.has(msg.timestamp);
-<<<<<<< HEAD
-    return <WSMessageItem message={msg} isOpen={isOpen} onToggle={handleMessageToggle} item={item} collection={collection} />;
-  }, [openMessages, handleMessageToggle, item, collection]);
-=======
     return (
       <WSMessageItem
         message={msg}
         isOpen={isOpen}
         onToggle={handleMessageToggle}
         streamFormat={streamFormat}
-<<<<<<< HEAD
-        onStreamFormatChange={onStreamFormatChange}
-      />
-    );
-  }, [openMessages, handleMessageToggle, streamFormat, onStreamFormatChange]);
->>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
-=======
         streamViewTab={streamViewTab}
         item={item}
         collection={collection}
       />
     );
   }, [openMessages, handleMessageToggle, streamFormat, streamViewTab, item, collection]);
->>>>>>> 8da70704f (feat: align streaming UI with SSE responses.)
 
   const computeItemKey = useCallback((_, msg) => {
     return msg.seq ?? msg.timestamp;

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
-import { updateResponsePaneTab, updateResponseFormat, updateResponseViewTab, updateResponseFilter, updateResponseFilterExpanded, updateStreamFormat } from 'providers/ReduxStore/slices/tabs';
+import { updateResponsePaneTab, updateResponseFormat, updateResponseViewTab, updateResponseFilter, updateResponseFilterExpanded, updateStreamFormat, updateStreamViewTab } from 'providers/ReduxStore/slices/tabs';
 import QueryResult from './QueryResult';
 import Overlay from './Overlay';
 import Placeholder from './Placeholder';
@@ -76,6 +76,14 @@ const ResponsePane = ({ item, collection }) => {
   const handleFormatChange = useCallback((newFormat) => {
     dispatch(updateResponseFormat({ uid: item.uid, responseFormat: newFormat }));
   }, [dispatch, item.uid]);
+
+  const handleStreamFormatChange = useCallback((newFormat) => {
+    dispatch(updateStreamFormat({ uid: activeTabUid, streamFormat: newFormat }));
+  }, [dispatch, activeTabUid]);
+
+  const handleStreamViewTabChange = useCallback((newViewTab) => {
+    dispatch(updateStreamViewTab({ uid: activeTabUid, streamViewTab: newViewTab }));
+  }, [dispatch, activeTabUid]);
 
   const handleViewTabChange = useCallback((newViewTab) => {
     dispatch(updateResponseViewTab({ uid: item.uid, responseViewTab: newViewTab }));
@@ -163,7 +171,7 @@ const ResponsePane = ({ item, collection }) => {
               order={-1}
               messages={item.response.data}
               streamFormat={focusedTab?.streamFormat}
-              onStreamFormatChange={(format) => dispatch(updateStreamFormat({ uid: activeTabUid, streamFormat: format }))}
+              streamViewTab={focusedTab?.streamViewTab || 'editor'}
             />
           );
 >>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
@@ -250,25 +258,41 @@ const ResponsePane = ({ item, collection }) => {
           onClick={() => setShowScriptErrorCard(true)}
         />
       )}
-      {focusedTab?.responsePaneTab === 'response' && item?.response && !(item.response?.stream ?? false) ? (
-        <>
-          {/* Result View Tabs (Visualizations + Response Format) */}
+      {focusedTab?.responsePaneTab === 'response' && item?.response ? (
+        (item.response?.stream ?? false) ? (
           <div className="result-view-tabs">
-
-            {/* Response Format */}
             <QueryResultTypeSelector
               formatOptions={previewFormatOptions}
-              formatValue={selectedFormat}
-              onFormatChange={handleFormatChange}
-              onPreviewTabSelect={handleViewTabChange}
-              selectedTab={selectedViewTab}
-              isActiveTab={selectedViewTab === 'editor' || selectedViewTab === 'preview'}
+              formatValue={focusedTab?.streamFormat || 'raw'}
+              onFormatChange={handleStreamFormatChange}
+              onPreviewTabSelect={handleStreamViewTabChange}
+              selectedTab={focusedTab?.streamViewTab || 'editor'}
+              isActiveTab={true}
               onTabSelect={() => {
-                handleViewTabChange('editor');
+                handleStreamViewTabChange('editor');
               }}
             />
           </div>
-        </>
+        ) : (
+          <>
+            {/* Result View Tabs (Visualizations + Response Format) */}
+            <div className="result-view-tabs">
+
+              {/* Response Format */}
+              <QueryResultTypeSelector
+                formatOptions={previewFormatOptions}
+                formatValue={selectedFormat}
+                onFormatChange={handleFormatChange}
+                onPreviewTabSelect={handleViewTabChange}
+                selectedTab={selectedViewTab}
+                isActiveTab={selectedViewTab === 'editor' || selectedViewTab === 'preview'}
+                onTabSelect={() => {
+                  handleViewTabChange('editor');
+                }}
+              />
+            </div>
+          </>
+        )
       ) : null}
       <div className="flex items-center response-pane-status" data-testid="response-pane-status">
         <StatusCode status={response.status} isStreaming={item.response?.stream?.running} />

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
-import { updateResponsePaneTab, updateResponseFormat, updateResponseViewTab, updateResponseFilter, updateResponseFilterExpanded } from 'providers/ReduxStore/slices/tabs';
+import { updateResponsePaneTab, updateResponseFormat, updateResponseViewTab, updateResponseFilter, updateResponseFilterExpanded, updateStreamFormat } from 'providers/ReduxStore/slices/tabs';
 import QueryResult from './QueryResult';
 import Overlay from './Overlay';
 import Placeholder from './Placeholder';
@@ -155,7 +155,18 @@ const ResponsePane = ({ item, collection }) => {
       case 'response': {
         const isStream = item.response?.stream ?? false;
         if (isStream) {
+<<<<<<< HEAD
           return <WSMessagesList order={-1} messages={item.response.data} item={item} collection={collection} />;
+=======
+          return (
+            <WSMessagesList
+              order={-1}
+              messages={item.response.data}
+              streamFormat={focusedTab?.streamFormat}
+              onStreamFormatChange={(format) => dispatch(updateStreamFormat({ uid: activeTabUid, streamFormat: format }))}
+            />
+          );
+>>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
         }
         return (
           <QueryResult

--- a/packages/bruno-app/src/components/ResponsePane/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/index.js
@@ -163,18 +163,16 @@ const ResponsePane = ({ item, collection }) => {
       case 'response': {
         const isStream = item.response?.stream ?? false;
         if (isStream) {
-<<<<<<< HEAD
-          return <WSMessagesList order={-1} messages={item.response.data} item={item} collection={collection} />;
-=======
           return (
             <WSMessagesList
               order={-1}
               messages={item.response.data}
               streamFormat={focusedTab?.streamFormat}
               streamViewTab={focusedTab?.streamViewTab || 'editor'}
+              item={item}
+              collection={collection}
             />
           );
->>>>>>> 1fc4b92e6 (fix: persist SSE response format preference)
         }
         return (
           <QueryResult

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -154,6 +154,7 @@ export const tabsSlice = createSlice({
           responsePaneTab: 'response',
           responseFormat: null,
           responseViewTab: null,
+          streamFormat: null,
           scriptPaneTab: null,
           preview: preview !== undefined
             ? preview
@@ -193,6 +194,7 @@ export const tabsSlice = createSlice({
         responseFilterExpanded: false,
         gqlDocsOpen: false,
         tableColumnWidths: {},
+        streamFormat: null,
         scriptPaneTab: null,
         docsEditing: false,
         ...(uid ? { folderUid: uid } : {}),
@@ -294,6 +296,13 @@ export const tabsSlice = createSlice({
 
       if (tab) {
         tab.responseFormat = action.payload.responseFormat;
+      }
+    },
+    updateStreamFormat: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+
+      if (tab) {
+        tab.streamFormat = action.payload.streamFormat;
       }
     },
     updateResponseViewTab: (state, action) => {
@@ -640,6 +649,7 @@ export const {
   updateResponsePaneTab,
   updateTabMeta,
   updateResponseFormat,
+  updateStreamFormat,
   updateResponseViewTab,
   updateResponseFilter,
   updateResponseFilterExpanded,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/tabs.js
@@ -155,6 +155,7 @@ export const tabsSlice = createSlice({
           responseFormat: null,
           responseViewTab: null,
           streamFormat: null,
+          streamViewTab: null,
           scriptPaneTab: null,
           preview: preview !== undefined
             ? preview
@@ -195,6 +196,7 @@ export const tabsSlice = createSlice({
         gqlDocsOpen: false,
         tableColumnWidths: {},
         streamFormat: null,
+        streamViewTab: null,
         scriptPaneTab: null,
         docsEditing: false,
         ...(uid ? { folderUid: uid } : {}),
@@ -303,6 +305,13 @@ export const tabsSlice = createSlice({
 
       if (tab) {
         tab.streamFormat = action.payload.streamFormat;
+      }
+    },
+    updateStreamViewTab: (state, action) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+
+      if (tab) {
+        tab.streamViewTab = action.payload.streamViewTab;
       }
     },
     updateResponseViewTab: (state, action) => {
@@ -650,6 +659,7 @@ export const {
   updateTabMeta,
   updateResponseFormat,
   updateStreamFormat,
+  updateStreamViewTab,
   updateResponseViewTab,
   updateResponseFilter,
   updateResponseFilterExpanded,


### PR DESCRIPTION
INTERNAL REF - BRU-4563

### Description

- Added `extractJsonFromSSE()` to parse JSON from SSE `data:` fields
- Added per-message JSON detection and formatted-view state
- Added Raw / JSON view dropdown for SSE messages containing JSON
- Reused the existing `CodeEditor` for raw and formatted views
- Added styling for the format dropdown trigger

### Problem

Closes: [https://github.com/usebruno/bruno/issues/9047](https://github.com/usebruno/bruno/issues/9047)
SSE responses containing JSON (e.g. JSON-RPC over `text/event-stream`) were displayed as raw text, making large payloads difficult to read. 

### Fix

The SSE response renderer now detects valid JSON payloads inside `data:` fields and provides a Raw / JSON dropdown for those messages.

- **Raw** preserves the original SSE response
- **JSON** displays the parsed payload with pretty-printing and the existing JSON editor features


### Screenshots

https://github.com/user-attachments/assets/7189baac-e76e-49fe-bb37-da6c09e23a26



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added format and view controls for WebSocket responses, including raw, JSON, and preview modes.
  * Formatted SSE JSON payloads now display with appropriate syntax highlighting.
  * Selected stream format and view mode are preserved when switching tabs.
  * Added visual styling for the active formatting option.

* **Bug Fixes**
  * Improved handling and presentation of SSE-formatted WebSocket responses.
  * Added clear messaging when a selected format is incompatible with the response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->