### PR TITLE
fix(tests): websocket messages scroll flaky tests

### DIFF
--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1862,21 +1862,21 @@ const selectGrpcMethod = async (page: Page, methodName: string) => {
 const closeAllTabsDiscardingChanges = async (page: Page) => {
   await test.step('Close all tabs, discarding changes', async () => {
     const locators = buildCommonLocators(page);
-    const requestTabs = page.locator('.request-tab').filter({ has: page.locator('.tab-method') });
+    const requestTabs = locators.tabs.requestTabsWithMethod();
+    const confirmClose = page.locator('.bruno-modal').filter({ hasText: 'Unsaved changes' });
 
     for (let remaining = await requestTabs.count(); remaining > 0; remaining--) {
       const tab = requestTabs.first();
-      const hasChanges = await locators.tabs.tabDraftIndicator(tab).isVisible();
 
       await tab.hover();
-      await tab.getByTestId('request-tab-close-icon').click({ force: true });
+      await locators.tabs.closeTabIcon(tab).click({ force: true });
 
-      if (hasChanges) {
-        const confirmClose = page.locator('.bruno-modal').filter({ hasText: 'Unsaved changes' });
-        await confirmClose.getByRole('button', { name: 'Don\'t Save' }).click();
-      }
-
-      await expect(requestTabs).toHaveCount(remaining - 1);
+      await expect(async () => {
+        if (await confirmClose.isVisible()) {
+          await confirmClose.getByRole('button', { name: 'Don\'t Save' }).click();
+        }
+        await expect(requestTabs).toHaveCount(remaining - 1, { timeout: 1000 });
+      }).toPass({ timeout: 15000 });
     }
 
     await expect(requestTabs).toHaveCount(0);

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1854,6 +1854,36 @@ const selectGrpcMethod = async (page: Page, methodName: string) => {
 };
 
 /**
+ * Close every open request tab, discarding unsaved changes instead of saving them.
+ *
+ * @param page - The page object
+ * @returns void
+ */
+const closeAllTabsDiscardingChanges = async (page: Page) => {
+  await test.step('Close all tabs, discarding changes', async () => {
+    const locators = buildCommonLocators(page);
+    const requestTabs = page.locator('.request-tab').filter({ has: page.locator('.tab-method') });
+
+    for (let remaining = await requestTabs.count(); remaining > 0; remaining--) {
+      const tab = requestTabs.first();
+      const hasChanges = await locators.tabs.tabDraftIndicator(tab).isVisible();
+
+      await tab.hover();
+      await tab.getByTestId('request-tab-close-icon').click({ force: true });
+
+      if (hasChanges) {
+        const confirmClose = page.locator('.bruno-modal').filter({ hasText: 'Unsaved changes' });
+        await confirmClose.getByRole('button', { name: 'Don\'t Save' }).click();
+      }
+
+      await expect(requestTabs).toHaveCount(remaining - 1);
+    }
+
+    await expect(requestTabs).toHaveCount(0);
+  });
+};
+
+/**
  * Close all open request tabs using the right-click context menu
  * @param page - The page object
  * @returns void
@@ -3057,6 +3087,7 @@ export {
   generateGrpcSampleMessage,
   selectGrpcMethod,
   closeAllTabs,
+  closeAllTabsDiscardingChanges,
   switchToOpenTab,
   createWorkspace,
   switchWorkspace,

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1854,32 +1854,33 @@ const selectGrpcMethod = async (page: Page, methodName: string) => {
 };
 
 /**
- * Close every open request tab, discarding unsaved changes instead of saving them.
+ * Close every open request tab, discarding or saving based on the saveChanges flag.
  *
  * @param page - The page object
  * @returns void
  */
-const closeAllTabsDiscardingChanges = async (page: Page) => {
-  await test.step('Close all tabs, discarding changes', async () => {
+const closeAllOpenTabs = async (page: Page, saveChanges = false) => {
+  await test.step(`Close all tabs, ${saveChanges ? 'saving' : 'discarding'} changes`, async () => {
     const locators = buildCommonLocators(page);
-    const requestTabs = locators.tabs.closableTabs();
+    const closableTabs = locators.tabs.closableTabs();
     const confirmClose = page.locator('.bruno-modal').filter({ hasText: 'Unsaved changes' });
+    const resolveButton = saveChanges
+      ? confirmClose.getByRole('button', { name: /^Save( All)?$/ })
+      : confirmClose.getByRole('button', { name: 'Don\'t Save' });
 
-    for (let remaining = await requestTabs.count(); remaining > 0; remaining--) {
-      const tab = requestTabs.first();
+    const pressCloseAllTabs = async () => {
+      await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+      await page.keyboard.press('ControlOrMeta+Shift+W');
+    };
 
-      await tab.hover();
-      await locators.tabs.closeTabIcon(tab).click({ force: true });
+    await pressCloseAllTabs();
 
-      await expect(async () => {
-        if (await confirmClose.isVisible()) {
-          await confirmClose.getByRole('button', { name: 'Don\'t Save' }).click();
-        }
-        await expect(requestTabs).toHaveCount(remaining - 1, { timeout: 1000 });
-      }).toPass({ timeout: 15000 });
-    }
-
-    await expect(requestTabs).toHaveCount(0);
+    await expect(async () => {
+      if (await confirmClose.isVisible()) {
+        await resolveButton.click();
+      }
+      await expect(closableTabs).toHaveCount(0, { timeout: 1000 });
+    }).toPass({ timeout: 15000 });
   });
 };
 
@@ -3087,7 +3088,7 @@ export {
   generateGrpcSampleMessage,
   selectGrpcMethod,
   closeAllTabs,
-  closeAllTabsDiscardingChanges,
+  closeAllOpenTabs,
   switchToOpenTab,
   createWorkspace,
   switchWorkspace,

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1862,7 +1862,7 @@ const selectGrpcMethod = async (page: Page, methodName: string) => {
 const closeAllTabsDiscardingChanges = async (page: Page) => {
   await test.step('Close all tabs, discarding changes', async () => {
     const locators = buildCommonLocators(page);
-    const requestTabs = locators.tabs.requestTabsWithMethod();
+    const requestTabs = locators.tabs.closableTabs();
     const confirmClose = page.locator('.bruno-modal').filter({ hasText: 'Unsaved changes' });
 
     for (let remaining = await requestTabs.count(); remaining > 0; remaining--) {

--- a/tests/utils/page/docs/index.ts
+++ b/tests/utils/page/docs/index.ts
@@ -1,4 +1,4 @@
-import { Page } from '../../../playwright';
+import { Page } from '../../../../playwright';
 
 /**
  * Locators for the request/collection/folder documentation (rich-text docs editor) section.

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -70,6 +70,8 @@ export const buildCommonLocators = (page: Page) => ({
     activeRequestTab: () => page.locator('.request-tab.active'),
     activeRequestTabMethod: () => page.locator('.request-tab.active .tab-method'),
     closeTab: (requestName: string) => page.locator('.request-tab').filter({ hasText: requestName }).getByTestId('request-tab-close-icon'),
+    requestTabsWithMethod: () => page.locator('.request-tab').filter({ has: page.locator('.tab-method') }),
+    closeTabIcon: (tab: Locator) => tab.getByTestId('request-tab-close-icon'),
     draftIndicator: () => page.locator('.request-tab.active .has-changes-icon'),
     tabDraftIndicator: (tab: Locator) => tab.locator('.has-changes-icon')
   },

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -70,7 +70,7 @@ export const buildCommonLocators = (page: Page) => ({
     activeRequestTab: () => page.locator('.request-tab.active'),
     activeRequestTabMethod: () => page.locator('.request-tab.active .tab-method'),
     closeTab: (requestName: string) => page.locator('.request-tab').filter({ hasText: requestName }).getByTestId('request-tab-close-icon'),
-    requestTabsWithMethod: () => page.locator('.request-tab').filter({ has: page.locator('.tab-method') }),
+    closableTabs: () => page.locator('.request-tab').filter({ has: page.getByTestId('request-tab-close-icon') }),
     closeTabIcon: (tab: Locator) => tab.getByTestId('request-tab-close-icon'),
     draftIndicator: () => page.locator('.request-tab.active .has-changes-icon'),
     tabDraftIndicator: (tab: Locator) => tab.locator('.has-changes-icon')

--- a/tests/utils/page/mounting.ts
+++ b/tests/utils/page/mounting.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { test, expect, Page, ElectronApplication } from '../../../playwright';
 
 /**
@@ -131,6 +132,44 @@ export const openCollectionFromPath = async (
     await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Open collection' }).click();
   });
 };
+
+/**
+ * Ensure a collection is open in the sidebar, opening it from disk if it is not.
+ *
+ * @param page - The Playwright page object
+ * @param collectionPath - Absolute path to the collection directory. Pass it with forward
+ *   slashes (see `toPosixPath`) so it matches the path recorded in the spec's
+ *   `collection-security.json`; the sandbox config is looked up by exact string, and a
+ *   miss puts the JavaScript sandbox modal in front of the test on Windows.
+ * @param collectionName - The name of the collection, used to wait for the sidebar row
+ */
+export const ensureCollectionOpen = async (
+  page: Page,
+  collectionPath: string,
+  collectionName: string
+): Promise<void> => {
+  await test.step(`Ensure collection "${collectionName}" is open`, async () => {
+    const result = await page.evaluate(
+      (pathname) => (window as any).ipcRenderer.invoke('renderer:open-multiple-collections', [pathname]),
+      collectionPath
+    );
+
+    const problems = [...(result?.failed ?? []), ...(result?.invalid ?? [])];
+    if (problems.length) {
+      throw new Error(`Could not open collection at "${collectionPath}": ${JSON.stringify(problems)}`);
+    }
+
+    await waitForCollectionMount(page, collectionName);
+  });
+};
+
+/**
+ * Normalize an absolute path to forward slashes, matching how collection paths are
+ * written into a spec's init-user-data (preferences.json, collection-security.json).
+ *
+ * @param pathname - The path to normalize
+ */
+export const toPosixPath = (pathname: string): string => pathname.split(path.sep).join('/');
 
 /**
  * Wait for a collection to finish mounting (loading spinner disappears and items are stable)

--- a/tests/utils/page/mounting.ts
+++ b/tests/utils/page/mounting.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import { test, expect, Page, ElectronApplication } from '../../../playwright';
 
 /**
@@ -132,44 +131,6 @@ export const openCollectionFromPath = async (
     await page.locator('.tippy-box .dropdown-item').filter({ hasText: 'Open collection' }).click();
   });
 };
-
-/**
- * Ensure a collection is open in the sidebar, opening it from disk if it is not.
- *
- * @param page - The Playwright page object
- * @param collectionPath - Absolute path to the collection directory. Pass it with forward
- *   slashes (see `toPosixPath`) so it matches the path recorded in the spec's
- *   `collection-security.json`; the sandbox config is looked up by exact string, and a
- *   miss puts the JavaScript sandbox modal in front of the test on Windows.
- * @param collectionName - The name of the collection, used to wait for the sidebar row
- */
-export const ensureCollectionOpen = async (
-  page: Page,
-  collectionPath: string,
-  collectionName: string
-): Promise<void> => {
-  await test.step(`Ensure collection "${collectionName}" is open`, async () => {
-    const result = await page.evaluate(
-      (pathname) => (window as any).ipcRenderer.invoke('renderer:open-multiple-collections', [pathname]),
-      collectionPath
-    );
-
-    const problems = [...(result?.failed ?? []), ...(result?.invalid ?? [])];
-    if (problems.length) {
-      throw new Error(`Could not open collection at "${collectionPath}": ${JSON.stringify(problems)}`);
-    }
-
-    await waitForCollectionMount(page, collectionName);
-  });
-};
-
-/**
- * Normalize an absolute path to forward slashes, matching how collection paths are
- * written into a spec's init-user-data (preferences.json, collection-security.json).
- *
- * @param pathname - The path to normalize
- */
-export const toPosixPath = (pathname: string): string => pathname.split(path.sep).join('/');
 
 /**
  * Wait for a collection to finish mounting (loading spinner disappears and items are stable)

--- a/tests/websockets/message-editor-scroll.spec.ts
+++ b/tests/websockets/message-editor-scroll.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../playwright';
-import { openRequest, closeAllTabsDiscardingChanges } from '../utils/page/actions';
+import { openRequest, closeAllOpenTabs } from '../utils/page/actions';
 import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
@@ -8,7 +8,7 @@ const TWO_MSG_REQ = 'ws-two-long-msgs';
 
 test.describe('websocket message editor scroll behaviour', () => {
   test.afterEach(async ({ pageWithUserData: page }) => {
-    await closeAllTabsDiscardingChanges(page);
+    await closeAllOpenTabs(page);
   });
 
   test('reopening a message restores the scroll position where we left it', async ({ pageWithUserData: page }) => {

--- a/tests/websockets/message-editor-scroll.spec.ts
+++ b/tests/websockets/message-editor-scroll.spec.ts
@@ -1,12 +1,20 @@
+import * as path from 'path';
 import { expect, test } from '../../playwright';
 import { openRequest, closeAllCollections } from '../utils/page/actions';
+import { ensureCollectionOpen, toPosixPath } from '../utils/page/mounting';
 import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
+
+const COLLECTION_PATH = toPosixPath(path.join(__dirname, 'fixtures', 'collection'));
 const SCROLL_REQ = 'ws-scroll-top';
 const TWO_MSG_REQ = 'ws-two-long-msgs';
 
 test.describe('websocket message editor scroll behaviour', () => {
+  test.beforeEach(async ({ pageWithUserData: page }) => {
+    await ensureCollectionOpen(page, COLLECTION_PATH, COLLECTION_NAME);
+  });
+
   test.afterEach(async ({ pageWithUserData: page }) => {
     await closeAllCollections(page);
   });

--- a/tests/websockets/message-editor-scroll.spec.ts
+++ b/tests/websockets/message-editor-scroll.spec.ts
@@ -1,22 +1,14 @@
-import * as path from 'path';
 import { expect, test } from '../../playwright';
-import { openRequest, closeAllCollections } from '../utils/page/actions';
-import { ensureCollectionOpen, toPosixPath } from '../utils/page/mounting';
+import { openRequest, closeAllTabsDiscardingChanges } from '../utils/page/actions';
 import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
-
-const COLLECTION_PATH = toPosixPath(path.join(__dirname, 'fixtures', 'collection'));
 const SCROLL_REQ = 'ws-scroll-top';
 const TWO_MSG_REQ = 'ws-two-long-msgs';
 
 test.describe('websocket message editor scroll behaviour', () => {
-  test.beforeEach(async ({ pageWithUserData: page }) => {
-    await ensureCollectionOpen(page, COLLECTION_PATH, COLLECTION_NAME);
-  });
-
   test.afterEach(async ({ pageWithUserData: page }) => {
-    await closeAllCollections(page);
+    await closeAllTabsDiscardingChanges(page);
   });
 
   test('reopening a message restores the scroll position where we left it', async ({ pageWithUserData: page }) => {

--- a/tests/websockets/message-scroll.spec.ts
+++ b/tests/websockets/message-scroll.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../playwright';
-import { openRequest, selectRequestPaneTab, closeAllCollections } from '../utils/page/actions';
+import { openRequest, selectRequestPaneTab, closeAllTabsDiscardingChanges } from '../utils/page/actions';
 import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
@@ -7,8 +7,9 @@ const LONG_MSG_REQ = 'ws-long-msg';
 const TWO_MSG_REQ = 'ws-two-long-msgs';
 
 test.describe('websocket message list scroll on tab switch', () => {
+  // Discard the draft rather than save it. Selecting a message drafts the request.
   test.afterEach(async ({ pageWithUserData: page }) => {
-    await closeAllCollections(page);
+    await closeAllTabsDiscardingChanges(page);
   });
 
   test('does not scroll the expanded message list when switching request pane tabs', async ({

--- a/tests/websockets/message-scroll.spec.ts
+++ b/tests/websockets/message-scroll.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../../playwright';
-import { openRequest, selectRequestPaneTab, closeAllTabsDiscardingChanges } from '../utils/page/actions';
+import { openRequest, selectRequestPaneTab, closeAllOpenTabs } from '../utils/page/actions';
 import { buildCommonLocators } from '../utils/page/locators';
 
 const COLLECTION_NAME = 'collection';
@@ -9,7 +9,7 @@ const TWO_MSG_REQ = 'ws-two-long-msgs';
 test.describe('websocket message list scroll on tab switch', () => {
   // Discard the draft rather than save it. Selecting a message drafts the request.
   test.afterEach(async ({ pageWithUserData: page }) => {
-    await closeAllTabsDiscardingChanges(page);
+    await closeAllOpenTabs(page);
   });
 
   test('does not scroll the expanded message list when switching request pane tabs', async ({


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
message-editor-scroll.spec.ts failed intermittently on CI with Target page, context or browser has been closed while waiting for the sidebar collection row.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
pageWithUserData caches one Electron app per test file per worker. Now we have a before each which clear the colelctions from sidebar. Next test running on same worker are not able to find the collections in sidebar.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
Created a new helper which closes the tabs without saving the changes. The collection is never removed, so no setup is needed to put it back.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated test cleanup to reliably close all open tabs.
  * Enhanced handling of unsaved changes, with support for saving or discarding them during cleanup.
  * Improved test isolation for message editor and scrolling scenarios.
  * Increased reliability when identifying tabs that can be closed.
* **Chores**
  * Refined shared browser-test utilities and navigation behavior.
  * Corrected an internal documentation import path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->