### PR TITLE
feat(tests): add tests for app creation and management

### DIFF
--- a/tests/apps/apps-create.spec.ts
+++ b/tests/apps/apps-create.spec.ts
@@ -161,14 +161,17 @@ test.describe('Apps - creation flows', () => {
     const modal = await openNewAppModal(page, () => openCollectionMenu(page, collectionName));
     const card = modal.locator('.bruno-modal-card');
     const beforeBox = await card.boundingBox();
+    expect(beforeBox).not.toBeNull();
 
     // The header sits inside the modal card but outside the name input — clicking it must be a no-op.
     await modal.locator('.bruno-modal-header').click({ position: { x: 5, y: 5 } });
 
     await expect(modal).toBeVisible();
     const afterBox = await card.boundingBox();
-    expect(afterBox?.width).toBe(beforeBox?.width);
-    expect(afterBox?.height).toBe(beforeBox?.height);
+    expect(afterBox).not.toBeNull();
+    // Tolerate sub-pixel drift from layout re-measurement while still catching an actual resize.
+    expect(afterBox!.width).toBeCloseTo(beforeBox!.width, 0);
+    expect(afterBox!.height).toBeCloseTo(beforeBox!.height, 0);
     await expect(page.locator('.bruno-modal [data-testid="form-error"]')).toHaveCount(0);
   });
 

--- a/tests/apps/apps-create.spec.ts
+++ b/tests/apps/apps-create.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect, Page } from '../../playwright';
+import {
+  createCollection,
+  createFolder,
+  createApp,
+  activeAppPreviewSlot,
+  buildCommonLocators,
+  expandFolder
+} from '../utils/page';
+
+const openCollectionMenu = async (page: Page, collectionName: string) => {
+  const { sidebar, actions } = buildCommonLocators(page);
+  await sidebar.collection(collectionName).hover();
+  const trigger = actions.collectionActions(collectionName);
+  await expect(trigger).toBeVisible({ timeout: 2000 });
+  await trigger.click();
+};
+
+const openFolderMenu = async (page: Page, collectionName: string, folderName: string) => {
+  const { sidebar } = buildCommonLocators(page);
+  const folderRow = sidebar.collectionScope(collectionName).locator('.collection-item-name').filter({ hasText: folderName });
+  await folderRow.hover();
+  await folderRow.locator('.menu-icon').click();
+};
+
+const openNewAppModal = async (page: Page, opener: () => Promise<void>) => {
+  await opener();
+  await page.locator('.tippy-box:visible .dropdown-item').filter({ hasText: 'New App' }).click();
+  const modal = page.locator('.bruno-modal').filter({ hasText: 'New App' });
+  await expect(modal).toBeVisible({ timeout: 5000 });
+  return modal;
+};
+
+const submitNewAppModal = async (modal: ReturnType<Page['locator']>) => {
+  await modal.getByRole('button', { name: 'Create', exact: true }).click();
+};
+
+const appSidebarItem = (page: Page, collectionName: string, appName: string) => {
+  const { sidebar } = buildCommonLocators(page);
+  return sidebar.collectionScope(collectionName).locator('.collection-item-name').filter({ hasText: appName });
+};
+
+const appTab = (page: Page, appName: string) =>
+  page.locator('.request-tab .tab-label').filter({ hasText: appName });
+
+test.describe('Apps - creation flows', () => {
+  // The Electron page is worker-scoped, so a modal or open menu left over from one test
+  // will block sidebar clicks in the next. Dismiss both after every test.
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape').catch(() => {});
+    if (await page.locator('.bruno-modal').count()) {
+      await page.keyboard.press('Escape').catch(() => {});
+      await page.locator('.bruno-modal').waitFor({ state: 'detached', timeout: 5000 }).catch(() => {});
+    }
+  });
+
+  test('TC-3372 New App option is available at folder level', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc3372');
+    const collectionName = 'apps-create-tc3372';
+    const folderName = 'folder-tc3372';
+    await createCollection(page, collectionName, collectionPath);
+    await createFolder(page, folderName, collectionName, true);
+
+    await openFolderMenu(page, collectionName, folderName);
+    await expect(
+      page.locator('.tippy-box:visible .dropdown-item').filter({ hasText: 'New App' })
+    ).toBeVisible();
+  });
+
+  test('TC-3374 Creating an app at folder level opens a new tab', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc3374');
+    const collectionName = 'apps-create-tc3374';
+    const folderName = 'folder-tc3374';
+    await createCollection(page, collectionName, collectionPath);
+    await createFolder(page, folderName, collectionName, true);
+
+    await createApp(page, 'folder-app', { collectionName, folderName });
+
+    await expandFolder(page, folderName);
+    await expect(appSidebarItem(page, collectionName, 'folder-app')).toBeVisible();
+    await expect(appTab(page, 'folder-app')).toBeVisible();
+    await expect(activeAppPreviewSlot(page).getByTestId('collection-app')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('TC-4170 User can create multiple apps in the same collection and folder', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4170');
+    const collectionName = 'apps-create-tc4170';
+    const folderName = 'folder-tc4170';
+    await createCollection(page, collectionName, collectionPath);
+    await createFolder(page, folderName, collectionName, true);
+
+    await test.step('Two collection-level apps coexist', async () => {
+      await createApp(page, 'collection1', { collectionName });
+      await createApp(page, 'collection2', { collectionName });
+      await expect(appSidebarItem(page, collectionName, 'collection1')).toBeVisible();
+      await expect(appSidebarItem(page, collectionName, 'collection2')).toBeVisible();
+    });
+
+    await test.step('Two folder-level apps coexist', async () => {
+      await createApp(page, 'folder1', { collectionName, folderName });
+      await createApp(page, 'folder2', { collectionName, folderName });
+      await expandFolder(page, folderName);
+      await expect(appSidebarItem(page, collectionName, 'folder1')).toBeVisible();
+      await expect(appSidebarItem(page, collectionName, 'folder2')).toBeVisible();
+    });
+  });
+
+  test('TC-4171 Duplicate collection-level app name is rejected with an error toast', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4171');
+    const collectionName = 'apps-create-tc4171';
+    await createCollection(page, collectionName, collectionPath);
+
+    await createApp(page, 'collectionapp', { collectionName });
+
+    const modal = await openNewAppModal(page, () => openCollectionMenu(page, collectionName));
+    await modal.locator('input[name="appName"]').fill('collectionapp');
+    await submitNewAppModal(modal);
+
+    const { toast } = buildCommonLocators(page);
+    await expect(toast.byMessage(/An item with this name already exists in this folder/)).toBeVisible({ timeout: 5000 });
+    await expect(modal).toBeVisible();
+  });
+
+  test('TC-4172 Duplicate folder-level app name is rejected with an error toast', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4172');
+    const collectionName = 'apps-create-tc4172';
+    const folderName = 'folder-tc4172';
+    await createCollection(page, collectionName, collectionPath);
+    await createFolder(page, folderName, collectionName, true);
+
+    await createApp(page, 'folderapp', { collectionName, folderName });
+
+    const modal = await openNewAppModal(page, () => openFolderMenu(page, collectionName, folderName));
+    await modal.locator('input[name="appName"]').fill('folderapp');
+    await submitNewAppModal(modal);
+
+    const { toast } = buildCommonLocators(page);
+    await expect(toast.byMessage(/An item with this name already exists in this folder/)).toBeVisible({ timeout: 5000 });
+    await expect(modal).toBeVisible();
+  });
+
+  test('TC-4173 Same app name is allowed when parents differ', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4173');
+    const collectionName = 'apps-create-tc4173';
+    const folderName = 'folder-tc4173';
+    await createCollection(page, collectionName, collectionPath);
+    await createFolder(page, folderName, collectionName, true);
+
+    await createApp(page, 'app11', { collectionName });
+    await createApp(page, 'app11', { collectionName, folderName });
+
+    await expandFolder(page, folderName);
+    await expect(appSidebarItem(page, collectionName, 'app11')).toHaveCount(2);
+  });
+
+  test('TC-4184 Clicking inside the modal but outside the name input does not close it', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4184');
+    const collectionName = 'apps-create-tc4184';
+    await createCollection(page, collectionName, collectionPath);
+
+    const modal = await openNewAppModal(page, () => openCollectionMenu(page, collectionName));
+    const card = modal.locator('.bruno-modal-card');
+    const beforeBox = await card.boundingBox();
+
+    // The header sits inside the modal card but outside the name input — clicking it must be a no-op.
+    await modal.locator('.bruno-modal-header').click({ position: { x: 5, y: 5 } });
+
+    await expect(modal).toBeVisible();
+    const afterBox = await card.boundingBox();
+    expect(afterBox?.width).toBe(beforeBox?.width);
+    expect(afterBox?.height).toBe(beforeBox?.height);
+    await expect(page.locator('.bruno-modal [data-testid="form-error"]')).toHaveCount(0);
+  });
+
+  test('TC-4185 Clicking on the backdrop closes the New App modal', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4185');
+    const collectionName = 'apps-create-tc4185';
+    await createCollection(page, collectionName, collectionPath);
+
+    const modal = await openNewAppModal(page, () => openCollectionMenu(page, collectionName));
+
+    await page.locator('.bruno-modal-backdrop').click();
+    await expect(modal).toBeHidden({ timeout: 5000 });
+    await expect(page.locator('.bruno-modal [data-testid="form-error"]')).toHaveCount(0);
+  });
+
+  test('TC-4186 Submitting the New App modal with no name shows a validation error', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4186');
+    const collectionName = 'apps-create-tc4186';
+    await createCollection(page, collectionName, collectionPath);
+
+    const modal = await openNewAppModal(page, () => openCollectionMenu(page, collectionName));
+    await submitNewAppModal(modal);
+
+    await expect(modal.getByText('App name is required')).toBeVisible();
+    await expect(modal).toBeVisible();
+  });
+
+  test('TC-4187 Submitting a valid name creates the app', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-create-tc4187');
+    const collectionName = 'apps-create-tc4187';
+    await createCollection(page, collectionName, collectionPath);
+
+    const modal = await openNewAppModal(page, () => openCollectionMenu(page, collectionName));
+    await modal.locator('input[name="appName"]').fill('my-first-app');
+    await submitNewAppModal(modal);
+
+    await expect(modal).toBeHidden({ timeout: 5000 });
+    await expect(appSidebarItem(page, collectionName, 'my-first-app')).toBeVisible();
+
+    const { toast } = buildCommonLocators(page);
+    await expect(toast.byMessage(/App created/)).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/tests/apps/apps-ui.spec.ts
+++ b/tests/apps/apps-ui.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../playwright';
+import { test, expect, Page } from '../../playwright';
 import {
   createCollection,
   createRequest,
@@ -22,7 +22,7 @@ const SIMPLE_APP = `<div id="hello">Hello from the app</div>`;
 
 // Assert the App tab is absent from the request pane — checks both the visible
 // tab row and the ResponsiveTabs overflow dropdown (tabs can overflow at narrow widths).
-const expectNoAppTab = async (page) => {
+const expectNoAppTab = async (page: Page) => {
   await expect(requestPaneAppTab(page)).toHaveCount(0);
   await openRequestPaneTabOverflow(page);
   await expect(requestPaneOverflowTabItem(page, /^App$/)).toHaveCount(0);
@@ -30,7 +30,7 @@ const expectNoAppTab = async (page) => {
 };
 
 test.describe('Apps - request-level UI', () => {
-  test('App tab and view-mode toggle are gated behind the Enable App setting', async ({ page, createTmpDir }) => {
+  test('TC-3370 TC-3371 App tab and view-mode toggle are gated behind the Enable App setting', async ({ page, createTmpDir }) => {
     const collectionPath = await createTmpDir('apps-ui-gating');
     const collectionName = 'apps-gate';
     await createCollection(page, collectionName, collectionPath);
@@ -140,28 +140,59 @@ test.describe('Apps - request-level UI', () => {
     });
   });
 
-  test('GraphQL requests do not expose the "Enable App" setting', async ({ page, createTmpDir }) => {
-    const collectionPath = await createTmpDir('apps-ui-graphql');
-    const collectionName = 'apps-gql';
+  test('TC-4197 Enable App setting is present only for HTTP requests', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-ui-http-only');
+    const collectionName = 'apps-http-only';
     await createCollection(page, collectionName, collectionPath);
+
+    await createRequest(page, 'http-req', collectionName, {
+      url: 'http://localhost:8081/api/echo/anything/x',
+      method: 'GET'
+    });
     await createRequest(page, 'gql-req', collectionName, {
       url: 'http://localhost:8081/api/graphql',
       requestType: 'graphql'
     });
-    await openRequest(page, collectionName, 'gql-req', { persist: true });
+    await createRequest(page, 'grpc-req', collectionName, {
+      url: 'grpc://localhost:50051',
+      requestType: 'grpc'
+    });
+    await createRequest(page, 'ws-req', collectionName, {
+      url: 'ws://localhost:8081/ws',
+      requestType: 'ws'
+    });
 
-    await selectRequestPaneTab(page, 'Settings');
+    await test.step('HTTP request exposes the Enable App toggle in Settings', async () => {
+      await openRequest(page, collectionName, 'http-req', { persist: true });
+      await selectRequestPaneTab(page, 'Settings');
+      await expect(page.getByTestId('enable-app-toggle')).toBeVisible();
+    });
 
-    // Sibling toggles render, confirming the Settings tab loaded.
-    await expect(page.getByTestId('encode-url-toggle')).toBeVisible();
-    await expect(page.getByTestId('follow-redirects-toggle')).toBeVisible();
+    // GraphQL renders the shared Settings component, so we can visit Settings and confirm
+    // the sibling toggles render while the app toggle stays absent. gRPC has no Settings tab
+    // and WS uses its own settings pane, so for those two we only assert the app surface is
+    // absent from the request pane.
+    await test.step('gql-req: shared Settings loads without the Enable App toggle', async () => {
+      await openRequest(page, collectionName, 'gql-req', { persist: true });
+      await selectRequestPaneTab(page, 'Settings');
+      await expect(page.getByTestId('encode-url-toggle')).toBeVisible();
+      await expect(page.getByTestId('follow-redirects-toggle')).toBeVisible();
+      await expect(page.getByTestId('enable-app-toggle')).toHaveCount(0);
+      await expectNoAppTab(page);
+      await expect(page.getByTestId('view-mode-toggle')).toHaveCount(0);
+    });
 
-    await expect(page.getByTestId('enable-app-toggle')).toHaveCount(0);
-    await expectNoAppTab(page);
-    await expect(page.getByTestId('view-mode-toggle')).toHaveCount(0);
+    for (const name of ['grpc-req', 'ws-req']) {
+      await test.step(`${name}: no Enable App toggle, App tab or view-mode toggle`, async () => {
+        await openRequest(page, collectionName, name, { persist: true });
+        await expect(page.getByTestId('enable-app-toggle')).toHaveCount(0);
+        await expectNoAppTab(page);
+        await expect(page.getByTestId('view-mode-toggle')).toHaveCount(0);
+      });
+    }
   });
 
-  test('Enable App and code persist; an enabled app opens in preview mode by default', async ({ page, createTmpDir }) => {
+  test('TC-3375 Enable App and code persist; an enabled app opens in preview mode by default', async ({ page, createTmpDir }) => {
     const collectionPath = await createTmpDir('apps-ui-persist');
     await createCollection(page, 'apps-persist', collectionPath);
     await createRequest(page, 'persist-req', 'apps-persist', { url: 'http://localhost:8081/api/echo/anything/x' });

--- a/tests/apps/collection-app-actions.spec.ts
+++ b/tests/apps/collection-app-actions.spec.ts
@@ -65,9 +65,17 @@ test.describe('Collection-level app actions', () => {
 
     const modal = page.locator('.bruno-modal').filter({ hasText: 'Info' });
     await expect(modal).toBeVisible({ timeout: 5000 });
-    await expect(modal).toContainText('App Name');
-    await expect(modal).toContainText('File Name');
-    await expect(modal).toContainText('info-app');
+
+    const rows = modal.locator('tbody tr');
+    const nameRow = rows.filter({ hasText: 'App Name' });
+    const fileRow = rows.filter({ hasText: 'File Name' });
+
+    await expect(nameRow.locator('td').nth(1)).toContainText('info-app');
+    // Filename is stored without extension; the .yml/.bru suffix is added at write time.
+    await expect(fileRow.locator('td').nth(1)).toContainText('info-app');
+
+    await modal.getByTestId('modal-close-button').click();
+    await expect(modal).toBeHidden({ timeout: 5000 });
   });
 
   test('TC-6039 Delete removes the collection-level app after confirmation', async ({ page, createTmpDir }) => {

--- a/tests/apps/collection-app-actions.spec.ts
+++ b/tests/apps/collection-app-actions.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect, Page } from '../../playwright';
+import {
+  createCollection,
+  createApp,
+  buildCommonLocators
+} from '../utils/page';
+
+const appSidebarRow = (page: Page, collectionName: string, appName: string) => {
+  const { sidebar } = buildCommonLocators(page);
+  return sidebar.collectionScope(collectionName).locator('.collection-item-name').filter({ hasText: appName });
+};
+
+const openAppRowMenu = async (page: Page, collectionName: string, appName: string) => {
+  const row = appSidebarRow(page, collectionName, appName);
+  await row.hover();
+  await row.locator('.menu-icon').click();
+};
+
+const menuItem = (page: Page, label: string) =>
+  page.locator('.tippy-box:visible .dropdown-item').filter({ hasText: label });
+
+test.describe('Collection-level app actions', () => {
+  test('TC-6035 Copy shows an "App copied" toast', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-actions-tc6035');
+    const collectionName = 'apps-actions-tc6035';
+    await createCollection(page, collectionName, collectionPath);
+    await createApp(page, 'copy-src-app', { collectionName });
+
+    await openAppRowMenu(page, collectionName, 'copy-src-app');
+    await menuItem(page, 'Copy').click();
+
+    const { toast } = buildCommonLocators(page);
+    await expect(toast.byMessage(/App copied/)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('TC-6036 Rename updates the collection-level app name', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-actions-tc6036');
+    const collectionName = 'apps-actions-tc6036';
+    await createCollection(page, collectionName, collectionPath);
+    await createApp(page, 'rename-src', { collectionName });
+
+    await openAppRowMenu(page, collectionName, 'rename-src');
+    await menuItem(page, 'Rename').click();
+
+    const modal = page.locator('.bruno-modal').filter({ hasText: 'Rename App' });
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    const nameInput = modal.locator('#collection-item-name');
+    await nameInput.fill('renamed-app');
+    await modal.getByTestId('rename-item-button').click();
+
+    await expect(modal).toBeHidden({ timeout: 5000 });
+    await expect(appSidebarRow(page, collectionName, 'renamed-app')).toBeVisible();
+    await expect(appSidebarRow(page, collectionName, 'rename-src')).toHaveCount(0);
+  });
+
+  test('TC-6038 Info modal shows the collection-level app name and filename', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-actions-tc6038');
+    const collectionName = 'apps-actions-tc6038';
+    await createCollection(page, collectionName, collectionPath);
+    await createApp(page, 'info-app', { collectionName });
+
+    await openAppRowMenu(page, collectionName, 'info-app');
+    await menuItem(page, 'Info').click();
+
+    const modal = page.locator('.bruno-modal').filter({ hasText: 'Info' });
+    await expect(modal).toBeVisible({ timeout: 5000 });
+    await expect(modal).toContainText('App Name');
+    await expect(modal).toContainText('File Name');
+    await expect(modal).toContainText('info-app');
+  });
+
+  test('TC-6039 Delete removes the collection-level app after confirmation', async ({ page, createTmpDir }) => {
+    const collectionPath = await createTmpDir('apps-actions-tc6039');
+    const collectionName = 'apps-actions-tc6039';
+    await createCollection(page, collectionName, collectionPath);
+    await createApp(page, 'doomed-app', { collectionName });
+
+    await expect(appSidebarRow(page, collectionName, 'doomed-app')).toBeVisible();
+
+    await openAppRowMenu(page, collectionName, 'doomed-app');
+    await menuItem(page, 'Delete').click();
+
+    const modal = page.getByTestId('delete-collection-item-modal');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+    await expect(modal).toContainText('doomed-app');
+    await modal.getByRole('button', { name: 'Delete', exact: true }).click();
+
+    await expect(appSidebarRow(page, collectionName, 'doomed-app')).toHaveCount(0);
+  });
+});

--- a/tests/apps/collection-apps.spec.ts
+++ b/tests/apps/collection-apps.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, ElectronApplication } from '../../playwright';
+import { test, expect, ElectronApplication, Page } from '../../playwright';
 import {
   createCollection,
   createRequest,
@@ -64,7 +64,7 @@ const waitForGuestReady = async (electronApp: ElectronApplication, collectionNam
 
 // Set the CodeMirror editor in the active CollectionApp tab. We use the API
 // directly to avoid auto-close-bracket corruption when typing HTML/JS.
-const setCollectionAppCode = async (page, code: string) => {
+const setCollectionAppCode = async (page: Page, code: string) => {
   await selectAppView(page, 'code');
   const editor = activeAppPreviewSlot(page).getByTestId('collection-app-code').locator('.CodeMirror').first();
   await editor.waitFor({ state: 'visible' });
@@ -103,7 +103,7 @@ const CTX_APP = `
 const ECHO_JSON_URL = 'http://localhost:8081/api/echo/json';
 
 test.describe('Collection apps', () => {
-  test('Create from collection menu → appears in sidebar → opens as own tab with Code/Preview', async ({ page, createTmpDir }) => {
+  test('TC-3369 TC-3373 New App menu at collection level creates an app that opens as its own tab', async ({ page, createTmpDir }) => {
     const collectionPath = await createTmpDir('collection-apps-create');
     await createCollection(page, 'col-apps-create', collectionPath);
 


### PR DESCRIPTION
### Description

TestCases: 
Existing specs (renamed with TC-####):
- tests/apps/apps-ui.spec.ts
  - TC-3370 TC-3371 gating test
  - TC-3375 persist test
  - TC-4197 extended to also cover gRPC + WebSocket + GraphQL
- tests/apps/collection-apps.spec.ts
  - TC-3369 TC-3373 create-from-collection-menu test

New spec tests/apps/apps-create.spec.ts (10 tests):
- TC-3372, TC-3374, TC-4170, TC-4171, TC-4172, TC-4173, TC-4184, TC-4185, TC-4186, TC-4187

New spec tests/apps/collection-app-actions.spec.ts (4 tests):
- TC-6035 (Copy), TC-6036 (Rename), TC-6038 (Info), TC-6039 (Delete)

- Introduced new test suite for app creation flows, covering scenarios for creating apps at both collection and folder levels, including validation for duplicate names.
- Added tests for collection-level app actions, including copy, rename, info display, and delete functionalities.
- Enhanced existing UI tests to ensure proper visibility of app-related features based on request types.
- Improved type annotations for better code clarity and maintainability.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for creating apps from collections and folders, including validation, duplicate names, multiple apps, and modal behavior.
  - Added coverage for copying, renaming, viewing details, and deleting apps.
  - Verified app availability across HTTP, GraphQL, gRPC, and WebSocket request types.
  - Improved checks for success and error notifications throughout app workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->