### PR TITLE
feat(environments): `collection` and `workspace` environments inheritance

### DIFF
--- a/packages/bruno-app/src/components/AppPreviewKeepAlive/index.js
+++ b/packages/bruno-app/src/components/AppPreviewKeepAlive/index.js
@@ -46,6 +46,8 @@ const AppPreviewKeepAlive = () => {
       for (const collection of draft) {
         collection.globalEnvironmentVariables = globalEnvironmentVariables;
         collection.globalEnvSecrets = globalEnvSecrets;
+        collection.globalEnvironments = globalEnvironments;
+        collection.activeGlobalEnvironmentUid = activeGlobalEnvironmentUid;
       }
     });
   }, [_collections, globalEnvironments, activeGlobalEnvironmentUid]);

--- a/packages/bruno-app/src/components/AppView/index.js
+++ b/packages/bruno-app/src/components/AppView/index.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useCallback, useMemo } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { useDispatch } from 'react-redux';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import { sendNetworkRequest } from 'utils/network/index';
 import { findEnvironmentInCollection } from 'utils/collections';
 import {
@@ -159,7 +160,11 @@ const AppView = ({ item, collection, code }) => {
   );
 
   const environment = useMemo(
-    () => findEnvironmentInCollection(collection, collection.activeEnvironmentUid),
+    () =>
+      resolveEnvironmentInheritance({
+        environments: collection.environments,
+        targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
+      }),
     [collection]
   );
   const variables = useMemo(() => buildVariables(collection, item), [collection, item]);

--- a/packages/bruno-app/src/components/CollectionApp/index.js
+++ b/packages/bruno-app/src/components/CollectionApp/index.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import { sendNetworkRequest } from 'utils/network/index';
 import {
   findEnvironmentInCollection,
@@ -193,7 +194,11 @@ const CollectionApp = ({ item, collection }) => {
   );
 
   const environment = useMemo(
-    () => findEnvironmentInCollection(collection, collection.activeEnvironmentUid),
+    () =>
+      resolveEnvironmentInheritance({
+        environments: collection.environments,
+        targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
+      }),
     [collection]
   );
   const variables = useMemo(() => buildVariables(collection), [collection]);

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/InheritedVariableRow/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/InheritedVariableRow/StyledWrapper.js
@@ -1,0 +1,59 @@
+import styled, { css } from 'styled-components';
+
+/* Virtuoso renders the row element, so each cell is styled on its own rather than under one wrapper. */
+
+const readOnlyText = css`
+  font-style: italic;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+export const EnabledCell = styled.td`
+  input[type='checkbox']:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+export const NameCell = styled.td`
+  .inherited-name {
+    ${readOnlyText}
+  }
+`;
+
+export const ValueCell = styled.td`
+  .inherited-value-cell {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .inherited-value {
+    ${readOnlyText}
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .inherited-data-type {
+    flex-shrink: 0;
+    padding-right: 18px;
+  }
+`;
+
+export const DescriptionCell = styled.td`
+  .inherited-description {
+    ${readOnlyText}
+  }
+`;
+
+export const SourceCell = styled.td`
+  .inherited-source {
+    display: inline-flex;
+    cursor: pointer;
+
+    &:hover {
+      color: ${(props) => props.theme.text};
+    }
+  }
+`;

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/InheritedVariableRow/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/InheritedVariableRow/index.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { IconArrowUpRight } from '@tabler/icons';
+import { valueToString } from '@usebruno/common/utils';
+import SecretEyeButton from 'components/MultiLineEditor/SecretEyeButton';
+import { useEnvironmentSelection } from 'hooks/useEnvironmentSelection';
+import { EnabledCell, NameCell, ValueCell, DescriptionCell, SourceCell } from './StyledWrapper';
+
+const MASK_CHARACTER = '*';
+const maskValue = (value) => value.replace(/[^\n]/g, MASK_CHARACTER);
+
+const InheritedVariableRow = ({ variable, columnWidths }) => {
+  const [masked, setMasked] = useState(true);
+  const { environments, onSelect } = useEnvironmentSelection();
+  const value = valueToString(variable.value, 2);
+  const isMasked = !!variable.secret && masked;
+
+  const openInheritedEnvironment = () => {
+    const inheritedEnvironment = environments?.find((env) => env.uid === variable.inheritedFrom.uid);
+    if (inheritedEnvironment) {
+      onSelect(inheritedEnvironment);
+    }
+  };
+
+  return (
+    <>
+      <EnabledCell className="text-center">
+        <input type="checkbox" checked={variable.enabled !== false} disabled readOnly />
+      </EnabledCell>
+      <NameCell style={{ width: columnWidths.name }}>
+        <span className="inherited-name">{variable.name}</span>
+      </NameCell>
+      <ValueCell style={{ width: columnWidths.value }} className="overflow-hidden">
+        <div className="inherited-value-cell">
+          <div className="inherited-value">{isMasked ? maskValue(value) : value}</div>
+          <span className="inherited-data-type" data-testid="inherited-data-type">
+            {variable.dataType || 'string'}
+          </span>
+          {variable.secret && (
+            <SecretEyeButton
+              masked={masked}
+              testId="inherited-secret-reveal-toggle"
+              onToggle={() => setMasked((prev) => !prev)}
+            />
+          )}
+        </div>
+      </ValueCell>
+      <DescriptionCell style={{ width: columnWidths.description }}>
+        <span className="inherited-description">{variable.description}</span>
+      </DescriptionCell>
+      <SourceCell>
+        <button
+          type="button"
+          className="inherited-source"
+          title={`Inherited from ${variable.inheritedFrom.name}`}
+          data-testid="inherited-source"
+          onClick={openInheritedEnvironment}
+        >
+          <IconArrowUpRight size={16} strokeWidth={1.5} />
+        </button>
+      </SourceCell>
+    </>
+  );
+};
+
+export default InheritedVariableRow;

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/InheritedVariableRow/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/InheritedVariableRow/index.js
@@ -62,4 +62,4 @@ const InheritedVariableRow = ({ variable, columnWidths }) => {
   );
 };
 
-export default InheritedVariableRow;
+export default React.memo(InheritedVariableRow);

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
@@ -18,7 +18,6 @@ const Wrapper = styled.div`
     transition: height 75ms cubic-bezier(0,1.12,.84,.64);
   }
 
-  /* The seeded height is an estimate; snap to the measured height instead of animating to it. */
   &.is-measuring .table-container {
     transition: none;
   }

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/StyledWrapper.js
@@ -18,6 +18,11 @@ const Wrapper = styled.div`
     transition: height 75ms cubic-bezier(0,1.12,.84,.64);
   }
 
+  /* The seeded height is an estimate; snap to the measured height instead of animating to it. */
+  &.is-measuring .table-container {
+    transition: none;
+  }
+
   table {
     width: 100%;
     border-collapse: collapse;
@@ -84,6 +89,11 @@ const Wrapper = styled.div`
     }
 
     tbody {
+      tr.section-header-row td {
+        border-right: none;
+        padding: 0;
+      }
+
       tr {
         transition: background 0.1s ease;
 
@@ -101,6 +111,26 @@ const Wrapper = styled.div`
         }
       }
     }
+  }
+
+  .section-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 6px;
+    width: 100%;
+    padding: 8px 10px;
+    color: ${(props) => props.theme.text};
+    font-size: ${(props) => props.theme.font.size.base};
+    font-weight: 600;
+
+    .section-count {
+      color: ${(props) => props.theme.colors.text.muted};
+    }
+  }
+
+  .inherited-row {
+    color: ${(props) => props.theme.colors.text.muted};
   }
 
   .tooltip-mod {

--- a/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
+++ b/packages/bruno-app/src/components/EnvironmentVariablesTable/index.js
@@ -2,7 +2,14 @@ import React, { useCallback, useRef, useState, useEffect, useMemo } from 'react'
 import { TableVirtuoso } from 'react-virtuoso';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
-import { IconTrash, IconAlertCircle, IconGripVertical, IconMinusVertical } from '@tabler/icons';
+import {
+  IconTrash,
+  IconAlertCircle,
+  IconChevronDown,
+  IconChevronRight,
+  IconGripVertical,
+  IconMinusVertical
+} from '@tabler/icons';
 import { useTheme } from 'providers/Theme';
 import { useSelector, useDispatch } from 'react-redux';
 import { updateTableColumnWidths } from 'providers/ReduxStore/slices/tabs';
@@ -32,10 +39,13 @@ import { sortRowsByName, reorderWithinSubset } from 'utils/sortableRows';
 import { useMouseRowDrag, DRAG_ROW_KEY_ATTR } from 'hooks/useMouseRowDrag';
 import ColumnSortHeader from 'components/EditableTable/ColumnSortHeader';
 import { useReconcileSavedEnvironment } from './useReconcileSavedEnvironment';
+import InheritedVariableRow from './InheritedVariableRow';
 
 const MIN_H = 35 * 2;
 const MIN_COLUMN_WIDTH = 80;
 const MIN_ROW_HEIGHT = 35;
+// The "Inherited <tab>" and "<tab>" headers, rendered only when something is inherited.
+const SECTION_HEADER_ROWS = 2;
 
 // Non-secret rows first, then secrets. The tabs save independently, so a stable
 // order keeps the "modified" comparison accurate regardless of which tab saved last.
@@ -46,9 +56,39 @@ const orderVarsBySecret = (vars) => {
   return [...nonSecret, ...secret];
 };
 
+const ROW_SECTION_HEADER = 'sectionHeader';
+const ROW_INHERITED_VARIABLE = 'inheritedVariable';
+
 const TableRow = React.memo(
   ({ children, item, style, context, ...rest }) => {
+    if (item?.type === ROW_SECTION_HEADER) {
+      return (
+        <tr
+          style={style}
+          {...rest}
+          className={`${rest.className || ''} section-header-row`.trim()}
+          data-testid={`env-var-section-${item.section}`}
+        >
+          {children}
+        </tr>
+      );
+    }
+
     const variable = item?.variable ?? item;
+
+    if (item?.type === ROW_INHERITED_VARIABLE) {
+      return (
+        <tr
+          style={style}
+          {...rest}
+          className={`${rest.className || ''} inherited-row`.trim()}
+          data-testid={`env-inherited-var-row-${variable?.name}`}
+        >
+          {children}
+        </tr>
+      );
+    }
+
     const canDrag = !!context?.dragEnabled && item?.index !== context?.lastFormikIndex;
     const isDragOver = canDrag && context?.dragOverKey === variable?.uid;
     const isBeingDragged = canDrag && context?.draggingKey === variable?.uid;
@@ -73,6 +113,7 @@ const TableRow = React.memo(
     const nextCtx = nextProps.context || {};
     return (
       prevUid === nextUid
+      && prevProps.item?.count === nextProps.item?.count
       && prevProps.children === nextProps.children
       && prevCtx.dragEnabled === nextCtx.dragEnabled
       && prevCtx.dragOverKey === nextCtx.dragOverKey
@@ -82,6 +123,12 @@ const TableRow = React.memo(
 );
 
 const columns = ['name', 'value', 'description'];
+
+const matchesSearchQuery = (variable, query) => {
+  const valueText = ['string', 'number', 'boolean'].includes(typeof variable.value) ? String(variable.value) : '';
+  const description = typeof variable.description === 'string' ? variable.description : '';
+  return `${variable.name ?? ''}\n${valueText}\n${description}`.toLowerCase().includes(query);
+};
 
 const EnvVarValueCell = ({
   variable,
@@ -133,7 +180,7 @@ const EnvVarValueCell = ({
             hideSecretEye={showAsSecret}
             onMaskChange={setMasked}
             onChange={(newValue) => {
-              formik.setFieldValue(`${actualIndex}.value`, newValue, true);
+              formik.setFieldValue(`${actualIndex}.value`, newValue, false);
               if (variable.ephemeral) {
                 formik.setFieldValue(`${actualIndex}.ephemeral`, undefined, false);
                 formik.setFieldValue(`${actualIndex}.persistedValue`, undefined, false);
@@ -176,6 +223,7 @@ const EnvVarValueCell = ({
 
 const EnvironmentVariablesTable = ({
   environment,
+  inheritedEnvironmentVariables = [],
   collection,
   onSave,
   draft,
@@ -200,8 +248,14 @@ const EnvironmentVariablesTable = ({
 
   const hasDraftForThisEnv = draft?.environmentUid === environment.uid;
 
-  const rowCount = (environment.variables?.length || 0) + 1;
-  const [tableHeight, setTableHeight] = useState(Math.max(rowCount * MIN_ROW_HEIGHT, MIN_H));
+  const [tableHeight, setTableHeight] = useState(() => {
+    const ownRows = (environment.variables || []).filter((variable) => !!variable.secret === isSecretTab).length + 1;
+    const inheritedRows = inheritedEnvironmentVariables.length
+      ? inheritedEnvironmentVariables.length + SECTION_HEADER_ROWS
+      : 0;
+    return Math.max((ownRows + inheritedRows) * MIN_ROW_HEIGHT, MIN_H);
+  });
+  const [hasMeasuredTableListHeight, setHasMeasuredTableListHeight] = useState(false);
 
   const [scroll, setScroll] = usePersistedState({
     key: `persisted::${activeTabUid}::collection-envs-scroll-${environment.uid}`,
@@ -228,6 +282,9 @@ const EnvironmentVariablesTable = ({
   const [resizing, setResizing] = useState(null);
   const [pinnedData, setPinnedData] = useState({ query: '', uids: new Set() });
   const isSearchActive = !!searchQuery?.trim();
+
+  const [collapsedSections, setCollapsedSections] = useState({ inherited: false, own: false });
+  const toggleSection = (section) => setCollapsedSections((prev) => ({ ...prev, [section]: !prev[section] }));
 
   const variablesSort = useSortCycle({ storageKey: `persisted::${activeTabUid}::env-var-sort::${environment.uid}::variables` });
   const secretsSort = useSortCycle({ storageKey: `persisted::${activeTabUid}::env-var-sort::${environment.uid}::secrets` });
@@ -290,6 +347,7 @@ const EnvironmentVariablesTable = ({
 
   const handleTotalHeightChanged = useCallback((h) => {
     setTableHeight(Math.max(h, MIN_H));
+    setHasMeasuredTableListHeight(true);
   }, []);
 
   const handleRowFocus = useCallback((uid) => {
@@ -321,6 +379,8 @@ const EnvironmentVariablesTable = ({
     const c = collection ? cloneDeep(collection) : {};
     c.globalEnvironmentVariables = globalEnvironmentVariables;
     c.globalEnvSecrets = globalEnvSecrets;
+    c.globalEnvironments = globalEnvironments;
+    c.activeGlobalEnvironmentUid = activeGlobalEnvironmentUid;
     // Preserve the actual active environment so variable existence and
     // interpolation environment can be resolved independently.
     c.realActiveEnvironmentUid = collection?.activeEnvironmentUid;
@@ -329,7 +389,15 @@ const EnvironmentVariablesTable = ({
       c.workspaceProcessEnvVariables = workspaceProcessEnvVariables;
     }
     return c;
-  }, [collection, globalEnvironmentVariables, globalEnvSecrets, workspaceProcessEnvVariables, environment.uid]);
+  }, [
+    collection,
+    globalEnvironmentVariables,
+    globalEnvSecrets,
+    globalEnvironments,
+    activeGlobalEnvironmentUid,
+    workspaceProcessEnvVariables,
+    environment.uid
+  ]);
 
   const resolvableVariables = useMemo(() => getAllVariables(_collection), [_collection]);
 
@@ -863,30 +931,15 @@ const EnvironmentVariablesTable = ({
         return isSecretTab ? !!variable.secret : !variable.secret;
       });
 
-    if (!searchQuery?.trim()) {
+    const query = searchQuery.toLowerCase().trim();
+    if (!query) {
       return tabVariables;
     }
 
-    const query = searchQuery.toLowerCase().trim();
-
     const effectivePins = pinnedData.query === searchQuery ? pinnedData.uids : new Set();
-    return tabVariables.filter(({ variable }) => {
-      if (effectivePins.has(variable.uid)) return true;
-      const nameMatch = variable.name ? variable.name.toLowerCase().includes(query) : false;
-      const valueText
-        = typeof variable.value === 'string'
-          ? variable.value
-          : typeof variable.value === 'number' || typeof variable.value === 'boolean'
-            ? String(variable.value)
-            : '';
-      const valueMatch = valueText.toLowerCase().includes(query);
-      const descriptionMatch
-        = variable.description && typeof variable.description === 'string'
-          ? variable.description.toLowerCase().includes(query)
-          : false;
-
-      return !!(nameMatch || valueMatch || descriptionMatch);
-    });
+    return tabVariables.filter(
+      ({ variable }) => effectivePins.has(variable.uid) || matchesSearchQuery(variable, query)
+    );
   }, [formik.values, searchQuery, pinnedData, isSecretTab]);
 
   const displayedVariables = (() => {
@@ -909,20 +962,52 @@ const EnvironmentVariablesTable = ({
     return hasTrailing ? [...sorted, trailing] : sorted;
   })();
 
+  const inheritedVariableRows = useMemo(() => {
+    const query = searchQuery.toLowerCase().trim();
+    const matching = query
+      ? inheritedEnvironmentVariables.filter((variable) => matchesSearchQuery(variable, query))
+      : inheritedEnvironmentVariables;
+    return matching.map((variable) => ({ type: ROW_INHERITED_VARIABLE, variable }));
+  }, [inheritedEnvironmentVariables, searchQuery]);
+
+  const tabLabel = isSecretTab ? 'Secrets' : 'Variables';
+  const variableRows = inheritedEnvironmentVariables.length
+    ? [
+        {
+          type: ROW_SECTION_HEADER,
+          section: 'inherited',
+          label: `Inherited ${tabLabel}`,
+          count: inheritedVariableRows.length
+        },
+        ...(collapsedSections.inherited ? [] : inheritedVariableRows),
+        {
+          type: ROW_SECTION_HEADER,
+          section: 'own',
+          label: tabLabel,
+          count: displayedVariables.filter(({ variable }) => variable.name && variable.name.trim() !== '').length
+        },
+        ...(collapsedSections.own ? [] : displayedVariables)
+      ]
+    : displayedVariables;
+
   return (
-    <StyledWrapper className={`${resizing ? 'is-resizing' : ''} has-description-column`.trim()}>
-      {isSearchActive && displayedVariables.length === 0 ? (
-        <div className="no-results">No results found for &ldquo;{searchQuery.trim()}&rdquo;</div>
+    <StyledWrapper
+      className={`${resizing ? 'is-resizing' : ''} ${hasMeasuredTableListHeight ? '' : 'is-measuring'} has-description-column`.trim()}
+    >
+      {isSearchActive && displayedVariables.length === 0 && inheritedVariableRows.length === 0 ? (
+        <div className="no-results" data-testid="env-vars-no-results">
+          No results found for &ldquo;{searchQuery.trim()}&rdquo;
+        </div>
       ) : (
         <TableVirtuoso
           className="table-container"
           style={{ height: tableHeight }}
           scrollerRef={setScrollerEl}
           initialTopMostItemIndex={initialTopMostItemIndex}
-          overscan={Math.min(30, displayedVariables.length)}
+          overscan={Math.min(30, variableRows.length)}
           components={{ TableRow }}
           context={dragContext}
-          data={displayedVariables}
+          data={variableRows}
           totalListHeightChanged={handleTotalHeightChanged}
           fixedHeaderContent={() => (
             <tr>
@@ -954,8 +1039,37 @@ const EnvironmentVariablesTable = ({
             </tr>
           )}
           defaultItemHeight={35}
-          computeItemKey={(virtualIndex, item) => `${environment.uid}-${item.index}`}
-          itemContent={(virtualIndex, { variable, index: actualIndex }) => {
+          computeItemKey={(virtualIndex, item) => {
+            if (item.type === ROW_SECTION_HEADER) return `section-${item.section}`;
+            if (item.type === ROW_INHERITED_VARIABLE) return `inherited-${item.variable.uid}`;
+            return item.variable.uid;
+          }}
+          itemContent={(virtualIndex, item) => {
+            if (item.type === ROW_SECTION_HEADER) {
+              const ChevronIcon = collapsedSections[item.section] ? IconChevronRight : IconChevronDown;
+              return (
+                <td colSpan={columns.length + 2}>
+                  <button
+                    type="button"
+                    className="section-toggle"
+                    onClick={() => toggleSection(item.section)}
+                    data-testid={`env-var-section-toggle-${item.section}`}
+                  >
+                    <ChevronIcon size={14} strokeWidth={1.5} />
+                    <span>{item.label}</span>
+                    <span className="section-count">({item.count})</span>
+                  </button>
+                </td>
+              );
+            }
+
+            if (item.type === ROW_INHERITED_VARIABLE) {
+              return (
+                <InheritedVariableRow variable={item.variable} columnWidths={columnWidths} />
+              );
+            }
+
+            const { variable, index: actualIndex } = item;
             const isLastRow = actualIndex === formik.values.length - 1;
             const isEmptyRow = !variable.name || variable.name.trim() === '';
             const isLastEmptyRow = isLastRow && isEmptyRow;
@@ -1034,7 +1148,7 @@ const EnvironmentVariablesTable = ({
                     value={variable.description ?? ''}
                     placeholder={isLastEmptyRow && (!variable.description || (typeof variable.description === 'string' && variable.description.trim() === '')) ? 'Description' : ''}
                     onChange={(newValue) => {
-                      formik.setFieldValue(`${actualIndex}.description`, newValue, true);
+                      formik.setFieldValue(`${actualIndex}.description`, newValue, false);
                       if (isLastRow) {
                         setTimeout(() => {
                           formik.setFieldValue(formik.values.length, {

--- a/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/StyledWrapper.js
@@ -19,6 +19,24 @@ const StyledWrapper = styled.div`
       flex: 1;
     }
   }
+
+  .inheritance-warning {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin: 0 0.5rem 0.25rem 1.75rem;
+    color: ${(props) => props.theme.status.warning.text};
+    font-size: ${(props) => props.theme.font.size.sm};
+
+    .warning-icon {
+      flex-shrink: 0;
+    }
+
+    .inherited-name {
+      font-weight: 600;
+      word-break: break-all;
+    }
+  }
 `;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.js
@@ -5,6 +5,8 @@ import { exportBrunoEnvironment } from 'utils/exporters/bruno-environment';
 import { browseDirectory } from 'providers/ReduxStore/slices/collections/actions';
 import { useDispatch } from 'react-redux';
 import toast from 'react-hot-toast';
+import { IconAlertTriangle } from '@tabler/icons';
+import { getInheritedEnvironments } from '@usebruno/common/utils';
 import StyledWrapper from './StyledWrapper';
 import Button from 'ui/Button';
 
@@ -87,6 +89,18 @@ const ExportEnvironmentModal = ({ onClose, environments = [], environmentType })
 
   const selectedCount = selectedEnvs.length;
 
+  const getUnselectedInheritedEnvironmentNames = (environment) => {
+    if (!selectedEnvironments[environment.uid]) {
+      return [];
+    }
+
+    const { inheritedEnvironments } = getInheritedEnvironments({ environments, environment });
+
+    return inheritedEnvironments
+      .filter((inheritedEnvironment) => !selectedEnvironments[inheritedEnvironment.uid])
+      .map((inheritedEnvironment) => inheritedEnvironment.name);
+  };
+
   const exportFormatOptions = useMemo(() => {
     const isMultiple = selectedCount > 1;
 
@@ -159,18 +173,33 @@ const ExportEnvironmentModal = ({ onClose, environments = [], environmentType })
                     </button>
                   </div>
                   <div className="flex flex-col gap-1 flex-1 overflow-y-auto">
-                    {environments.map((env) => (
-                      <label key={env.uid} className="environment-item">
-                        <input
-                          type="checkbox"
-                          checked={selectedEnvironments[env.uid] || false}
-                          onChange={() => handleEnvironmentToggle(env.uid)}
-                          disabled={isExporting}
-                          className="w-3.5 h-3.5 flex-shrink-0"
-                        />
-                        <span className="environment-name">{truncateEnvName(env.name)}</span>
-                      </label>
-                    ))}
+                    {environments.map((env) => {
+                      const unselectedInheritedEnvironmentNames = getUnselectedInheritedEnvironmentNames(env);
+
+                      return (
+                        <div key={env.uid}>
+                          <label className="environment-item">
+                            <input
+                              type="checkbox"
+                              checked={selectedEnvironments[env.uid] || false}
+                              onChange={() => handleEnvironmentToggle(env.uid)}
+                              disabled={isExporting}
+                              className="w-3.5 h-3.5 flex-shrink-0"
+                            />
+                            <span className="environment-name">{truncateEnvName(env.name)}</span>
+                          </label>
+                          {unselectedInheritedEnvironmentNames.length > 0 && (
+                            <div className="inheritance-warning" data-testid="env-export-inheritance-warning">
+                              <IconAlertTriangle size={14} strokeWidth={1.5} className="warning-icon" />
+                              <span>
+                                inherits{' '}
+                                <span className="inherited-name">{unselectedInheritedEnvironmentNames.join(', ')}</span>
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               ) : (

--- a/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.js
@@ -98,11 +98,18 @@ const ExportEnvironmentModal = ({ onClose, environments = [], environmentType })
         return;
       }
 
-      const { inheritedEnvironments } = getInheritedEnvironments({ environments, environment });
+      const { inheritedEnvironments, missingInheritedEnvironmentName } = getInheritedEnvironments({
+        environments,
+        environment
+      });
 
-      namesByUid[environment.uid] = inheritedEnvironments
+      const unselectedNames = inheritedEnvironments
         .filter((inheritedEnvironment) => !selectedEnvironments[inheritedEnvironment.uid])
         .map((inheritedEnvironment) => inheritedEnvironment.name);
+
+      namesByUid[environment.uid] = missingInheritedEnvironmentName
+        ? [missingInheritedEnvironmentName, ...unselectedNames]
+        : unselectedNames;
     });
 
     return namesByUid;

--- a/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.js
@@ -89,17 +89,24 @@ const ExportEnvironmentModal = ({ onClose, environments = [], environmentType })
 
   const selectedCount = selectedEnvs.length;
 
-  const getUnselectedInheritedEnvironmentNames = (environment) => {
-    if (!selectedEnvironments[environment.uid]) {
-      return [];
-    }
+  const unselectedInheritedEnvironmentNamesByUid = useMemo(() => {
+    const namesByUid = {};
 
-    const { inheritedEnvironments } = getInheritedEnvironments({ environments, environment });
+    environments.forEach((environment) => {
+      if (!selectedEnvironments[environment.uid]) {
+        namesByUid[environment.uid] = [];
+        return;
+      }
 
-    return inheritedEnvironments
-      .filter((inheritedEnvironment) => !selectedEnvironments[inheritedEnvironment.uid])
-      .map((inheritedEnvironment) => inheritedEnvironment.name);
-  };
+      const { inheritedEnvironments } = getInheritedEnvironments({ environments, environment });
+
+      namesByUid[environment.uid] = inheritedEnvironments
+        .filter((inheritedEnvironment) => !selectedEnvironments[inheritedEnvironment.uid])
+        .map((inheritedEnvironment) => inheritedEnvironment.name);
+    });
+
+    return namesByUid;
+  }, [environments, selectedEnvironments]);
 
   const exportFormatOptions = useMemo(() => {
     const isMultiple = selectedCount > 1;
@@ -174,7 +181,7 @@ const ExportEnvironmentModal = ({ onClose, environments = [], environmentType })
                   </div>
                   <div className="flex flex-col gap-1 flex-1 overflow-y-auto">
                     {environments.map((env) => {
-                      const unselectedInheritedEnvironmentNames = getUnselectedInheritedEnvironmentNames(env);
+                      const unselectedInheritedEnvironmentNames = unselectedInheritedEnvironmentNamesByUid[env.uid];
 
                       return (
                         <div key={env.uid}>

--- a/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.spec.js
+++ b/packages/bruno-app/src/components/Environments/Common/ExportEnvironmentModal/index.spec.js
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { ThemeProvider } from 'styled-components';
+import themes from 'themes/index';
+import ExportEnvironmentModal from './index';
+
+jest.mock('components/Portal/index', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>
+}));
+
+jest.mock('components/Modal', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>
+}));
+
+const buildEnvironment = ({ uid, name, extendsFrom }) => ({
+  uid,
+  name,
+  variables: [],
+  extends: extendsFrom
+});
+
+const renderModal = (environments) => {
+  const slice = createSlice({ name: 'collections', initialState: { collections: [] }, reducers: {} });
+  const store = configureStore({ reducer: { collections: slice.reducer } });
+
+  return render(
+    <Provider store={store}>
+      <ThemeProvider theme={themes.light}>
+        <ExportEnvironmentModal onClose={jest.fn()} environments={environments} environmentType="collection" />
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+const inheritanceWarningTexts = () =>
+  screen.queryAllByTestId('env-export-inheritance-warning').map((warning) => warning.textContent);
+
+describe('ExportEnvironmentModal', () => {
+  it('does not warn when every inherited environment is selected', () => {
+    renderModal([
+      buildEnvironment({ uid: 'env-local', name: 'local' }),
+      buildEnvironment({ uid: 'env-derived', name: 'derived', extendsFrom: 'local' })
+    ]);
+
+    expect(inheritanceWarningTexts()).toEqual([]);
+  });
+
+  it('warns about an inherited environment that is left out of the export', () => {
+    renderModal([
+      buildEnvironment({ uid: 'env-local', name: 'local' }),
+      buildEnvironment({ uid: 'env-derived', name: 'derived', extendsFrom: 'local' })
+    ]);
+
+    fireEvent.click(screen.getByLabelText('local'));
+
+    expect(inheritanceWarningTexts()).toEqual(['inherits local']);
+  });
+
+  it('warns about a referenced parent environment that no longer exists', () => {
+    renderModal([buildEnvironment({ uid: 'env-derived', name: 'derived', extendsFrom: 'deleted-parent' })]);
+
+    expect(inheritanceWarningTexts()).toEqual(['inherits deleted-parent']);
+  });
+
+  it('names the missing parent ahead of the left-out ancestors below it', () => {
+    renderModal([
+      buildEnvironment({ uid: 'env-middle', name: 'middle', extendsFrom: 'deleted-root' }),
+      buildEnvironment({ uid: 'env-leaf', name: 'leaf', extendsFrom: 'middle' })
+    ]);
+
+    fireEvent.click(screen.getByLabelText('middle'));
+
+    expect(inheritanceWarningTexts()).toEqual(['inherits deleted-root, middle']);
+  });
+});

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
@@ -30,6 +30,11 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
     // A parent imported alongside its child can land under a different name — a copy suffix, or the
     // name of the environment it replaced — and the child's `extends` has to follow it there.
     const importedNames = new Map();
+    const updateImportedNames = (sourceName, landedName) => {
+      if (!importedNames.has(sourceName)) {
+        importedNames.set(sourceName, landedName);
+      }
+    };
     const inheritedNameFor = (environment) =>
       typeof environment.extends === 'string'
         ? importedNames.get(environment.extends) ?? environment.extends
@@ -49,7 +54,7 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
             if (existingEnv) {
               await saveEnv(environmentToImport, existingEnv);
               replacedNames.add(normalizedName);
-              importedNames.set(environment.name, existingEnv.name);
+              updateImportedNames(environment.name, existingEnv.name);
               importedCount++;
             } else {
               throw new Error(`Environment ${environment.name} not found for replacement`);
@@ -59,7 +64,7 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
             const copyName = generateCopyName(environment.name, currentExistingNames);
             currentExistingNames.push(copyName);
             await createEnv(copyName, environmentToImport);
-            importedNames.set(environment.name, copyName);
+            updateImportedNames(environment.name, copyName);
             importedCount++;
           }
         } else {
@@ -68,7 +73,7 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
             : environment.name;
           currentExistingNames.push(name);
           await createEnv(name, environmentToImport);
-          importedNames.set(environment.name, name);
+          updateImportedNames(environment.name, name);
           importedCount++;
         }
       } catch (error) {

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
@@ -4,7 +4,7 @@ import importPostmanEnvironment from 'utils/importers/postman-environment';
 import importBrunoEnvironment from 'utils/importers/bruno-environment';
 import { readMultipleFiles } from 'utils/importers/file-reader';
 import { toastError } from 'utils/common/error';
-import { generateCopyName, normalizeEnvName } from 'utils/environments';
+import { generateCopyName, normalizeEnvName, orderEnvironmentsByInheritance } from 'utils/environments';
 import { detectEnvironmentFormat, RESOLUTION_TYPES } from '../../utils';
 import { useEnvironmentTarget } from '../useEnvironmentTarget';
 
@@ -27,11 +27,19 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
 
     const isNameDuplicate = (envName) => currentExistingNames.some((existingName) => normalizeEnvName(existingName) === normalizeEnvName(envName));
     const replacedNames = new Set();
+    // A parent imported alongside its child can land under a different name — a copy suffix, or the
+    // name of the environment it replaced — and the child's `extends` has to follow it there.
+    const importedNames = new Map();
+    const inheritedNameFor = (environment) =>
+      typeof environment.extends === 'string'
+        ? importedNames.get(environment.extends) ?? environment.extends
+        : environment.extends;
 
     setIsImporting(true);
-    for (const environment of environmentsToImport) {
+    for (const environment of orderEnvironmentsByInheritance(environmentsToImport)) {
       try {
         const isDuplicate = environment.status === ENV_STATUS.DUPLICATE;
+        const environmentToImport = { ...environment, extends: inheritedNameFor(environment) };
 
         if (isDuplicate) {
           const resolution = itemResolutions.get(environment.id) || RESOLUTION_TYPES.CREATE_NEW;
@@ -39,8 +47,9 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
           if (resolution === RESOLUTION_TYPES.REPLACE && !replacedNames.has(normalizedName)) {
             const existingEnv = getExistingEnv(environment.name);
             if (existingEnv) {
-              await saveEnv(environment, existingEnv);
+              await saveEnv(environmentToImport, existingEnv);
               replacedNames.add(normalizedName);
+              importedNames.set(environment.name, existingEnv.name);
               importedCount++;
             } else {
               throw new Error(`Environment ${environment.name} not found for replacement`);
@@ -49,7 +58,8 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
             // copy
             const copyName = generateCopyName(environment.name, currentExistingNames);
             currentExistingNames.push(copyName);
-            await createEnv(copyName, environment);
+            await createEnv(copyName, environmentToImport);
+            importedNames.set(environment.name, copyName);
             importedCount++;
           }
         } else {
@@ -57,7 +67,8 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
             ? generateCopyName(environment.name, currentExistingNames)
             : environment.name;
           currentExistingNames.push(name);
-          await createEnv(name, environment);
+          await createEnv(name, environmentToImport);
+          importedNames.set(environment.name, name);
           importedCount++;
         }
       } catch (error) {

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentTarget/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentTarget/index.js
@@ -1,7 +1,7 @@
 import { useMemo, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { importEnvironment, saveEnvironment, updateEnvironmentColor } from 'providers/ReduxStore/slices/collections/actions';
-import { addGlobalEnvironment, saveGlobalEnvironment, updateGlobalEnvironmentColor } from 'providers/ReduxStore/slices/global-environments';
+import { importEnvironment, saveEnvironment, saveEnvironmentExtends, updateEnvironmentColor } from 'providers/ReduxStore/slices/collections/actions';
+import { addGlobalEnvironment, saveGlobalEnvironment, saveGlobalEnvironmentExtends, updateGlobalEnvironmentColor } from 'providers/ReduxStore/slices/global-environments';
 import { normalizeEnvName } from 'utils/environments';
 
 export const useEnvironmentTarget = (type, collection) => {
@@ -25,12 +25,25 @@ export const useEnvironmentTarget = (type, collection) => {
         : updateEnvironmentColor(existingEnv.uid, environment.color, collection.uid);
       await dispatch(colorAction);
     }
+
+    // The replaced environment keeps its identity, so the parent named by the imported file only
+    // reaches it through the dedicated extends write.
+    if (environment.extends !== existingEnv.extends) {
+      const extendsAction = isGlobal
+        ? saveGlobalEnvironmentExtends({ environmentUid: existingEnv.uid, extends: environment.extends })
+        : saveEnvironmentExtends({
+            environmentUid: existingEnv.uid,
+            inheritedEnvironmentName: environment.extends,
+            collectionUid: collection.uid
+          });
+      await dispatch(extendsAction);
+    }
   }, [isGlobal, collection, dispatch]);
 
   const createEnv = useCallback(async (name, environment) => {
     const action = isGlobal
-      ? addGlobalEnvironment({ name, variables: environment.variables, color: environment.color })
-      : importEnvironment({ name, variables: environment.variables, color: environment.color, collectionUid: collection?.uid });
+      ? addGlobalEnvironment({ name, variables: environment.variables, color: environment.color, extends: environment.extends })
+      : importEnvironment({ name, variables: environment.variables, color: environment.color, extends: environment.extends, collectionUid: collection?.uid });
     await dispatch(action);
   }, [isGlobal, collection, dispatch]);
 

--- a/packages/bruno-app/src/components/Environments/Common/InheritsFrom/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/Common/InheritsFrom/StyledWrapper.js
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 4px;
+
+  .inherits-from-pill {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 8px;
+    border: 1px solid ${(props) => props.theme.input.border};
+    border-radius: 0.3rem;
+    background: transparent;
+    color: ${(props) => props.theme.colors.text.muted};
+    font-size: 11px;
+    line-height: 1.4;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.15s ease;
+
+    &:hover {
+      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+    }
+
+    .inherits-from-icon {
+      color: ${(props) => props.theme.colors.text.yellow};
+    }
+
+    .inherits-from-name {
+      color: ${(props) => props.theme.text};
+      font-weight: 500;
+      max-width: 160px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Environments/Common/InheritsFrom/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/InheritsFrom/index.js
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { getInheritableEnvironments } from '@usebruno/common/utils';
+import { IconBinaryTree2, IconCaretDown } from '@tabler/icons';
+import MenuDropdown from 'ui/MenuDropdown';
+import ActionIcon from 'ui/ActionIcon';
+import StyledWrapper from './StyledWrapper';
+
+const NO_INHERITANCE_ID = 'no-environment';
+
+const ColorDot = ({ color }) => (
+  <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: color || 'transparent' }} />
+);
+
+const InheritsFrom = ({ environment, environments, inheritedEnvironmentName, onChange }) => {
+  const inheritableEnvironments = useMemo(
+    () => getInheritableEnvironments({ environments, targetEnvironment: environment }),
+    [environments, environment]
+  );
+
+  const items = useMemo(
+    () => [
+      {
+        name: 'Inherit variables from',
+        options: [
+          {
+            id: NO_INHERITANCE_ID,
+            label: 'No Environment',
+            leftSection: <ColorDot />,
+            onClick: () => onChange(null)
+          },
+          ...inheritableEnvironments.map((env) => ({
+            id: env.name,
+            label: env.name,
+            leftSection: <ColorDot color={env.color} />,
+            onClick: () => inheritedEnvironmentName !== env.name && onChange(env.name)
+          }))
+        ]
+      }
+    ],
+    [inheritableEnvironments, inheritedEnvironmentName, onChange]
+  );
+
+  if (!inheritableEnvironments.length && typeof inheritedEnvironmentName !== 'string') {
+    return null;
+  }
+
+  return (
+    <StyledWrapper>
+      <MenuDropdown
+        items={items}
+        selectedItemId={inheritedEnvironmentName || NO_INHERITANCE_ID}
+        data-testid="env-inherits-from"
+      >
+        {typeof inheritedEnvironmentName === 'string' ? (
+          <button type="button" className="inherits-from-pill" data-testid="env-inherits-from-action">
+            <IconBinaryTree2 className="inherits-from-icon" size={14} strokeWidth={1.5} />
+            <span>Inherits from:</span>
+            <span className="inherits-from-name">{inheritedEnvironmentName}</span>
+            <IconCaretDown size={12} strokeWidth={2} />
+          </button>
+        ) : (
+          <ActionIcon label="Inherit variables from" data-testid="env-inherits-from-action">
+            <IconBinaryTree2 size={15} strokeWidth={1.5} />
+          </ActionIcon>
+        )}
+      </MenuDropdown>
+    </StyledWrapper>
+  );
+};
+
+export default InheritsFrom;

--- a/packages/bruno-app/src/components/Environments/Common/MissingInheritedEnvironmentWarning/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/Common/MissingInheritedEnvironmentWarning/StyledWrapper.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: ${(props) => props.theme.status.danger.text};
+  background-color: ${(props) => props.theme.status.danger.background};
+  border-radius: ${(props) => props.theme.border.radius.base};
+  padding: 0.375rem 0.5rem;
+  margin: 0 20px 8px;
+  font-size: ${(props) => props.theme.font.size.sm};
+
+  .warning-icon {
+    flex-shrink: 0;
+  }
+
+  .missing-name {
+    font-weight: 600;
+    word-break: break-all;
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Environments/Common/MissingInheritedEnvironmentWarning/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/MissingInheritedEnvironmentWarning/index.js
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { IconAlertTriangle } from '@tabler/icons';
+import { getInheritedEnvironments } from '@usebruno/common/utils';
+import StyledWrapper from './StyledWrapper';
+
+const MissingInheritedEnvironmentWarning = ({ environment, environments }) => {
+  const { missingInheritedEnvironmentName } = useMemo(
+    () => getInheritedEnvironments({ environments: environments || [], environment }),
+    [environments, environment]
+  );
+
+  if (!missingInheritedEnvironmentName) {
+    return null;
+  }
+
+  return (
+    <StyledWrapper data-testid="env-missing-inherited-environment">
+      <IconAlertTriangle size={16} strokeWidth={1.5} className="warning-icon" />
+      <span>
+        Referenced parent environment not found:{' '}
+        <span className="missing-name">{missingInheritedEnvironmentName}</span>
+      </span>
+    </StyledWrapper>
+  );
+};
+
+export default MissingInheritedEnvironmentWarning;

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
@@ -9,7 +9,7 @@ import SensitiveFieldWarning from 'components/SensitiveFieldWarning';
 import EnvironmentVariablesTable from 'components/EnvironmentVariablesTable';
 import { sensitiveFields } from './constants';
 
-const EnvironmentVariables = ({ environment, setIsModified, collection, searchQuery = '', variableType = 'variables' }) => {
+const EnvironmentVariables = ({ environment, setIsModified, collection, inheritedEnvironmentVariables, searchQuery = '', variableType = 'variables' }) => {
   const dispatch = useDispatch();
 
   const environmentsDraft = collection?.environmentsDraft;
@@ -105,6 +105,7 @@ const EnvironmentVariables = ({ environment, setIsModified, collection, searchQu
     <EnvironmentVariablesTable
       key={environment?.uid}
       environment={environment}
+      inheritedEnvironmentVariables={inheritedEnvironmentVariables}
       collection={collection}
       onSave={handleSave}
       draft={hasDraftForThisEnv ? environmentsDraft : null}

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
@@ -1,12 +1,15 @@
 import { IconCopy, IconEdit, IconTrash, IconCheck, IconX, IconSearch, IconDeviceFloppy } from '@tabler/icons';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { renameEnvironment, updateEnvironmentColor } from 'providers/ReduxStore/slices/collections/actions';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
+import { renameEnvironment, saveEnvironmentExtends, updateEnvironmentColor } from 'providers/ReduxStore/slices/collections/actions';
 import { validateName, validateNameError } from 'utils/common/regex';
 import toast from 'react-hot-toast';
 import CopyEnvironment from 'components/Environments/EnvironmentSettings/CopyEnvironment';
 import DeleteEnvironment from 'components/Environments/EnvironmentSettings/DeleteEnvironment';
 import EnvironmentVariables from './EnvironmentVariables';
+import InheritsFrom from 'components/Environments/Common/InheritsFrom';
+import MissingInheritedEnvironmentWarning from 'components/Environments/Common/MissingInheritedEnvironmentWarning';
 import ColorPicker from 'components/ColorPicker';
 import ActionIcon from 'ui/ActionIcon';
 import ResponsiveTabs from 'ui/ResponsiveTabs';
@@ -27,7 +30,21 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
   const activeTab = useSelector((state) => state.tabs.tabs.find((t) => t.uid === activeTabUid)?.tabState?.environment?.tab) || 'variables';
   const setActiveTab = (tab) => dispatch(updateTabState({ uid: activeTabUid, tabState: { environment: { tab } } }));
 
-  const tabs = useEnvironmentTabs({ environment, draft: collection?.environmentsDraft });
+  const environmentsDraft = collection?.environmentsDraft;
+
+  const inheritedEnvironmentVariables = useMemo(() => {
+    const draft = environmentsDraft?.environmentUid === environment.uid ? environmentsDraft : null;
+    const liveEnvironment = { ...environment, variables: draft?.variables || environment.variables || [] };
+    const { inheritedVariables } = resolveEnvironmentInheritance({
+      environments: collection?.environments || [],
+      targetEnvironment: liveEnvironment
+    });
+    return inheritedVariables;
+  }, [environment, environmentsDraft, collection?.environments]);
+
+  const tabs = useEnvironmentTabs({ environment, draft: environmentsDraft, inheritedEnvironmentVariables });
+
+  const inheritedEnvironmentVariablesForActiveTab = inheritedEnvironmentVariables.filter((variable) => !!variable.secret === (activeTab === 'secrets'));
 
   // Use the immediate query on a tab switch (debounced value lags and briefly
   // flashes the unfiltered table).
@@ -153,6 +170,21 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
     dispatch(updateEnvironmentColor(environment.uid, color, collection.uid));
   };
 
+  const handleExtendsChange = (inheritedEnvironmentName) => {
+    dispatch(saveEnvironmentExtends({ environmentUid: environment.uid, inheritedEnvironmentName, collectionUid: collection.uid }))
+      .then(() => {
+        toast.success(
+          inheritedEnvironmentName
+            ? `Inheriting variables from ${inheritedEnvironmentName}`
+            : 'Stopped inheriting variables'
+        );
+      })
+      .catch((err) => {
+        console.error(err);
+        toast.error('An error occurred while saving the inherited environment');
+      });
+  };
+
   const handleSaveAll = () => {
     window.dispatchEvent(new Event('environment-save-all'));
   };
@@ -174,6 +206,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
                 ref={inputRef}
                 type="text"
                 className="title-input"
+                data-testid="env-rename-input"
                 value={newName}
                 onChange={handleNameChange}
                 onBlur={handleNameBlur}
@@ -204,13 +237,19 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
             </>
           ) : (
             <div className="flex items-center gap-2">
-              <h2 className="title">{environment.name}</h2>
+              <h2 className="title" data-testid="env-details-title">{environment.name}</h2>
               <ColorPicker color={environment.color} onChange={handleColorChange} />
             </div>
           )}
         </div>
         {nameError && isRenaming && <div className="title-error">{nameError}</div>}
         <div className="actions">
+          <InheritsFrom
+            environment={environment}
+            environments={environments}
+            inheritedEnvironmentName={environment.extends}
+            onChange={handleExtendsChange}
+          />
           <ActionIcon label="Save All" onClick={handleSaveAll} data-testid="save-all-env">
             <IconDeviceFloppy size={15} strokeWidth={1.5} />
           </ActionIcon>
@@ -225,6 +264,8 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
           </ActionIcon>
         </div>
       </div>
+
+      <MissingInheritedEnvironmentWarning environment={environment} environments={environments} />
 
       <div className="tabs-container">
         <ResponsiveTabs
@@ -278,6 +319,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
           environment={environment}
           setIsModified={setIsModified}
           collection={collection}
+          inheritedEnvironmentVariables={inheritedEnvironmentVariablesForActiveTab}
           searchQuery={tableSearchQuery}
           variableType={activeTab}
         />

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/index.js
@@ -44,7 +44,10 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
 
   const tabs = useEnvironmentTabs({ environment, draft: environmentsDraft, inheritedEnvironmentVariables });
 
-  const inheritedEnvironmentVariablesForActiveTab = inheritedEnvironmentVariables.filter((variable) => !!variable.secret === (activeTab === 'secrets'));
+  const inheritedEnvironmentVariablesForActiveTab = useMemo(
+    () => inheritedEnvironmentVariables.filter((variable) => !!variable.secret === (activeTab === 'secrets')),
+    [inheritedEnvironmentVariables, activeTab]
+  );
 
   // Use the immediate query on a tab switch (debounced value lags and briefly
   // flashes the unfiltered table).

--- a/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSettings/EnvironmentList/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef, useCallback } from 'react';
 import usePrevious from 'hooks/usePrevious';
 import useOnClickOutside from 'hooks/useOnClickOutside';
 import useDebounce from 'hooks/useDebounce';
+import { EnvironmentSelectionProvider } from 'hooks/useEnvironmentSelection';
 import EnvironmentDetails from './EnvironmentDetails';
 import { IconDownload, IconUpload, IconSearch, IconPlus, IconCheck, IconX, IconFileAlert } from '@tabler/icons';
 import Button from 'ui/Button';
@@ -506,18 +507,20 @@ const EnvironmentList = ({
 
     if (selectedEnvironment) {
       return (
-        <EnvironmentDetails
-          environment={selectedEnvironment}
-          setIsModified={setIsModified}
-          originalEnvironmentVariables={originalEnvironmentVariables}
-          collection={collection}
-          searchQuery={envSearchQuery}
-          setSearchQuery={setEnvSearchQuery}
-          isSearchExpanded={isEnvSearchExpanded}
-          setIsSearchExpanded={setIsEnvSearchExpanded}
-          debouncedSearchQuery={debouncedEnvSearchQuery}
-          searchInputRef={envSearchInputRef}
-        />
+        <EnvironmentSelectionProvider environments={environments} onSelect={handleEnvironmentClick}>
+          <EnvironmentDetails
+            environment={selectedEnvironment}
+            setIsModified={setIsModified}
+            originalEnvironmentVariables={originalEnvironmentVariables}
+            collection={collection}
+            searchQuery={envSearchQuery}
+            setSearchQuery={setEnvSearchQuery}
+            isSearchExpanded={isEnvSearchExpanded}
+            setIsSearchExpanded={setIsEnvSearchExpanded}
+            debouncedSearchQuery={debouncedEnvSearchQuery}
+            searchInputRef={envSearchInputRef}
+          />
+        </EnvironmentSelectionProvider>
       );
     }
 

--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -25,6 +25,7 @@ import StyledWrapper from './StyledWrapper';
 import { updateRequestGraphqlQuery, updateRequestGraphqlVariables } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import useGraphqlSchema from '../GraphQLSchemaActions/useGraphqlSchema';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import { findEnvironmentInCollection } from 'utils/collections';
 import { hasEffectiveAuth } from 'utils/auth';
 import HeightBoundContainer from 'ui/HeightBoundContainer';
@@ -73,7 +74,10 @@ const GraphQLRequestPane = ({ item, collection, onSchemaLoad, toggleDocs, handle
   const url = item.draft ? get(item, 'draft.request.url', '') : get(item, 'request.url', '');
   const pathname = item.draft ? get(item, 'draft.pathname', '') : get(item, 'pathname', '');
   const uid = item.draft ? get(item, 'draft.uid', '') : get(item, 'uid', '');
-  const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+  const environment = resolveEnvironmentInheritance({
+    environments: collection.environments,
+    targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
+  });
   const request = item.draft ? { ...item.draft.request, pathname, uid } : { ...item.request, pathname, uid };
 
   const { schema, schemaSource, loadSchema, isLoading: isSchemaLoading, error: schemaError } = useGraphqlSchema(url, environment, request, collection);

--- a/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLRequestPane/index.js
@@ -74,10 +74,14 @@ const GraphQLRequestPane = ({ item, collection, onSchemaLoad, toggleDocs, handle
   const url = item.draft ? get(item, 'draft.request.url', '') : get(item, 'request.url', '');
   const pathname = item.draft ? get(item, 'draft.pathname', '') : get(item, 'pathname', '');
   const uid = item.draft ? get(item, 'draft.uid', '') : get(item, 'uid', '');
-  const environment = resolveEnvironmentInheritance({
-    environments: collection.environments,
-    targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
-  });
+  const environment = useMemo(
+    () =>
+      resolveEnvironmentInheritance({
+        environments: collection.environments,
+        targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
+      }),
+    [collection.environments, collection.activeEnvironmentUid]
+  );
   const request = item.draft ? { ...item.draft.request, pathname, uid } : { ...item.request, pathname, uid };
 
   const { schema, schemaSource, loadSchema, isLoading: isSchemaLoading, error: schemaError } = useGraphqlSchema(url, environment, request, collection);

--- a/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, forwardRef } from 'react';
 import useGraphqlSchema from './useGraphqlSchema';
 import { IconBook, IconDownload, IconLoader2, IconRefresh } from '@tabler/icons';
 import get from 'lodash/get';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import { findEnvironmentInCollection } from 'utils/collections';
 import Dropdown from '../../Dropdown';
 
@@ -9,7 +10,10 @@ const GraphQLSchemaActions = ({ item, collection, onSchemaLoad, toggleDocs }) =>
   const url = item.draft ? get(item, 'draft.request.url', '') : get(item, 'request.url', '');
   const pathname = item.draft ? get(item, 'draft.pathname', '') : get(item, 'pathname', '');
   const uid = item.draft ? get(item, 'draft.uid', '') : get(item, 'uid', '');
-  const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+  const environment = resolveEnvironmentInheritance({
+    environments: collection.environments,
+    targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
+  });
   const request = item.draft ? { ...item.draft.request, pathname, uid } : { ...item.request, pathname, uid };
 
   let {

--- a/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/index.js
+++ b/packages/bruno-app/src/components/RequestPane/GraphQLSchemaActions/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, forwardRef } from 'react';
+import React, { useEffect, useMemo, useRef, forwardRef } from 'react';
 import useGraphqlSchema from './useGraphqlSchema';
 import { IconBook, IconDownload, IconLoader2, IconRefresh } from '@tabler/icons';
 import get from 'lodash/get';
@@ -10,10 +10,14 @@ const GraphQLSchemaActions = ({ item, collection, onSchemaLoad, toggleDocs }) =>
   const url = item.draft ? get(item, 'draft.request.url', '') : get(item, 'request.url', '');
   const pathname = item.draft ? get(item, 'draft.pathname', '') : get(item, 'pathname', '');
   const uid = item.draft ? get(item, 'draft.uid', '') : get(item, 'uid', '');
-  const environment = resolveEnvironmentInheritance({
-    environments: collection.environments,
-    targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
-  });
+  const environment = useMemo(
+    () =>
+      resolveEnvironmentInheritance({
+        environments: collection.environments,
+        targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid)
+      }),
+    [collection.environments, collection.activeEnvironmentUid]
+  );
   const request = item.draft ? { ...item.draft.request, pathname, uid } : { ...item.request, pathname, uid };
 
   let {

--- a/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/bruno-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -1,4 +1,5 @@
 import { IconTrash, IconSend, IconChevronRight, IconChevronDown } from '@tabler/icons';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import CodeEditor from 'components/CodeEditor/index';
 import ToolHint from 'components/ToolHint/index';
 import { get } from 'lodash';
@@ -162,7 +163,10 @@ export const SingleWSMessage = ({
   const onSendMessage = useCallback(async () => {
     try {
       const col = findCollectionByUid(collections, collection.uid);
-      const environment = findEnvironmentInCollection(col, col?.activeEnvironmentUid);
+      const environment = resolveEnvironmentInheritance({
+        environments: col?.environments,
+        targetEnvironment: findEnvironmentInCollection(col, col?.activeEnvironmentUid)
+      });
 
       // Auto-connect if needed; while CONNECTING just queue — open flushes.
       await ensureWsConnection(item, col, environment, col?.runtimeVariables);

--- a/packages/bruno-app/src/components/RequestTabPanel/index.js
+++ b/packages/bruno-app/src/components/RequestTabPanel/index.js
@@ -115,6 +115,8 @@ const RequestTabPanel = () => {
       const globalEnvSecrets = getGlobalEnvironmentVariablesMasked({ globalEnvironments, activeGlobalEnvironmentUid });
       collection.globalEnvironmentVariables = globalEnvironmentVariables;
       collection.globalEnvSecrets = globalEnvSecrets;
+      collection.globalEnvironments = globalEnvironments;
+      collection.activeGlobalEnvironmentUid = activeGlobalEnvironmentUid;
     }
   });
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/CodeView/index.js
@@ -29,6 +29,8 @@ const CodeView = ({ language, item }) => {
     });
     c.globalEnvironmentVariables = globalEnvironmentVariables;
     c.globalEnvSecrets = getGlobalEnvironmentVariablesMasked({ globalEnvironments, activeGlobalEnvironmentUid });
+    c.globalEnvironments = globalEnvironments;
+    c.activeGlobalEnvironmentUid = activeGlobalEnvironmentUid;
     return c;
   }, [collectionOriginal, globalEnvironments, activeGlobalEnvironmentUid]);
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/index.js
@@ -5,9 +5,6 @@ import CodeViewToolbar from './CodeViewToolbar';
 import StyledWrapper from './StyledWrapper';
 import { isValidUrl } from 'utils/url';
 import { get } from 'lodash';
-import {
-  findEnvironmentInCollection
-} from 'utils/collections';
 import { interpolateUrl, interpolateUrlPathParams } from 'utils/url/index';
 import { getLanguages } from 'utils/codegenerator/targets';
 import { useSelector } from 'react-redux';
@@ -31,16 +28,6 @@ const GenerateCodeItem = ({ collectionUid, item, onClose, isExample = false, exa
     globalEnvironments,
     activeGlobalEnvironmentUid
   });
-  const environment = findEnvironmentInCollection(collection, collection?.activeEnvironmentUid);
-
-  let envVars = {};
-  if (environment) {
-    const vars = get(environment, 'variables', []);
-    envVars = vars.reduce((acc, curr) => {
-      acc[curr.name] = curr.value;
-      return acc;
-    }, {});
-  }
 
   // Function to handle normal request data
   const getNormalRequestData = () => {

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.js
@@ -1,5 +1,4 @@
-import React, { useCallback, useRef, useMemo } from 'react';
-import { TableVirtuoso } from 'react-virtuoso';
+import React, { useCallback } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -9,9 +8,9 @@ import {
 } from 'providers/ReduxStore/slices/global-environments';
 import EnvironmentVariablesTable from 'components/EnvironmentVariablesTable';
 
-const EnvironmentVariables = ({ environment, setIsModified, collection, searchQuery = '', variableType = 'variables' }) => {
+const EnvironmentVariables = ({ environment, setIsModified, collection, inheritedEnvironmentVariables, searchQuery = '', variableType = 'variables' }) => {
   const dispatch = useDispatch();
-  const { globalEnvironmentDraft } = useSelector((state) => state.globalEnvironments);
+  const globalEnvironmentDraft = useSelector((state) => state.globalEnvironments.globalEnvironmentDraft);
 
   const hasDraftForThisEnv = globalEnvironmentDraft?.environmentUid === environment.uid;
 
@@ -42,6 +41,7 @@ const EnvironmentVariables = ({ environment, setIsModified, collection, searchQu
     <EnvironmentVariablesTable
       key={environment?.uid}
       environment={environment}
+      inheritedEnvironmentVariables={inheritedEnvironmentVariables}
       collection={collection}
       onSave={handleSave}
       draft={hasDraftForThisEnv ? globalEnvironmentDraft : null}

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
@@ -1,13 +1,20 @@
 import { IconCopy, IconEdit, IconTrash, IconCheck, IconX, IconSearch, IconDeviceFloppy } from '@tabler/icons';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { renameGlobalEnvironment, updateGlobalEnvironmentColor } from 'providers/ReduxStore/slices/global-environments';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
+import {
+  renameGlobalEnvironment,
+  saveGlobalEnvironmentExtends,
+  updateGlobalEnvironmentColor
+} from 'providers/ReduxStore/slices/global-environments';
 import { updateTabState } from 'providers/ReduxStore/slices/tabs';
 import { validateName, validateNameError } from 'utils/common/regex';
 import toast from 'react-hot-toast';
 import CopyEnvironment from '../../CopyEnvironment';
 import DeleteEnvironment from '../../DeleteEnvironment';
 import EnvironmentVariables from './EnvironmentVariables';
+import InheritsFrom from 'components/Environments/Common/InheritsFrom';
+import MissingInheritedEnvironmentWarning from 'components/Environments/Common/MissingInheritedEnvironmentWarning';
 import ColorPicker from 'components/ColorPicker';
 import ActionIcon from 'ui/ActionIcon';
 import ResponsiveTabs from 'ui/ResponsiveTabs';
@@ -28,7 +35,19 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
   const activeTab = useSelector((state) => state.tabs.tabs.find((t) => t.uid === activeTabUid)?.tabState?.environment?.tab) || 'variables';
   const setActiveTab = (tab) => dispatch(updateTabState({ uid: activeTabUid, tabState: { environment: { tab } } }));
 
-  const tabs = useEnvironmentTabs({ environment, draft: globalEnvironmentDraft });
+  const inheritedEnvironmentVariables = useMemo(() => {
+    const draft = globalEnvironmentDraft?.environmentUid === environment.uid ? globalEnvironmentDraft : null;
+    const liveEnvironment = { ...environment, variables: draft?.variables || environment.variables || [] };
+    const { inheritedVariables } = resolveEnvironmentInheritance({
+      environments: globalEnvs || [],
+      targetEnvironment: liveEnvironment
+    });
+    return inheritedVariables;
+  }, [environment, globalEnvironmentDraft, globalEnvs]);
+
+  const tabs = useEnvironmentTabs({ environment, draft: globalEnvironmentDraft, inheritedEnvironmentVariables });
+
+  const inheritedEnvironmentVariablesForActiveTab = inheritedEnvironmentVariables.filter((variable) => !!variable.secret === (activeTab === 'secrets'));
 
   // Use the immediate query on a tab switch (debounced value lags and briefly
   // flashes the unfiltered table).
@@ -153,6 +172,23 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
     dispatch(updateGlobalEnvironmentColor(environment.uid, color));
   };
 
+  const handleExtendsChange = (inheritedEnvironmentName) => {
+    dispatch(
+      saveGlobalEnvironmentExtends({ environmentUid: environment.uid, extends: inheritedEnvironmentName })
+    )
+      .then(() => {
+        toast.success(
+          inheritedEnvironmentName
+            ? `Inheriting variables from ${inheritedEnvironmentName}`
+            : 'Stopped inheriting variables'
+        );
+      })
+      .catch((err) => {
+        console.error(err);
+        toast.error('An error occurred while saving the inherited environment');
+      });
+  };
+
   const handleSaveAll = () => {
     window.dispatchEvent(new Event('environment-save-all'));
   };
@@ -177,6 +213,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
                 ref={inputRef}
                 type="text"
                 className="title-input"
+                data-testid="env-rename-input"
                 value={newName}
                 onChange={handleNameChange}
                 onBlur={handleNameBlur}
@@ -207,13 +244,19 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
             </>
           ) : (
             <div className="flex items-center gap-2">
-              <h2 className="title">{environment.name}</h2>
+              <h2 className="title" data-testid="env-details-title">{environment.name}</h2>
               <ColorPicker color={environment.color} onChange={handleColorChange} />
             </div>
           )}
         </div>
         {nameError && isRenaming && <div className="title-error">{nameError}</div>}
         <div className="actions">
+          <InheritsFrom
+            environment={environment}
+            environments={globalEnvs || []}
+            inheritedEnvironmentName={environment.extends}
+            onChange={handleExtendsChange}
+          />
           <ActionIcon label="Save All" onClick={handleSaveAll} data-testid="save-all-env">
             <IconDeviceFloppy size={15} strokeWidth={1.5} />
           </ActionIcon>
@@ -228,6 +271,8 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
           </ActionIcon>
         </div>
       </div>
+
+      <MissingInheritedEnvironmentWarning environment={environment} environments={globalEnvs || []} />
 
       <div className="tabs-container">
         <ResponsiveTabs
@@ -281,6 +326,7 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
           environment={environment}
           setIsModified={setIsModified}
           collection={collection}
+          inheritedEnvironmentVariables={inheritedEnvironmentVariablesForActiveTab}
           searchQuery={tableSearchQuery}
           variableType={activeTab}
         />

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/EnvironmentDetails/index.js
@@ -47,7 +47,10 @@ const EnvironmentDetails = ({ environment, setIsModified, collection, searchQuer
 
   const tabs = useEnvironmentTabs({ environment, draft: globalEnvironmentDraft, inheritedEnvironmentVariables });
 
-  const inheritedEnvironmentVariablesForActiveTab = inheritedEnvironmentVariables.filter((variable) => !!variable.secret === (activeTab === 'secrets'));
+  const inheritedEnvironmentVariablesForActiveTab = useMemo(
+    () => inheritedEnvironmentVariables.filter((variable) => !!variable.secret === (activeTab === 'secrets')),
+    [inheritedEnvironmentVariables, activeTab]
+  );
 
   // Use the immediate query on a tab switch (debounced value lags and briefly
   // flashes the unfiltered table).

--- a/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/index.js
+++ b/packages/bruno-app/src/components/WorkspaceHome/WorkspaceEnvironments/EnvironmentList/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef, useCallback } from 'react';
 import usePrevious from 'hooks/usePrevious';
 import useOnClickOutside from 'hooks/useOnClickOutside';
 import useDebounce from 'hooks/useDebounce';
+import { EnvironmentSelectionProvider } from 'hooks/useEnvironmentSelection';
 import EnvironmentDetails from './EnvironmentDetails';
 import { IconDownload, IconUpload, IconSearch, IconPlus, IconCheck, IconX, IconFileAlert } from '@tabler/icons';
 import Button from 'ui/Button';
@@ -513,18 +514,20 @@ const EnvironmentList = ({
 
     if (selectedEnvironment) {
       return (
-        <EnvironmentDetails
-          environment={selectedEnvironment}
-          setIsModified={setIsModified}
-          originalEnvironmentVariables={originalEnvironmentVariables}
-          collection={collection}
-          searchQuery={envSearchQuery}
-          setSearchQuery={setEnvSearchQuery}
-          isSearchExpanded={isEnvSearchExpanded}
-          setIsSearchExpanded={setIsEnvSearchExpanded}
-          debouncedSearchQuery={debouncedEnvSearchQuery}
-          searchInputRef={envSearchInputRef}
-        />
+        <EnvironmentSelectionProvider environments={environments} onSelect={handleEnvironmentClick}>
+          <EnvironmentDetails
+            environment={selectedEnvironment}
+            setIsModified={setIsModified}
+            originalEnvironmentVariables={originalEnvironmentVariables}
+            collection={collection}
+            searchQuery={envSearchQuery}
+            setSearchQuery={setEnvSearchQuery}
+            isSearchExpanded={isEnvSearchExpanded}
+            setIsSearchExpanded={setIsEnvSearchExpanded}
+            debouncedSearchQuery={debouncedEnvSearchQuery}
+            searchInputRef={envSearchInputRef}
+          />
+        </EnvironmentSelectionProvider>
       );
     }
 

--- a/packages/bruno-app/src/hooks/useEnvironmentSelection/index.js
+++ b/packages/bruno-app/src/hooks/useEnvironmentSelection/index.js
@@ -1,0 +1,11 @@
+import React, { createContext, useContext } from 'react';
+
+const EnvironmentSelectionContext = createContext({});
+
+export const EnvironmentSelectionProvider = ({ environments, onSelect, children }) => (
+  <EnvironmentSelectionContext.Provider value={{ environments, onSelect }}>
+    {children}
+  </EnvironmentSelectionContext.Provider>
+);
+
+export const useEnvironmentSelection = () => useContext(EnvironmentSelectionContext);

--- a/packages/bruno-app/src/hooks/useEnvironmentTabs/index.js
+++ b/packages/bruno-app/src/hooks/useEnvironmentTabs/index.js
@@ -3,7 +3,7 @@ import { stripEnvVarUid } from 'utils/environments';
 
 const belongsToTab = (variable, isSecret) => (isSecret ? !!variable.secret : !variable.secret);
 
-const useEnvironmentTabs = ({ environment, draft }) =>
+const useEnvironmentTabs = ({ environment, draft, inheritedEnvironmentVariables = [] }) =>
   useMemo(() => {
     const environmentsDraft = draft?.environmentUid === environment?.uid ? draft : null;
 
@@ -16,11 +16,13 @@ const useEnvironmentTabs = ({ environment, draft }) =>
 
     // Reflects the live draft while editing, else the saved values.
     const liveVariables = environmentsDraft?.variables || environment?.variables || [];
-    const countForTab = (isSecret) =>
+    const ownVariablesCountForTab = (isSecret) =>
       liveVariables.filter((v) => belongsToTab(v, isSecret) && v.enabled && v.name && v.name.trim() !== '').length;
 
+    const inheritedVariablesCountForTab = (isSecret) => inheritedEnvironmentVariables.filter((v) => belongsToTab(v, isSecret)).length;
+
     const tabIndicator = (isSecret) => {
-      const count = countForTab(isSecret);
+      const count = ownVariablesCountForTab(isSecret) + inheritedVariablesCountForTab(isSecret);
       if (count === 0) return null;
       return (
         <sup
@@ -36,6 +38,6 @@ const useEnvironmentTabs = ({ environment, draft }) =>
       { key: 'variables', label: 'Variables', indicator: tabIndicator(false) },
       { key: 'secrets', label: 'Secrets', indicator: tabIndicator(true) }
     ];
-  }, [draft, environment?.uid, environment?.variables]);
+  }, [draft, environment, inheritedEnvironmentVariables]);
 
 export default useEnvironmentTabs;

--- a/packages/bruno-app/src/hooks/useEnvironmentTabs/index.spec.js
+++ b/packages/bruno-app/src/hooks/useEnvironmentTabs/index.spec.js
@@ -1,0 +1,87 @@
+const { describe, it, expect } = require('@jest/globals');
+import { render, renderHook, within } from '@testing-library/react';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
+import useEnvironmentTabs from './index';
+
+const variable = (name, overrides = {}) => ({ uid: name, name, value: '', enabled: true, secret: false, ...overrides });
+
+// Mirrors how EnvironmentDetails resolves the inherited variables before handing them to the hook.
+const renderTabs = ({ environment, draft, environments }) =>
+  renderHook(() => {
+    const liveEnvironment = { ...environment, variables: draft?.variables || environment.variables };
+    const { inheritedVariables } = resolveEnvironmentInheritance({ environments, targetEnvironment: liveEnvironment });
+    return useEnvironmentTabs({ environment, draft, inheritedEnvironmentVariables: inheritedVariables });
+  });
+
+const countOnTab = (tabs, key) => {
+  const { indicator } = tabs.find((tab) => tab.key === key);
+  if (!indicator) return null;
+  const { container } = render(indicator);
+  return within(container).getByTestId('env-tab-count').textContent;
+};
+
+describe('useEnvironmentTabs', () => {
+  it('counts only the environment own variables when it inherits nothing', () => {
+    const environment = {
+      uid: 'env-dev',
+      name: 'Dev',
+      variables: [variable('host'), variable('port'), variable('token', { secret: true })]
+    };
+
+    const { result } = renderTabs({ environment, environments: [environment] });
+
+    expect(countOnTab(result.current, 'variables')).toBe('2');
+    expect(countOnTab(result.current, 'secrets')).toBe('1');
+  });
+
+  it('adds the variables inherited from an ancestor to the count', () => {
+    const base = {
+      uid: 'env-base',
+      name: 'Base',
+      variables: [variable('host'), variable('region'), variable('token', { secret: true })]
+    };
+    const dev = {
+      uid: 'env-dev',
+      name: 'Dev',
+      extends: 'Base',
+      variables: [variable('port'), variable('apiKey', { secret: true })]
+    };
+
+    const { result } = renderTabs({ environment: dev, environments: [base, dev] });
+
+    expect(countOnTab(result.current, 'variables')).toBe('3');
+    expect(countOnTab(result.current, 'secrets')).toBe('2');
+  });
+
+  it('counts a redefined variable once', () => {
+    const base = { uid: 'env-base', name: 'Base', variables: [variable('host'), variable('region')] };
+    const dev = {
+      uid: 'env-dev',
+      name: 'Dev',
+      extends: 'Base',
+      variables: [variable('host', { value: 'localhost' })]
+    };
+
+    const { result } = renderTabs({ environment: dev, environments: [base, dev] });
+
+    expect(countOnTab(result.current, 'variables')).toBe('2');
+  });
+
+  it('keeps the inherited variables in the count while the environment own rows are a draft', () => {
+    const base = { uid: 'env-base', name: 'Base', variables: [variable('host')] };
+    const dev = { uid: 'env-dev', name: 'Dev', extends: 'Base', variables: [] };
+    const draft = { environmentUid: 'env-dev', variables: [variable('port')] };
+
+    const { result } = renderTabs({ environment: dev, draft, environments: [base, dev] });
+
+    expect(countOnTab(result.current, 'variables')).toBe('2');
+  });
+
+  it('shows no count on a tab whose variables are all disabled and none are inherited', () => {
+    const environment = { uid: 'env-dev', name: 'Dev', variables: [variable('host', { enabled: false })] };
+
+    const { result } = renderTabs({ environment, environments: [environment] });
+
+    expect(countOnTab(result.current, 'variables')).toBeNull();
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -1,5 +1,5 @@
 import { collectionSchema, environmentSchema, itemSchema } from '@usebruno/schema';
-import { parseQueryParams, extractPromptVariables, getDataTypeFromValue } from '@usebruno/common/utils';
+import { parseQueryParams, extractPromptVariables, getDataTypeFromValue, resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import { DEFAULT_HTTP_ITEM_SETTINGS } from '@usebruno/common';
 import { REQUEST_TYPES, DEFAULT_COLLECTION_FORMAT } from 'utils/common/constants';
 import cloneDeep from 'lodash/cloneDeep';
@@ -60,6 +60,7 @@ import {
   updateActiveConnections,
   saveRequest as _saveRequest,
   saveEnvironment as _saveEnvironment,
+  saveEnvironmentExtends as _saveEnvironmentExtends,
   updateEnvironmentColor as _updateEnvironmentColor,
   saveCollectionDraft,
   saveFolderDraft,
@@ -474,7 +475,10 @@ export const sendCollectionOauth2Request = (collectionUid, itemUid) => (dispatch
     });
     collectionCopy.globalEnvironmentVariables = globalEnvironmentVariables;
 
-    const environment = findEnvironmentInCollection(collectionCopy, collection.activeEnvironmentUid);
+    const environment = resolveEnvironmentInheritance({
+      environments: collectionCopy.environments,
+      targetEnvironment: findEnvironmentInCollection(collectionCopy, collection.activeEnvironmentUid)
+    });
 
     _sendCollectionOauth2Request(collectionCopy, environment, collectionCopy.runtimeVariables)
       .then((response) => {
@@ -515,7 +519,10 @@ export const wsConnectOnly = (item, collectionUid) => (dispatch, getState) => {
     });
     collectionCopy.globalEnvironmentVariables = globalEnvironmentVariables;
 
-    const environment = findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid);
+    const environment = resolveEnvironmentInheritance({
+      environments: collectionCopy.environments,
+      targetEnvironment: findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid)
+    });
 
     // WS connect does not run user scripts — no baseline to clear.
 
@@ -647,7 +654,10 @@ export const sendRequest = (item, collectionUid) => (dispatch, getState) => {
       })
     );
 
-    const environment = findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid);
+    const environment = resolveEnvironmentInheritance({
+      environments: collectionCopy.environments,
+      targetEnvironment: findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid)
+    });
     const isGrpcRequest = itemCopy.type === 'grpc-request';
     const isWsRequest = itemCopy.type === 'ws-request';
     if (isGrpcRequest) {
@@ -767,7 +777,10 @@ export const runCollectionFolder
         return reject(new Error('Folder not found'));
       }
 
-      const environment = findEnvironmentInCollection(collectionCopy, collection.activeEnvironmentUid);
+      const environment = resolveEnvironmentInheritance({
+        environments: collectionCopy.environments,
+        targetEnvironment: findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid)
+      });
 
       dispatch(
         resetRunResults({
@@ -1915,7 +1928,10 @@ export const loadGrpcMethodsFromReflection = (item, collectionUid, url) => async
       activeGlobalEnvironmentUid
     });
     collectionCopy.globalEnvironmentVariables = globalEnvironmentVariables;
-    const environment = findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid);
+    const environment = resolveEnvironmentInheritance({
+      environments: collectionCopy.environments,
+      targetEnvironment: findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid)
+    });
     const runtimeVariables = collectionCopy.runtimeVariables;
 
     try {
@@ -1961,7 +1977,10 @@ export const generateGrpcurlCommand = (item, collectionUid) => async (dispatch, 
       activeGlobalEnvironmentUid
     });
     collectionCopy.globalEnvironmentVariables = globalEnvironmentVariables;
-    const environment = findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid);
+    const environment = resolveEnvironmentInheritance({
+      environments: collectionCopy.environments,
+      targetEnvironment: findEnvironmentInCollection(collectionCopy, collectionCopy.activeEnvironmentUid)
+    });
     const runtimeVariables = collectionCopy.runtimeVariables;
 
     const { ipcRenderer } = window;
@@ -1999,7 +2018,7 @@ export const addEnvironment = (name, collectionUid) => (dispatch, getState) => {
   });
 };
 
-export const importEnvironment = ({ name, variables, color, collectionUid }) => (dispatch, getState) => {
+export const importEnvironment = ({ name, variables, color, extends: inheritedEnvironmentName, collectionUid }) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const state = getState();
     const collection = findCollectionByUid(state.collections.collections, collectionUid);
@@ -2011,7 +2030,7 @@ export const importEnvironment = ({ name, variables, color, collectionUid }) => 
 
     const { ipcRenderer } = window;
     ipcRenderer
-      .invoke('renderer:create-environment', collection.pathname, sanitizedName, variables, color)
+      .invoke('renderer:create-environment', collection.pathname, sanitizedName, variables, color, inheritedEnvironmentName)
       .then(
         dispatch(
           updateLastAction({
@@ -2048,7 +2067,7 @@ export const copyEnvironment = (name, baseEnvUid, collectionUid) => (dispatch, g
     const variablesToCopy = baseEnv.variables || [];
 
     ipcRenderer
-      .invoke('renderer:create-environment', collection.pathname, sanitizedName, variablesToCopy)
+      .invoke('renderer:create-environment', collection.pathname, sanitizedName, variablesToCopy, undefined, baseEnv.extends)
       .then(
         dispatch(
           updateLastAction({
@@ -2175,6 +2194,30 @@ export const updateEnvironmentColor = (environmentUid, color, collectionUid) => 
     ipcRenderer.invoke('renderer:update-environment-color', collection.pathname, environment.name, color)
       .then(() => {
         dispatch(_updateEnvironmentColor({ environmentUid, color, collectionUid }));
+        resolve();
+      })
+      .catch(reject);
+  });
+};
+
+export const saveEnvironmentExtends = ({ environmentUid, inheritedEnvironmentName, collectionUid }) => (dispatch, getState) => {
+  return new Promise((resolve, reject) => {
+    const state = getState();
+    const collection = findCollectionByUid(state.collections.collections, collectionUid);
+    if (!collection) {
+      return reject(new Error('Collection not found'));
+    }
+
+    const environment = findEnvironmentInCollection(collection, environmentUid);
+    if (!environment) {
+      return reject(new Error('Environment not found'));
+    }
+
+    const { ipcRenderer } = window;
+    ipcRenderer
+      .invoke('renderer:save-environment-extends', collection.pathname, environment.name, inheritedEnvironmentName)
+      .then(() => {
+        dispatch(_saveEnvironmentExtends({ environmentUid, collectionUid, extends: inheritedEnvironmentName }));
         resolve();
       })
       .catch(reject);

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/draft-env-merge.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/draft-env-merge.spec.js
@@ -31,8 +31,10 @@ const makeInitialState = (envVars = [], opts = {}) => ({
         {
           uid: ENV_UID,
           name: 'Test',
-          variables: envVars
-        }
+          variables: envVars,
+          ...(opts.inheritedVars ? { extends: 'Base' } : {})
+        },
+        ...(opts.inheritedVars ? [{ uid: 'env-base', name: 'Base', variables: opts.inheritedVars }] : [])
       ],
       environmentsDraft: opts.draft || null,
       _scriptEnvBaseline: opts.baseline || undefined,
@@ -103,6 +105,26 @@ describe('scriptEnvironmentUpdateEvent — draft-aware merge', () => {
 
       expect(getEnv(state).variables).toHaveLength(2);
       expect(getEnv(state).variables[1].name).toBe('DISABLED_VAR');
+    });
+  });
+
+  describe('inherited variables — a script write lands only when the value differs', () => {
+    test('a write of the value already inherited leaves the environment empty', () => {
+      let state = makeInitialState([], { inheritedVars: [makeVar('BASE_ONLY', 'base_only_value')] });
+
+      state = reducer(state, scriptEvent({ BASE_ONLY: 'base_only_value', __name__: 'Test' }));
+
+      expect(getEnv(state).variables).toEqual([]);
+    });
+
+    test('a write of a different value becomes a row of the environment own', () => {
+      let state = makeInitialState([], { inheritedVars: [makeVar('SESSION_ID', 'base_session')] });
+
+      state = reducer(state, scriptEvent({ SESSION_ID: 'script_session', __name__: 'Test' }));
+
+      expect(getEnv(state).variables).toEqual([
+        expect.objectContaining({ name: 'SESSION_ID', value: 'script_session', enabled: true })
+      ]);
     });
   });
 
@@ -506,6 +528,14 @@ describe('scriptEnvironmentUpdateEvent — draft-aware merge', () => {
       const v = getEnv(state).variables.find((v) => v.name === 'CONFIG');
       expect(v.value).toEqual({ port: 3000 });
       expect(v.dataType).toBe('object');
+    });
+
+    test('leaves an inherited typed var the script echoed back unchanged out of the environment', () => {
+      let state = makeInitialState([], { inheritedVars: [{ ...makeVar('PORT', '3000'), dataType: 'number' }] });
+
+      state = reducer(state, scriptEvent({ PORT: 3000, __name__: 'Test' }));
+
+      expect(getEnv(state).variables).toEqual([]);
     });
 
     test('keeps existing dataType on a typed var the script did not touch', () => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/environment-import.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/environment-import.spec.js
@@ -1,0 +1,63 @@
+const { describe, it, expect } = require('@jest/globals');
+const { configureStore } = require('@reduxjs/toolkit');
+
+jest.mock('@usebruno/schema', () => ({
+  collectionSchema: { validate: () => Promise.resolve() },
+  environmentSchema: { validate: () => Promise.resolve() },
+  itemSchema: { validate: () => Promise.resolve() }
+}));
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn()
+}));
+
+const collectionsReducer = require('providers/ReduxStore/slices/collections').default;
+const { importEnvironment } = require('providers/ReduxStore/slices/collections/actions');
+
+const COLLECTION_UID = 'col-1';
+const COLLECTION_PATH = '/workspace/collections/MyCollection';
+
+const importIntoCollection = async (environment) => {
+  const invoke = jest.fn().mockResolvedValue(null);
+  window.ipcRenderer = { invoke };
+
+  const store = configureStore({
+    reducer: { collections: collectionsReducer },
+    preloadedState: {
+      collections: {
+        collectionSortOrder: 'default',
+        collections: [{
+          uid: COLLECTION_UID,
+          pathname: COLLECTION_PATH,
+          environments: [],
+          collapsed: false,
+          items: []
+        }],
+        tempDirectories: {}
+      }
+    }
+  });
+
+  await store.dispatch(importEnvironment({ ...environment, collectionUid: COLLECTION_UID }));
+
+  return invoke.mock.calls.find(([channel]) => channel === 'renderer:create-environment');
+};
+
+describe('importEnvironment — inheritance', () => {
+  it('passes the extends reference of an imported environment through to the file write', async () => {
+    const [, , , , , inheritedEnvironmentName] = await importIntoCollection({
+      name: 'dev',
+      variables: [],
+      extends: 'Base'
+    });
+
+    expect(inheritedEnvironmentName).toBe('Base');
+  });
+
+  it('passes no extends reference for an environment that inherits from nothing', async () => {
+    const [, , , , , inheritedEnvironmentName] = await importIntoCollection({ name: 'dev', variables: [] });
+
+    expect(inheritedEnvironmentName).toBeUndefined();
+  });
+});

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -25,7 +25,6 @@ import mime from 'mime-types';
 import path from 'utils/common/path';
 import { getUniqueTagsFromItems } from 'utils/collections/index';
 import { DEFAULT_HTTP_ITEM_SETTINGS, GRPC_SCRIPT_KEYS, SCRIPT_TYPES } from '@usebruno/common';
-import { getDataTypeFromValue } from '@usebruno/common/utils';
 import * as exampleReducers from './exampleReducers';
 import * as mockResponseEditorReducers from './mockResponseEditorReducers';
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1,6 +1,6 @@
-import { parseQueryParams, buildQueryString as stringifyQueryParams } from '@usebruno/common/utils';
+import { parseQueryParams, buildQueryString as stringifyQueryParams, getDataTypeFromValue, parseValueByDataType, resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import { uuid } from 'utils/common';
-import { find, map, forOwn, concat, filter, each, cloneDeep, get, set, findIndex, pick } from 'lodash';
+import { find, map, concat, filter, each, cloneDeep, get, set, pick, isEqual } from 'lodash';
 import { createSlice } from '@reduxjs/toolkit';
 import { hexy as hexdump } from 'hexy';
 import {
@@ -468,6 +468,18 @@ export const collectionsSlice = createSlice({
         }
       }
     },
+    saveEnvironmentExtends: (state, action) => {
+      const { environmentUid, collectionUid, extends: inheritedEnvironmentName } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+
+      if (collection) {
+        const environment = findEnvironmentInCollection(collection, environmentUid);
+
+        if (environment) {
+          environment.extends = inheritedEnvironmentName;
+        }
+      }
+    },
     newItem: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
 
@@ -526,6 +538,23 @@ export const collectionsSlice = createSlice({
         const activeEnvironment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
 
         if (activeEnvironment) {
+          const { inheritedVariables } = resolveEnvironmentInheritance({
+            environments: collection.environments,
+            targetEnvironment: activeEnvironment
+          });
+
+          const skipKeys = ['__name__'];
+
+          // add inherited variables names to `skipKeys` to avoid the `create new variable` path
+          // except the variables whose values have been updated.
+          // An inherited row holds the value as the file spells it — a string — while the script
+          // reports it parsed by its `dataType`, so the inherited value has to be parsed to compare.
+          Object.entries(envVariables).forEach(([key, value]) => {
+            if (inheritedVariables.find((iv) => (iv.name === key) && isEqual(parseValueByDataType(iv.value, iv.dataType), value))) {
+              skipKeys.push(key);
+            }
+          });
+
           const draft = collection.environmentsDraft;
           if (draft && draft.environmentUid === activeEnvironment.uid && draft.variables) {
             const baseline = {};
@@ -542,12 +571,12 @@ export const collectionsSlice = createSlice({
             activeEnvironment.variables,
             envVariables,
             collection._scriptEnvBaseline,
-            { skipKeys: ['__name__'] }
+            { skipKeys, inheritedVariables }
           );
 
           // Re-infer dataType only for vars the script actually modified — otherwise a no-op
           // script re-write would clobber a user's in-progress draft type change.
-          const modifiedKeys = getScriptModifiedKeys(envVariables, collection._scriptEnvBaseline, { skipKeys: ['__name__'] });
+          const modifiedKeys = getScriptModifiedKeys(envVariables, collection._scriptEnvBaseline, { skipKeys });
           activeEnvironment.variables.forEach((v) => {
             if (!modifiedKeys.has(v.name)) return;
             const inferred = getDataTypeFromValue(envVariables[v.name]);
@@ -3300,6 +3329,7 @@ export const collectionsSlice = createSlice({
           existingEnv.variables = environment.variables;
           existingEnv.color = environment.color;
           existingEnv.externalSecrets = environment.externalSecrets;
+          existingEnv.extends = environment.extends;
         } else {
           collection.environments.push(environment);
           collection.environments.sort((a, b) => a.name.localeCompare(b.name));
@@ -4204,6 +4234,7 @@ export const {
   selectEnvironment,
   applyDefaultEnvironment,
   updateEnvironmentColor,
+  saveEnvironmentExtends,
   newItem,
   deleteItem,
   renameItem,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.js
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { uuid } from 'utils/common/index';
 import { environmentSchema } from '@usebruno/schema';
-import { getDataTypeFromValue } from '@usebruno/common/utils';
-import { cloneDeep } from 'lodash';
+import { getDataTypeFromValue, parseValueByDataType, resolveEnvironmentInheritance } from '@usebruno/common/utils';
+import { cloneDeep, isEqual } from 'lodash';
 import { applyScriptEnvVars, getScriptModifiedKeys, writesCollidingSecrets, DUPLICATE_SECRET_NAMES_ERROR } from 'utils/environments';
 import { getInvalidVariableNames, invalidVariableNamesError } from 'utils/common/variables';
 
@@ -31,13 +31,14 @@ export const globalEnvironmentsSlice = createSlice({
       state.activeGlobalEnvironmentUid = resolvedActiveUid;
     },
     _addGlobalEnvironment: (state, action) => {
-      const { name, uid, variables = [], color } = action.payload;
+      const { name, uid, variables = [], color, extends: inheritedGlobalEnvironmentName } = action.payload;
       if (name?.length) {
         state.globalEnvironments.push({
           uid,
           name,
           variables,
-          color
+          color,
+          extends: inheritedGlobalEnvironmentName
         });
       }
     },
@@ -47,6 +48,15 @@ export const globalEnvironmentsSlice = createSlice({
         const environment = state.globalEnvironments.find((env) => env?.uid == globalEnvironmentUid);
         if (environment) {
           environment.variables = variables;
+        }
+      }
+    },
+    _saveGlobalEnvironmentExtends: (state, action) => {
+      const { environmentUid, extends: inheritedEnvironmentName } = action.payload;
+      if (environmentUid) {
+        const environment = state.globalEnvironments.find((env) => env?.uid == environmentUid);
+        if (environment) {
+          environment.extends = inheritedEnvironmentName;
         }
       }
     },
@@ -60,12 +70,13 @@ export const globalEnvironmentsSlice = createSlice({
       }
     },
     _copyGlobalEnvironment: (state, action) => {
-      const { name, uid, variables } = action.payload;
+      const { name, uid, variables, extends: inheritedGlobalEnvironmentName } = action.payload;
       if (name?.length && uid) {
         state.globalEnvironments.push({
           uid,
           name,
-          variables
+          variables,
+          extends: inheritedGlobalEnvironmentName
         });
       }
     },
@@ -115,6 +126,7 @@ export const {
   updateGlobalEnvironments,
   _addGlobalEnvironment,
   _saveGlobalEnvironment,
+  _saveGlobalEnvironmentExtends,
   _renameGlobalEnvironment,
   _copyGlobalEnvironment,
   _selectGlobalEnvironment,
@@ -132,23 +144,23 @@ const getWorkspaceContext = (state) => {
   return { workspaceUid, workspacePath: workspace?.pathname };
 };
 
-export const addGlobalEnvironment = ({ name, variables = [], color }) => (dispatch, getState) => {
+export const addGlobalEnvironment = ({ name, variables = [], color, extends: inheritedGlobalEnvironmentName }) => (dispatch, getState) => {
   return new Promise((resolve, reject) => {
     const uid = uuid();
-    const environment = { name, uid, variables };
+    const environment = { name, uid, variables, extends: inheritedGlobalEnvironmentName };
     const { ipcRenderer } = window;
     const state = getState();
     const { workspaceUid, workspacePath } = getWorkspaceContext(state);
 
     environmentSchema
       .validate(environment)
-      .then(() => ipcRenderer.invoke('renderer:create-global-environment', { name, uid, variables, color, workspaceUid, workspacePath }))
+      .then(() => ipcRenderer.invoke('renderer:create-global-environment', { name, uid, variables, color, extends: inheritedGlobalEnvironmentName, workspaceUid, workspacePath }))
       .then((result) => {
         const finalUid = result?.uid || uid;
         const finalName = result?.name || name;
         const finalVariables = result?.variables || variables;
         const finalColor = result?.color || color;
-        dispatch(_addGlobalEnvironment({ name: finalName, uid: finalUid, variables: finalVariables, color: finalColor }));
+        dispatch(_addGlobalEnvironment({ name: finalName, uid: finalUid, variables: finalVariables, color: finalColor, extends: inheritedGlobalEnvironmentName }));
         return finalUid;
       })
       .then((finalUid) => dispatch(selectGlobalEnvironment({ environmentUid: finalUid })))
@@ -167,17 +179,18 @@ export const copyGlobalEnvironment = ({ name, environmentUid: baseEnvUid }) => (
       return reject(new Error('Base environment not found'));
     }
     const uid = uuid();
-    const environment = { uid, name, variables: baseEnv.variables };
+    const inheritedGlobalEnvironmentName = baseEnv.extends;
+    const environment = { uid, name, variables: baseEnv.variables, extends: inheritedGlobalEnvironmentName };
     const { ipcRenderer } = window;
 
     environmentSchema
       .validate(environment)
-      .then(() => ipcRenderer.invoke('renderer:create-global-environment', { uid, name, variables: baseEnv.variables, workspaceUid, workspacePath }))
+      .then(() => ipcRenderer.invoke('renderer:create-global-environment', { uid, name, variables: baseEnv.variables, extends: inheritedGlobalEnvironmentName, workspaceUid, workspacePath }))
       .then((result) => {
         const finalUid = result?.uid || uid;
         const finalName = result?.name || name;
         const finalVariables = result?.variables || baseEnv.variables;
-        dispatch(_copyGlobalEnvironment({ name: finalName, uid: finalUid, variables: finalVariables }));
+        dispatch(_copyGlobalEnvironment({ name: finalName, uid: finalUid, variables: finalVariables, extends: inheritedGlobalEnvironmentName }));
       })
       .then(resolve)
       .catch(reject);
@@ -259,6 +272,7 @@ export const saveGlobalEnvironment = ({ variables, environmentUid }) => (dispatc
         environmentUid,
         variables,
         color: environment.color,
+        extends: environment.extends,
         workspaceUid,
         workspacePath
       }))
@@ -307,6 +321,23 @@ export const globalEnvironmentsUpdateEvent = ({ globalEnvironmentVariables }) =>
 
   if (!environment || !environmentUid) return;
 
+  const { inheritedVariables } = resolveEnvironmentInheritance({
+    environments: globalEnvironments,
+    targetEnvironment: environment
+  });
+
+  const skipKeys = ['__name__'];
+
+  // add inherited variables names to `skipKeys` to avoid the `create new variable` path
+  // except the variables whose values have been updated.
+  // An inherited row holds the value as the file spells it — a string — while the script reports it
+  // parsed by its `dataType`, so the inherited value has to be parsed to compare.
+  Object.entries(globalEnvironmentVariables).forEach(([key, value]) => {
+    if (inheritedVariables.find((iv) => (iv.name === key) && isEqual(parseValueByDataType(iv.value, iv.dataType), value))) {
+      skipKeys.push(key);
+    }
+  });
+
   const draft = state?.globalEnvironments?.globalEnvironmentDraft;
   if (draft && draft.environmentUid === environmentUid && draft.variables) {
     const baseline = {};
@@ -324,11 +355,11 @@ export const globalEnvironmentsUpdateEvent = ({ globalEnvironmentVariables }) =>
   const baseline = updatedState?.globalEnvironments?._scriptGlobalEnvBaseline;
   let variables = cloneDeep(updatedEnv?.variables || []);
 
-  variables = applyScriptEnvVars(variables, globalEnvironmentVariables, baseline, { skipKeys: ['__name__'] });
+  variables = applyScriptEnvVars(variables, globalEnvironmentVariables, baseline, { skipKeys, inheritedVariables });
 
   // Re-infer dataType only for vars the script actually modified — preserves draft-only type edits
   // when a script does a structurally-equal no-op write.
-  const modifiedKeys = getScriptModifiedKeys(globalEnvironmentVariables, baseline, { skipKeys: ['__name__'] });
+  const modifiedKeys = getScriptModifiedKeys(globalEnvironmentVariables, baseline, { skipKeys });
   variables.forEach((v) => {
     if (!modifiedKeys.has(v.name)) return;
     const inferred = getDataTypeFromValue(globalEnvironmentVariables[v.name]);
@@ -349,10 +380,30 @@ export const globalEnvironmentsUpdateEvent = ({ globalEnvironmentVariables }) =>
       environmentUid,
       variables,
       color: environment.color,
+      extends: environment.extends,
       workspaceUid,
       workspacePath
     }))
     .catch((err) => console.error('Failed to persist global environment:', err));
+};
+
+export const saveGlobalEnvironmentExtends = ({ environmentUid, extends: inheritedGlobalEnvironmentName }) => (dispatch, getState) => {
+  return new Promise((resolve, reject) => {
+    const { ipcRenderer } = window;
+    const state = getState();
+    const { workspaceUid, workspacePath } = getWorkspaceContext(state);
+
+    ipcRenderer
+      .invoke('renderer:save-global-environment-extends', {
+        environmentUid,
+        extends: inheritedGlobalEnvironmentName,
+        workspaceUid,
+        workspacePath
+      })
+      .then(() => dispatch(_saveGlobalEnvironmentExtends({ environmentUid, extends: inheritedGlobalEnvironmentName })))
+      .then(resolve)
+      .catch(reject);
+  });
 };
 
 export const updateGlobalEnvironmentColor = (environmentUid, color) => (dispatch, getState) => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.spec.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/global-environments.spec.js
@@ -8,6 +8,7 @@ jest.mock('@usebruno/schema', () => ({
 
 import { configureStore } from '@reduxjs/toolkit';
 import globalEnvironmentsReducer, {
+  addGlobalEnvironment,
   globalEnvironmentsUpdateEvent,
   _clearScriptGlobalEnvBaseline,
   updateGlobalEnvironments
@@ -30,10 +31,20 @@ beforeAll(() => {
 });
 
 const createStore = (envVars = [], opts = {}) => {
+  const parentEnvironments = opts.inheritedVars
+    ? [{ uid: 'genv-parent', name: 'Base', variables: opts.inheritedVars, color: null }]
+    : [];
   const preloadedState = {
     globalEnvironments: {
       globalEnvironments: [
-        { uid: ENV_UID, name: 'GlobalTest', variables: envVars, color: null }
+        ...parentEnvironments,
+        {
+          uid: ENV_UID,
+          name: 'GlobalTest',
+          variables: envVars,
+          color: null,
+          ...(opts.inheritedVars ? { extends: 'Base' } : {})
+        }
       ],
       activeGlobalEnvironmentUid: ENV_UID,
       globalEnvironmentDraft: opts.draft || null,
@@ -397,6 +408,14 @@ describe('globalEnvironmentsUpdateEvent — draft-aware merge', () => {
       expect(v.dataType).toBe('object');
     });
 
+    test('leaves an inherited typed var the script echoed back unchanged out of the environment', () => {
+      const store = createStore([], { inheritedVars: [{ ...makeVar('PORT', '3000'), dataType: 'number' }] });
+
+      store.dispatch(globalEnvironmentsUpdateEvent({ globalEnvironmentVariables: { PORT: 3000 } }));
+
+      expect(getEnv(store).variables).toEqual([]);
+    });
+
     test('keeps existing dataType on a typed var the script did not touch', () => {
       const typedVar = { ...makeVar('COUNT', 42), dataType: 'number' };
       const store = createStore([typedVar, makeVar('HOST', 'https://example.com')]);
@@ -472,6 +491,34 @@ describe('globalEnvironmentsUpdateEvent — draft-aware merge', () => {
       expect(xVars.find((v) => v.enabled === false).value).toBe('archived');
       expect(xVars.find((v) => v.enabled === true).value).toBe('updated');
     });
+  });
+});
+
+describe('addGlobalEnvironment — inheritance', () => {
+  const addEnvironment = async (payload) => {
+    const invoke = jest.fn().mockResolvedValue({});
+    window.ipcRenderer = { invoke };
+    const store = createStore();
+
+    await store.dispatch(addGlobalEnvironment(payload));
+
+    const [, createArgs] = invoke.mock.calls.find(([channel]) => channel === 'renderer:create-global-environment');
+    const added = store.getState().globalEnvironments.globalEnvironments.find((env) => env.name === payload.name);
+    return { createArgs, added };
+  };
+
+  test('an imported environment persists and stores its extends reference', async () => {
+    const { createArgs, added } = await addEnvironment({ name: 'dev', variables: [], extends: 'Base' });
+
+    expect(createArgs.extends).toBe('Base');
+    expect(added.extends).toBe('Base');
+  });
+
+  test('an environment created without a parent has no extends reference', async () => {
+    const { createArgs, added } = await addEnvironment({ name: 'dev', variables: [] });
+
+    expect(createArgs.extends).toBeUndefined();
+    expect(added.extends).toBeUndefined();
   });
 });
 

--- a/packages/bruno-app/src/utils/ai/index.js
+++ b/packages/bruno-app/src/utils/ai/index.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
 import { callIpc } from 'utils/common/ipc';
 import {
   findEnvironmentInCollection,
@@ -173,8 +174,13 @@ export const buildAiVariablesPayload = (collection, item, redactVariablesOverrid
     claim(name, 'global', globalSecrets.has(name));
   }
 
-  // Active environment - explicit `secret` flag per variable.
-  const env = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+  // Active environment - explicit `secret` flag per variable. Inherited variables are
+  // merged in so a secret defined on a parent environment is redacted too.
+  const env = resolveEnvironmentInheritance({
+    environments: collection.environments,
+    targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid),
+    merge: true
+  });
   if (env && Array.isArray(env.variables)) {
     for (const v of env.variables) {
       if (v?.name && v.enabled) claim(v.name, 'env', Boolean(v.secret));

--- a/packages/bruno-app/src/utils/ai/index.spec.js
+++ b/packages/bruno-app/src/utils/ai/index.spec.js
@@ -183,6 +183,32 @@ describe('utils/ai', () => {
       expect(gs).toEqual({ name: 'GLOBAL_SECRET', value: '<redacted>', scope: 'global', secret: true });
     });
 
+    it('redacts a secret inherited from a parent environment', () => {
+      const collectionWithInheritance = {
+        activeEnvironmentUid: 'env-child',
+        environments: [
+          {
+            uid: 'env-parent',
+            name: 'Base',
+            variables: [{ name: 'PARENT_PIN', value: 'parent-pin', enabled: true, secret: true }]
+          },
+          { uid: 'env-child', name: 'Staging', extends: 'Base', variables: [] }
+        ],
+        globalEnvironmentVariables: {},
+        globalEnvSecrets: [],
+        runtimeVariables: {}
+      };
+
+      const result = buildAiVariablesPayload(collectionWithInheritance, null);
+
+      expect(result.find((v) => v.name === 'PARENT_PIN')).toEqual({
+        name: 'PARENT_PIN',
+        value: '<redacted>',
+        scope: 'env',
+        secret: true
+      });
+    });
+
     it('drops disabled environment variables', () => {
       const result = buildAiVariablesPayload(variablesCollection, null);
       expect(result.find((v) => v.name === 'DISABLED')).toBeUndefined();

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -361,8 +361,9 @@ export const renderVarInfo = (token, options) => {
 
   // Check if a runtime variable exists with the same name (even if scope is detected as collection/folder/environment)
   const hasRuntimeVariable = collection && collection.runtimeVariables && collection.runtimeVariables[variableName];
-  // Check if variable is read-only (process.env, runtime, dynamic/faker, oauth2, and undefined variables cannot be edited)
-  const isReadOnly = scopeInfo.type === 'process.env' || scopeInfo.type === 'runtime' || scopeInfo.type === 'dynamic' || scopeInfo.type === 'oauth2' || scopeInfo.type === 'undefined' || hasRuntimeVariable;
+  // Check if variable is read-only (process.env, runtime, dynamic/faker, oauth2, and undefined variables cannot be
+  // edited; an inherited variable is owned by the environment it comes from, so it is edited there)
+  const isReadOnly = scopeInfo.type === 'process.env' || scopeInfo.type === 'runtime' || scopeInfo.type === 'dynamic' || scopeInfo.type === 'oauth2' || scopeInfo.type === 'undefined' || hasRuntimeVariable || !!scopeInfo.inheritedFrom;
 
   // `??` preserves typed falsy values (false / 0); `||` would clobber them to ''.
   const rawValue = scopeInfo.value ?? '';
@@ -1003,6 +1004,12 @@ export const renderVarInfo = (token, options) => {
       readOnlyNote.className = 'var-readonly-note';
       readOnlyNote.setAttribute('data-testid', 'var-info-readonly-note');
       readOnlyNote.textContent = 'No active environment';
+      into.appendChild(readOnlyNote);
+    } else if (scopeInfo.inheritedFrom) {
+      const readOnlyNote = document.createElement('div');
+      readOnlyNote.className = 'var-readonly-note';
+      readOnlyNote.setAttribute('data-testid', 'var-info-readonly-note');
+      readOnlyNote.textContent = `Inherited from ${scopeInfo.inheritedFrom.name} (read-only)`;
       into.appendChild(readOnlyNote);
     }
   }

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1225,10 +1225,20 @@ export const getDefaultRequestPaneTab = (item) => {
 
 const toVariablesMap = (environmentVariables = []) => {
   const variables = {};
-  const enabledVars = environmentVariables.filter((v) => v.name && v.enabled);
-  [...enabledVars.filter((v) => !v.secret), ...enabledVars.filter((v) => v.secret)].forEach((variable) => {
+  const secretNames = new Set();
+
+  for (const variable of environmentVariables) {
+    if (!variable.name || !variable.enabled) {
+      continue;
+    }
+    if (variable.secret) {
+      secretNames.add(variable.name);
+    } else if (secretNames.has(variable.name)) {
+      continue;
+    }
     variables[variable.name] = variable.value;
-  });
+  }
+
   return variables;
 };
 

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -10,7 +10,7 @@ import {
   doesFolderHaveItemsMatchSearchText,
   doesCollectionHaveItemsMatchingSearchText
 } from 'utils/collections/search';
-import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
+import { resolveEnvironmentInheritance, toVariablesMap } from '@usebruno/common/utils';
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
@@ -1221,25 +1221,6 @@ export const getDefaultRequestPaneTab = (item) => {
   if (['ws-request', 'grpc-request'].includes(item.type)) {
     return 'body';
   }
-};
-
-const toVariablesMap = (environmentVariables = []) => {
-  const variables = {};
-  const secretNames = new Set();
-
-  for (const variable of environmentVariables) {
-    if (!variable.name || !variable.enabled) {
-      continue;
-    }
-    if (variable.secret) {
-      secretNames.add(variable.name);
-    } else if (secretNames.has(variable.name)) {
-      continue;
-    }
-    variables[variable.name] = variable.value;
-  }
-
-  return variables;
 };
 
 export const getGlobalEnvironmentVariables = ({ globalEnvironments, activeGlobalEnvironmentUid }) => {

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -10,6 +10,7 @@ import {
   doesFolderHaveItemsMatchSearchText,
   doesCollectionHaveItemsMatchingSearchText
 } from 'utils/collections/search';
+import { resolveEnvironmentInheritance } from '@usebruno/common/utils';
 
 const replaceTabsWithSpaces = (str, numSpaces = 2) => {
   if (!str || !str.length || !isString(str)) {
@@ -1222,22 +1223,30 @@ export const getDefaultRequestPaneTab = (item) => {
   }
 };
 
-export const getGlobalEnvironmentVariables = ({ globalEnvironments, activeGlobalEnvironmentUid }) => {
-  let variables = {};
-  const environment = globalEnvironments?.find((env) => env?.uid === activeGlobalEnvironmentUid);
-  if (environment) {
-    each(environment.variables, (variable) => {
-      if (variable.name && variable.enabled) {
-        variables[variable.name] = variable.value;
-      }
-    });
-  }
+const toVariablesMap = (environmentVariables = []) => {
+  const variables = {};
+  const enabledVars = environmentVariables.filter((v) => v.name && v.enabled);
+  [...enabledVars.filter((v) => !v.secret), ...enabledVars.filter((v) => v.secret)].forEach((variable) => {
+    variables[variable.name] = variable.value;
+  });
   return variables;
 };
 
-export const getGlobalEnvironmentVariablesMasked = ({ globalEnvironments, activeGlobalEnvironmentUid }) => {
-  const environment = globalEnvironments?.find((env) => env?.uid === activeGlobalEnvironmentUid);
+export const getGlobalEnvironmentVariables = ({ globalEnvironments, activeGlobalEnvironmentUid }) => {
+  const environment = resolveEnvironmentInheritance({
+    environments: globalEnvironments,
+    targetEnvironment: globalEnvironments?.find((env) => env?.uid === activeGlobalEnvironmentUid),
+    merge: true
+  });
+  return toVariablesMap(environment?.variables);
+};
 
+export const getGlobalEnvironmentVariablesMasked = ({ globalEnvironments, activeGlobalEnvironmentUid }) => {
+  const environment = resolveEnvironmentInheritance({
+    environments: globalEnvironments,
+    targetEnvironment: globalEnvironments?.find((env) => env?.uid === activeGlobalEnvironmentUid),
+    merge: true
+  });
   if (environment && Array.isArray(environment.variables)) {
     return environment.variables
       .filter((variable) => variable.name && variable.enabled && variable.secret)
@@ -1248,20 +1257,17 @@ export const getGlobalEnvironmentVariablesMasked = ({ globalEnvironments, active
 };
 
 export const getEnvironmentVariables = (collection) => {
-  let variables = {};
-  if (collection) {
-    const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
-    if (environment) {
-      // Apply secrets last so a secret wins over a plain variable of the same name,
-      // regardless of their order in the array.
-      const enabledVars = (environment.variables || []).filter((v) => v.name && v.enabled);
-      [...enabledVars.filter((v) => !v.secret), ...enabledVars.filter((v) => v.secret)].forEach((variable) => {
-        variables[variable.name] = variable.value;
-      });
-    }
+  if (!collection) {
+    return {};
   }
 
-  return variables;
+  const environment = resolveEnvironmentInheritance({
+    environments: collection.environments,
+    targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid),
+    merge: true
+  });
+
+  return toVariablesMap(environment?.variables);
 };
 
 export const getEnvironmentVariablesMasked = (collection) => {
@@ -1270,8 +1276,12 @@ export const getEnvironmentVariablesMasked = (collection) => {
     return [];
   }
 
-  // Find the active environment in the collection
-  const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+  // Inherited variables are merged in so a secret defined on a parent is masked too.
+  const environment = resolveEnvironmentInheritance({
+    environments: collection.environments,
+    targetEnvironment: findEnvironmentInCollection(collection, collection.activeEnvironmentUid),
+    merge: true
+  });
   if (!environment || !environment.variables) {
     return [];
   }
@@ -1482,27 +1492,6 @@ const mergeVars = (collection, requestTreePath = []) => {
     collectionVariables,
     folderVariables,
     requestVariables
-  };
-};
-
-export const getEnvVars = (environment = {}) => {
-  const variables = environment.variables;
-  if (!variables || !variables.length) {
-    return {
-      __name__: environment.name
-    };
-  }
-
-  const envVars = {};
-  each(variables, (variable) => {
-    if (variable.enabled) {
-      envVars[variable.name] = variable.value;
-    }
-  });
-
-  return {
-    ...envVars,
-    __name__: environment.name
   };
 };
 
@@ -1817,13 +1806,19 @@ export const getVariableScope = (variableName, collection, item) => {
   const activeEnvironmentUidForScope = collection.realActiveEnvironmentUid ?? collection.activeEnvironmentUid;
   if (activeEnvironmentUidForScope) {
     const environment = findEnvironmentInCollection(collection, activeEnvironmentUidForScope);
-    if (environment && environment.variables) {
-      const envVar = resolveEnabledVariable(environment.variables, variableName);
+    if (environment) {
+      const { variables } = resolveEnvironmentInheritance({
+        environments: collection.environments,
+        targetEnvironment: environment,
+        merge: true
+      });
+      const envVar = resolveEnabledVariable(variables, variableName);
       if (envVar) {
         return {
           type: 'environment',
           value: envVar.value,
-          data: { environment, variable: envVar }
+          data: { environment, variable: envVar },
+          inheritedFrom: envVar.inheritedFrom
         };
       }
     }
@@ -1843,18 +1838,23 @@ export const getVariableScope = (variableName, collection, item) => {
   }
 
   // 5. Check Global Environment Variables
-  const { globalEnvironmentVariables = {}, globalEnvSecrets = [] } = collection;
-  if (variableName in globalEnvironmentVariables) {
-    const isSecret = globalEnvSecrets.includes(variableName);
-    return {
-      type: 'global',
-      value: globalEnvironmentVariables[variableName],
-      data: {
-        variableName,
-        value: globalEnvironmentVariables[variableName],
-        variable: { name: variableName, secret: isSecret }
-      }
-    };
+  const { globalEnvironments, activeGlobalEnvironmentUid } = collection;
+  const globalEnvironment = find(globalEnvironments, (e) => e.uid === activeGlobalEnvironmentUid);
+  if (globalEnvironment) {
+    const { variables } = resolveEnvironmentInheritance({
+      environments: globalEnvironments,
+      targetEnvironment: globalEnvironment,
+      merge: true
+    });
+    const globalVar = resolveEnabledVariable(variables, variableName);
+    if (globalVar) {
+      return {
+        type: 'global',
+        value: globalVar.value,
+        data: { variableName, value: globalVar.value, variable: globalVar },
+        inheritedFrom: globalVar.inheritedFrom
+      };
+    }
   }
 
   // 6. Check Runtime Variables (set during request execution via scripts)

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -177,32 +177,147 @@ describe('getCollectionVersion', () => {
 });
 
 describe('getVariableScope — global environment secrets', () => {
-  it('flags a global-scoped variable as secret when its name is in globalEnvSecrets', () => {
-    const collection = {
-      globalEnvironmentVariables: { apiToken: 'super-secret' },
-      globalEnvSecrets: ['apiToken']
-    };
+  const buildCollection = (variables) => ({
+    activeGlobalEnvironmentUid: 'genv-1',
+    globalEnvironments: [{ uid: 'genv-1', name: 'Workspace', variables }]
+  });
 
-    const scopeInfo = getVariableScope('apiToken', collection, null);
+  it('flags a global-scoped variable as secret when its row is marked secret', () => {
+    const variable = { uid: 'v1', name: 'apiToken', value: 'super-secret', enabled: true, secret: true };
+
+    const scopeInfo = getVariableScope('apiToken', buildCollection([variable]), null);
 
     expect(scopeInfo).toEqual({
       type: 'global',
       value: 'super-secret',
-      data: { variableName: 'apiToken', value: 'super-secret', variable: { name: 'apiToken', secret: true } }
+      data: { variableName: 'apiToken', value: 'super-secret', variable }
     });
     expect(isVariableSecret(scopeInfo)).toBe(true);
   });
 
-  it('does not flag a global-scoped variable as secret when its name is not in globalEnvSecrets', () => {
+  it('does not flag a global-scoped variable as secret when its row is not marked secret', () => {
+    const variable = { uid: 'v1', name: 'baseUrl', value: 'https://api.example.com', enabled: true, secret: false };
+
+    const scopeInfo = getVariableScope('baseUrl', buildCollection([variable]), null);
+
+    expect(scopeInfo.data.variable).toEqual(variable);
+    expect(isVariableSecret(scopeInfo)).toBe(false);
+  });
+});
+
+describe('getVariableScope — global environment inheritance', () => {
+  const buildCollection = () => ({
+    activeGlobalEnvironmentUid: 'genv-dev',
+    globalEnvironments: [
+      {
+        uid: 'genv-base',
+        name: 'workspace_base',
+        variables: [{ uid: 'v1', name: 'host', value: 'http://base.example.com', enabled: true, secret: false }]
+      },
+      {
+        uid: 'genv-dev',
+        name: 'workspace_dev',
+        extends: 'workspace_base',
+        variables: [{ uid: 'v2', name: 'token', value: 'dev-token', enabled: true, secret: false }]
+      }
+    ]
+  });
+
+  it('names the ancestor a variable is inherited from', () => {
+    const scopeInfo = getVariableScope('host', buildCollection(), null);
+
+    expect(scopeInfo.type).toBe('global');
+    expect(scopeInfo.value).toBe('http://base.example.com');
+    expect(scopeInfo.inheritedFrom).toEqual({ uid: 'genv-base', name: 'workspace_base' });
+  });
+
+  it('leaves a variable the active global environment owns unmarked', () => {
+    const scopeInfo = getVariableScope('token', buildCollection(), null);
+
+    expect(scopeInfo.type).toBe('global');
+    expect(scopeInfo.inheritedFrom).toBeUndefined();
+  });
+
+  it('leaves a variable unmarked when the environment redeclares the name it inherits', () => {
+    const collection = buildCollection();
+    collection.globalEnvironments[1].variables.push({
+      uid: 'v3',
+      name: 'host',
+      value: 'http://dev.example.com',
+      enabled: true,
+      secret: false
+    });
+
+    const scopeInfo = getVariableScope('host', collection, null);
+
+    expect(scopeInfo.inheritedFrom).toBeUndefined();
+  });
+});
+
+describe('getVariableScope — secrets win over plain variables across inheritance', () => {
+  const buildCollection = ({ inheritedSecret, ownSecret }) => ({
+    activeEnvironmentUid: 'env-dev',
+    environments: [
+      {
+        uid: 'env-base',
+        name: 'base',
+        variables: [{ uid: 'v1', name: 'apiToken', value: 'base-token', enabled: true, secret: inheritedSecret }]
+      },
+      {
+        uid: 'env-dev',
+        name: 'dev',
+        extends: 'base',
+        variables: [{ uid: 'v2', name: 'apiToken', value: 'dev-token', enabled: true, secret: ownSecret }]
+      }
+    ]
+  });
+
+  it('resolves to the inherited secret when the active environment declares the name as a plain variable', () => {
+    const scopeInfo = getVariableScope('apiToken', buildCollection({ inheritedSecret: true, ownSecret: false }), null);
+
+    expect(scopeInfo.value).toBe('base-token');
+    expect(isVariableSecret(scopeInfo)).toBe(true);
+    expect(scopeInfo.inheritedFrom).toEqual({ uid: 'env-base', name: 'base' });
+  });
+
+  it('resolves to the active environment\'s secret when the inherited declaration is plain', () => {
+    const scopeInfo = getVariableScope('apiToken', buildCollection({ inheritedSecret: false, ownSecret: true }), null);
+
+    expect(scopeInfo.value).toBe('dev-token');
+    expect(isVariableSecret(scopeInfo)).toBe(true);
+    expect(scopeInfo.inheritedFrom).toBeUndefined();
+  });
+
+  it('resolves to the active environment when both declarations are equally secret', () => {
+    const scopeInfo = getVariableScope('apiToken', buildCollection({ inheritedSecret: true, ownSecret: true }), null);
+
+    expect(scopeInfo.value).toBe('dev-token');
+    expect(scopeInfo.inheritedFrom).toBeUndefined();
+  });
+
+  it('resolves a global-scoped name to the inherited secret over the active plain declaration', () => {
     const collection = {
-      globalEnvironmentVariables: { baseUrl: 'https://api.example.com' },
-      globalEnvSecrets: ['apiToken']
+      activeGlobalEnvironmentUid: 'genv-dev',
+      globalEnvironments: [
+        {
+          uid: 'genv-base',
+          name: 'workspace_base',
+          variables: [{ uid: 'v1', name: 'apiToken', value: 'base-token', enabled: true, secret: true }]
+        },
+        {
+          uid: 'genv-dev',
+          name: 'workspace_dev',
+          extends: 'workspace_base',
+          variables: [{ uid: 'v2', name: 'apiToken', value: 'dev-token', enabled: true, secret: false }]
+        }
+      ]
     };
 
-    const scopeInfo = getVariableScope('baseUrl', collection, null);
+    const scopeInfo = getVariableScope('apiToken', collection, null);
 
-    expect(scopeInfo.data.variable).toEqual({ name: 'baseUrl', secret: false });
-    expect(isVariableSecret(scopeInfo)).toBe(false);
+    expect(scopeInfo.value).toBe('base-token');
+    expect(isVariableSecret(scopeInfo)).toBe(true);
+    expect(scopeInfo.inheritedFrom).toEqual({ uid: 'genv-base', name: 'workspace_base' });
   });
 });
 
@@ -380,6 +495,30 @@ describe('getEnvironmentVariablesMasked', () => {
   it('returns an empty array when there is no active environment', () => {
     expect(getEnvironmentVariablesMasked({ activeEnvironmentUid: null, environments: [] })).toEqual([]);
   });
+
+  it('masks secrets inherited from a parent environment', () => {
+    const names = getEnvironmentVariablesMasked({
+      activeEnvironmentUid: 'env-child',
+      environments: [
+        {
+          uid: 'env-parent',
+          name: 'Base',
+          variables: [
+            { name: 'PARENT_SECRET', value: 'parent-secret', enabled: true, secret: true },
+            { name: 'PARENT_PLAIN', value: 'parent-plain', enabled: true, secret: false }
+          ]
+        },
+        {
+          uid: 'env-child',
+          name: 'Staging',
+          extends: 'Base',
+          variables: [{ name: 'CHILD_SECRET', value: 'child-secret', enabled: true, secret: true }]
+        }
+      ]
+    });
+
+    expect(names.sort()).toEqual(['CHILD_SECRET', 'PARENT_SECRET']);
+  });
 });
 
 describe('resolveEnabledVariable — precedence matches getEnvironmentVariables interpolation', () => {
@@ -515,5 +654,96 @@ describe('getSelectionInfo', () => {
 
     expect(info.effectiveSelection.map((e) => e.uid).sort()).toEqual(['colA', 'colB']);
     expect(info).toMatchObject({ hasCollection: true, hasFolder: false, hasRequest: false });
+  });
+});
+
+describe('getEnvironmentVariables', () => {
+  const collection = {
+    activeEnvironmentUid: 'env-dev',
+    environments: [
+      {
+        uid: 'env-base',
+        name: 'base',
+        variables: [
+          { name: 'host', value: 'http://localhost:8081', enabled: true, secret: false },
+          { name: 'api_url', value: 'https://base.example.com', enabled: true, secret: false },
+          { name: 'base_only', value: 'base_only_value', enabled: true, secret: false },
+          { name: 'api_key', value: 'plain_api_key', enabled: true, secret: false },
+          { name: 'shadowed_by_disabled', value: 'from_base', enabled: true, secret: false },
+          { name: 'overridden_plain', value: 'plain_from_base', enabled: true, secret: false },
+          { name: 'disabled_in_base', value: 'should_not_resolve', enabled: false, secret: false },
+          { name: 'base_token', value: 'token-from-base', enabled: true, secret: true },
+          { name: 'overridden_secret', value: 'secret-from-base', enabled: true, secret: true }
+        ]
+      },
+      {
+        uid: 'env-dev',
+        name: 'dev',
+        extends: 'base',
+        variables: [
+          { name: 'api_url', value: 'https://dev.example.com', enabled: true, secret: false },
+          { name: 'dev_only', value: 'dev_only_value', enabled: true, secret: false },
+          { name: 'shadowed_by_disabled', value: 'never_applied', enabled: false, secret: false },
+          { name: 'overridden_secret', value: 'plain_wins_in_dev', enabled: true, secret: false },
+          { name: 'overridden_plain', value: '', enabled: true, secret: true }
+        ]
+      },
+      {
+        uid: 'env-staging',
+        name: 'staging',
+        extends: 'base',
+        variables: [{ name: 'api_key', value: 'api-key-from-staging', enabled: true, secret: true }]
+      },
+      {
+        uid: 'env-qa',
+        name: 'qa',
+        extends: 'staging',
+        variables: [{ name: 'api_url', value: 'https://qa.example.com', enabled: true, secret: false }]
+      }
+    ]
+  };
+
+  const variablesFor = (environmentUid) =>
+    getEnvironmentVariables({ ...collection, activeEnvironmentUid: environmentUid });
+
+  it('resolves inherited variables alongside the own rows that override them', () => {
+    const variables = variablesFor('env-dev');
+
+    expect(variables.host).toBe('http://localhost:8081');
+    expect(variables.base_only).toBe('base_only_value');
+    expect(variables.dev_only).toBe('dev_only_value');
+    expect(variables.api_url).toBe('https://dev.example.com');
+  });
+
+  it('ignores a disabled row on either side of the merge', () => {
+    const variables = variablesFor('env-dev');
+
+    expect(variables).not.toHaveProperty('disabled_in_base');
+    // `dev` declares this name too, but disabled, so the inherited row still applies.
+    expect(variables.shadowed_by_disabled).toBe('from_base');
+  });
+
+  it('resolves a secret inherited from either ancestor of a three-level chain', () => {
+    const variables = variablesFor('env-qa');
+
+    expect(variables.base_token).toBe('token-from-base');
+    // `base` declares `api_key` plain and `staging` redeclares it secret, so both are
+    // inherited by `qa` — the secret is the one that must reach the request.
+    expect(variables.api_key).toBe('api-key-from-staging');
+  });
+
+  it('resolves a name declared on both sides of the secret split to the secret', () => {
+    const variables = variablesFor('env-dev');
+
+    // `dev` redeclares the secret `overridden_secret` it inherits as a non-secret, and the
+    // non-secret `overridden_plain` as a secret. Both ancestor rows survive the redeclaration,
+    // and in each pair the secret is the one that wins.
+    expect(variables.overridden_secret).toBe('secret-from-base');
+    expect(variables.overridden_plain).toBe('');
+  });
+
+  it('returns no variables without a collection or an active environment', () => {
+    expect(getEnvironmentVariables(null)).toEqual({});
+    expect(variablesFor(null)).toEqual({});
   });
 });

--- a/packages/bruno-app/src/utils/environments.js
+++ b/packages/bruno-app/src/utils/environments.js
@@ -62,11 +62,32 @@ const dropWrittenSecretNamesakes = (variables, writtenNames) => {
  *
  * Pure: does not mutate the input array or its entries. Returns a new array of new objects.
  */
-export const applyScriptEnvVars = (variables, scriptVars, baseline, { skipKeys = [] } = {}) => {
+export const applyScriptEnvVars = (variables, scriptVars, baseline, { skipKeys = [], inheritedVariables = [] } = {}) => {
   const scriptVarNames = new Set(Object.keys(scriptVars));
   const skip = new Set(skipKeys);
   const next = (variables || []).map((v) => ({ ...v }));
   const writtenNames = new Set();
+  // A rotated inherited secret lands here as an override; as a plain var its value would be
+  // written to the environment file in cleartext, so the parent's secret flag has to come with it.
+  const inheritedSecretNames = new Set(inheritedVariables.filter((v) => v.secret).map((v) => v.name));
+
+  const writeScriptValue = (name, value) => {
+    writtenNames.add(name);
+    // Target only the enabled slot — a draft-disabled var with the same name must be preserved.
+    const existing = next.find((v) => v.name === name && v.enabled);
+    if (!existing) {
+      next.push({ uid: uuid(), name, value, type: 'text', secret: inheritedSecretNames.has(name), enabled: true });
+      return;
+    }
+
+    existing.value = value;
+    // A plain row of the same name shadows the parent's secret rather than replacing it, so the
+    // rotated value would otherwise land on that plain row and reach disk in cleartext. The row
+    // becoming a secret is the cost of keeping the value off disk.
+    if (inheritedSecretNames.has(name)) {
+      existing.secret = true;
+    }
+  };
 
   if (baseline) {
     Object.entries(scriptVars).forEach(([key, value]) => {
@@ -77,14 +98,7 @@ export const applyScriptEnvVars = (variables, scriptVars, baseline, { skipKeys =
       const isModified = !isNew && !isEqual(baseline[key], value);
 
       if (isNew || isModified) {
-        writtenNames.add(key);
-        // Target only the enabled slot — a draft-disabled var with the same name must be preserved.
-        const existing = next.find((v) => v.name === key && v.enabled);
-        if (existing) {
-          existing.value = value;
-        } else {
-          next.push({ uid: uuid(), name: key, value, type: 'text', secret: false, enabled: true });
-        }
+        writeScriptValue(key, value);
       }
     });
 
@@ -97,13 +111,7 @@ export const applyScriptEnvVars = (variables, scriptVars, baseline, { skipKeys =
 
   Object.entries(scriptVars).forEach(([key, value]) => {
     if (skip.has(key)) return;
-    writtenNames.add(key);
-    const existing = next.find((v) => v.name === key && v.enabled);
-    if (existing) {
-      existing.value = value;
-    } else {
-      next.push({ uid: uuid(), name: key, value, type: 'text', secret: false, enabled: true });
-    }
+    writeScriptValue(key, value);
   });
 
   return dropWrittenSecretNamesakes(next.filter((v) => !v.enabled || scriptVarNames.has(v.name)), writtenNames);
@@ -194,6 +202,43 @@ export const dedupeImportedSecrets = (variables) => {
     const name = (v.name || '').trim();
     return !v.secret || !duplicates.has(name) || survivors.get(name) === v;
   });
+};
+
+/**
+ * Orders environments so one imported alongside its parent lands after it. A parent only reveals
+ * the name it was created under — a collision appends a suffix — once it exists, and the child's
+ * `extends` has to be repointed at that name. A reference to an environment outside the set, or
+ * one caught in a cycle, keeps its input position.
+ */
+export const orderEnvironmentsByInheritance = (environments) => {
+  const firstByName = new Map();
+  environments.forEach((environment) => {
+    if (!firstByName.has(environment.name)) {
+      firstByName.set(environment.name, environment);
+    }
+  });
+
+  const ordered = [];
+  const placed = new Set();
+
+  const place = (environment, seen) => {
+    if (placed.has(environment) || seen.has(environment)) {
+      return;
+    }
+    seen.add(environment);
+
+    const parent = typeof environment.extends === 'string' ? firstByName.get(environment.extends) : undefined;
+    if (parent) {
+      place(parent, seen);
+    }
+
+    placed.add(environment);
+    ordered.push(environment);
+  };
+
+  environments.forEach((environment) => place(environment, new Set()));
+
+  return ordered;
 };
 
 /**

--- a/packages/bruno-app/src/utils/environments.js
+++ b/packages/bruno-app/src/utils/environments.js
@@ -76,7 +76,11 @@ export const applyScriptEnvVars = (variables, scriptVars, baseline, { skipKeys =
     // Target only the enabled slot — a draft-disabled var with the same name must be preserved.
     const existing = next.find((v) => v.name === name && v.enabled);
     if (!existing) {
-      next.push({ uid: uuid(), name, value, type: 'text', secret: inheritedSecretNames.has(name), enabled: true });
+      // A disabled row is never a write target, so the appended row is the one the value lands on.
+      // Appended as a plain row it would carry a secret this name already stands for — whether the
+      // parent chain declares it or a disabled row here does — into the file in cleartext.
+      const isSecretName = inheritedSecretNames.has(name) || next.some((v) => v.name === name && v.secret);
+      next.push({ uid: uuid(), name, value, type: 'text', secret: isSecretName, enabled: true });
       return;
     }
 

--- a/packages/bruno-app/src/utils/environments.spec.js
+++ b/packages/bruno-app/src/utils/environments.spec.js
@@ -3,7 +3,7 @@ jest.mock('nanoid', () => ({
   customAlphabet: () => () => 'aaaaaaaaaaaaaaaaaaaa1'
 }));
 
-import { applyScriptEnvVars, buildEnvVariable, stripEnvVarUid, getDuplicateSecretNames, writesCollidingSecrets, resolveSecretNameCollision, dedupeImportedSecrets, isEnvironmentValidationError, DUPLICATE_SECRET_NAMES_ERROR, generateCopyName } from './environments';
+import { applyScriptEnvVars, buildEnvVariable, stripEnvVarUid, getDuplicateSecretNames, writesCollidingSecrets, resolveSecretNameCollision, dedupeImportedSecrets, orderEnvironmentsByInheritance, isEnvironmentValidationError, DUPLICATE_SECRET_NAMES_ERROR, generateCopyName } from './environments';
 import { invalidVariableNamesError } from './common/variables';
 
 describe('buildEnvVariable — dataType preservation for env export/import', () => {
@@ -137,6 +137,55 @@ describe('applyScriptEnvVars', () => {
       });
     });
 
+    it('keeps an appended override secret when the script rewrote an inherited secret', () => {
+      const result = applyScriptEnvVars(
+        [v('host', 'h')],
+        { host: 'h', token: 'rotated' },
+        null,
+        { inheritedVariables: [{ name: 'token', value: 'parent-secret', secret: true }] }
+      );
+
+      expect(result.find((x) => x.name === 'token')).toMatchObject({
+        name: 'token',
+        value: 'rotated',
+        secret: true,
+        enabled: true
+      });
+    });
+
+    // A child plain row shadows the parent's secret rather than replacing it, so the parent secret
+    // stays inherited and the rotated value lands on that plain row — in cleartext, without this.
+    it('turns a plain row shadowing an inherited secret into a secret when the script rotates it', () => {
+      const result = applyScriptEnvVars(
+        [v('token', 'dev-placeholder')],
+        { token: 'rotated' },
+        null,
+        { inheritedVariables: [{ name: 'token', value: 'parent-secret', secret: true }] }
+      );
+
+      expect(result.find((x) => x.name === 'token')).toMatchObject({
+        name: 'token',
+        value: 'rotated',
+        secret: true,
+        enabled: true
+      });
+    });
+
+    it('leaves a plain row shadowing an inherited secret alone when the script did not write it', () => {
+      const result = applyScriptEnvVars(
+        [v('token', 'dev-placeholder')],
+        { token: 'dev-placeholder' },
+        null,
+        { skipKeys: ['token'], inheritedVariables: [{ name: 'token', value: 'parent-secret', secret: true }] }
+      );
+
+      expect(result.find((x) => x.name === 'token')).toMatchObject({
+        name: 'token',
+        value: 'dev-placeholder',
+        secret: false
+      });
+    });
+
     it('removes enabled variables missing from scriptVars (script deleted them)', () => {
       const result = applyScriptEnvVars([v('host', 'h'), v('stale', 'remove-me')], { host: 'h' }, null);
       expect(result).toHaveLength(1);
@@ -219,6 +268,40 @@ describe('applyScriptEnvVars', () => {
       expect(result.find((x) => x.name === 'fresh')).toMatchObject({
         name: 'fresh',
         value: 'from-script',
+        enabled: true
+      });
+    });
+
+    it('keeps an added override secret when the script rewrote an inherited secret', () => {
+      const draftVars = [v('host', 'h')];
+      const baseline = { host: 'h' };
+      const scriptVars = { host: 'h', token: 'rotated' };
+
+      const result = applyScriptEnvVars(draftVars, scriptVars, baseline, {
+        inheritedVariables: [{ name: 'token', value: 'parent-secret', secret: true }]
+      });
+
+      expect(result.find((x) => x.name === 'token')).toMatchObject({
+        name: 'token',
+        value: 'rotated',
+        secret: true,
+        enabled: true
+      });
+    });
+
+    it('turns a plain row shadowing an inherited secret into a secret when the script rotates it', () => {
+      const draftVars = [v('token', 'dev-placeholder')];
+      const baseline = { token: 'dev-placeholder' };
+      const scriptVars = { token: 'rotated' };
+
+      const result = applyScriptEnvVars(draftVars, scriptVars, baseline, {
+        inheritedVariables: [{ name: 'token', value: 'parent-secret', secret: true }]
+      });
+
+      expect(result.find((x) => x.name === 'token')).toMatchObject({
+        name: 'token',
+        value: 'rotated',
+        secret: true,
         enabled: true
       });
     });
@@ -712,5 +795,59 @@ describe('generateCopyName', () => {
   it('treats an existing name as taken even when it differs only by case or whitespace', () => {
     const existing = ['production', ' Production copy  '];
     expect(generateCopyName('Production', existing)).toEqual('Production copy 2');
+  });
+});
+
+describe('orderEnvironmentsByInheritance', () => {
+  const env = (name, extendsFrom) => ({ name, extends: extendsFrom });
+
+  it('places a parent before the child that inherits from it', () => {
+    const dev = env('dev', 'base');
+    const base = env('base');
+
+    expect(orderEnvironmentsByInheritance([dev, base])).toEqual([base, dev]);
+  });
+
+  it('orders a whole chain root first', () => {
+    const leaf = env('leaf', 'middle');
+    const middle = env('middle', 'root');
+    const root = env('root');
+
+    expect(orderEnvironmentsByInheritance([leaf, middle, root])).toEqual([root, middle, leaf]);
+  });
+
+  it('keeps the input order when no environment inherits from another', () => {
+    const first = env('first');
+    const second = env('second');
+
+    expect(orderEnvironmentsByInheritance([first, second])).toEqual([first, second]);
+  });
+
+  it('keeps a reference to an environment outside the set in place', () => {
+    const dev = env('dev', 'NotImported');
+    const other = env('other');
+
+    expect(orderEnvironmentsByInheritance([dev, other])).toEqual([dev, other]);
+  });
+
+  it('returns every environment exactly once for a cyclic pair', () => {
+    const first = env('first', 'second');
+    const second = env('second', 'first');
+
+    expect(orderEnvironmentsByInheritance([first, second])).toHaveLength(2);
+  });
+
+  it('keeps both environments that share a name', () => {
+    const first = env('dev');
+    const second = env('dev');
+
+    expect(orderEnvironmentsByInheritance([first, second])).toEqual([first, second]);
+  });
+
+  it('ignores a list-shaped reference, which no resolver follows', () => {
+    const dev = { name: 'dev', extends: ['base'] };
+    const base = env('base');
+
+    expect(orderEnvironmentsByInheritance([dev, base])).toEqual([dev, base]);
   });
 });

--- a/packages/bruno-app/src/utils/environments.spec.js
+++ b/packages/bruno-app/src/utils/environments.spec.js
@@ -487,6 +487,22 @@ describe('applyScriptEnvVars', () => {
       const result = applyScriptEnvVars([secretVar('apiToken', 'old')], { apiToken: 'new' }, null);
       expect(result[0]).toMatchObject({ name: 'apiToken', value: 'new', secret: true });
     });
+
+    // The write lands on a freshly appended row, since a disabled row is never a write target.
+    // Appended as a plain row it would put the secret in the environment file in cleartext.
+    it('appends the write to a disabled secret row as a secret (direct-apply)', () => {
+      const result = applyScriptEnvVars([secretVar('apiToken', '', false)], { apiToken: 'rotated' }, null);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ name: 'apiToken', value: 'rotated', secret: true, enabled: true });
+    });
+
+    it('appends the write to a disabled secret row as a secret (baseline mode)', () => {
+      const result = applyScriptEnvVars([secretVar('apiToken', '', false)], { apiToken: 'rotated' }, {});
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ name: 'apiToken', value: 'rotated', secret: true, enabled: true });
+    });
   });
 });
 

--- a/packages/bruno-app/src/utils/exporters/bruno-environment.js
+++ b/packages/bruno-app/src/utils/exporters/bruno-environment.js
@@ -7,7 +7,8 @@ export const exportBrunoEnvironment = async ({ environments, environmentType, fi
     let cleanEnvironments = environments.map((environment) => ({
       name: environment.name,
       variables: (environment.variables || []).map((envVariable) => buildEnvVariable({ envVariable })),
-      color: environment.color ?? undefined
+      color: environment.color ?? undefined,
+      extends: environment.extends ?? undefined
     }));
 
     await ipcRenderer.invoke('renderer:export-environment', {

--- a/packages/bruno-app/src/utils/exporters/bruno-environment.spec.js
+++ b/packages/bruno-app/src/utils/exporters/bruno-environment.spec.js
@@ -1,0 +1,35 @@
+jest.mock('nanoid', () => ({
+  nanoid: () => 'aaaaaaaaaaaaaaaaaaaa1',
+  customAlphabet: () => () => 'aaaaaaaaaaaaaaaaaaaa1'
+}));
+
+import { exportBrunoEnvironment } from './bruno-environment';
+
+const exportedEnvironments = async (environments) => {
+  const invoke = jest.fn().mockResolvedValue(undefined);
+  window.ipcRenderer = { invoke };
+
+  await exportBrunoEnvironment({ environments, environmentType: 'collection', filePath: '/tmp/export' });
+
+  return invoke.mock.calls[0][1].environments;
+};
+
+describe('exportBrunoEnvironment — inheritance', () => {
+  it('carries the extends reference of an inheriting environment', async () => {
+    const [environment] = await exportedEnvironments([{ name: 'dev', variables: [], extends: 'Base' }]);
+
+    expect(environment.extends).toBe('Base');
+  });
+
+  it('leaves out extends for an environment that inherits from nothing', async () => {
+    const [environment] = await exportedEnvironments([{ name: 'dev', variables: [], extends: null }]);
+
+    expect(environment.extends).toBeUndefined();
+  });
+
+  it('carries a list of extends references', async () => {
+    const [environment] = await exportedEnvironments([{ name: 'dev', variables: [], extends: ['base', 'shared'] }]);
+
+    expect(environment.extends).toEqual(['base', 'shared']);
+  });
+});

--- a/packages/bruno-app/src/utils/exporters/bruno-environment.spec.js
+++ b/packages/bruno-app/src/utils/exporters/bruno-environment.spec.js
@@ -3,13 +3,17 @@ jest.mock('nanoid', () => ({
   customAlphabet: () => () => 'aaaaaaaaaaaaaaaaaaaa1'
 }));
 
+import os from 'os';
+import path from 'path';
 import { exportBrunoEnvironment } from './bruno-environment';
+
+const exportFilePath = path.join(os.tmpdir(), 'export');
 
 const exportedEnvironments = async (environments) => {
   const invoke = jest.fn().mockResolvedValue(undefined);
   window.ipcRenderer = { invoke };
 
-  await exportBrunoEnvironment({ environments, environmentType: 'collection', filePath: '/tmp/export' });
+  await exportBrunoEnvironment({ environments, environmentType: 'collection', filePath: exportFilePath });
 
   return invoke.mock.calls[0][1].environments;
 };

--- a/packages/bruno-app/src/utils/importers/bruno-environment.js
+++ b/packages/bruno-app/src/utils/importers/bruno-environment.js
@@ -1,5 +1,6 @@
 import { BrunoError } from 'utils/common/error';
 import { buildEnvVariable, dedupeImportedSecrets } from 'utils/environments';
+import { validatedEnvironmentExtendsFrom } from '@usebruno/common/utils';
 
 const validateBrunoEnvironment = (env, filePath, fileName) => {
   if (!env || typeof env !== 'object') {
@@ -20,12 +21,18 @@ const validateBrunoEnvironment = (env, filePath, fileName) => {
     }
   });
 
+  const environmentExtendsFrom = validatedEnvironmentExtendsFrom(env.extends);
+  if (env.extends && !environmentExtendsFrom) {
+    throw new BrunoError('Invalid environment: extends is not a valid environment name');
+  }
+
   const variables = env.variables.map((envVariable) => buildEnvVariable({ envVariable, withUuid: true }));
 
   return {
     name: env.name,
     variables: dedupeImportedSecrets(variables),
     color: env.color,
+    extends: environmentExtendsFrom,
     filePath,
     fileName
   };

--- a/packages/bruno-app/src/utils/importers/bruno-environment.js
+++ b/packages/bruno-app/src/utils/importers/bruno-environment.js
@@ -22,7 +22,8 @@ const validateBrunoEnvironment = (env, filePath, fileName) => {
   });
 
   const environmentExtendsFrom = validatedEnvironmentExtendsFrom(env.extends);
-  if (env.extends && !environmentExtendsFrom) {
+  const hasExtendsReference = env.extends !== undefined && env.extends !== null && env.extends !== '';
+  if (hasExtendsReference && !environmentExtendsFrom) {
     throw new BrunoError('Invalid environment: extends is not a valid environment name');
   }
 

--- a/packages/bruno-app/src/utils/importers/bruno-environment.spec.js
+++ b/packages/bruno-app/src/utils/importers/bruno-environment.spec.js
@@ -135,4 +135,25 @@ describe('importBrunoEnvironment — inheritance', () => {
     expect(valid).toEqual([]);
     expect(invalid[0].error).toMatch(/not a valid environment name/);
   });
+
+  it('rejects an extends reference of 0', () => {
+    const { valid, invalid } = importSingleEnvironment({ name: 'dev', variables: [], extends: 0 });
+
+    expect(valid).toEqual([]);
+    expect(invalid[0].error).toMatch(/not a valid environment name/);
+  });
+
+  it('rejects an extends reference of false', () => {
+    const { valid, invalid } = importSingleEnvironment({ name: 'dev', variables: [], extends: false });
+
+    expect(valid).toEqual([]);
+    expect(invalid[0].error).toMatch(/not a valid environment name/);
+  });
+
+  it('treats an empty extends reference as no inheritance', () => {
+    const { valid: [environment], invalid } = importSingleEnvironment({ name: 'dev', variables: [], extends: '' });
+
+    expect(invalid).toEqual([]);
+    expect(environment.extends).toBeUndefined();
+  });
 });

--- a/packages/bruno-app/src/utils/importers/bruno-environment.spec.js
+++ b/packages/bruno-app/src/utils/importers/bruno-environment.spec.js
@@ -65,3 +65,74 @@ describe('importBrunoEnvironment — duplicate secrets', () => {
     expect(environments.map((env) => env.variables.length)).toEqual([1, 1]);
   });
 });
+
+describe('importBrunoEnvironment — inheritance', () => {
+  const importSingleEnvironment = (env) => importBrunoEnvironment([parsedFile(env)]);
+
+  it('carries the extends reference of a single environment', () => {
+    const { valid: [environment] } = importBrunoEnvironment([
+      parsedFile({ name: 'dev', variables: [], extends: 'Base', info: { type: 'bruno-environment' } })
+    ]);
+
+    expect(environment.extends).toBe('Base');
+  });
+
+  it('carries the extends reference of each environment of a multi-environment file', () => {
+    const { valid: environments } = importBrunoEnvironment([
+      parsedFile({
+        info: { type: 'bruno-environment' },
+        environments: [
+          { name: 'base', variables: [] },
+          { name: 'dev', variables: [], extends: 'base' }
+        ]
+      })
+    ]);
+
+    expect(environments.map((env) => env.extends)).toEqual([undefined, 'base']);
+  });
+
+  it('keeps a reference to an environment absent from the import', () => {
+    const { valid: [environment] } = importBrunoEnvironment([
+      parsedFile({ name: 'dev', variables: [], extends: 'NotImported' })
+    ]);
+
+    expect(environment.extends).toBe('NotImported');
+  });
+
+  it('carries a list of extends references', () => {
+    const { valid: [environment] } = importBrunoEnvironment([
+      parsedFile({ name: 'dev', variables: [], extends: ['base', 'shared'] })
+    ]);
+
+    expect(environment.extends).toEqual(['base', 'shared']);
+  });
+
+  it('rejects an extends reference carrying a newline, which would inject directives into the file', () => {
+    const { valid, invalid } = importSingleEnvironment({
+      name: 'dev',
+      variables: [],
+      extends: 'base\nvars {\n  injected: pwned\n}'
+    });
+
+    expect(valid).toEqual([]);
+    expect(invalid[0].error).toMatch(/not a valid environment name/);
+  });
+
+  it('rejects a list holding an extends reference carrying a newline', () => {
+    const { valid, invalid } = importSingleEnvironment({
+      name: 'dev',
+      variables: [],
+      extends: ['base', 'shared\nvars {\n  injected: pwned\n}']
+    });
+
+    expect(valid).toEqual([]);
+    expect(invalid[0].error).toMatch(/not a valid environment name/);
+  });
+
+  it('rejects an extends reference that is not a string', () => {
+    const { valid, invalid } = importSingleEnvironment({ name: 'dev', variables: [], extends: 42 });
+
+    expect(valid).toEqual([]);
+    expect(invalid[0].error).toMatch(/not a valid environment name/);
+  });
+});

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -1,18 +1,15 @@
 const fs = require('fs');
 const chalk = require('chalk');
 const path = require('path');
-const yaml = require('js-yaml');
 const { forOwn, cloneDeep } = require('lodash');
 const { getRunnerSummary } = require('@usebruno/common/runner');
 const { exists, stripExtension, isSafeFileName } = require('../utils/filesystem');
 const { runSingleRequest } = require('../runner/run-single-request');
-const { getEnvVars } = require('../utils/bru');
-const { parseEnvironmentJson } = require('../utils/environment');
 const { isRequestTagsIncluded } = require('@usebruno/common');
 const makeJUnitOutput = require('../reporters/junit');
 const makeHtmlOutput = require('../reporters/html');
 const { getOptions } = require('../utils/bru');
-const { parseDotEnv, parseEnvironment } = require('@usebruno/filestore');
+const { parseDotEnv } = require('@usebruno/filestore');
 const constants = require('../constants');
 const Table = require('cli-table3');
 const { findItemInCollection, createCollectionJsonFromPathname, getCallStack, FORMAT_CONFIG } = require('../utils/collection');
@@ -20,6 +17,7 @@ const { hasExecutableTestInScript } = require('../utils/request');
 const { createSkippedFileResults } = require('../utils/run');
 const { sanitizeResultsForReporter } = require('../utils/sanitize-results');
 const { getSystemProxy } = require('@usebruno/requests');
+const { loadEnvironmentFromFile } = require('../utils/environment');
 const command = 'run [paths...]';
 const desc = 'Run one or more requests/folders';
 
@@ -388,34 +386,6 @@ const handler = async function (argv) {
       return 'bru';
     };
 
-    // Helper to load environment variables from a file
-    const loadEnvFromFile = (filePath, nameOverride) => {
-      const fileExt = path.extname(filePath).toLowerCase();
-      let result = {};
-
-      if (fileExt === '.json') {
-        const content = fs.readFileSync(filePath, 'utf8');
-        const parsed = JSON.parse(content);
-        const normalizedEnv = parseEnvironmentJson(parsed);
-        result = getEnvVars(normalizedEnv);
-        const rawName = normalizedEnv?.name;
-        const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
-        result.__name__ = trimmedName || path.basename(filePath, '.json');
-      } else if (fileExt === '.yml') {
-        const content = fs.readFileSync(filePath, 'utf8');
-        const envJson = parseEnvironment(content, { format: 'yml' });
-        result = getEnvVars(envJson);
-        result.__name__ = nameOverride || path.basename(filePath, '.yml');
-      } else {
-        const content = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
-        const envJson = parseEnvironment(content, { format: 'bru' });
-        result = getEnvVars(envJson);
-        result.__name__ = nameOverride || path.basename(filePath, '.bru');
-      }
-
-      return result;
-    };
-
     // Load --env-file if provided
     if (envFile) {
       const envFilePath = path.resolve(collectionPath, envFile);
@@ -424,8 +394,13 @@ const handler = async function (argv) {
         process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
       try {
-        envVars = loadEnvFromFile(envFilePath);
-        envFileDescriptor = { path: envFilePath, format: resolveEnvFileFormat(envFilePath) };
+        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(envFilePath);
+        envVars = environmentVariables;
+        envFileDescriptor = {
+          path: envFilePath,
+          format: resolveEnvFileFormat(envFilePath),
+          inheritedEnvironmentVariables
+        };
       } catch (err) {
         console.error(chalk.red(`Failed to parse environment file: ${err.message}`));
         process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
@@ -449,9 +424,13 @@ const handler = async function (argv) {
         const defaultEnvFilePath = path.join(collectionPath, 'environments', `${defaultEnvironment}${envExt}`);
         if (await exists(defaultEnvFilePath)) {
           try {
-            const defaultEnvVars = loadEnvFromFile(defaultEnvFilePath, defaultEnvironment);
-            envVars = { ...envVars, ...defaultEnvVars };
-            envFileDescriptor = { path: defaultEnvFilePath, format: collection.format };
+            const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(defaultEnvFilePath, defaultEnvironment);
+            envVars = { ...envVars, ...environmentVariables };
+            envFileDescriptor = {
+              path: defaultEnvFilePath,
+              format: collection.format,
+              inheritedEnvironmentVariables
+            };
             console.log(chalk.dim(`Using default environment: ${defaultEnvironment}`));
           } catch (err) {
             console.error(chalk.red(`Failed to parse default environment file: ${err.message}`));
@@ -475,9 +454,13 @@ const handler = async function (argv) {
         process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
       try {
-        const collectionEnvVars = loadEnvFromFile(collectionEnvFilePath, env);
-        envVars = { ...envVars, ...collectionEnvVars };
-        envFileDescriptor = { path: collectionEnvFilePath, format: collection.format };
+        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(collectionEnvFilePath, env);
+        envVars = { ...envVars, ...environmentVariables };
+        envFileDescriptor = {
+          path: collectionEnvFilePath,
+          format: collection.format,
+          inheritedEnvironmentVariables
+        };
       } catch (err) {
         console.error(chalk.red(`Failed to parse Environment file: ${err.message}`));
         process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);
@@ -528,11 +511,13 @@ const handler = async function (argv) {
       }
 
       try {
-        const globalEnvContent = fs.readFileSync(globalEnvFilePath, 'utf8');
-        const globalEnvJson = parseEnvironment(globalEnvContent, { format: 'yml' });
-        globalEnvVars = getEnvVars(globalEnvJson);
-        globalEnvVars.__name__ = globalEnv;
-        globalEnvFileDescriptor = { path: globalEnvFilePath, format: 'yml' };
+        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(globalEnvFilePath, globalEnv);
+        globalEnvVars = environmentVariables;
+        globalEnvFileDescriptor = {
+          path: globalEnvFilePath,
+          format: 'yml',
+          inheritedEnvironmentVariables
+        };
       } catch (err) {
         console.error(chalk.red(`Failed to parse global environment: ${err.message}`));
         process.exit(constants.EXIT_STATUS.ERROR_INVALID_FILE);

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -370,6 +370,10 @@ const handler = async function (argv) {
     let globalEnvVars = {};
     let envFileDescriptor = null;
     let globalEnvFileDescriptor = null;
+    // Enabled entries of an `--env-file`, handed to a `--env` passed alongside it: both files'
+    // variables reach the same runtime map, but only the `--env` file is written back, and a name
+    // belongs to the file that declares it.
+    let envFileVariables = [];
     // --env-var overrides as Map<name, injected value>. The persistence layer compares the
     // script's resulting value against the injected value to tell a leaked override (same
     // value passed through unchanged) apart from a deliberate same-named script write that
@@ -394,12 +398,17 @@ const handler = async function (argv) {
         process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
       try {
-        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile({ filePath: envFilePath, isEnvFile: true });
+        // An `--env-file` is loaded exactly as the file reads: its `extends` chain is left
+        // unresolved, even when the path points at one of the collection's own environments.
+        const { variables: environmentVariables, ownVariables } = loadEnvironmentFromFile({
+          filePath: envFilePath,
+          resolveInheritance: false
+        });
         envVars = environmentVariables;
+        envFileVariables = ownVariables;
         envFileDescriptor = {
           path: envFilePath,
-          format: resolveEnvFileFormat(envFilePath),
-          inheritedEnvironmentVariables
+          format: resolveEnvFileFormat(envFilePath)
         };
       } catch (err) {
         console.error(chalk.red(`Failed to parse environment file: ${err.message}`));
@@ -459,7 +468,8 @@ const handler = async function (argv) {
         envFileDescriptor = {
           path: collectionEnvFilePath,
           format: collection.format,
-          inheritedEnvironmentVariables
+          inheritedEnvironmentVariables,
+          envFileVariables
         };
       } catch (err) {
         console.error(chalk.red(`Failed to parse Environment file: ${err.message}`));

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -394,7 +394,7 @@ const handler = async function (argv) {
         process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
       try {
-        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(envFilePath);
+        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile({ filePath: envFilePath, isEnvFile: true });
         envVars = environmentVariables;
         envFileDescriptor = {
           path: envFilePath,
@@ -424,7 +424,7 @@ const handler = async function (argv) {
         const defaultEnvFilePath = path.join(collectionPath, 'environments', `${defaultEnvironment}${envExt}`);
         if (await exists(defaultEnvFilePath)) {
           try {
-            const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(defaultEnvFilePath, defaultEnvironment);
+            const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile({ filePath: defaultEnvFilePath, name: defaultEnvironment });
             envVars = { ...envVars, ...environmentVariables };
             envFileDescriptor = {
               path: defaultEnvFilePath,
@@ -454,7 +454,7 @@ const handler = async function (argv) {
         process.exit(constants.EXIT_STATUS.ERROR_ENV_NOT_FOUND);
       }
       try {
-        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(collectionEnvFilePath, env);
+        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile({ filePath: collectionEnvFilePath, name: env });
         envVars = { ...envVars, ...environmentVariables };
         envFileDescriptor = {
           path: collectionEnvFilePath,
@@ -511,7 +511,7 @@ const handler = async function (argv) {
       }
 
       try {
-        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile(globalEnvFilePath, globalEnv);
+        const { variables: environmentVariables, inheritedVariables: inheritedEnvironmentVariables } = loadEnvironmentFromFile({ filePath: globalEnvFilePath, name: globalEnv });
         globalEnvVars = environmentVariables;
         globalEnvFileDescriptor = {
           path: globalEnvFilePath,

--- a/packages/bruno-cli/src/utils/bru.js
+++ b/packages/bruno-cli/src/utils/bru.js
@@ -129,16 +129,17 @@ const bruToJson = (bru) => {
 };
 
 const getEnvVars = (environment = {}) => {
-  const variables = environment.variables;
-  if (!variables || !variables.length) {
+  const variables = [...(environment.inheritedVariables || []), ...(environment.variables || [])];
+  if (!variables.length) {
     return {};
   }
 
   const envVars = {};
-  _.each(variables, (variable) => {
-    if (variable.enabled) {
-      envVars[variable.name] = variable.value;
-    }
+  // Apply secrets last so a secret wins over a plain variable of the same name,
+  // regardless of their order in the array.
+  const enabledVars = variables.filter((variable) => variable.enabled);
+  _.each([...enabledVars.filter((variable) => !variable.secret), ...enabledVars.filter((variable) => variable.secret)], (variable) => {
+    envVars[variable.name] = variable.value;
   });
 
   return envVars;

--- a/packages/bruno-cli/src/utils/bru.js
+++ b/packages/bruno-cli/src/utils/bru.js
@@ -3,6 +3,7 @@ const {
   parseRequest: _parseRequest,
   parseCollection: _parseCollection
 } = require('@usebruno/filestore');
+const { toVariablesMap } = require('@usebruno/common').utils;
 
 const collectionBruToJson = (bru) => {
   try {
@@ -128,22 +129,8 @@ const bruToJson = (bru) => {
   }
 };
 
-const getEnvVars = (environment = {}) => {
-  const variables = [...(environment.inheritedVariables || []), ...(environment.variables || [])];
-  if (!variables.length) {
-    return {};
-  }
-
-  const envVars = {};
-  // Apply secrets last so a secret wins over a plain variable of the same name,
-  // regardless of their order in the array.
-  const enabledVars = variables.filter((variable) => variable.enabled);
-  _.each([...enabledVars.filter((variable) => !variable.secret), ...enabledVars.filter((variable) => variable.secret)], (variable) => {
-    envVars[variable.name] = variable.value;
-  });
-
-  return envVars;
-};
+const getEnvVars = (environment = {}) =>
+  toVariablesMap([...(environment.inheritedVariables || []), ...(environment.variables || [])]);
 
 const options = {};
 const getOptions = () => {

--- a/packages/bruno-cli/src/utils/environment.js
+++ b/packages/bruno-cli/src/utils/environment.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const { parseEnvironment } = require('@usebruno/filestore');
+const { getEnvVars } = require('../utils/bru');
+const { isSafeFileName } = require('./filesystem');
 
 /**
  * Parse a Bruno JSON environment object and normalize variables
@@ -61,7 +63,110 @@ const loadEnvironments = async (collectionPath, format) => {
   return environments.sort((a, b) => a.name.localeCompare(b.name));
 };
 
+const environmentNameOf = (filePath) => path.basename(filePath, path.extname(filePath));
+
+const environmentNamesIn = (directory, fileExt) =>
+  fs
+    .readdirSync(directory)
+    .filter((fileName) => path.extname(fileName) === fileExt)
+    .map((fileName) => path.basename(fileName, fileExt));
+
+/**
+ * Resolve the `extends` chain of the environment at `filePath`, reading each ancestor from the
+ * sibling file of the same name and format.
+ * With `merge`, the inherited variables are folded into `variables`; otherwise they are returned
+ * separately as `inheritedVariables`.
+ */
+const resolveEnvironmentInheritance = ({ filePath, merge }) => {
+  const directory = path.dirname(filePath);
+  const fileExt = path.extname(filePath);
+  const targetEnvironment = parseEnvironment(filePath);
+  const environmentNames = environmentNamesIn(directory, fileExt);
+
+  const inheritedEnvironments = [];
+  const walked = new Set([environmentNameOf(filePath)]);
+
+  let current = targetEnvironment;
+  while (typeof current?.extends === 'string') {
+    if (!isSafeFileName(current.extends)) {
+      break;
+    }
+
+    const parentName = current.extends;
+    if (!environmentNames.includes(parentName) || walked.has(parentName)) {
+      break;
+    }
+
+    walked.add(parentName);
+    current = { ...parseEnvironment(path.join(directory, `${parentName}${fileExt}`)), name: parentName };
+    inheritedEnvironments.push(current);
+  }
+
+  inheritedEnvironments.reverse();
+
+  const nonSecrets = new Map();
+  const secrets = new Map();
+
+  inheritedEnvironments.forEach((environment) => {
+    const inheritedFrom = { name: environment.name };
+
+    environment.variables?.forEach((v) => {
+      if (!v.enabled) {
+        return;
+      }
+
+      const variable = { ...v, inheritedFrom };
+      if (v.secret) {
+        secrets.set(v.name, variable);
+      } else {
+        nonSecrets.set(v.name, variable);
+      }
+    });
+  });
+
+  const ownVariables = targetEnvironment?.variables ?? [];
+  ownVariables.forEach((v) => {
+    if (!v.enabled) {
+      return;
+    }
+
+    if (v.secret) {
+      secrets.delete(v.name);
+    } else {
+      nonSecrets.delete(v.name);
+    }
+  });
+
+  const inheritedVariables = [...nonSecrets.values(), ...secrets.values()];
+
+  if (merge) {
+    return { ...targetEnvironment, variables: [...inheritedVariables, ...ownVariables] };
+  }
+
+  return { ...targetEnvironment, inheritedVariables };
+};
+
+// Helper to load environment variables from a file. Returns the inherited variables too, so
+// callers can tell which names it merely inherits — those belong to the parent file.
+const loadEnvironmentFromFile = (filePath, nameOverride) => {
+  const fileExt = path.extname(filePath).toLowerCase();
+  const environment = resolveEnvironmentInheritance({ filePath });
+  const variables = getEnvVars(environment);
+
+  if (fileExt === '.json') {
+    const rawName = environment?.name;
+    const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
+    variables.__name__ = trimmedName || path.basename(filePath, '.json');
+  } else {
+    variables.__name__ = nameOverride || path.basename(filePath, fileExt === '.yml' ? '.yml' : '.bru');
+  }
+
+  return { variables, inheritedVariables: environment?.inheritedVariables || [] };
+};
+
 module.exports = {
   parseEnvironmentJson,
-  loadEnvironments
+  loadEnvironments,
+  resolveEnvironmentInheritance,
+  loadEnvironmentFromFile
 };

--- a/packages/bruno-cli/src/utils/environment.js
+++ b/packages/bruno-cli/src/utils/environment.js
@@ -100,7 +100,7 @@ const resolveEnvironmentInheritance = ({ filePath, merge }) => {
     merge
   });
 
-  return { ...resolved, name: targetEnvironment.name };
+  return { ...resolved, name: environment.name };
 };
 
 // Helper to load environment variables from a file. Returns the inherited variables too, so

--- a/packages/bruno-cli/src/utils/environment.js
+++ b/packages/bruno-cli/src/utils/environment.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { parseEnvironment } = require('@usebruno/filestore');
 const { getEnvVars } = require('../utils/bru');
-const { isSafeFileName } = require('./filesystem');
+const { resolveEnvironmentInheritance: resolveEnvironmentInheritanceCommon } = require('@usebruno/common').utils;
 
 /**
  * Parse a Bruno JSON environment object and normalize variables
@@ -65,92 +65,51 @@ const loadEnvironments = async (collectionPath, format) => {
 
 const environmentNameOf = (filePath) => path.basename(filePath, path.extname(filePath));
 
-const environmentNamesIn = (directory, fileExt) =>
+const environmentsIn = (directory, fileExt) =>
   fs
     .readdirSync(directory)
     .filter((fileName) => path.extname(fileName) === fileExt)
-    .map((fileName) => path.basename(fileName, fileExt));
+    .map((fileName) => {
+      try {
+        return {
+          ...parseEnvironment(path.join(directory, fileName)),
+          name: path.basename(fileName, fileExt)
+        };
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
 
 /**
- * Resolve the `extends` chain of the environment at `filePath`, reading each ancestor from the
- * sibling file of the same name and format.
+ * Resolve the `extends` chain of the environment at `filePath` against its sibling environment files.
  * With `merge`, the inherited variables are folded into `variables`; otherwise they are returned
  * separately as `inheritedVariables`.
  */
 const resolveEnvironmentInheritance = ({ filePath, merge }) => {
-  const directory = path.dirname(filePath);
-  const fileExt = path.extname(filePath);
   const targetEnvironment = parseEnvironment(filePath);
-  const environmentNames = environmentNamesIn(directory, fileExt);
+  const environment = { ...targetEnvironment, name: environmentNameOf(filePath) };
 
-  const inheritedEnvironments = [];
-  const walked = new Set([environmentNameOf(filePath)]);
+  const environments = environment.extends
+    ? environmentsIn(path.dirname(filePath), path.extname(filePath))
+    : [];
 
-  let current = targetEnvironment;
-  while (typeof current?.extends === 'string') {
-    if (!isSafeFileName(current.extends)) {
-      break;
-    }
-
-    const parentName = current.extends;
-    if (!environmentNames.includes(parentName) || walked.has(parentName)) {
-      break;
-    }
-
-    walked.add(parentName);
-    current = { ...parseEnvironment(path.join(directory, `${parentName}${fileExt}`)), name: parentName };
-    inheritedEnvironments.push(current);
-  }
-
-  inheritedEnvironments.reverse();
-
-  const nonSecrets = new Map();
-  const secrets = new Map();
-
-  inheritedEnvironments.forEach((environment) => {
-    const inheritedFrom = { name: environment.name };
-
-    environment.variables?.forEach((v) => {
-      if (!v.enabled) {
-        return;
-      }
-
-      const variable = { ...v, inheritedFrom };
-      if (v.secret) {
-        secrets.set(v.name, variable);
-      } else {
-        nonSecrets.set(v.name, variable);
-      }
-    });
+  const resolved = resolveEnvironmentInheritanceCommon({
+    environments,
+    targetEnvironment: environment,
+    merge
   });
 
-  const ownVariables = targetEnvironment?.variables ?? [];
-  ownVariables.forEach((v) => {
-    if (!v.enabled) {
-      return;
-    }
-
-    if (v.secret) {
-      secrets.delete(v.name);
-    } else {
-      nonSecrets.delete(v.name);
-    }
-  });
-
-  const inheritedVariables = [...nonSecrets.values(), ...secrets.values()];
-
-  if (merge) {
-    return { ...targetEnvironment, variables: [...inheritedVariables, ...ownVariables] };
-  }
-
-  return { ...targetEnvironment, inheritedVariables };
+  return { ...resolved, name: targetEnvironment.name };
 };
 
 // Helper to load environment variables from a file. Returns the inherited variables too, so
 // callers can tell which names it merely inherits — those belong to the parent file.
-const loadEnvironmentFromFile = (filePath, nameOverride) => {
+const loadEnvironmentFromFile = ({ filePath, name, isEnvFile }) => {
   const fileExt = path.extname(filePath).toLowerCase();
-  const environment = resolveEnvironmentInheritance({ filePath });
+
+  const canInherit = !isEnvFile && path.basename(path.dirname(filePath)) === 'environments';
+  const environment = canInherit ? resolveEnvironmentInheritance({ filePath }) : parseEnvironment(filePath);
   const variables = getEnvVars(environment);
 
   if (fileExt === '.json') {
@@ -158,7 +117,7 @@ const loadEnvironmentFromFile = (filePath, nameOverride) => {
     const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
     variables.__name__ = trimmedName || path.basename(filePath, '.json');
   } else {
-    variables.__name__ = nameOverride || path.basename(filePath, fileExt === '.yml' ? '.yml' : '.bru');
+    variables.__name__ = name || path.basename(filePath, fileExt === '.yml' ? '.yml' : '.bru');
   }
 
   return { variables, inheritedVariables: environment?.inheritedVariables || [] };

--- a/packages/bruno-cli/src/utils/environment.js
+++ b/packages/bruno-cli/src/utils/environment.js
@@ -68,12 +68,12 @@ const environmentNameOf = (filePath) => path.basename(filePath, path.extname(fil
 const environmentsIn = (directory, fileExt) =>
   fs
     .readdirSync(directory)
-    .filter((fileName) => path.extname(fileName) === fileExt)
+    .filter((fileName) => path.extname(fileName).toLowerCase() === fileExt)
     .map((fileName) => {
       try {
         return {
           ...parseEnvironment(path.join(directory, fileName)),
-          name: path.basename(fileName, fileExt)
+          name: environmentNameOf(fileName)
         };
       } catch {
         return null;
@@ -91,7 +91,7 @@ const resolveEnvironmentInheritance = ({ filePath, merge }) => {
   const environment = { ...targetEnvironment, name: environmentNameOf(filePath) };
 
   const environments = environment.extends
-    ? environmentsIn(path.dirname(filePath), path.extname(filePath))
+    ? environmentsIn(path.dirname(filePath), path.extname(filePath).toLowerCase())
     : [];
 
   const resolved = resolveEnvironmentInheritanceCommon({
@@ -104,23 +104,29 @@ const resolveEnvironmentInheritance = ({ filePath, merge }) => {
 };
 
 // Helper to load environment variables from a file. Returns the inherited variables too, so
-// callers can tell which names it merely inherits — those belong to the parent file.
-const loadEnvironmentFromFile = ({ filePath, name, isEnvFile }) => {
+// callers can tell which names it merely inherits — those belong to the parent file — and its own
+// entries, so a caller that loads this file alongside another environment can tell that one which
+// names it must leave to this file. With `resolveInheritance` off the file is loaded exactly as it
+// reads, `extends` chain and all left unresolved.
+const loadEnvironmentFromFile = ({ filePath, name, resolveInheritance = true }) => {
   const fileExt = path.extname(filePath).toLowerCase();
 
-  const canInherit = !isEnvFile && path.basename(path.dirname(filePath)) === 'environments';
-  const environment = canInherit ? resolveEnvironmentInheritance({ filePath }) : parseEnvironment(filePath);
+  const environment = resolveInheritance ? resolveEnvironmentInheritance({ filePath }) : parseEnvironment(filePath);
   const variables = getEnvVars(environment);
 
   if (fileExt === '.json') {
     const rawName = environment?.name;
     const trimmedName = typeof rawName === 'string' ? rawName.trim() : '';
-    variables.__name__ = trimmedName || path.basename(filePath, '.json');
+    variables.__name__ = trimmedName || environmentNameOf(filePath);
   } else {
-    variables.__name__ = name || path.basename(filePath, fileExt === '.yml' ? '.yml' : '.bru');
+    variables.__name__ = name || environmentNameOf(filePath);
   }
 
-  return { variables, inheritedVariables: environment?.inheritedVariables || [] };
+  return {
+    variables,
+    inheritedVariables: environment?.inheritedVariables || [],
+    ownVariables: (environment?.variables || []).filter((v) => v.enabled)
+  };
 };
 
 module.exports = {

--- a/packages/bruno-cli/src/utils/environment.js
+++ b/packages/bruno-cli/src/utils/environment.js
@@ -72,7 +72,7 @@ const environmentsIn = (directory, fileExt) =>
     .map((fileName) => {
       try {
         return {
-          ...parseEnvironment(path.join(directory, fileName)),
+          ...parseEnvFile(path.join(directory, fileName)),
           name: environmentNameOf(fileName)
         };
       } catch {
@@ -87,7 +87,7 @@ const environmentsIn = (directory, fileExt) =>
  * separately as `inheritedVariables`.
  */
 const resolveEnvironmentInheritance = ({ filePath, merge }) => {
-  const targetEnvironment = parseEnvironment(filePath);
+  const targetEnvironment = parseEnvFile(filePath);
   const environment = { ...targetEnvironment, name: environmentNameOf(filePath) };
 
   const environments = environment.extends
@@ -111,7 +111,7 @@ const resolveEnvironmentInheritance = ({ filePath, merge }) => {
 const loadEnvironmentFromFile = ({ filePath, name, resolveInheritance = true }) => {
   const fileExt = path.extname(filePath).toLowerCase();
 
-  const environment = resolveInheritance ? resolveEnvironmentInheritance({ filePath }) : parseEnvironment(filePath);
+  const environment = resolveInheritance ? resolveEnvironmentInheritance({ filePath }) : parseEnvFile(filePath);
   const variables = getEnvVars(environment);
 
   if (fileExt === '.json') {

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -35,6 +35,26 @@ const applyInferredDataType = (variable, value) => {
 };
 
 /**
+ * Marks a variable secret and empties its value, so a script-written secret cannot reach disk.
+ * The `.bru` and `.yml` writers emit secrets as name-only rows, but the JSON path serializes the
+ * entry as-is — a retained value would land there in cleartext. Emptied rather than deleted: `''`
+ * is the value a secret parses back as, so the entry keeps the shape every reader expects.
+ * Only the disk copy is emptied; the runtime map still carries the value for later requests.
+ *
+ * @param {{ name: string, value?: any, secret?: boolean }} variable - Variable entry to mutate in place.
+ * @returns {object} The same `variable` reference, after mutation.
+ *
+ * @example
+ * markSecretWithEmptyValue({ name: 'token', value: 'rotated', secret: false });
+ *  → { name: 'token', value: '', secret: true }
+ */
+const markSecretWithEmptyValue = (variable) => {
+  variable.secret = true;
+  variable.value = '';
+  return variable;
+};
+
+/**
  * Returns a shallow copy of `vars` with internal keys (`__name__`) removed.
  *
  * @param {Object<string, any>} vars - Flat name→value map; may be null/undefined.
@@ -132,7 +152,8 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
  * Reconcile the env file's array of variable entries against the script's flat name→value map.
  * - Disabled entries are always preserved (user intent — toggled off, not deleted).
  * - Enabled entries absent from script output are dropped (so `bru.deleteEnvVar` reaches disk).
- * - New script keys are appended as enabled text vars with inferred dataType.
+ * - New script keys are appended as enabled text vars with inferred dataType, except a name a
+ *   disabled secret entry already declares — a secret's value has no on-disk representation here.
  * - `overrides`: names supplied via CLI (`--env-var`, or `--global-env-var` when merging the
  *   global env file) keyed to their injected value. The leaked override value never reaches
  *   disk and the file's entry is preserved, but a deliberate script write of a *different*
@@ -141,10 +162,10 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
  * @param {Array<{ name: string, value: any, enabled?: boolean, type?: string, secret?: boolean, dataType?: string }>} variables
  *   Existing entries from the env file.
  * @param {Object<string, any>} scriptVarsRaw - Flat map from the script runtime; may include `__name__`.
- * @param {{ overrides?: Map<string, string>, skipKeys?: string[], inheritedVariables?: Array<object> }} [options] -
- *   Names → injected override values, names that must never be written to this file (e.g. inherited
- *   from a parent env), and the resolved parent-chain entries an appended override inherits its
- *   `secret` flag from.
+ * @param {{ overrides?: Map<string, string>, skipKeys?: string[], variablesFromOtherEnvironmentFiles?: Array<object> }} [options] -
+ *   Names → injected override values, names that must never be written to this file (e.g. ones a
+ *   parent env declares), and the entries of every other environment file feeding the same runtime
+ *   map, which an appended override takes its `secret` flag from.
  * @returns {Array<object>} New array of merged variable entries.
  *
  * @example
@@ -186,12 +207,9 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
 const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw, options = {}) => {
   const overrides = options.overrides instanceof Map ? options.overrides : new Map();
   const scriptVars = stripInternal(scriptVarsRaw);
-  // A name the script still reported is a live name, whatever the reason it must not be written
-  // here. Absence from this set — and only that — is what marks a `bru.deleteEnvVar` below, so it
-  // is captured before any key is withheld.
-  const declaredKeys = new Set(Object.keys(scriptVars));
-  // Inherited names reach the runtime map but are declared in the parent file. Writing them here
-  // would fork a private copy that shadows the parent — and strip a parent secret down to a plain row.
+  const scriptVarsKeys = new Set(Object.keys(scriptVars));
+  // These names belong to another environment source (an `extends` parent, or an `--env-file`
+  // loaded alongside this one); writing them here would shadow that source with a copy.
   for (const name of options.skipKeys || []) {
     delete scriptVars[name];
   }
@@ -204,36 +222,50 @@ const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw, options = {}) => {
     }
   }
   const scriptKeys = new Set(Object.keys(scriptVars));
-  // A rotated inherited secret lands here as an override; as a plain row its value would reach
-  // disk in cleartext, so the parent's secret flag has to come with it.
-  const inheritedSecretNames = new Set((options.inheritedVariables || []).filter((v) => v.secret).map((v) => v.name));
+  // A rotated secret from another environment file lands here as an override; as a plain row its
+  // value would reach disk in cleartext, so that file's secret flag has to come with it.
+  const secretNamesFromOtherEnvironmentFiles = new Set(
+    (options.variablesFromOtherEnvironmentFiles || []).filter((v) => v.secret).map((v) => v.name)
+  );
 
   const next = (variables || [])
     .filter((v) => {
       if (v.enabled === false) return true;
-      if (declaredKeys.has(v.name)) return true;
+      if (scriptVarsKeys.has(v.name)) return true;
       // Keep the file's entry for an overridden name even if the script didn't echo it back.
       if (overrides.has(v.name)) return true;
       return false;
     })
     .map((v) => {
       if (v.enabled === false || !scriptKeys.has(v.name)) return v;
-      const entry = { ...v, value: scriptVars[v.name] };
-      // A plain row of the same name shadows the parent's secret rather than replacing it, so the
-      // rotated value would otherwise land on that plain row and reach disk in cleartext. The row
-      // becoming a secret is the cost of keeping the value off disk.
-      if (inheritedSecretNames.has(v.name)) {
-        entry.secret = true;
+      // A plain row of the same name shadows the other file's secret rather than replacing it, so
+      // the rotated value would otherwise land on that plain row and reach disk in cleartext. The
+      // row becoming a secret is the cost of keeping the value off disk.
+      if (v.secret || secretNamesFromOtherEnvironmentFiles.has(v.name)) {
+        // The written value is dropped, so a dataType inferred from it would type a value no reader
+        // can see — and retype the secret the app holds in its own store. The row keeps the type its
+        // file declares.
+        return markSecretWithEmptyValue({ ...v });
       }
-      return applyInferredDataType(entry, scriptVars[v.name]);
+      return applyInferredDataType({ ...v, value: scriptVars[v.name] }, scriptVars[v.name]);
     });
 
   // Skip names that already appear as enabled entries; a same-named disabled entry still gets a fresh enabled row appended.
   const presentEnabled = new Set(next.filter((v) => v.enabled !== false).map((v) => v.name));
+  // A disabled secret row is preserved untouched above, so an appended row is what would carry the
+  // script's value — in cleartext, since nothing marks it secret. The row is skipped rather than
+  // appended as a secret: the CLI cannot persist a secret's value at all, so it would add only a
+  // second row of the same name, and secret names must be unique for the app to save the file again.
+  const disabledSecretNames = new Set(next.filter((v) => v.enabled === false && v.secret).map((v) => v.name));
   for (const key of scriptKeys) {
-    if (presentEnabled.has(key)) continue;
-    const entry = { name: key, value: scriptVars[key], type: 'text', enabled: true, secret: inheritedSecretNames.has(key) };
-    next.push(applyInferredDataType(entry, scriptVars[key]));
+    if (presentEnabled.has(key) || disabledSecretNames.has(key)) continue;
+    const entry = { name: key, value: scriptVars[key], type: 'text', enabled: true, secret: false };
+    // An appended secret row is name-only, so there is no value left for a dataType to describe.
+    next.push(
+      secretNamesFromOtherEnvironmentFiles.has(key)
+        ? markSecretWithEmptyValue(entry)
+        : applyInferredDataType(entry, scriptVars[key])
+    );
   }
   return next;
 };
@@ -294,22 +326,24 @@ const writeIfChanged = (filePath, content, existing) => {
 };
 
 /**
- * @param {Array<{ name: string, value: any }>} [inheritedVariables] - Vars resolved from the `extends` chain.
+ * @param {Array<{ name: string, value: any }>} [variablesFromOtherEnvironmentFiles] - Entries an
+ *   environment source other than the file being written declares — its `extends` chain, or an
+ *   `--env-file` loaded alongside it.
  * @param {Object<string, any>} scriptVars - Flat map from the script runtime.
- * @returns {string[]} Inherited names to keep off disk.
+ * @returns {string[]} Names the script left at the other source's value, to keep off disk.
  *
  * @example
- * inheritedKeysLeftUnchanged(
+ * keysLeftUnchanged(
  *   [{ name: 'host', value: 'parent' }, { name: 'token', value: 'secret' }],
  *   { host: 'parent', token: 'rotated' }
  * );
  *  → ['host']   // `token` was rewritten by the script, so it persists here as an override
  */
-const inheritedKeysLeftUnchanged = (inheritedVariables, scriptVars) => {
-  const inherited = inheritedVariables || [];
-  if (!inherited.length) return [];
+const keysLeftUnchanged = (variablesFromOtherEnvironmentFiles, scriptVars) => {
+  const otherFileVariables = variablesFromOtherEnvironmentFiles || [];
+  if (!otherFileVariables.length) return [];
   return Object.entries(scriptVars || {})
-    .filter(([name, value]) => inherited.some((v) => v.name === name && isEqual(v.value, value)))
+    .filter(([name, value]) => otherFileVariables.some((v) => v.name === name && isEqual(v.value, value)))
     .map(([name]) => name);
 };
 
@@ -317,7 +351,10 @@ const inheritedKeysLeftUnchanged = (inheritedVariables, scriptVars) => {
  * Read → merge → write one env file. Used for both per-env and global-env files
  * (same shape, different descriptor).
  *
- * @param {{ path: string, format: 'json' | 'yml' | 'bru' } | null | undefined} envFile - Env file descriptor; no-op when missing.
+ * @param {{ path: string, format: 'json' | 'yml' | 'bru', inheritedEnvironmentVariables?: Array<object>, envFileVariables?: Array<object> } | null | undefined} envFile -
+ *   Env file descriptor; no-op when missing. `inheritedEnvironmentVariables` are the entries this
+ *   file resolves from its `extends` chain, `envFileVariables` the entries of an `--env-file`
+ *   loaded alongside it — both are names another file owns and this one must not absorb.
  * @param {Object<string, any>} scriptVars - Flat map of vars the script declared.
  * @param {{ overrides?: Map<string, string> }} [options] - Injected override values keyed by name (`--env-var`, or `--global-env-var` for the global env file); forwarded to `mergeScriptVarsIntoEnvList` to keep override values off disk.
  * @returns {void}
@@ -342,10 +379,17 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
   // No descriptor means no `--env` flag was passed — nothing to persist to.
   if (!envFile || !envFile.path) return;
   const { path: filePath, format } = envFile;
+  // An `--env-file` supplied alongside `--env` is merged into the same runtime map as this file but
+  // is never itself written back, so it is another environment source for this file in exactly the
+  // sense the `extends` chain is — same guard, same secret flags.
+  const variablesFromOtherEnvironmentFiles = [
+    ...(envFile.envFileVariables || []),
+    ...(envFile.inheritedEnvironmentVariables || [])
+  ];
   const mergeOptions = {
     ...options,
-    skipKeys: inheritedKeysLeftUnchanged(envFile.inheritedEnvironmentVariables, scriptVars),
-    inheritedVariables: envFile.inheritedEnvironmentVariables
+    skipKeys: keysLeftUnchanged(variablesFromOtherEnvironmentFiles, scriptVars),
+    variablesFromOtherEnvironmentFiles
   };
   if (!fs.existsSync(filePath)) return;
 

--- a/packages/bruno-cli/src/utils/persist-variables.js
+++ b/packages/bruno-cli/src/utils/persist-variables.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { isEqual } = require('lodash');
 const { stringifyEnvironment, stringifyCollection, parseEnvironment } = require('@usebruno/filestore');
 const { getDataTypeFromValue } = require('@usebruno/common').utils;
 const { parseEnvironmentJson } = require('./environment');
@@ -140,7 +141,10 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
  * @param {Array<{ name: string, value: any, enabled?: boolean, type?: string, secret?: boolean, dataType?: string }>} variables
  *   Existing entries from the env file.
  * @param {Object<string, any>} scriptVarsRaw - Flat map from the script runtime; may include `__name__`.
- * @param {{ overrides?: Map<string, string> }} [options] - Names → injected override values.
+ * @param {{ overrides?: Map<string, string>, skipKeys?: string[], inheritedVariables?: Array<object> }} [options] -
+ *   Names → injected override values, names that must never be written to this file (e.g. inherited
+ *   from a parent env), and the resolved parent-chain entries an appended override inherits its
+ *   `secret` flag from.
  * @returns {Array<object>} New array of merged variable entries.
  *
  * @example
@@ -182,6 +186,15 @@ const applyVariableUpdates = (result, { envVariables, runtimeVariables, globalEn
 const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw, options = {}) => {
   const overrides = options.overrides instanceof Map ? options.overrides : new Map();
   const scriptVars = stripInternal(scriptVarsRaw);
+  // A name the script still reported is a live name, whatever the reason it must not be written
+  // here. Absence from this set — and only that — is what marks a `bru.deleteEnvVar` below, so it
+  // is captured before any key is withheld.
+  const declaredKeys = new Set(Object.keys(scriptVars));
+  // Inherited names reach the runtime map but are declared in the parent file. Writing them here
+  // would fork a private copy that shadows the parent — and strip a parent secret down to a plain row.
+  for (const name of options.skipKeys || []) {
+    delete scriptVars[name];
+  }
   // Drop a script value only when it still matches the injected override — a different
   // value means the script deliberately wrote it (e.g. `bru.setEnvVar('token', 'rotated')`)
   // and must reach disk.
@@ -191,25 +204,35 @@ const mergeScriptVarsIntoEnvList = (variables, scriptVarsRaw, options = {}) => {
     }
   }
   const scriptKeys = new Set(Object.keys(scriptVars));
+  // A rotated inherited secret lands here as an override; as a plain row its value would reach
+  // disk in cleartext, so the parent's secret flag has to come with it.
+  const inheritedSecretNames = new Set((options.inheritedVariables || []).filter((v) => v.secret).map((v) => v.name));
 
   const next = (variables || [])
     .filter((v) => {
       if (v.enabled === false) return true;
-      if (scriptKeys.has(v.name)) return true;
+      if (declaredKeys.has(v.name)) return true;
       // Keep the file's entry for an overridden name even if the script didn't echo it back.
       if (overrides.has(v.name)) return true;
       return false;
     })
     .map((v) => {
       if (v.enabled === false || !scriptKeys.has(v.name)) return v;
-      return applyInferredDataType({ ...v, value: scriptVars[v.name] }, scriptVars[v.name]);
+      const entry = { ...v, value: scriptVars[v.name] };
+      // A plain row of the same name shadows the parent's secret rather than replacing it, so the
+      // rotated value would otherwise land on that plain row and reach disk in cleartext. The row
+      // becoming a secret is the cost of keeping the value off disk.
+      if (inheritedSecretNames.has(v.name)) {
+        entry.secret = true;
+      }
+      return applyInferredDataType(entry, scriptVars[v.name]);
     });
 
   // Skip names that already appear as enabled entries; a same-named disabled entry still gets a fresh enabled row appended.
   const presentEnabled = new Set(next.filter((v) => v.enabled !== false).map((v) => v.name));
   for (const key of scriptKeys) {
     if (presentEnabled.has(key)) continue;
-    const entry = { name: key, value: scriptVars[key], type: 'text', enabled: true, secret: false };
+    const entry = { name: key, value: scriptVars[key], type: 'text', enabled: true, secret: inheritedSecretNames.has(key) };
     next.push(applyInferredDataType(entry, scriptVars[key]));
   }
   return next;
@@ -271,6 +294,26 @@ const writeIfChanged = (filePath, content, existing) => {
 };
 
 /**
+ * @param {Array<{ name: string, value: any }>} [inheritedVariables] - Vars resolved from the `extends` chain.
+ * @param {Object<string, any>} scriptVars - Flat map from the script runtime.
+ * @returns {string[]} Inherited names to keep off disk.
+ *
+ * @example
+ * inheritedKeysLeftUnchanged(
+ *   [{ name: 'host', value: 'parent' }, { name: 'token', value: 'secret' }],
+ *   { host: 'parent', token: 'rotated' }
+ * );
+ *  → ['host']   // `token` was rewritten by the script, so it persists here as an override
+ */
+const inheritedKeysLeftUnchanged = (inheritedVariables, scriptVars) => {
+  const inherited = inheritedVariables || [];
+  if (!inherited.length) return [];
+  return Object.entries(scriptVars || {})
+    .filter(([name, value]) => inherited.some((v) => v.name === name && isEqual(v.value, value)))
+    .map(([name]) => name);
+};
+
+/**
  * Read → merge → write one env file. Used for both per-env and global-env files
  * (same shape, different descriptor).
  *
@@ -299,6 +342,11 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
   // No descriptor means no `--env` flag was passed — nothing to persist to.
   if (!envFile || !envFile.path) return;
   const { path: filePath, format } = envFile;
+  const mergeOptions = {
+    ...options,
+    skipKeys: inheritedKeysLeftUnchanged(envFile.inheritedEnvironmentVariables, scriptVars),
+    inheritedVariables: envFile.inheritedEnvironmentVariables
+  };
   if (!fs.existsSync(filePath)) return;
 
   if (format === 'json') {
@@ -310,7 +358,7 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
     parseEnvironmentJson(parsed);
 
     const rawVariables = Array.isArray(parsed.variables) ? parsed.variables.filter(Boolean) : [];
-    const mergedVars = mergeScriptVarsIntoEnvList(rawVariables, scriptVars, options);
+    const mergedVars = mergeScriptVarsIntoEnvList(rawVariables, scriptVars, mergeOptions);
     // Spread preserves any top-level fields the user has beyond `variables` (name, metadata, etc.).
     const next = { ...parsed, variables: mergedVars };
     const content = JSON.stringify(next, null, 2) + '\n';
@@ -322,7 +370,7 @@ const persistEnvFile = (envFile, scriptVars, options = {}) => {
   // Bru parser expects \n line endings; yml parser is tolerant.
   const sourceForParse = format === 'bru' ? existingRaw.replace(/\r\n/g, '\n') : existingRaw;
   const parsed = parseEnvironment(sourceForParse, { format });
-  const mergedVars = mergeScriptVarsIntoEnvList(parsed.variables || [], scriptVars, options);
+  const mergedVars = mergeScriptVarsIntoEnvList(parsed.variables || [], scriptVars, mergeOptions);
   const next = { ...parsed, variables: mergedVars };
   const content = stringifyEnvironment(next, { format });
   writeIfChanged(filePath, content, existingRaw);

--- a/packages/bruno-cli/tests/integration/collection-env-var-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/collection-env-var-persistence.spec.js
@@ -1,0 +1,165 @@
+const { describe, it, expect, beforeAll, afterAll, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const {
+  startLocalServer,
+  createFixtureSeeder,
+  runCollection,
+  readEnvironment,
+  variableNames,
+  findVariable,
+  expectValueNotWritten
+} = require('./helpers/environments');
+
+// Shared with the Playwright suite: a yml collection whose environment carries a secret row.
+const COLLECTION_FIXTURE_DIR = path.resolve(
+  __dirname,
+  '..', '..', '..', '..',
+  'tests', 'environments', 'api-setEnvVar-secret', 'fixtures', 'collections', 'yml'
+);
+
+const RUN_TIMEOUT = 60_000;
+
+const ENV_FILE_SECRET = 'secret-declared-in-env-file';
+const ROTATED_SECRET = 'rotated-by-the-script';
+// The value set-secret.yml writes to the `apiToken` row the fixture's environment declares secret.
+const FIXTURE_ENVIRONMENT_SECRET = 'NEW_VALUE_collection_env_e2e_42';
+
+// Its secret row carries no value, the way an environment file on disk never should; the run
+// supplies one with `--env-var`, as CI does for a secret the CLI cannot decrypt at rest.
+const ENV_FILE = {
+  name: 'EnvFile',
+  variables: [
+    { name: 'envFilePlain', value: 'from-env-file', enabled: true, secret: false },
+    { name: 'envFileToken', value: '', enabled: true, secret: true }
+  ]
+};
+
+const REWRITE_ENV_FILE_VARS = `info:
+  name: rewrite-env-file-vars
+  type: http
+  seq: 10
+
+http:
+  method: GET
+  url: '{{baseUrl}}/ping'
+
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        bru.setEnvVar('envFilePlain', 'rewritten');
+        bru.setEnvVar('envFileToken', '${ROTATED_SECRET}');
+`;
+
+// Which file a script's writes land in is the contract here; what gets written into it (data types,
+// --env-var leak-guards) is covered by run-typed-persistence.spec.js.
+describe('CLI run — persisting script writes to a collection environment', () => {
+  const { seedFixture, removeSeededFixtures } = createFixtureSeeder();
+  let server;
+  let baseUrl;
+
+  beforeAll(async () => {
+    server = await startLocalServer();
+    baseUrl = server.baseUrl;
+  });
+
+  afterAll(() => server.close());
+
+  afterEach(removeSeededFixtures);
+
+  const seedCollection = () => {
+    const collectionDir = seedFixture(COLLECTION_FIXTURE_DIR, 'collection-env-persistence');
+    const envFilePath = path.join(collectionDir, 'env-file.json');
+    fs.writeFileSync(envFilePath, JSON.stringify(ENV_FILE, null, 2) + '\n');
+    fs.writeFileSync(path.join(collectionDir, 'rewrite-env-file-vars.yml'), REWRITE_ENV_FILE_VARS);
+    return { collectionDir, localEnvPath: path.join(collectionDir, 'environments', 'Local.yml'), envFilePath };
+  };
+
+  // `baseUrl` is an override so the run reaches the local server; the leak-guard keeps both it and
+  // the injected secret off disk.
+  const run = (collectionDir, args) =>
+    runCollection(collectionDir, [
+      'run', ...args,
+      '--env-var', `baseUrl=${baseUrl}`,
+      '--env-var', `envFileToken=${ENV_FILE_SECRET}`
+    ]);
+
+  it('keeps a script-written secret out of the environment file', async () => {
+    const { collectionDir, localEnvPath } = seedCollection();
+
+    await run(collectionDir, ['set-secret.yml', '--env', 'Local']);
+
+    expect(findVariable(readEnvironment(localEnvPath), 'apiToken')).toMatchObject({ secret: true });
+    expectValueNotWritten(FIXTURE_ENVIRONMENT_SECRET, [localEnvPath]);
+  }, RUN_TIMEOUT);
+
+  describe('with an --env-file alongside --env', () => {
+    // Both files feed one runtime map, but only the --env file is written back. Copying the other
+    // file's names into it forks rows that shadow it from then on — and a json env file's secrets
+    // carry inline values, so the copy would put one on disk, and in git, in cleartext.
+    it('leaves the --env-file variables out of the --env file when a script writes another var', async () => {
+      const { collectionDir, localEnvPath } = seedCollection();
+
+      await run(collectionDir, ['set-secret.yml', '--env', 'Local', '--env-file', 'env-file.json']);
+
+      expect(variableNames(readEnvironment(localEnvPath))).toEqual(['apiToken', 'baseUrl']);
+      expectValueNotWritten(ENV_FILE_SECRET, [localEnvPath]);
+    }, RUN_TIMEOUT);
+
+    it('does not write back to the --env-file itself', async () => {
+      const { collectionDir, envFilePath } = seedCollection();
+      const before = fs.readFileSync(envFilePath, 'utf8');
+
+      await run(collectionDir, ['set-secret.yml', '--env', 'Local', '--env-file', 'env-file.json']);
+
+      expect(fs.readFileSync(envFilePath, 'utf8')).toBe(before);
+    }, RUN_TIMEOUT);
+
+    it('persists a rewritten --env-file variable into the --env file as an override', async () => {
+      const { collectionDir, localEnvPath } = seedCollection();
+
+      await run(collectionDir, ['rewrite-env-file-vars.yml', '--env', 'Local', '--env-file', 'env-file.json']);
+
+      expect(findVariable(readEnvironment(localEnvPath), 'envFilePlain'))
+        .toMatchObject({ value: 'rewritten', enabled: true });
+    }, RUN_TIMEOUT);
+
+    // The forked override row takes its secret flag from the file that declared the name; written
+    // as a plain row instead, the rotated value would land in the --env file in cleartext.
+    it('persists a rewritten --env-file secret as a secret, keeping its value off disk', async () => {
+      const { collectionDir, localEnvPath, envFilePath } = seedCollection();
+
+      await run(collectionDir, ['rewrite-env-file-vars.yml', '--env', 'Local', '--env-file', 'env-file.json']);
+
+      expect(findVariable(readEnvironment(localEnvPath), 'envFileToken')).toMatchObject({ secret: true, enabled: true });
+      expectValueNotWritten(ROTATED_SECRET, [localEnvPath, envFilePath]);
+    }, RUN_TIMEOUT);
+  });
+
+  describe('with only an --env-file', () => {
+    it('persists script writes into the --env-file', async () => {
+      const { collectionDir, envFilePath } = seedCollection();
+
+      await run(collectionDir, ['rewrite-env-file-vars.yml', '--env-file', 'env-file.json']);
+
+      expect(JSON.parse(fs.readFileSync(envFilePath, 'utf8')).variables).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'envFilePlain', value: 'rewritten', enabled: true })
+      ]));
+    }, RUN_TIMEOUT);
+
+    // No format can hold a secret's value, json included: a rewritten secret row is emptied rather
+    // than left carrying one.
+    it('empties a rewritten secret row instead of carrying its value', async () => {
+      const { collectionDir, envFilePath } = seedCollection();
+
+      await run(collectionDir, ['rewrite-env-file-vars.yml', '--env-file', 'env-file.json']);
+
+      expect(JSON.parse(fs.readFileSync(envFilePath, 'utf8')).variables).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'envFileToken', value: '', secret: true })
+      ]));
+      expectValueNotWritten(ROTATED_SECRET, [envFilePath]);
+      expectValueNotWritten(ENV_FILE_SECRET, [envFilePath]);
+    }, RUN_TIMEOUT);
+  });
+});

--- a/packages/bruno-cli/tests/integration/environment-inheritance.spec.js
+++ b/packages/bruno-cli/tests/integration/environment-inheritance.spec.js
@@ -1,10 +1,13 @@
 const { describe, it, expect, beforeAll, afterAll, afterEach } = require('@jest/globals');
-const fs = require('fs');
 const path = require('path');
-const http = require('http');
-const { parseEnvironment } = require('@usebruno/filestore');
-const { runCli } = require('./helpers/run-cli');
-const { copyFixtureToTmpDir, removeTmpDir } = require('./helpers/tmp-dir');
+const {
+  echoRequest,
+  startLocalServer,
+  createFixtureSeeder,
+  runCollection,
+  readEnvironment,
+  variableNames
+} = require('./helpers/environments');
 
 const WORKSPACE_FIXTURE_DIR = path.resolve(
   __dirname,
@@ -31,54 +34,23 @@ const envVarArgs = (flag, secrets) =>
   Object.entries(secrets).flatMap(([name, value]) => [flag, `${name}=${value}`]);
 
 describe('CLI run - environment inheritance (extends)', () => {
+  const { seedFixture, removeSeededFixtures } = createFixtureSeeder();
   let server;
   let baseUrl;
-  let tmpDirs = [];
 
   beforeAll(async () => {
-    server = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ method: req.method, url: req.url, headers: req.headers, body }));
-      });
-    });
-    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const { port } = server.address();
-    baseUrl = `http://127.0.0.1:${port}`;
+    server = await startLocalServer(echoRequest);
+    baseUrl = server.baseUrl;
   });
 
-  afterAll(async () => {
-    await new Promise((resolve) => server.close(resolve));
-  });
+  afterAll(() => server.close());
 
-  afterEach(() => {
-    tmpDirs.forEach(removeTmpDir);
-    tmpDirs = [];
-  });
-
-  // A run rewrites the environment files it is pointed at, so it never sees the committed fixture.
-  const seedFixture = (fixtureDir, tag) => {
-    const tmpDir = copyFixtureToTmpDir(fixtureDir, tag);
-    tmpDirs.push(tmpDir);
-    return tmpDir;
-  };
+  afterEach(removeSeededFixtures);
 
   const seedCollection = (format) => seedFixture(path.join(COLLECTIONS_FIXTURE_DIR, format), `env-inheritance-${format}`);
 
-  const assertSucceeded = (result) => {
-    if (result.code !== 0) {
-      throw new Error(
-        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
-      );
-    }
-  };
-
-  const readEnvironment = (collectionDir, name, format) =>
-    parseEnvironment(fs.readFileSync(path.join(collectionDir, 'environments', `${name}.${format}`), 'utf8'), { format });
-
-  const variableNames = (environment) => environment.variables.map((variable) => variable.name).sort();
+  const environmentPath = (collectionDir, name, format) =>
+    path.join(collectionDir, 'environments', `${name}.${format}`);
 
   // `host` carries the echo endpoint and is only declared in `base`, so a run that failed to
   // inherit could not reach the server at all. What each row resolved to is asserted by the
@@ -89,18 +61,29 @@ describe('CLI run - environment inheritance (extends)', () => {
   ])('resolves the inheritance chain of the environment it runs with in a %s collection', async (format, request) => {
     const collectionDir = seedCollection(format);
 
-    const result = await runCli(
-      [
-        'run', request,
-        '--env', 'dev',
-        '--env-var', `host=${baseUrl}`,
-        ...envVarArgs('--env-var', COLLECTION_SECRETS),
-        '--sandbox', 'developer', '--noproxy'
-      ],
-      collectionDir
-    );
+    await runCollection(collectionDir, [
+      'run', request,
+      '--env', 'dev',
+      '--env-var', `host=${baseUrl}`,
+      ...envVarArgs('--env-var', COLLECTION_SECRETS)
+    ]);
+  }, RUN_TIMEOUT);
 
-    assertSucceeded(result);
+  // --env-file loads the file as it reads, even when the path it is given is one of the collection's
+  // own environments. Nothing the parent declares reaches the run, so a script write of a name the
+  // parent owns is this file's own new row rather than a value it already inherits.
+  it('leaves the inheritance chain of an env file unresolved', async () => {
+    const collectionDir = seedCollection('yml');
+
+    await runCollection(collectionDir, [
+      'run', 'set-env-var.yml',
+      '--env-file', path.join('environments', 'scripted.yml'),
+      '--env-var', `host=${baseUrl}`
+    ]);
+
+    const scripted = readEnvironment(environmentPath(collectionDir, 'scripted', 'yml'));
+    expect(scripted.extends).toBe('base');
+    expect(variableNames(scripted)).toEqual(['base_only', 'scripted_only', 'session_id']);
   }, RUN_TIMEOUT);
 
   // Global environments resolve their chain against <workspace>/environments, a separate code path
@@ -108,19 +91,13 @@ describe('CLI run - environment inheritance (extends)', () => {
   it('resolves the inheritance chain of a global environment', async () => {
     const workspaceDir = seedFixture(WORKSPACE_FIXTURE_DIR, 'env-inheritance-workspace');
 
-    const result = await runCli(
-      [
-        'run', 'workspace-vars.yml',
-        '--global-env', 'workspace_dev',
-        '--workspace-path', workspaceDir,
-        '--global-env-var', `workspace_host=${baseUrl}`,
-        ...envVarArgs('--global-env-var', WORKSPACE_SECRETS),
-        '--sandbox', 'developer', '--noproxy'
-      ],
-      path.join(workspaceDir, 'collections', 'yml')
-    );
-
-    assertSucceeded(result);
+    await runCollection(path.join(workspaceDir, 'collections', 'yml'), [
+      'run', 'workspace-vars.yml',
+      '--global-env', 'workspace_dev',
+      '--workspace-path', workspaceDir,
+      '--global-env-var', `workspace_host=${baseUrl}`,
+      ...envVarArgs('--global-env-var', WORKSPACE_SECRETS)
+    ]);
   }, RUN_TIMEOUT);
 
   // A script write must not fork private copies of the parent's variables into the child file:
@@ -128,15 +105,11 @@ describe('CLI run - environment inheritance (extends)', () => {
   it('persists only the variables a script gave a value the environment does not already inherit', async () => {
     const collectionDir = seedCollection('yml');
 
-    const result = await runCli(
-      ['run', 'set-env-var.yml', '--env', 'scripted', '--env-var', `host=${baseUrl}`, '--sandbox', 'developer', '--noproxy'],
-      collectionDir
-    );
+    await runCollection(collectionDir, ['run', 'set-env-var.yml', '--env', 'scripted', '--env-var', `host=${baseUrl}`]);
 
-    assertSucceeded(result);
     // The script rewrote `base_only` with the value it already inherits, so that write is a no-op;
     // `session_id` differs from the parent's value and persists as an override.
-    const scripted = readEnvironment(collectionDir, 'scripted', 'yml');
+    const scripted = readEnvironment(environmentPath(collectionDir, 'scripted', 'yml'));
     expect(scripted.extends).toBe('base');
     expect(variableNames(scripted)).toEqual(['scripted_only', 'session_id']);
     expect(scripted.variables.find((variable) => variable.name === 'session_id').value).toBe('script_session');

--- a/packages/bruno-cli/tests/integration/global-env-var-persistence.spec.js
+++ b/packages/bruno-cli/tests/integration/global-env-var-persistence.spec.js
@@ -1,0 +1,159 @@
+const { describe, it, expect, beforeAll, afterAll, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const {
+  startLocalServer,
+  createFixtureSeeder,
+  runCollection,
+  readEnvironment,
+  variableNames,
+  findVariable,
+  expectValueNotWritten
+} = require('./helpers/environments');
+
+const E2E_FIXTURES_DIR = path.resolve(__dirname, '..', '..', '..', '..', 'tests', 'environments');
+
+// Shared with the Playwright suites: a workspace whose environment carries a secret row, and — for
+// the two-scope cases — the one that puts a collection environment in a workspace tree.
+const WORKSPACE_FIXTURE_DIR = path.join(E2E_FIXTURES_DIR, 'api-setGlobalEnvVar-secret', 'fixtures', 'workspace');
+const TWO_SCOPE_FIXTURE_DIR = path.join(E2E_FIXTURES_DIR, 'environment-inheritance', 'fixtures', 'workspace');
+
+const RUN_TIMEOUT = 60_000;
+
+const ROTATED_SECRET = 'rotated-by-the-script';
+
+// api-setGlobalEnvVar-secret ships only a .bru collection, and the format is per-collection — so the
+// run copy gets a yml one over the reused workspace, whose environments/Local.yml is what's asserted.
+const YML_COLLECTION = 'opencollection: "1.0.0"\ninfo:\n  name: workspace-env-persistence\n';
+
+const workspaceEnvRequest = (name, script) => `info:
+  name: ${name}
+  type: http
+  seq: 10
+
+http:
+  method: GET
+  url: '{{baseUrl}}/ping'
+
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        ${script}
+`;
+
+const WRITE_WORKSPACE_VARS = workspaceEnvRequest(
+  'write-workspace-vars',
+  `bru.setGlobalEnvVar('workspacePlain', 'written-by-script');\n        bru.setGlobalEnvVar('apiToken', '${ROTATED_SECRET}');`
+);
+const DELETE_WORKSPACE_VAR = workspaceEnvRequest('delete-workspace-var', `bru.deleteGlobalEnvVar('apiToken');`);
+
+// Which file a script's writes land in is the contract here; override leak-guards for this scope
+// live in cli-global-env-var-override.spec.js.
+describe('CLI run — persisting script writes to a workspace environment', () => {
+  const { seedFixture, removeSeededFixtures } = createFixtureSeeder();
+  let server;
+  let baseUrl;
+
+  beforeAll(async () => {
+    server = await startLocalServer();
+    baseUrl = server.baseUrl;
+  });
+
+  afterAll(() => server.close());
+
+  afterEach(removeSeededFixtures);
+
+  const seedWorkspace = () => {
+    const workspaceDir = seedFixture(WORKSPACE_FIXTURE_DIR, 'workspace-env-persistence');
+    const collectionDir = path.join(workspaceDir, 'collections', 'test-collection');
+    fs.writeFileSync(path.join(collectionDir, 'opencollection.yml'), YML_COLLECTION);
+    fs.writeFileSync(path.join(collectionDir, 'write-workspace-vars.yml'), WRITE_WORKSPACE_VARS);
+    fs.writeFileSync(path.join(collectionDir, 'delete-workspace-var.yml'), DELETE_WORKSPACE_VAR);
+    return { workspaceDir, collectionDir, workspaceEnvPath: path.join(workspaceDir, 'environments', 'Local.yml') };
+  };
+
+  const run = (collectionDir, workspaceDir, args) =>
+    runCollection(collectionDir, [
+      'run', ...args,
+      '--global-env', 'Local',
+      '--workspace-path', workspaceDir,
+      '--global-env-var', `baseUrl=${baseUrl}`
+    ]);
+
+  it('persists a script-written workspace var into the workspace environment file', async () => {
+    const { workspaceDir, collectionDir, workspaceEnvPath } = seedWorkspace();
+
+    await run(collectionDir, workspaceDir, ['write-workspace-vars.yml']);
+
+    expect(findVariable(readEnvironment(workspaceEnvPath), 'workspacePlain'))
+      .toMatchObject({ value: 'written-by-script', enabled: true });
+  }, RUN_TIMEOUT);
+
+  it('keeps a script-written workspace secret out of the workspace environment file', async () => {
+    const { workspaceDir, collectionDir, workspaceEnvPath } = seedWorkspace();
+
+    await run(collectionDir, workspaceDir, ['write-workspace-vars.yml']);
+
+    expect(findVariable(readEnvironment(workspaceEnvPath), 'apiToken')).toMatchObject({ secret: true });
+    expectValueNotWritten(ROTATED_SECRET, [workspaceEnvPath]);
+  }, RUN_TIMEOUT);
+
+  it('drops a deleted workspace var from the workspace environment file', async () => {
+    const { workspaceDir, collectionDir, workspaceEnvPath } = seedWorkspace();
+
+    await run(collectionDir, workspaceDir, ['delete-workspace-var.yml']);
+
+    expect(variableNames(readEnvironment(workspaceEnvPath))).toEqual(['baseUrl']);
+  }, RUN_TIMEOUT);
+
+  // The two scopes travel with the same request but in separate maps, so a write to one must reach
+  // only that scope's file.
+  describe('alongside a collection environment', () => {
+    const seedBothScopes = () => {
+      const workspaceDir = seedFixture(TWO_SCOPE_FIXTURE_DIR, 'both-scopes-env-persistence');
+      const collectionDir = path.join(workspaceDir, 'collections', 'yml');
+      return {
+        workspaceDir,
+        collectionDir,
+        collectionEnvPath: path.join(collectionDir, 'environments', 'scripted.yml'),
+        workspaceEnvPath: path.join(workspaceDir, 'environments', 'workspace_scripted.yml')
+      };
+    };
+
+    it('sends a workspace env write to the workspace file and leaves the collection file alone', async () => {
+      const { workspaceDir, collectionDir, collectionEnvPath, workspaceEnvPath } = seedBothScopes();
+      const collectionEnvBefore = fs.readFileSync(collectionEnvPath, 'utf8');
+
+      await runCollection(collectionDir, [
+        'run', 'set-global-env-var.yml',
+        '--env', 'scripted',
+        '--global-env', 'workspace_scripted',
+        '--workspace-path', workspaceDir,
+        '--global-env-var', `workspace_host=${baseUrl}`
+      ]);
+
+      // `workspace_base_only` was rewritten with the value it already inherits, so only the session
+      // id persists.
+      expect(variableNames(readEnvironment(workspaceEnvPath)))
+        .toEqual(['workspace_scripted_only', 'workspace_session_id']);
+      expect(fs.readFileSync(collectionEnvPath, 'utf8')).toBe(collectionEnvBefore);
+    }, RUN_TIMEOUT);
+
+    it('sends a collection env write to the collection file and leaves the workspace file alone', async () => {
+      const { workspaceDir, collectionDir, collectionEnvPath, workspaceEnvPath } = seedBothScopes();
+      const workspaceEnvBefore = fs.readFileSync(workspaceEnvPath, 'utf8');
+
+      await runCollection(collectionDir, [
+        'run', 'set-env-var.yml',
+        '--env', 'scripted',
+        '--global-env', 'workspace_scripted',
+        '--workspace-path', workspaceDir,
+        '--env-var', `host=${baseUrl}`
+      ]);
+
+      expect(variableNames(readEnvironment(collectionEnvPath))).toEqual(['scripted_only', 'session_id']);
+      expect(fs.readFileSync(workspaceEnvPath, 'utf8')).toBe(workspaceEnvBefore);
+    }, RUN_TIMEOUT);
+  });
+});

--- a/packages/bruno-cli/tests/integration/helpers/environments/index.js
+++ b/packages/bruno-cli/tests/integration/helpers/environments/index.js
@@ -1,0 +1,128 @@
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { expect } = require('@jest/globals');
+const { parseEnvironment } = require('@usebruno/filestore');
+const { runCli } = require('../run-cli');
+const { copyFixtureToTmpDir, removeTmpDir } = require('../tmp-dir');
+
+// Nothing asserts on the response; the requests just need an endpoint that answers.
+const respondOk = (_req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ ok: true }));
+};
+
+/**
+ * Hands the request back as the response body, so a request's own `tests` block can assert on
+ * what the run actually sent. The shape mirrors the testbench's /api/echo/everything
+ * (packages/bruno-tests/src/index.js), which the Playwright suites run these fixtures against.
+ *
+ * @type {import('http').RequestListener}
+ */
+const echoRequest = (req, res) => {
+  let body = '';
+  req.on('data', (chunk) => { body += chunk; });
+  req.on('end', () => {
+    const { searchParams } = new URL(req.url, `http://${req.headers.host}`);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      method: req.method,
+      url: req.url,
+      query: Object.fromEntries(searchParams),
+      headers: req.headers,
+      body
+    }));
+  });
+};
+
+/**
+ * Binds an HTTP server to an ephemeral port on the loopback interface.
+ *
+ * @param {import('http').RequestListener} [handler] - Defaults to a 200 `{ ok: true }`
+ * @returns {Promise<{ baseUrl: string, close: () => Promise<void> }>}
+ */
+const startLocalServer = async (handler = respondOk) => {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve))
+  };
+};
+
+/**
+ * Tracks the temp copies a suite seeds, so one `afterEach` removes them all.
+ *
+ * @returns {{ seedFixture: (fixtureDir: string, tag: string) => string, removeSeededFixtures: () => void }}
+ */
+const createFixtureSeeder = () => {
+  let tmpDirs = [];
+
+  // A run rewrites the environment files it is pointed at, so it never sees the committed fixture.
+  const seedFixture = (fixtureDir, tag) => {
+    const tmpDir = copyFixtureToTmpDir(fixtureDir, tag);
+    tmpDirs.push(tmpDir);
+    return tmpDir;
+  };
+
+  const removeSeededFixtures = () => {
+    tmpDirs.forEach(removeTmpDir);
+    tmpDirs = [];
+  };
+
+  return { seedFixture, removeSeededFixtures };
+};
+
+/**
+ * Runs the CLI against a collection under the developer sandbox and without a proxy, the way every
+ * environment suite does, and throws on a non-zero exit so a broken run cannot read as a pass.
+ *
+ * @param {string} collectionDir - Directory to run from
+ * @param {string[]} args - CLI arguments, starting with the command
+ * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
+ */
+const runCollection = async (collectionDir, args) => {
+  const result = await runCli([...args, '--sandbox', 'developer', '--noproxy'], collectionDir);
+
+  if (result.code !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+    );
+  }
+
+  return result;
+};
+
+/**
+ * @param {string} filePath - Environment file to read; its extension selects the format
+ */
+const readEnvironment = (filePath) =>
+  parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: path.extname(filePath).slice(1) });
+
+const variableNames = (environment) => environment.variables.map((variable) => variable.name).sort();
+
+const findVariable = (environment, name) => environment.variables.find((variable) => variable.name === name);
+
+/**
+ * Asserted on the raw bytes: a secret can also reach disk through a field no parser surfaces.
+ *
+ * @param {string} value - Value that must appear in none of the files
+ * @param {string[]} filePaths - Files to search
+ */
+const expectValueNotWritten = (value, filePaths) => {
+  const carrying = filePaths.filter((filePath) => fs.readFileSync(filePath, 'utf8').includes(value));
+  expect(carrying).toEqual([]);
+};
+
+module.exports = {
+  echoRequest,
+  startLocalServer,
+  createFixtureSeeder,
+  runCollection,
+  readEnvironment,
+  variableNames,
+  findVariable,
+  expectValueNotWritten
+};

--- a/packages/bruno-cli/tests/integration/run-environment-inheritance.spec.js
+++ b/packages/bruno-cli/tests/integration/run-environment-inheritance.spec.js
@@ -1,0 +1,144 @@
+const { describe, it, expect, beforeAll, afterAll, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { parseEnvironment } = require('@usebruno/filestore');
+const { runCli } = require('./helpers/run-cli');
+const { copyFixtureToTmpDir, removeTmpDir } = require('./helpers/tmp-dir');
+
+const WORKSPACE_FIXTURE_DIR = path.resolve(
+  __dirname,
+  '..', '..', '..', '..',
+  'tests', 'environments', 'environment-inheritance', 'fixtures', 'workspace'
+);
+const COLLECTIONS_FIXTURE_DIR = path.join(WORKSPACE_FIXTURE_DIR, 'collections');
+
+const RUN_TIMEOUT = 60_000;
+
+const COLLECTION_SECRETS = {
+  base_token: 'token-from-base',
+  overridden_plain: 'secret-from-dev',
+  overridden_secret: 'secret-from-base'
+};
+
+const WORKSPACE_SECRETS = {
+  workspace_token: 'token-from-workspace-base',
+  workspace_overridden_plain: 'secret-from-workspace-dev',
+  workspace_overridden_secret: 'secret-from-workspace-base'
+};
+
+const envVarArgs = (flag, secrets) =>
+  Object.entries(secrets).flatMap(([name, value]) => [flag, `${name}=${value}`]);
+
+describe('CLI run - environment inheritance (extends)', () => {
+  let server;
+  let baseUrl;
+  let tmpDirs = [];
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ method: req.method, url: req.url, headers: req.headers, body }));
+      });
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  afterEach(() => {
+    tmpDirs.forEach(removeTmpDir);
+    tmpDirs = [];
+  });
+
+  // A run rewrites the environment files it is pointed at, so it never sees the committed fixture.
+  const seedFixture = (fixtureDir, tag) => {
+    const tmpDir = copyFixtureToTmpDir(fixtureDir, tag);
+    tmpDirs.push(tmpDir);
+    return tmpDir;
+  };
+
+  const seedCollection = (format) => seedFixture(path.join(COLLECTIONS_FIXTURE_DIR, format), `env-inheritance-${format}`);
+
+  const assertSucceeded = (result) => {
+    if (result.code !== 0) {
+      throw new Error(
+        `CLI exited with code ${result.code}.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+      );
+    }
+  };
+
+  const readEnvironment = (collectionDir, name, format) =>
+    parseEnvironment(fs.readFileSync(path.join(collectionDir, 'environments', `${name}.${format}`), 'utf8'), { format });
+
+  const variableNames = (environment) => environment.variables.map((variable) => variable.name).sort();
+
+  // `host` carries the echo endpoint and is only declared in `base`, so a run that failed to
+  // inherit could not reach the server at all. What each row resolved to is asserted by the
+  // request's own `tests` block — shared with the GUI suite — and reaches here as the exit code.
+  it.each([
+    ['bru', 'echo.bru'],
+    ['yml', 'echo.yml']
+  ])('resolves the inheritance chain of the environment it runs with in a %s collection', async (format, request) => {
+    const collectionDir = seedCollection(format);
+
+    const result = await runCli(
+      [
+        'run', request,
+        '--env', 'dev',
+        '--env-var', `host=${baseUrl}`,
+        ...envVarArgs('--env-var', COLLECTION_SECRETS),
+        '--sandbox', 'developer', '--noproxy'
+      ],
+      collectionDir
+    );
+
+    assertSucceeded(result);
+  }, RUN_TIMEOUT);
+
+  // Global environments resolve their chain against <workspace>/environments, a separate code path
+  // from the collection environments above.
+  it('resolves the inheritance chain of a global environment', async () => {
+    const workspaceDir = seedFixture(WORKSPACE_FIXTURE_DIR, 'env-inheritance-workspace');
+
+    const result = await runCli(
+      [
+        'run', 'workspace-vars.yml',
+        '--global-env', 'workspace_dev',
+        '--workspace-path', workspaceDir,
+        '--global-env-var', `workspace_host=${baseUrl}`,
+        ...envVarArgs('--global-env-var', WORKSPACE_SECRETS),
+        '--sandbox', 'developer', '--noproxy'
+      ],
+      path.join(workspaceDir, 'collections', 'yml')
+    );
+
+    assertSucceeded(result);
+  }, RUN_TIMEOUT);
+
+  // A script write must not fork private copies of the parent's variables into the child file:
+  // they would shadow the parent from then on, and a parent secret would land as a plain row.
+  it('persists only the variables a script gave a value the environment does not already inherit', async () => {
+    const collectionDir = seedCollection('yml');
+
+    const result = await runCli(
+      ['run', 'set-env-var.yml', '--env', 'scripted', '--env-var', `host=${baseUrl}`, '--sandbox', 'developer', '--noproxy'],
+      collectionDir
+    );
+
+    assertSucceeded(result);
+    // The script rewrote `base_only` with the value it already inherits, so that write is a no-op;
+    // `session_id` differs from the parent's value and persists as an override.
+    const scripted = readEnvironment(collectionDir, 'scripted', 'yml');
+    expect(scripted.extends).toBe('base');
+    expect(variableNames(scripted)).toEqual(['scripted_only', 'session_id']);
+    expect(scripted.variables.find((variable) => variable.name === 'session_id').value).toBe('script_session');
+  }, RUN_TIMEOUT);
+});

--- a/packages/bruno-cli/tests/utils/environment.spec.js
+++ b/packages/bruno-cli/tests/utils/environment.spec.js
@@ -1,9 +1,11 @@
-const path = require('path');
-const fs = require('fs');
 const os = require('os');
+const fs = require('fs');
+const path = require('path');
 const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const { stringifyEnvironment } = require('@usebruno/filestore');
 const { loadEnvironments } = require('../../src/utils/environment');
 const { getEnvVars } = require('../../src/utils/bru');
+const { loadEnvironmentFromFile } = require('../../src/utils/environment');
 
 describe('loadEnvironments', () => {
   let collDir;
@@ -171,5 +173,66 @@ describe('getEnvVars', () => {
     };
 
     expect(getEnvVars(environment)).toEqual({ token: 'plain-token' });
+  });
+});
+
+// Inheritance walks the sibling files, so it applies to the collection and workspace environments
+// — the ones the run names inside an `environments` directory — and not to a file passed by path
+// (--env-file).
+describe('loadEnvironmentFromFile', () => {
+  let collectionDir;
+
+  beforeEach(() => {
+    collectionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-load-environment-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(collectionDir, { recursive: true, force: true });
+  });
+
+  // Returns the path of the inheriting child, `dev`, written alongside the `base` it extends.
+  const writeInheritingEnvironments = (directory) => {
+    fs.mkdirSync(directory, { recursive: true });
+
+    const write = ({ name, ...environment }) => {
+      const filePath = path.join(directory, `${name}.yml`);
+      fs.writeFileSync(filePath, stringifyEnvironment({ name, variables: [], ...environment }, { format: 'yml' }));
+      return filePath;
+    };
+
+    write({ name: 'base', variables: [variable({ name: 'scheme', value: 'https', type: 'text' })] });
+
+    return write({
+      name: 'dev',
+      extends: 'base',
+      variables: [variable({ name: 'host', value: 'dev-host', type: 'text' })]
+    });
+  };
+
+  it('inherits from the parent environment for a named environment', () => {
+    const filePath = writeInheritingEnvironments(path.join(collectionDir, 'environments'));
+
+    const { variables, inheritedVariables } = loadEnvironmentFromFile({ filePath, name: 'dev' });
+
+    expect(variables).toEqual({ scheme: 'https', host: 'dev-host', __name__: 'dev' });
+    expect(inheritedVariables.map((row) => row.name)).toEqual(['scheme']);
+  });
+
+  it('inherits nothing for an environment passed as an env file', () => {
+    const filePath = writeInheritingEnvironments(path.join(collectionDir, 'environments'));
+
+    const { variables, inheritedVariables } = loadEnvironmentFromFile({ filePath, isEnvFile: true });
+
+    expect(variables).toEqual({ host: 'dev-host', __name__: 'dev' });
+    expect(inheritedVariables).toEqual([]);
+  });
+
+  it('inherits nothing for an environment outside an environments directory', () => {
+    const filePath = writeInheritingEnvironments(collectionDir);
+
+    const { variables, inheritedVariables } = loadEnvironmentFromFile({ filePath, name: 'dev' });
+
+    expect(variables).toEqual({ host: 'dev-host', __name__: 'dev' });
+    expect(inheritedVariables).toEqual([]);
   });
 });

--- a/packages/bruno-cli/tests/utils/environment.spec.js
+++ b/packages/bruno-cli/tests/utils/environment.spec.js
@@ -176,63 +176,87 @@ describe('getEnvVars', () => {
   });
 });
 
-// Inheritance walks the sibling files, so it applies to the collection and workspace environments
-// — the ones the run names inside an `environments` directory — and not to a file passed by path
-// (--env-file).
+// Whether the `extends` chain is resolved is the caller's choice, not a property of where the file
+// sits: an environment the run names (--env, --global-env) inherits, one it is pointed at by path
+// (--env-file) is loaded as the file reads.
 describe('loadEnvironmentFromFile', () => {
-  let collectionDir;
+  let environmentsDir;
 
   beforeEach(() => {
-    collectionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-load-environment-'));
+    environmentsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-load-environment-'));
   });
 
   afterEach(() => {
-    fs.rmSync(collectionDir, { recursive: true, force: true });
+    fs.rmSync(environmentsDir, { recursive: true, force: true });
   });
 
   // Returns the path of the inheriting child, `dev`, written alongside the `base` it extends.
-  const writeInheritingEnvironments = (directory) => {
-    fs.mkdirSync(directory, { recursive: true });
-
+  const writeInheritingEnvironments = () => {
     const write = ({ name, ...environment }) => {
-      const filePath = path.join(directory, `${name}.yml`);
+      const filePath = path.join(environmentsDir, `${name}.yml`);
       fs.writeFileSync(filePath, stringifyEnvironment({ name, variables: [], ...environment }, { format: 'yml' }));
       return filePath;
     };
 
-    write({ name: 'base', variables: [variable({ name: 'scheme', value: 'https', type: 'text' })] });
+    write({
+      name: 'base',
+      variables: [
+        variable({ name: 'scheme', value: 'https', type: 'text' }),
+        secret({ name: 'token', value: '', type: 'text' })
+      ]
+    });
 
     return write({
       name: 'dev',
       extends: 'base',
-      variables: [variable({ name: 'host', value: 'dev-host', type: 'text' })]
+      variables: [
+        variable({ name: 'host', value: 'dev-host', type: 'text' }),
+        variable({ name: 'port', value: '8081', type: 'text', enabled: false })
+      ]
     });
   };
 
-  it('inherits from the parent environment for a named environment', () => {
-    const filePath = writeInheritingEnvironments(path.join(collectionDir, 'environments'));
+  it('resolves the parent environment into the variables by default', () => {
+    const filePath = writeInheritingEnvironments();
 
     const { variables, inheritedVariables } = loadEnvironmentFromFile({ filePath, name: 'dev' });
 
-    expect(variables).toEqual({ scheme: 'https', host: 'dev-host', __name__: 'dev' });
-    expect(inheritedVariables.map((row) => row.name)).toEqual(['scheme']);
+    expect(variables).toEqual({ scheme: 'https', token: '', host: 'dev-host', __name__: 'dev' });
+    expect(inheritedVariables.map((row) => row.name)).toEqual(['scheme', 'token']);
   });
 
-  it('inherits nothing for an environment passed as an env file', () => {
-    const filePath = writeInheritingEnvironments(path.join(collectionDir, 'environments'));
+  // Nothing a parent declares reaches the runtime map, so no name the run is not pointed at can
+  // travel with it — a parent's secret least of all.
+  it('leaves the parent environment out entirely when inheritance is off', () => {
+    const filePath = writeInheritingEnvironments();
 
-    const { variables, inheritedVariables } = loadEnvironmentFromFile({ filePath, isEnvFile: true });
+    const { variables, inheritedVariables } = loadEnvironmentFromFile({
+      filePath,
+      name: 'dev',
+      resolveInheritance: false
+    });
 
     expect(variables).toEqual({ host: 'dev-host', __name__: 'dev' });
     expect(inheritedVariables).toEqual([]);
   });
 
-  it('inherits nothing for an environment outside an environments directory', () => {
-    const filePath = writeInheritingEnvironments(collectionDir);
+  it('names the environment after the file even when its extension is uppercased', () => {
+    const filePath = path.join(environmentsDir, 'dev.YML');
+    const environment = { name: 'dev', variables: [variable({ name: 'host', value: 'dev-host', type: 'text' })] };
+    fs.writeFileSync(filePath, stringifyEnvironment(environment, { format: 'yml' }));
 
-    const { variables, inheritedVariables } = loadEnvironmentFromFile({ filePath, name: 'dev' });
+    const { variables } = loadEnvironmentFromFile({ filePath });
 
-    expect(variables).toEqual({ host: 'dev-host', __name__: 'dev' });
-    expect(inheritedVariables).toEqual([]);
+    expect(variables.__name__).toBe('dev');
+  });
+
+  // A caller loading this file alongside another environment writes the other one back, and uses
+  // these entries to know which names it must leave to this file.
+  it('reports the enabled entries the file itself declares as its own variables', () => {
+    const filePath = writeInheritingEnvironments();
+
+    const { ownVariables } = loadEnvironmentFromFile({ filePath, name: 'dev', resolveInheritance: false });
+
+    expect(ownVariables.map((row) => row.name)).toEqual(['host']);
   });
 });

--- a/packages/bruno-cli/tests/utils/environment.spec.js
+++ b/packages/bruno-cli/tests/utils/environment.spec.js
@@ -3,9 +3,12 @@ const fs = require('fs');
 const path = require('path');
 const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
 const { stringifyEnvironment } = require('@usebruno/filestore');
-const { loadEnvironments } = require('../../src/utils/environment');
+const { loadEnvironments, loadEnvironmentFromFile } = require('../../src/utils/environment');
 const { getEnvVars } = require('../../src/utils/bru');
-const { loadEnvironmentFromFile } = require('../../src/utils/environment');
+
+const variable = (props) => ({ enabled: true, secret: false, ...props });
+
+const secret = (props) => variable({ ...props, secret: true });
 
 describe('loadEnvironments', () => {
   let collDir;
@@ -105,9 +108,6 @@ describe('loadEnvironments', () => {
 });
 
 describe('getEnvVars', () => {
-  const variable = (props) => ({ enabled: true, secret: false, ...props });
-  const secret = (props) => variable({ ...props, secret: true });
-
   it('returns an empty object for an environment with no variables', () => {
     expect(getEnvVars({})).toEqual({});
   });

--- a/packages/bruno-cli/tests/utils/environment.spec.js
+++ b/packages/bruno-cli/tests/utils/environment.spec.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const os = require('os');
 const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
 const { loadEnvironments } = require('../../src/utils/environment');
+const { getEnvVars } = require('../../src/utils/bru');
 
 describe('loadEnvironments', () => {
   let collDir;
@@ -98,5 +99,77 @@ describe('loadEnvironments', () => {
     writeEnvFile('Alpha.bru', 'vars {\n  K: v\n}\n');
 
     expect((await loadEnvironments(collDir, 'bru')).map((e) => e.name)).toEqual(['Alpha', 'Zeta']);
+  });
+});
+
+describe('getEnvVars', () => {
+  const variable = (props) => ({ enabled: true, secret: false, ...props });
+  const secret = (props) => variable({ ...props, secret: true });
+
+  it('returns an empty object for an environment with no variables', () => {
+    expect(getEnvVars({})).toEqual({});
+  });
+
+  it('flattens the inherited variables ahead of the environment own variables', () => {
+    const environment = {
+      inheritedVariables: [variable({ name: 'scheme', value: 'https' }), variable({ name: 'host', value: 'base-host' })],
+      variables: [variable({ name: 'host', value: 'dev-host' })]
+    };
+
+    expect(getEnvVars(environment)).toEqual({ scheme: 'https', host: 'dev-host' });
+  });
+
+  it('skips disabled variables', () => {
+    const environment = {
+      variables: [variable({ name: 'host', value: 'dev-host', enabled: false })]
+    };
+
+    expect(getEnvVars(environment)).toEqual({});
+  });
+
+  it('lets a secret win over a plain variable of the same name declared after it', () => {
+    const environment = {
+      variables: [secret({ name: 'token', value: 'secret-token' }), variable({ name: 'token', value: 'plain-token' })]
+    };
+
+    expect(getEnvVars(environment)).toEqual({ token: 'secret-token' });
+  });
+
+  it('lets an inherited secret win over a plain variable of the same name on the environment', () => {
+    const environment = {
+      inheritedVariables: [secret({ name: 'token', value: 'base-secret' })],
+      variables: [variable({ name: 'token', value: 'dev-plain-token' })]
+    };
+
+    expect(getEnvVars(environment)).toEqual({ token: 'base-secret' });
+  });
+
+  it('lets a secret on the environment win over an inherited plain variable of the same name', () => {
+    const environment = {
+      inheritedVariables: [variable({ name: 'token', value: 'base-plain-token' })],
+      variables: [secret({ name: 'token', value: 'dev-secret' })]
+    };
+
+    expect(getEnvVars(environment)).toEqual({ token: 'dev-secret' });
+  });
+
+  it('lets a secret on the environment win over an inherited secret of the same name', () => {
+    const environment = {
+      inheritedVariables: [secret({ name: 'token', value: 'base-secret' })],
+      variables: [secret({ name: 'token', value: 'dev-secret' })]
+    };
+
+    expect(getEnvVars(environment)).toEqual({ token: 'dev-secret' });
+  });
+
+  it('ignores a disabled secret so the plain variable of the same name stands', () => {
+    const environment = {
+      variables: [
+        variable({ name: 'token', value: 'plain-token' }),
+        secret({ name: 'token', value: 'secret-token', enabled: false })
+      ]
+    };
+
+    expect(getEnvVars(environment)).toEqual({ token: 'plain-token' });
   });
 });

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -2,6 +2,7 @@ const { describe, it, expect, beforeEach, afterEach, jest: jestObj } = require('
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { parseEnvironment } = require('@usebruno/filestore');
 const {
   applyVariableUpdates,
   persistVariableUpdates,
@@ -736,6 +737,143 @@ describe('mergeScriptVarsIntoEnvList — --env-var overrides', () => {
     expect(tokenEntry.value).toBe('rotated');
     // Existing on-disk metadata (secret flag) is preserved during the update.
     expect(tokenEntry.secret).toBe(true);
+  });
+});
+
+describe('persistVariableUpdates — inherited env vars', () => {
+  it('does not write an inherited name the script left at the parent value', () => {
+    const filePath = writeFile('dev.yml', 'name: dev\nextends: base\nvariables:\n  - name: dev_only\n    value: dev\n');
+
+    persistVariableUpdates(
+      { envVariables: { dev_only: 'dev', base_host: 'from-parent', touched: 'yes', __name__: 'dev' } },
+      {
+        envFile: {
+          path: filePath,
+          format: 'yml',
+          inheritedEnvironmentVariables: [{ name: 'base_host', value: 'from-parent' }]
+        }
+      }
+    );
+
+    const written = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    expect(written.variables.map((v) => v.name).sort()).toEqual(['dev_only', 'touched']);
+  });
+
+  it('persists an inherited name the script rewrote as an override in this file', () => {
+    const filePath = writeFile('dev.yml', 'name: dev\nextends: base\nvariables:\n  - name: dev_only\n    value: dev\n');
+
+    persistVariableUpdates(
+      { envVariables: { dev_only: 'dev', base_host: 'rewritten', __name__: 'dev' } },
+      {
+        envFile: {
+          path: filePath,
+          format: 'yml',
+          inheritedEnvironmentVariables: [{ name: 'base_host', value: 'from-parent' }]
+        }
+      }
+    );
+
+    const written = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    expect(written.variables).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'base_host', value: 'rewritten', enabled: true })
+    ]));
+  });
+
+  // The override row a rewrite forks into this file inherits the parent's secret flag; written as a
+  // plain row instead, the rotated secret would land on disk — and in git — in cleartext.
+  it('persists a rewritten inherited secret as a secret, keeping its value off disk', () => {
+    const filePath = writeFile('dev.yml', 'name: dev\nextends: base\nvariables:\n  - name: dev_only\n    value: dev\n');
+
+    persistVariableUpdates(
+      { envVariables: { dev_only: 'dev', base_token: 'rotated-super-secret', __name__: 'dev' } },
+      {
+        envFile: {
+          path: filePath,
+          format: 'yml',
+          inheritedEnvironmentVariables: [{ name: 'base_token', value: 'from-parent', secret: true }]
+        }
+      }
+    );
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).not.toContain('rotated-super-secret');
+    const written = parseEnvironment(raw, { format: 'yml' });
+    expect(written.variables).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'base_token', secret: true, enabled: true })
+    ]));
+  });
+
+  // A name withheld from the write is still a name the script declared. Reading its absence from
+  // the write set as a `bru.deleteEnvVar` would delete the row this file owns — silently, since
+  // the value on the runtime map came from the parent all along.
+  it('keeps this file\'s own row for a name the parent also declares', () => {
+    const filePath = writeFile(
+      'dev.yml',
+      'name: dev\nextends: base\nvariables:\n  - name: token\n    value: dev-token\n  - name: dev_only\n    value: dev\n'
+    );
+
+    persistVariableUpdates(
+      { envVariables: { token: 'from-parent', dev_only: 'dev', __name__: 'dev' } },
+      {
+        envFile: {
+          path: filePath,
+          format: 'yml',
+          inheritedEnvironmentVariables: [{ name: 'token', value: 'from-parent', secret: true }]
+        }
+      }
+    );
+
+    const written = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    expect(written.variables).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'token', value: 'dev-token', secret: false })
+    ]));
+  });
+
+  // A plain row here shadows the parent's secret rather than replacing it, so the parent secret is
+  // still inherited and the rotated value lands on that plain row — in cleartext, without the flag.
+  it('persists a rewritten inherited secret as a secret even when this file already holds a plain row for it', () => {
+    const filePath = writeFile(
+      'dev.yml',
+      'name: dev\nextends: base\nvariables:\n  - name: token\n    value: dev-placeholder\n'
+    );
+
+    persistVariableUpdates(
+      { envVariables: { token: 'rotated-super-secret', __name__: 'dev' } },
+      {
+        envFile: {
+          path: filePath,
+          format: 'yml',
+          inheritedEnvironmentVariables: [{ name: 'token', value: 'from-parent', secret: true }]
+        }
+      }
+    );
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).not.toContain('rotated-super-secret');
+    const written = parseEnvironment(raw, { format: 'yml' });
+    expect(written.variables).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'token', secret: true, enabled: true })
+    ]));
+  });
+
+  // Deep compare, so a structurally-equal re-write of an inherited object/array var still counts
+  // as "unchanged" and does not fork a copy into this file.
+  it('treats a structurally-equal rewrite of an inherited typed var as unchanged', () => {
+    const filePath = writeFile('dev.yml', 'name: dev\nextends: base\nvariables:\n  - name: dev_only\n    value: dev\n');
+
+    persistVariableUpdates(
+      { envVariables: { dev_only: 'dev', base_config: { retries: 2 }, __name__: 'dev' } },
+      {
+        envFile: {
+          path: filePath,
+          format: 'yml',
+          inheritedEnvironmentVariables: [{ name: 'base_config', value: { retries: 2 } }]
+        }
+      }
+    );
+
+    const written = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    expect(written.variables.map((v) => v.name)).toEqual(['dev_only']);
   });
 });
 

--- a/packages/bruno-cli/tests/utils/persist-variables.spec.js
+++ b/packages/bruno-cli/tests/utils/persist-variables.spec.js
@@ -726,7 +726,7 @@ describe('mergeScriptVarsIntoEnvList — --env-var overrides', () => {
   // script's value differs from the injected override value.
   it('persists a deliberate same-named script write that differs from the override value', () => {
     const variables = [
-      { name: 'token', value: 'real', enabled: true, type: 'text', secret: true }
+      { name: 'token', value: 'real', enabled: true, type: 'text', secret: false }
     ];
     const merged = mergeScriptVarsIntoEnvList(variables, { token: 'rotated' }, {
       overrides: new Map([['token', 'transient-cli-value']])
@@ -735,8 +735,149 @@ describe('mergeScriptVarsIntoEnvList — --env-var overrides', () => {
     const tokenEntry = merged.find((v) => v.name === 'token');
     expect(tokenEntry).toBeDefined();
     expect(tokenEntry.value).toBe('rotated');
-    // Existing on-disk metadata (secret flag) is preserved during the update.
+  });
+
+  // The write itself is honoured — the row is the script's now — but a secret's value belongs in
+  // the runtime map, not on disk; the .bru/.yml writers drop it and the json path must match.
+  it('withholds a deliberate script write to a secret row while keeping the row secret', () => {
+    const variables = [
+      { name: 'token', value: 'real', enabled: true, type: 'text', secret: true }
+    ];
+    const merged = mergeScriptVarsIntoEnvList(variables, { token: 'rotated' }, {
+      overrides: new Map([['token', 'transient-cli-value']])
+    });
+
+    const tokenEntry = merged.find((v) => v.name === 'token');
+    expect(tokenEntry.value).toBe('');
     expect(tokenEntry.secret).toBe(true);
+  });
+});
+
+// A row the env file itself declares secret is the common case: the CLI can't decrypt secrets at
+// rest, so a script write is the only way one gets a value — and that value must not land on disk.
+describe('persistVariableUpdates — script writes to a secret row', () => {
+  it.each([
+    ['json', 'dev.json', JSON.stringify({
+      name: 'dev',
+      variables: [{ name: 'secret', value: '', type: 'text', enabled: true, secret: true }]
+    }, null, 2)],
+    ['yml', 'dev.yml', 'name: dev\nvariables:\n  - secret: true\n    name: secret\n'],
+    ['bru', 'dev.bru', 'vars:secret [\n  secret\n]\n']
+  ])('keeps the written value out of the %s env file', (format, fileName, seed) => {
+    const filePath = writeFile(fileName, seed);
+
+    persistVariableUpdates(
+      { envVariables: { secret: 'secret-value', __name__: 'dev' } },
+      { envFile: { path: filePath, format } }
+    );
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).not.toContain('secret-value');
+    const written = format === 'json'
+      ? JSON.parse(raw).variables
+      : parseEnvironment(raw, { format }).variables;
+    expect(written).toEqual([
+      expect.objectContaining({ name: 'secret', value: '', secret: true })
+    ]);
+  });
+
+  // A disabled secret row is preserved untouched, so a write to that name would otherwise land on a
+  // freshly appended plain row — putting the secret on disk, and in git, in cleartext.
+  it('does not append a row for a write to a disabled secret name, keeping its value off disk', () => {
+    const filePath = writeFile('dev.json', JSON.stringify({
+      name: 'dev',
+      variables: [{ name: 'token', value: '', type: 'text', enabled: false, secret: true }]
+    }, null, 2));
+
+    persistVariableUpdates(
+      { envVariables: { token: 'rotated-super-secret', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'json' } }
+    );
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).not.toContain('rotated-super-secret');
+    expect(JSON.parse(raw).variables).toEqual([
+      { name: 'token', value: '', type: 'text', enabled: false, secret: true }
+    ]);
+  });
+
+  // The script runtime hands back the whole env map, not just the names it wrote, so every enabled
+  // secret row is reconciled on any persist — including one the script never touched. Blanking its
+  // inline value is the intended outcome: no env file the CLI writes may carry a secret's value.
+  it('empties the inline value of an untouched secret row when an unrelated var is persisted', () => {
+    const filePath = writeFile('dev.json', JSON.stringify({
+      name: 'dev',
+      variables: [
+        { name: 'token', value: 'inline-super-secret', type: 'text', enabled: true, secret: true },
+        { name: 'host', value: 'localhost', type: 'text', enabled: true, secret: false }
+      ]
+    }, null, 2));
+
+    persistVariableUpdates(
+      { envVariables: { token: 'inline-super-secret', host: 'api.example.com', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'json' } }
+    );
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).not.toContain('inline-super-secret');
+    expect(JSON.parse(raw).variables).toEqual([
+      { name: 'token', value: '', type: 'text', enabled: true, secret: true },
+      { name: 'host', value: 'api.example.com', type: 'text', enabled: true, secret: false }
+    ]);
+  });
+
+  // The value is emptied on the way to disk, so a dataType inferred from it would annotate the row
+  // with the type of a value no reader can see — and the app applies that type to the secret it
+  // holds in its own store, retyping a value the CLI never saw.
+  it('leaves a secret row untyped when the script writes a non-string value', () => {
+    const filePath = writeFile('dev.yml', 'name: dev\nvariables:\n  - secret: true\n    name: token\n');
+
+    persistVariableUpdates(
+      { envVariables: { token: 4242, __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+
+    const written = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format: 'yml' });
+    expect(written.variables).toEqual([
+      expect.objectContaining({ name: 'token', value: '', secret: true })
+    ]);
+    expect(written.variables[0].dataType).toBeUndefined();
+  });
+
+  // The counterpart: the row's declared type describes the secret in the app's store, so a write of
+  // a differently-typed value must not strip it the way it would on a plain row.
+  it('keeps a secret row\'s declared dataType when the script writes a differently-typed value', () => {
+    const filePath = writeFile(
+      'dev.yml',
+      'name: dev\nvariables:\n  - secret: true\n    name: token\n    type: number\n'
+    );
+
+    persistVariableUpdates(
+      { envVariables: { token: 'rotated-super-secret', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'yml' } }
+    );
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).not.toContain('rotated-super-secret');
+    expect(parseEnvironment(raw, { format: 'yml' }).variables[0].dataType).toBe('number');
+  });
+
+  // A disabled plain row carries no secret, so the write still needs a row to land on.
+  it('appends an enabled row for a write to a disabled plain name', () => {
+    const filePath = writeFile('dev.json', JSON.stringify({
+      name: 'dev',
+      variables: [{ name: 'host', value: 'parked', type: 'text', enabled: false, secret: false }]
+    }, null, 2));
+
+    persistVariableUpdates(
+      { envVariables: { host: 'live', __name__: 'dev' } },
+      { envFile: { path: filePath, format: 'json' } }
+    );
+
+    expect(JSON.parse(fs.readFileSync(filePath, 'utf8')).variables).toEqual([
+      { name: 'host', value: 'parked', type: 'text', enabled: false, secret: false },
+      { name: 'host', value: 'live', type: 'text', enabled: true, secret: false }
+    ]);
   });
 });
 
@@ -801,6 +942,32 @@ describe('persistVariableUpdates — inherited env vars', () => {
     expect(written.variables).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'base_token', secret: true, enabled: true })
     ]));
+  });
+
+  // The json path serializes the merged entries verbatim — it has no secret-aware writer to drop
+  // the value the way the .bru and .yml writers do.
+  it('keeps a rewritten inherited secret off disk in a json env file', () => {
+    const filePath = writeFile('dev.json', JSON.stringify({
+      name: 'dev',
+      extends: 'base',
+      variables: [{ name: 'dev_only', value: 'dev', type: 'text', enabled: true, secret: false }]
+    }, null, 2));
+
+    persistVariableUpdates(
+      { envVariables: { dev_only: 'dev', base_token: 'rotated-super-secret', __name__: 'dev' } },
+      {
+        envFile: {
+          path: filePath,
+          format: 'json',
+          inheritedEnvironmentVariables: [{ name: 'base_token', value: 'from-parent', secret: true }]
+        }
+      }
+    );
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    expect(raw).not.toContain('rotated-super-secret');
+    const tokenEntry = JSON.parse(raw).variables.find((v) => v.name === 'base_token');
+    expect(tokenEntry).toEqual({ name: 'base_token', value: '', type: 'text', enabled: true, secret: true });
   });
 
   // A name withheld from the write is still a name the script declared. Reading its absence from

--- a/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
+++ b/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
@@ -1,0 +1,433 @@
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const { stringifyEnvironment } = require('@usebruno/filestore');
+const { resolveEnvironmentInheritance } = require('../../src/utils/environment');
+
+// The resolution algorithm itself is owned by @usebruno/common's environment-inheritance.spec.ts.
+// This spec covers what the CLI adds on top: the chain is walked across sibling *files*, so the
+// ancestor is looked up by file name, is confined to one directory and one extension, and `extends`
+// only survives in the formats that persist it.
+describe('resolveEnvironmentInheritance', () => {
+  let environmentsDir;
+
+  beforeEach(() => {
+    environmentsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-cli-env-inheritance-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(environmentsDir, { recursive: true, force: true });
+  });
+
+  const variable = ({ name, value = '', enabled = true, secret = false }) => ({
+    name,
+    value,
+    enabled,
+    secret,
+    type: 'text'
+  });
+
+  // Secrets are stored by name only on disk — their value lives outside the environment file.
+  const secretVariable = (props) => variable({ ...props, value: '', secret: true });
+
+  const writeEnvironment = ({
+    name,
+    fileName = name,
+    format = 'yml',
+    directory = environmentsDir,
+    eol = '\n',
+    ...environment
+  }) => {
+    const filePath = path.join(directory, `${fileName}.${format}`);
+    const content
+      = format === 'json'
+        ? JSON.stringify({ name, variables: [], ...environment })
+        : stringifyEnvironment({ name, variables: [], ...environment }, { format });
+
+    fs.writeFileSync(filePath, content.replace(/\n/g, eol));
+
+    return filePath;
+  };
+
+  // Parsing stamps a fresh uid on the environment and on every row; they identify nothing on disk,
+  // so drop them before comparing against the variables the fixture wrote.
+  const withoutUids = (value) => JSON.parse(JSON.stringify(value, (key, v) => (key === 'uid' ? undefined : v)));
+
+  const rowsOf = (result) => withoutUids([...(result.inheritedVariables ?? []), ...(result.variables ?? [])]);
+
+  const valueOf = (result, name) => rowsOf(result).find((row) => row.name === name)?.value;
+
+  const sourceOf = (result, name) => rowsOf(result).find((row) => row.name === name)?.inheritedFrom?.name;
+
+  describe('an environment with nothing to inherit', () => {
+    it('leaves a non-inheriting environment untouched, disabled and secret rows included', () => {
+      const variables = [
+        variable({ name: 'host', value: 'a' }),
+        variable({ name: 'off', value: 'x', enabled: false }),
+        secretVariable({ name: 'token' })
+      ];
+      const filePath = writeEnvironment({ name: 'base', variables });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(withoutUids(result)).toEqual({ name: 'base', color: null, variables, inheritedVariables: [] });
+    });
+
+    it('resolves an environment whose reference has no sibling file instead of throwing', () => {
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(withoutUids(result)).toEqual({
+        name: 'dev',
+        color: null,
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })],
+        inheritedVariables: []
+      });
+    });
+  });
+
+  describe('a chain of ancestor files', () => {
+    it('merges the parent file into the child', () => {
+      writeEnvironment({
+        name: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' }), variable({ name: 'host', value: 'base-host' })]
+      });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(valueOf(result, 'host')).toBe('dev-host');
+    });
+
+    it('applies a three-level chain furthest-ancestor first', () => {
+      writeEnvironment({
+        name: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' }), variable({ name: 'retries', value: '3' })]
+      });
+      writeEnvironment({
+        name: 'staging',
+        extends: 'base',
+        variables: [variable({ name: 'retries', value: '5' }), variable({ name: 'host', value: 'stg' })]
+      });
+      const filePath = writeEnvironment({
+        name: 'staging-gw',
+        extends: 'staging',
+        variables: [variable({ name: 'host', value: 'gw' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(valueOf(result, 'retries')).toBe('5');
+      expect(valueOf(result, 'host')).toBe('gw');
+    });
+
+    it('credits each row of a three-level chain to the ancestor it came from', () => {
+      writeEnvironment({ name: 'base', variables: [variable({ name: 'baseOnly', value: 'from-base' })] });
+      writeEnvironment({
+        name: 'staging',
+        extends: 'base',
+        variables: [variable({ name: 'stagingOnly', value: 'from-staging' })]
+      });
+      const filePath = writeEnvironment({
+        name: 'qa',
+        extends: 'staging',
+        variables: [variable({ name: 'qaOnly', value: 'from-qa' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(sourceOf(result, 'baseOnly')).toBe('base');
+      expect(sourceOf(result, 'stagingOnly')).toBe('staging');
+      expect(sourceOf(result, 'qaOnly')).toBeUndefined();
+    });
+
+    it('credits an inherited row to the ancestor file name, not the name written inside it', () => {
+      writeEnvironment({
+        name: 'Renamed Elsewhere',
+        fileName: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' })]
+      });
+      const filePath = writeEnvironment({ name: 'dev', extends: 'base' });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(sourceOf(result, 'scheme')).toBe('base');
+    });
+
+    it('resolves an environment with no rows of its own entirely from its ancestors', () => {
+      writeEnvironment({ name: 'base', variables: [variable({ name: 'baseOnly', value: 'from-base' })] });
+      writeEnvironment({ name: 'qa', extends: 'base', variables: [variable({ name: 'host', value: 'qa' })] });
+      const filePath = writeEnvironment({ name: 'mirror', extends: 'qa' });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.variables).toEqual([]);
+      expect(valueOf(result, 'baseOnly')).toBe('from-base');
+      expect(valueOf(result, 'host')).toBe('qa');
+    });
+  });
+
+  describe('the file the reference resolves to', () => {
+    it('inherits nothing from an ancestor stored in another format', () => {
+      writeEnvironment({ name: 'base', format: 'bru', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.inheritedVariables).toEqual([]);
+    });
+
+    it('inherits nothing into a json environment, a format that does not persist the reference', () => {
+      writeEnvironment({ name: 'base', format: 'json', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        format: 'json',
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.extends).toBeUndefined();
+      expect(result.inheritedVariables).toEqual([]);
+    });
+
+    it('inherits from a parent file written with CRLF line endings', () => {
+      writeEnvironment({ name: 'base', eol: '\r\n', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+    });
+
+    it('inherits nothing from a differently-cased reference', () => {
+      writeEnvironment({ name: 'Base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const filePath = writeEnvironment({ name: 'dev', extends: 'base' });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.inheritedVariables).toEqual([]);
+    });
+  });
+
+  describe('a reference that cannot be followed', () => {
+    it('inherits nothing from an environment that extends itself', () => {
+      const filePath = writeEnvironment({
+        name: 'base',
+        extends: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.inheritedVariables).toEqual([]);
+    });
+
+    it('inherits nothing from a reference that would escape the environments directory', () => {
+      writeEnvironment({ name: 'base', variables: [variable({ name: 'scheme', value: 'leaked' })] });
+      const nestedDir = path.join(environmentsDir, 'nested');
+      fs.mkdirSync(nestedDir);
+      const filePath = writeEnvironment({ name: 'dev', directory: nestedDir, extends: '../base' });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.inheritedVariables).toEqual([]);
+    });
+
+    it('inherits nothing from a list-shaped reference, since a single parent is the only supported shape', () => {
+      writeEnvironment({ name: 'base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const filePath = writeEnvironment({ name: 'dev', extends: ['base'] });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.inheritedVariables).toEqual([]);
+    });
+  });
+
+  describe('a cycle in the chain', () => {
+    it('resolves a two-environment cycle up to the repeat', () => {
+      writeEnvironment({ name: 'base', extends: 'dev', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(valueOf(result, 'host')).toBe('dev-host');
+    });
+
+    it('never re-inherits the rows the target already declares', () => {
+      writeEnvironment({
+        name: 'cycle-b',
+        extends: 'cycle-a',
+        variables: [variable({ name: 'cycleBOnly', value: 'b-value' })]
+      });
+      const filePath = writeEnvironment({
+        name: 'cycle-a',
+        extends: 'cycle-b',
+        variables: [variable({ name: 'cycleAOnly', value: 'a-value' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(result.inheritedVariables.map((row) => row.name)).toEqual(['cycleBOnly']);
+      expect(valueOf(result, 'cycleAOnly')).toBe('a-value');
+    });
+  });
+
+  describe('disabled rows', () => {
+    it('skips disabled rows on both sides of the merge', () => {
+      writeEnvironment({
+        name: 'base',
+        variables: [
+          variable({ name: 'legacyFlag', value: 'on', enabled: false }),
+          variable({ name: 'apiVersion', value: 'v2' })
+        ]
+      });
+      const filePath = writeEnvironment({
+        name: 'prod',
+        extends: 'base',
+        variables: [variable({ name: 'apiVersion', value: 'v3', enabled: false })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(rowsOf(result).find((row) => row.name === 'legacyFlag')).toBeUndefined();
+      expect(valueOf(result, 'apiVersion')).toBe('v2');
+    });
+
+    it('keeps an inherited secret when the environment redeclares it as a disabled secret', () => {
+      writeEnvironment({ name: 'base', variables: [secretVariable({ name: 'token' })] });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [secretVariable({ name: 'token', enabled: false })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(withoutUids(result.inheritedVariables)).toEqual([
+        { ...secretVariable({ name: 'token' }), inheritedFrom: { name: 'base' } }
+      ]);
+    });
+  });
+
+  describe('the split between secrets and non-secrets', () => {
+    it('merges secrets only against secrets', () => {
+      writeEnvironment({
+        name: 'base',
+        variables: [variable({ name: 'host', value: 'base-host' }), secretVariable({ name: 'token' })]
+      });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [secretVariable({ name: 'token' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(rowsOf(result).filter((row) => row.name === 'token')).toEqual([secretVariable({ name: 'token' })]);
+      expect(sourceOf(result, 'host')).toBe('base');
+    });
+
+    it('keeps an inherited secret that the environment redeclares as a non-secret', () => {
+      writeEnvironment({ name: 'base', variables: [secretVariable({ name: 'token' })] });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [variable({ name: 'token', value: 'dev-plain-token' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(rowsOf(result)).toEqual([
+        { ...secretVariable({ name: 'token' }), inheritedFrom: { name: 'base' } },
+        variable({ name: 'token', value: 'dev-plain-token' })
+      ]);
+    });
+
+    it('keeps an inherited non-secret that the environment redeclares as a secret', () => {
+      writeEnvironment({ name: 'base', variables: [variable({ name: 'token', value: 'base-plain-token' })] });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [secretVariable({ name: 'token' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(rowsOf(result)).toEqual([
+        { ...variable({ name: 'token', value: 'base-plain-token' }), inheritedFrom: { name: 'base' } },
+        secretVariable({ name: 'token' })
+      ]);
+    });
+
+    it('scopes shadowing to the redeclared kind across a three-level chain', () => {
+      writeEnvironment({ name: 'base', variables: [variable({ name: 'apiKey', value: 'base-plain-key' })] });
+      writeEnvironment({ name: 'staging', extends: 'base', variables: [secretVariable({ name: 'apiKey' })] });
+      const filePath = writeEnvironment({
+        name: 'staging-gw',
+        extends: 'staging',
+        variables: [variable({ name: 'apiKey', value: 'gw-plain-key' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(withoutUids(result.inheritedVariables)).toEqual([
+        { ...secretVariable({ name: 'apiKey' }), inheritedFrom: { name: 'staging' } }
+      ]);
+    });
+  });
+
+  describe('the merged variable list', () => {
+    it('places the inherited rows ahead of the environment rows, disabled ones included', () => {
+      writeEnvironment({
+        name: 'base',
+        variables: [variable({ name: 'host', value: 'base-host' }), secretVariable({ name: 'token' })]
+      });
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [
+          variable({ name: 'token', value: 'dev-plain-token' }),
+          variable({ name: 'stale', value: 'x', enabled: false })
+        ]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath, merge: true });
+
+      expect(result.inheritedVariables).toBeUndefined();
+      expect(withoutUids(result.variables)).toEqual([
+        { ...variable({ name: 'host', value: 'base-host' }), inheritedFrom: { name: 'base' } },
+        { ...secretVariable({ name: 'token' }), inheritedFrom: { name: 'base' } },
+        variable({ name: 'token', value: 'dev-plain-token' }),
+        variable({ name: 'stale', value: 'x', enabled: false })
+      ]);
+    });
+  });
+});

--- a/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
+++ b/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
@@ -236,6 +236,17 @@ describe('resolveEnvironmentInheritance', () => {
       expect(valueOf(result, 'scheme')).toBe('https');
     });
 
+    it('inherits from a parent file whose extension is cased differently', () => {
+      const basePath = writeEnvironment({ name: 'base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      fs.renameSync(basePath, path.join(environmentsDir, 'base.YML'));
+      const filePath = writeEnvironment({ name: 'dev', extends: 'base' });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(sourceOf(result, 'scheme')).toBe('base');
+    });
+
     it('inherits nothing from a differently-cased reference', () => {
       writeEnvironment({ name: 'Base', variables: [variable({ name: 'scheme', value: 'https' })] });
       const filePath = writeEnvironment({ name: 'dev', extends: 'base' });

--- a/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
+++ b/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
@@ -222,6 +222,20 @@ describe('resolveEnvironmentInheritance', () => {
       expect(valueOf(result, 'scheme')).toBe('https');
     });
 
+    it('inherits from the parent file even when another sibling file fails to parse', () => {
+      writeEnvironment({ name: 'base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      fs.writeFileSync(path.join(environmentsDir, 'broken.yml'), 'variables: [\n');
+      const filePath = writeEnvironment({
+        name: 'dev',
+        extends: 'base',
+        variables: [variable({ name: 'host', value: 'dev-host' })]
+      });
+
+      const result = resolveEnvironmentInheritance({ filePath });
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+    });
+
     it('inherits nothing from a differently-cased reference', () => {
       writeEnvironment({ name: 'Base', variables: [variable({ name: 'scheme', value: 'https' })] });
       const filePath = writeEnvironment({ name: 'dev', extends: 'base' });

--- a/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
+++ b/packages/bruno-cli/tests/utils/resolve-environment-inheritance.spec.js
@@ -432,11 +432,13 @@ describe('resolveEnvironmentInheritance', () => {
   describe('the merged variable list', () => {
     it('places the inherited rows ahead of the environment rows, disabled ones included', () => {
       writeEnvironment({
-        name: 'base',
+        name: 'Renamed Base',
+        fileName: 'base',
         variables: [variable({ name: 'host', value: 'base-host' }), secretVariable({ name: 'token' })]
       });
       const filePath = writeEnvironment({
-        name: 'dev',
+        name: 'Renamed Dev',
+        fileName: 'dev',
         extends: 'base',
         variables: [
           variable({ name: 'token', value: 'dev-plain-token' }),
@@ -446,6 +448,7 @@ describe('resolveEnvironmentInheritance', () => {
 
       const result = resolveEnvironmentInheritance({ filePath, merge: true });
 
+      expect(result.name).toBe('dev');
       expect(result.inheritedVariables).toBeUndefined();
       expect(withoutUids(result.variables)).toEqual([
         { ...variable({ name: 'host', value: 'base-host' }), inheritedFrom: { name: 'base' } },

--- a/packages/bruno-common/src/utils/environment-inheritance.spec.ts
+++ b/packages/bruno-common/src/utils/environment-inheritance.spec.ts
@@ -1,0 +1,748 @@
+import {
+  getInheritableEnvironments,
+  getInheritedEnvironments,
+  resolveEnvironmentInheritance,
+  validatedEnvironmentExtendsFrom
+} from './environment-inheritance';
+
+type VariableProps = {
+  name: string;
+  value: string;
+  enabled?: boolean;
+  secret?: boolean;
+};
+
+type EnvironmentProps = {
+  name: string;
+  variables?: ReturnType<typeof variable>[];
+  extends?: string;
+};
+
+const variable = (props: VariableProps) => ({ enabled: true, secret: false, ...props });
+
+const secret = (props: Omit<VariableProps, 'secret'>) => variable({ ...props, secret: true });
+
+const environment = ({ name, variables = [], extends: extendsRef }: EnvironmentProps) => ({
+  uid: `uid-${name}`,
+  name,
+  variables,
+  ...(extendsRef ? { extends: extendsRef } : {})
+});
+
+const resolve = ({ environments, target, merge }: { environments: any[]; target: string; merge?: boolean }) =>
+  resolveEnvironmentInheritance({
+    environments,
+    targetEnvironment: environments.find((env) => env.name === target),
+    merge
+  });
+
+const rowsOf = (result: any) => [...result.inheritedVariables, ...(result.variables ?? [])];
+
+const valueOf = (result: any, name: string) => rowsOf(result).find((v: any) => v.name === name)?.value;
+
+// This spec owns the resolution algorithm end to end — chains, references, cycles, disabled rows
+// and the secret split. The e2e suite covers how the resolved rows are rendered and interpolated,
+// and relies on the groups below rather than re-walking each rule through the UI.
+describe('resolveEnvironmentInheritance', () => {
+  describe('an environment with nothing to inherit', () => {
+    it('returns undefined when there is no target environment', () => {
+      expect(resolveEnvironmentInheritance({ environments: [], targetEnvironment: undefined })).toBeUndefined();
+    });
+
+    it('leaves a non-inheriting environment untouched, rows and order included', () => {
+      const base = environment({
+        name: 'base',
+        variables: [
+          secret({ name: 'token', value: 'shh' }),
+          variable({ name: 'host', value: 'a' }),
+          variable({ name: 'off', value: 'x', enabled: false })
+        ]
+      });
+
+      const result = resolve({ environments: [base], target: 'base' });
+
+      expect(result).toEqual({ ...base, inheritedVariables: [] });
+    });
+  });
+
+  describe('a chain of ancestors', () => {
+    it('merges a parent into the child', () => {
+      const base = environment({
+        name: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' }), variable({ name: 'host', value: 'base-host' })]
+      });
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'host', value: 'dev-host' })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, dev], target: 'dev' })!;
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(valueOf(result, 'host')).toBe('dev-host');
+    });
+
+    it('applies a three-level chain furthest-ancestor first', () => {
+      const base = environment({
+        name: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' }), variable({ name: 'retries', value: '3' })]
+      });
+      const staging = environment({
+        name: 'staging',
+        variables: [variable({ name: 'retries', value: '5' }), variable({ name: 'host', value: 'stg' })],
+        extends: 'base'
+      });
+      const stagingGw = environment({
+        name: 'staging-gw',
+        variables: [variable({ name: 'host', value: 'gw' })],
+        extends: 'staging'
+      });
+
+      const result = resolve({ environments: [base, staging, stagingGw], target: 'staging-gw' })!;
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(valueOf(result, 'retries')).toBe('5');
+      expect(valueOf(result, 'host')).toBe('gw');
+    });
+
+    it('tags inherited rows with their source and leaves the child rows untagged', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'host', value: 'dev-host' })],
+        extends: 'base'
+      });
+
+      const rows = rowsOf(resolve({ environments: [base, dev], target: 'dev' })!);
+
+      expect(rows.find((row) => row.name === 'scheme').inheritedFrom).toEqual({ name: 'base', uid: 'uid-base' });
+      expect(rows.find((row) => row.name === 'host').inheritedFrom).toBeUndefined();
+    });
+
+    it('credits each row of a three-level chain to the ancestor it came from', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'baseOnly', value: 'from-base' })] });
+      const staging = environment({
+        name: 'staging',
+        variables: [variable({ name: 'stagingOnly', value: 'from-staging' })],
+        extends: 'base'
+      });
+      const qa = environment({
+        name: 'qa',
+        variables: [variable({ name: 'qaOnly', value: 'from-qa' })],
+        extends: 'staging'
+      });
+
+      const rows = rowsOf(resolve({ environments: [base, staging, qa], target: 'qa' })!);
+      const sourceOf = (name: string) => rows.find((row) => row.name === name).inheritedFrom?.name;
+
+      expect(sourceOf('baseOnly')).toBe('base');
+      expect(sourceOf('stagingOnly')).toBe('staging');
+      expect(sourceOf('qaOnly')).toBeUndefined();
+    });
+
+    it('resolves an environment with no rows of its own entirely from its ancestors', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'baseOnly', value: 'from-base' })] });
+      const staging = environment({
+        name: 'staging',
+        variables: [variable({ name: 'host', value: 'stg' })],
+        extends: 'base'
+      });
+      const qa = environment({ name: 'qa', variables: [variable({ name: 'host', value: 'qa' })], extends: 'staging' });
+      const mirror = environment({ name: 'mirror', extends: 'qa' });
+
+      const result = resolve({ environments: [base, staging, qa, mirror], target: 'mirror' })!;
+
+      expect(result.variables).toEqual([]);
+      expect(valueOf(result, 'baseOnly')).toBe('from-base');
+      expect(valueOf(result, 'host')).toBe('qa');
+    });
+
+    it('treats an environment with no variables key at all as empty', () => {
+      const base = { name: 'base', extends: 'grandparent' } as any;
+      const grandparent = environment({
+        name: 'grandparent',
+        variables: [variable({ name: 'scheme', value: 'https' })]
+      });
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'host', value: 'dev-host' })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, grandparent, dev], target: 'dev' })!;
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(valueOf(result, 'host')).toBe('dev-host');
+    });
+  });
+
+  describe('a reference that cannot be followed', () => {
+    it('resolves an environment whose parent is missing instead of throwing', () => {
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'host', value: 'dev-host' })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [dev], target: 'dev' })!;
+
+      expect(result).toEqual({ ...dev, inheritedVariables: [] });
+    });
+
+    it('inherits nothing from an environment that extends itself', () => {
+      const base = environment({
+        name: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' })],
+        extends: 'base'
+      });
+
+      expect(resolve({ environments: [base], target: 'base' })).toEqual({ ...base, inheritedVariables: [] });
+    });
+
+    it('ignores a list-shaped reference, since a single parent is the only supported shape', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const dev = { name: 'dev', variables: [variable({ name: 'host', value: 'dev-host' })], extends: ['base'] } as any;
+
+      const result = resolve({ environments: [base, dev], target: 'dev' })!;
+
+      expect(result).toEqual({ ...dev, inheritedVariables: [] });
+    });
+
+    it('inherits nothing from a reference containing a path separator', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const dev = environment({ name: 'dev', extends: '../base' });
+
+      expect(resolve({ environments: [base, dev], target: 'dev' })).toEqual({ ...dev, inheritedVariables: [] });
+    });
+
+    it('inherits nothing from a reference carrying a line break', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'scheme', value: 'https' })] });
+      const dev = environment({ name: 'dev', extends: 'base\nvars {\n  injected: pwned\n}' });
+
+      expect(resolve({ environments: [base, dev], target: 'dev' })).toEqual({ ...dev, inheritedVariables: [] });
+    });
+  });
+
+  describe('matching a reference to an environment', () => {
+    it('inherits nothing from a differently-cased reference', () => {
+      const differentCase = environment({
+        name: 'Prod',
+        variables: [variable({ name: 'host', value: 'different-case' })]
+      });
+      const child = environment({ name: 'child', extends: 'prod' });
+
+      expect(resolve({ environments: [differentCase, child], target: 'child' })).toEqual({
+        ...child,
+        inheritedVariables: []
+      });
+    });
+
+    it('inherits from the exactly-cased environment when a differently-cased one is also present', () => {
+      const exact = environment({ name: 'prod', variables: [variable({ name: 'host', value: 'exact' })] });
+      const differentCase = environment({
+        name: 'Prod',
+        variables: [variable({ name: 'host', value: 'different-case' })]
+      });
+      const child = environment({ name: 'child', extends: 'prod' });
+
+      expect(valueOf(resolve({ environments: [exact, differentCase, child], target: 'child' })!, 'host')).toBe('exact');
+    });
+  });
+
+  describe('a cycle in the chain', () => {
+    it('resolves a two-environment cycle up to the repeat', () => {
+      const base = environment({
+        name: 'base',
+        variables: [variable({ name: 'scheme', value: 'https' })],
+        extends: 'dev'
+      });
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'host', value: 'dev-host' })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, dev], target: 'dev' })!;
+
+      expect(valueOf(result, 'scheme')).toBe('https');
+      expect(valueOf(result, 'host')).toBe('dev-host');
+    });
+
+    it('never re-inherits the rows the target already declares', () => {
+      const cycleA = environment({
+        name: 'cycle-a',
+        variables: [variable({ name: 'cycleAOnly', value: 'a-value' })],
+        extends: 'cycle-b'
+      });
+      const cycleB = environment({
+        name: 'cycle-b',
+        variables: [variable({ name: 'cycleBOnly', value: 'b-value' })],
+        extends: 'cycle-a'
+      });
+
+      const result = resolve({ environments: [cycleA, cycleB], target: 'cycle-a' })!;
+
+      expect(result.inheritedVariables.map((row: any) => row.name)).toEqual(['cycleBOnly']);
+      expect(valueOf(result, 'cycleAOnly')).toBe('a-value');
+    });
+
+    it('stops at the repeat when the cycle closes on a mid-chain ancestor', () => {
+      const leaf = environment({ name: 'leaf', extends: 'outer' });
+      const outer = environment({
+        name: 'outer',
+        variables: [variable({ name: 'host', value: 'outer-host' })],
+        extends: 'inner'
+      });
+      const inner = environment({
+        name: 'inner',
+        variables: [variable({ name: 'host', value: 'inner-host' }), variable({ name: 'scheme', value: 'https' })],
+        extends: 'outer'
+      });
+
+      const result = resolve({ environments: [leaf, outer, inner], target: 'leaf' })!;
+
+      expect(valueOf(result, 'host')).toBe('outer-host');
+      expect(valueOf(result, 'scheme')).toBe('https');
+    });
+  });
+
+  describe('disabled rows', () => {
+    it('skips disabled rows on both sides of the merge', () => {
+      const base = environment({
+        name: 'base',
+        variables: [
+          variable({ name: 'legacyFlag', value: 'on', enabled: false }),
+          variable({ name: 'apiVersion', value: 'v2' })
+        ]
+      });
+      const prod = environment({
+        name: 'prod',
+        variables: [variable({ name: 'apiVersion', value: 'v3', enabled: false })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, prod], target: 'prod' })!;
+
+      expect(rowsOf(result).find((row: any) => row.name === 'legacyFlag')).toBeUndefined();
+      expect(valueOf(result, 'apiVersion')).toBe('v2');
+    });
+
+    it('keeps an inherited secret when the environment redeclares it as a disabled secret', () => {
+      const base = environment({ name: 'base', variables: [secret({ name: 'token', value: 'base-secret' })] });
+      const dev = environment({
+        name: 'dev',
+        variables: [secret({ name: 'token', value: 'dev-secret', enabled: false })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, dev], target: 'dev' })!;
+
+      expect(result.inheritedVariables).toEqual([
+        {
+          name: 'token',
+          value: 'base-secret',
+          enabled: true,
+          secret: true,
+          inheritedFrom: { name: 'base', uid: 'uid-base' }
+        }
+      ]);
+    });
+  });
+
+  describe('the split between secrets and non-secrets', () => {
+    it('merges secrets only against secrets', () => {
+      const base = environment({
+        name: 'base',
+        variables: [secret({ name: 'token', value: 'base-secret' }), variable({ name: 'host', value: 'base-host' })]
+      });
+      const dev = environment({
+        name: 'dev',
+        variables: [secret({ name: 'token', value: 'dev-secret' })],
+        extends: 'base'
+      });
+
+      const rows = rowsOf(resolve({ environments: [base, dev], target: 'dev' })!);
+
+      expect(rows.filter((row) => row.name === 'token')).toHaveLength(1);
+      expect(rows.find((row) => row.name === 'token').value).toBe('dev-secret');
+    });
+
+    it('keeps an inherited secret that the environment redeclares as a non-secret', () => {
+      const base = environment({ name: 'base', variables: [secret({ name: 'token', value: 'base-secret' })] });
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'token', value: 'dev-plain-token' })],
+        extends: 'base'
+      });
+
+      const rows = rowsOf(resolve({ environments: [base, dev], target: 'dev' })!);
+
+      expect(rows).toEqual([
+        {
+          name: 'token',
+          value: 'base-secret',
+          enabled: true,
+          secret: true,
+          inheritedFrom: { name: 'base', uid: 'uid-base' }
+        },
+        { name: 'token', value: 'dev-plain-token', enabled: true, secret: false }
+      ]);
+    });
+
+    it('keeps an inherited non-secret that the environment redeclares as a secret', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'token', value: 'base-plain-token' })] });
+      const dev = environment({
+        name: 'dev',
+        variables: [secret({ name: 'token', value: 'dev-secret' })],
+        extends: 'base'
+      });
+
+      const rows = rowsOf(resolve({ environments: [base, dev], target: 'dev' })!);
+
+      expect(rows).toEqual([
+        {
+          name: 'token',
+          value: 'base-plain-token',
+          enabled: true,
+          secret: false,
+          inheritedFrom: { name: 'base', uid: 'uid-base' }
+        },
+        { name: 'token', value: 'dev-secret', enabled: true, secret: true }
+      ]);
+    });
+
+    it('shadows only the inherited secret when the environment redeclares the name as a secret', () => {
+      const base = environment({
+        name: 'base',
+        variables: [
+          variable({ name: 'token', value: 'base-plain-token' }),
+          secret({ name: 'token', value: 'base-secret' })
+        ]
+      });
+      const dev = environment({
+        name: 'dev',
+        variables: [secret({ name: 'token', value: 'dev-secret' })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, dev], target: 'dev' })!;
+
+      expect(result.inheritedVariables).toEqual([
+        {
+          name: 'token',
+          value: 'base-plain-token',
+          enabled: true,
+          secret: false,
+          inheritedFrom: { name: 'base', uid: 'uid-base' }
+        }
+      ]);
+    });
+
+    it('shadows only the inherited non-secret when the environment redeclares the name as a non-secret', () => {
+      const base = environment({
+        name: 'base',
+        variables: [
+          variable({ name: 'token', value: 'base-plain-token' }),
+          secret({ name: 'token', value: 'base-secret' })
+        ]
+      });
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'token', value: 'dev-plain-token' })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, dev], target: 'dev' })!;
+
+      expect(result.inheritedVariables).toEqual([
+        {
+          name: 'token',
+          value: 'base-secret',
+          enabled: true,
+          secret: true,
+          inheritedFrom: { name: 'base', uid: 'uid-base' }
+        }
+      ]);
+    });
+
+    it('scopes shadowing to the redeclared kind across a three-level chain', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'apiKey', value: 'base-plain-key' })] });
+      const staging = environment({
+        name: 'staging',
+        variables: [secret({ name: 'apiKey', value: 'staging-secret-key' })],
+        extends: 'base'
+      });
+      const stagingGw = environment({
+        name: 'staging-gw',
+        variables: [variable({ name: 'apiKey', value: 'gw-plain-key' })],
+        extends: 'staging'
+      });
+
+      const result = resolve({ environments: [base, staging, stagingGw], target: 'staging-gw' })!;
+
+      expect(result.inheritedVariables).toEqual([
+        {
+          name: 'apiKey',
+          value: 'staging-secret-key',
+          enabled: true,
+          secret: true,
+          inheritedFrom: { name: 'staging', uid: 'uid-staging' }
+        }
+      ]);
+    });
+
+    it('keeps a non-secret and a secret of the same name declared side by side, secret last', () => {
+      const base = environment({ name: 'base', variables: [variable({ name: 'host', value: 'base-host' })] });
+      const dev = environment({
+        name: 'dev',
+        variables: [
+          variable({ name: 'token', value: 'dev-plain-token' }),
+          secret({ name: 'token', value: 'dev-secret' })
+        ],
+        extends: 'base'
+      });
+
+      const rows = rowsOf(resolve({ environments: [base, dev], target: 'dev' })!);
+
+      expect(rows.map((row) => [row.name, row.secret, row.value])).toEqual([
+        ['host', false, 'base-host'],
+        ['token', false, 'dev-plain-token'],
+        ['token', true, 'dev-secret']
+      ]);
+    });
+  });
+
+  describe('the merged variable list', () => {
+    it('merges an inherited secret and a redeclared non-secret of the same name, own rows last', () => {
+      const base = environment({
+        name: 'base',
+        variables: [variable({ name: 'host', value: 'base-host' }), secret({ name: 'token', value: 'base-secret' })]
+      });
+      const dev = environment({
+        name: 'dev',
+        variables: [variable({ name: 'token', value: 'dev-plain-token' })],
+        extends: 'base'
+      });
+
+      const result = resolve({ environments: [base, dev], target: 'dev', merge: true })!;
+
+      expect(result.variables).toEqual([
+        {
+          name: 'host',
+          value: 'base-host',
+          enabled: true,
+          secret: false,
+          inheritedFrom: { name: 'base', uid: 'uid-base' }
+        },
+        {
+          name: 'token',
+          value: 'base-secret',
+          enabled: true,
+          secret: true,
+          inheritedFrom: { name: 'base', uid: 'uid-base' }
+        },
+        { name: 'token', value: 'dev-plain-token', enabled: true, secret: false }
+      ]);
+    });
+  });
+});
+
+describe('getInheritedEnvironments', () => {
+  const walk = ({ environments, target }: { environments: any[]; target: string }) =>
+    getInheritedEnvironments({
+      environments,
+      environment: environments.find((env) => env.name === target)
+    });
+
+  it('reports no missing parent when the whole chain resolves', () => {
+    const base = environment({ name: 'base' });
+    const staging = environment({ name: 'staging', extends: 'base' });
+    const dev = environment({ name: 'dev', extends: 'staging' });
+
+    const { inheritedEnvironments, missingInheritedEnvironmentName } = walk({
+      environments: [base, staging, dev],
+      target: 'dev'
+    });
+
+    expect(inheritedEnvironments.map((env) => env.name)).toEqual(['base', 'staging']);
+    expect(missingInheritedEnvironmentName).toBeNull();
+  });
+
+  it('reports the reference that resolves to nothing', () => {
+    const dev = environment({ name: 'dev', extends: 'base' });
+
+    const { inheritedEnvironments, missingInheritedEnvironmentName } = walk({ environments: [dev], target: 'dev' });
+
+    expect(inheritedEnvironments).toEqual([]);
+    expect(missingInheritedEnvironmentName).toBe('base');
+  });
+
+  it('reports a missing reference found part way up the chain', () => {
+    const staging = environment({ name: 'staging', extends: 'base' });
+    const dev = environment({ name: 'dev', extends: 'staging' });
+
+    const { inheritedEnvironments, missingInheritedEnvironmentName } = walk({
+      environments: [staging, dev],
+      target: 'dev'
+    });
+
+    expect(inheritedEnvironments.map((env) => env.name)).toEqual(['staging']);
+    expect(missingInheritedEnvironmentName).toBe('base');
+  });
+
+  it('reports no missing parent for a cyclic chain', () => {
+    const base = environment({ name: 'base', extends: 'dev' });
+    const dev = environment({ name: 'dev', extends: 'base' });
+
+    expect(walk({ environments: [base, dev], target: 'dev' }).missingInheritedEnvironmentName).toBeNull();
+  });
+
+  it('reports a missing parent for a differently-cased reference', () => {
+    const base = environment({ name: 'Base' });
+    const dev = environment({ name: 'dev', extends: 'base' });
+
+    const { inheritedEnvironments, missingInheritedEnvironmentName } = walk({
+      environments: [base, dev],
+      target: 'dev'
+    });
+
+    expect(inheritedEnvironments).toEqual([]);
+    expect(missingInheritedEnvironmentName).toBe('base');
+  });
+
+  it('reports no missing parent for a list-shaped reference, which is not followed', () => {
+    const dev = { ...environment({ name: 'dev' }), extends: ['base'] } as any;
+
+    const { inheritedEnvironments, missingInheritedEnvironmentName } = walk({ environments: [dev], target: 'dev' });
+
+    expect(inheritedEnvironments).toEqual([]);
+    expect(missingInheritedEnvironmentName).toBeNull();
+  });
+});
+
+describe('getInheritableEnvironments', () => {
+  // Environments are named after their depth in the inheritance chain: `inherit-level-2`
+  // inherits from `inherit-level-1`, `inherit-level-3` from `inherit-level-2`, and
+  // `inherit-standalone` sits outside the chain.
+  const LEVEL_1 = 'inherit-level-1';
+  const LEVEL_2 = 'inherit-level-2';
+  const LEVEL_3 = 'inherit-level-3';
+  const STANDALONE = 'inherit-standalone';
+
+  const inheritableNames = ({ environments, target }: { environments: any[]; target?: string }) =>
+    getInheritableEnvironments({
+      environments,
+      targetEnvironment: environments.find((env) => env.name === target)
+    }).map((env) => env.name);
+
+  it('offers every other environment when none of them inherit from the target', () => {
+    const level1 = environment({ name: LEVEL_1 });
+    const level2 = environment({ name: LEVEL_2, extends: LEVEL_1 });
+    const standalone = environment({ name: STANDALONE });
+
+    expect(inheritableNames({ environments: [level1, level2, standalone], target: STANDALONE })).toEqual([
+      LEVEL_1,
+      LEVEL_2
+    ]);
+  });
+
+  it('never offers the target itself', () => {
+    const level1 = environment({ name: LEVEL_1 });
+
+    expect(inheritableNames({ environments: [level1], target: LEVEL_1 })).toEqual([]);
+  });
+
+  it('hides an environment that inherits from the target directly', () => {
+    const level1 = environment({ name: LEVEL_1 });
+    const level2 = environment({ name: LEVEL_2, extends: LEVEL_1 });
+
+    expect(inheritableNames({ environments: [level1, level2], target: LEVEL_1 })).toEqual([]);
+  });
+
+  it('hides an environment that inherits from the target through a chain', () => {
+    const level1 = environment({ name: LEVEL_1 });
+    const level2 = environment({ name: LEVEL_2, extends: LEVEL_1 });
+    const level3 = environment({ name: LEVEL_3, extends: LEVEL_2 });
+    const standalone = environment({ name: STANDALONE });
+
+    expect(inheritableNames({ environments: [level1, level2, level3, standalone], target: LEVEL_1 })).toEqual([
+      STANDALONE
+    ]);
+  });
+
+  it('offers a descendant referencing the target by a different case, since that reference resolves to nothing', () => {
+    const level1 = environment({ name: 'Inherit-Level-1' });
+    const level2 = environment({ name: LEVEL_2, extends: LEVEL_1 });
+
+    expect(inheritableNames({ environments: [level1, level2], target: 'Inherit-Level-1' })).toEqual([LEVEL_2]);
+  });
+
+  it('offers an environment caught in a cycle of its own', () => {
+    const cycleA = environment({ name: 'cycle-a', extends: 'cycle-b' });
+    const cycleB = environment({ name: 'cycle-b', extends: 'cycle-a' });
+    const standalone = environment({ name: STANDALONE });
+
+    expect(inheritableNames({ environments: [cycleA, cycleB, standalone], target: STANDALONE })).toEqual([
+      'cycle-a',
+      'cycle-b'
+    ]);
+  });
+
+  it('offers an environment whose parent is missing', () => {
+    const orphan = environment({ name: 'orphan', extends: 'gone' });
+    const standalone = environment({ name: STANDALONE });
+
+    expect(inheritableNames({ environments: [orphan, standalone], target: STANDALONE })).toEqual(['orphan']);
+  });
+
+  it('offers every environment when there is no target', () => {
+    const level1 = environment({ name: LEVEL_1 });
+    const standalone = environment({ name: STANDALONE });
+
+    expect(inheritableNames({ environments: [level1, standalone] })).toEqual([LEVEL_1, STANDALONE]);
+  });
+});
+
+describe('validatedEnvironmentExtendsFrom', () => {
+  it('trims a name', () => {
+    expect(validatedEnvironmentExtendsFrom('  staging  ')).toBe('staging');
+  });
+
+  it('keeps a list of names as given', () => {
+    expect(validatedEnvironmentExtendsFrom(['base', 'staging'])).toEqual(['base', 'staging']);
+  });
+
+  it.each([
+    ['nothing', undefined],
+    ['null', null],
+    ['an empty name', ''],
+    ['a whitespace-only name', '   '],
+    ['an empty list', []],
+    ['a list holding a non-name', ['base', 42]],
+    ['a non-reference type', { name: 'base' }]
+  ])('returns undefined for %s', (_label, reference) => {
+    expect(validatedEnvironmentExtendsFrom(reference)).toBeUndefined();
+  });
+
+  describe('a name no environment could be created with', () => {
+    it.each([
+      ['a path separator', 'reports/weekly'],
+      ['a quote', 'say "hi"'],
+      ['a leading hyphen', '-staging'],
+      ['a trailing dot', 'staging.'],
+      ['a reserved device name', 'CON'],
+      ['more than 255 characters', 'e'.repeat(256)]
+    ])('returns undefined for %s', (_label, reference) => {
+      expect(validatedEnvironmentExtendsFrom(reference)).toBeUndefined();
+    });
+
+    it('drops the whole list rather than the offending entry alone', () => {
+      expect(validatedEnvironmentExtendsFrom(['base', 'reports/weekly'])).toBeUndefined();
+    });
+  });
+
+  it('trims each name in a list', () => {
+    expect(validatedEnvironmentExtendsFrom(['  base  ', 'staging'])).toEqual(['base', 'staging']);
+  });
+});

--- a/packages/bruno-common/src/utils/environment-inheritance.ts
+++ b/packages/bruno-common/src/utils/environment-inheritance.ts
@@ -122,6 +122,12 @@ export const resolveEnvironmentInheritance = <E extends ExtendableEnvironment, M
     return undefined;
   }
 
+  if (!targetEnvironment.extends) {
+    return (
+      merge ? { ...targetEnvironment } : { ...targetEnvironment, inheritedVariables: [] }
+    ) as ResolvedEnvironment<E, Merge>;
+  }
+
   const { inheritedEnvironments } = getInheritedEnvironments({
     environments: environments ?? [],
     environment: targetEnvironment

--- a/packages/bruno-common/src/utils/environment-inheritance.ts
+++ b/packages/bruno-common/src/utils/environment-inheritance.ts
@@ -1,0 +1,170 @@
+import { validateName } from './naming';
+
+export interface InheritedFrom {
+  name: string;
+  uid: string;
+}
+
+export interface InheritableVariable {
+  name: string;
+  enabled?: boolean;
+  secret?: boolean;
+  inheritedFrom?: InheritedFrom;
+}
+
+export interface ExtendableEnvironment {
+  uid: string;
+  name: string;
+  variables: InheritableVariable[];
+  extends?: string | null;
+}
+
+export type ResolvedEnvironment<E extends ExtendableEnvironment, Merge extends boolean = false> = Merge extends true
+  ? E
+  : E & { inheritedVariables: E['variables'] };
+
+const validatedEnvironmentName = (reference: unknown): string | undefined => {
+  if (typeof reference !== 'string') {
+    return undefined;
+  }
+
+  const name = reference.trim();
+  return validateName(name) ? name : undefined;
+};
+
+export const validatedEnvironmentExtendsFrom = (environmentExtendsReference: unknown): string | string[] | undefined => {
+  if (typeof environmentExtendsReference === 'string') {
+    return validatedEnvironmentName(environmentExtendsReference);
+  }
+
+  if (!Array.isArray(environmentExtendsReference) || !environmentExtendsReference.length) {
+    return undefined;
+  }
+
+  const names = environmentExtendsReference.map(validatedEnvironmentName);
+  return names.every((name): name is string => name !== undefined) ? names : undefined;
+};
+
+/**
+ * An environment's `extends` chain, root ancestor first, so later entries override earlier ones.
+ * The walk stops at an unresolvable reference or at a name already seen, so a broken or cyclic
+ * chain yields the ancestors found so far, alongside the name that resolved to nothing — a parent
+ * that was deleted, or renamed outside the app, leaves the references to it behind.
+ */
+export const getInheritedEnvironments = <E extends ExtendableEnvironment>({
+  environments,
+  environment
+}: {
+  environments: E[];
+  environment: E;
+}): { inheritedEnvironments: E[]; missingInheritedEnvironmentName: string | null } => {
+  const scope = environments ?? [];
+  const inheritedEnvironments: E[] = [];
+  const walked = new Set<string>([environment.name]);
+
+  let current: E = environment;
+  let missingInheritedEnvironmentName: string | null = null;
+
+  while (typeof current.extends === 'string') {
+    const parent = scope.find((environment) => environment.name === current.extends);
+    if (!parent) {
+      missingInheritedEnvironmentName = current.extends;
+      break;
+    }
+
+    if (walked.has(parent.name)) {
+      break;
+    }
+
+    walked.add(parent.name);
+    inheritedEnvironments.push(parent);
+    current = parent;
+  }
+
+  return { inheritedEnvironments: inheritedEnvironments.reverse(), missingInheritedEnvironmentName };
+};
+
+/**
+ * The environments a target may inherit from: everything but itself and its descendants,
+ * since picking one of those closes a cycle.
+ */
+export const getInheritableEnvironments = <E extends ExtendableEnvironment>({
+  environments = [],
+  targetEnvironment
+}: {
+  environments: E[];
+  targetEnvironment: E | undefined;
+}): E[] => {
+  if (!targetEnvironment) {
+    return environments;
+  }
+
+  return environments.filter((environment) => {
+    if (environment.uid === targetEnvironment.uid) {
+      return false;
+    }
+
+    const { inheritedEnvironments } = getInheritedEnvironments({ environments, environment });
+    return !inheritedEnvironments.some((inheritedEnvironment) => inheritedEnvironment.uid === targetEnvironment.uid);
+  });
+};
+
+export const resolveEnvironmentInheritance = <E extends ExtendableEnvironment, Merge extends boolean = false>({
+  environments,
+  targetEnvironment,
+  merge
+}: {
+  environments: E[];
+  targetEnvironment: E | undefined;
+  merge?: Merge;
+}): ResolvedEnvironment<E, Merge> | undefined => {
+  if (!targetEnvironment) {
+    return undefined;
+  }
+
+  const { inheritedEnvironments } = getInheritedEnvironments({
+    environments: environments ?? [],
+    environment: targetEnvironment
+  });
+
+  const nonSecrets = new Map<string, InheritableVariable>();
+  const secrets = new Map<string, InheritableVariable>();
+
+  inheritedEnvironments.forEach((environment) => {
+    const inheritedFrom = { name: environment.name, uid: environment.uid };
+
+    environment.variables?.forEach((v) => {
+      if (!v.enabled) {
+        return;
+      }
+
+      const variable = { ...v, inheritedFrom };
+      if (v.secret) {
+        secrets.set(v.name, variable);
+      } else {
+        nonSecrets.set(v.name, variable);
+      }
+    });
+  });
+
+  const ownVariables = targetEnvironment.variables ?? [];
+  ownVariables.forEach((v) => {
+    if (!v.enabled) {
+      return;
+    }
+
+    if (v.secret) {
+      secrets.delete(v.name);
+    } else {
+      nonSecrets.delete(v.name);
+    }
+  });
+
+  const inheritedVariables = [...nonSecrets.values(), ...secrets.values()] as E['variables'];
+
+  if (merge) {
+    return { ...targetEnvironment, variables: [...inheritedVariables, ...ownVariables] } as ResolvedEnvironment<E, Merge>;
+  }
+
+  return { ...targetEnvironment, inheritedVariables } as ResolvedEnvironment<E, Merge>;
+};

--- a/packages/bruno-common/src/utils/environment-inheritance.ts
+++ b/packages/bruno-common/src/utils/environment-inheritance.ts
@@ -23,7 +23,7 @@ export type ResolvedEnvironment<E extends ExtendableEnvironment, Merge extends b
   ? E
   : E & { inheritedVariables: E['variables'] };
 
-const validatedEnvironmentName = (reference: unknown): string | undefined => {
+export const validatedEnvironmentName = (reference: unknown): string | undefined => {
   if (typeof reference !== 'string') {
     return undefined;
   }

--- a/packages/bruno-common/src/utils/environment-variables.spec.ts
+++ b/packages/bruno-common/src/utils/environment-variables.spec.ts
@@ -1,0 +1,63 @@
+import { toVariablesMap } from './environment-variables';
+
+type VariableProps = {
+  name?: string;
+  value?: unknown;
+  enabled?: boolean;
+  secret?: boolean;
+};
+
+const variable = (props: VariableProps) => ({ enabled: true, secret: false, ...props });
+
+const secret = (props: Omit<VariableProps, 'secret'>) => variable({ ...props, secret: true });
+
+describe('toVariablesMap', () => {
+  it('returns an empty map when there are no variables', () => {
+    expect(toVariablesMap()).toEqual({});
+  });
+
+  it('maps enabled variables by name', () => {
+    const variables = [variable({ name: 'scheme', value: 'https' }), variable({ name: 'host', value: 'dev-host' })];
+
+    expect(toVariablesMap(variables)).toEqual({ scheme: 'https', host: 'dev-host' });
+  });
+
+  it('skips disabled variables', () => {
+    const variables = [variable({ name: 'host', value: 'dev-host', enabled: false })];
+
+    expect(toVariablesMap(variables)).toEqual({});
+  });
+
+  it('skips variables without a name', () => {
+    const variables = [variable({ value: 'orphan' })];
+
+    expect(toVariablesMap(variables)).toEqual({});
+  });
+
+  it('lets a later variable override an earlier one of the same name', () => {
+    const variables = [variable({ name: 'host', value: 'base-host' }), variable({ name: 'host', value: 'dev-host' })];
+
+    expect(toVariablesMap(variables)).toEqual({ host: 'dev-host' });
+  });
+
+  it('lets a secret win over a plain variable of the same name declared after it', () => {
+    const variables = [secret({ name: 'token', value: 'secret-token' }), variable({ name: 'token', value: 'plain-token' })];
+
+    expect(toVariablesMap(variables)).toEqual({ token: 'secret-token' });
+  });
+
+  it('lets a secret win over a plain variable of the same name declared before it', () => {
+    const variables = [variable({ name: 'token', value: 'plain-token' }), secret({ name: 'token', value: 'secret-token' })];
+
+    expect(toVariablesMap(variables)).toEqual({ token: 'secret-token' });
+  });
+
+  it('ignores a disabled secret so the plain variable of the same name stands', () => {
+    const variables = [
+      variable({ name: 'token', value: 'plain-token' }),
+      secret({ name: 'token', value: 'secret-token', enabled: false })
+    ];
+
+    expect(toVariablesMap(variables)).toEqual({ token: 'plain-token' });
+  });
+});

--- a/packages/bruno-common/src/utils/environment-variables.ts
+++ b/packages/bruno-common/src/utils/environment-variables.ts
@@ -1,0 +1,30 @@
+export interface EnvironmentVariable {
+  name?: string;
+  value?: unknown;
+  enabled?: boolean;
+  secret?: boolean;
+}
+
+/**
+ * Flattens environment variables into a name → value map. Later entries override earlier ones, so
+ * callers order the list by precedence (inherited variables ahead of the environment's own), and a
+ * secret wins over a plain variable of the same name whichever order the two appear in.
+ */
+export const toVariablesMap = (environmentVariables: EnvironmentVariable[] = []): Record<string, unknown> => {
+  const variables: Record<string, unknown> = {};
+  const secretNames = new Set<string>();
+
+  for (const variable of environmentVariables) {
+    if (!variable.name || !variable.enabled) {
+      continue;
+    }
+    if (variable.secret) {
+      secretNames.add(variable.name);
+    } else if (secretNames.has(variable.name)) {
+      continue;
+    }
+    variables[variable.name] = variable.value;
+  }
+
+  return variables;
+};

--- a/packages/bruno-common/src/utils/index.ts
+++ b/packages/bruno-common/src/utils/index.ts
@@ -57,6 +57,13 @@ export {
 } from './naming';
 
 export {
+  getInheritableEnvironments,
+  getInheritedEnvironments,
+  resolveEnvironmentInheritance,
+  validatedEnvironmentExtendsFrom
+} from './environment-inheritance';
+
+export {
   toBool,
   toNumber
 } from './type-helpers';

--- a/packages/bruno-common/src/utils/index.ts
+++ b/packages/bruno-common/src/utils/index.ts
@@ -60,8 +60,13 @@ export {
   getInheritableEnvironments,
   getInheritedEnvironments,
   resolveEnvironmentInheritance,
+  validatedEnvironmentName,
   validatedEnvironmentExtendsFrom
 } from './environment-inheritance';
+
+export {
+  toVariablesMap
+} from './environment-variables';
 
 export {
   toBool,

--- a/packages/bruno-converters/src/opencollection/environment.ts
+++ b/packages/bruno-converters/src/opencollection/environment.ts
@@ -1,4 +1,4 @@
-import { validateName } from '@usebruno/common/utils';
+import { validatedEnvironmentName } from '@usebruno/common/utils';
 import { uuid } from '../common/index.js';
 import {
   isTypedValue,
@@ -20,15 +20,6 @@ interface OCVariable extends Omit<Variable, 'value'> {
   secret?: boolean;
   disabled?: boolean;
 }
-
-const validatedEnvironmentExtendsFrom = (environmentExtendsFrom: unknown): string | undefined => {
-  if (typeof environmentExtendsFrom !== 'string') {
-    return undefined;
-  }
-
-  const name = environmentExtendsFrom.trim();
-  return validateName(name) ? name : undefined;
-};
 
 export const fromOpenCollectionEnvironments = (environments: Environment[] | undefined): BrunoEnvironment[] => {
   if (!environments?.length) {
@@ -82,7 +73,7 @@ export const fromOpenCollectionEnvironments = (environments: Environment[] | und
       return result;
     }),
     color: env.color || null,
-    extends: validatedEnvironmentExtendsFrom(env.extends) || null
+    extends: validatedEnvironmentName(env.extends) || null
   }));
 };
 
@@ -118,7 +109,7 @@ export const toOpenCollectionEnvironments = (environments: BrunoEnvironment[] | 
       }) as Variable[]
     };
 
-    const environmentExtendsFrom = validatedEnvironmentExtendsFrom(env.extends);
+    const environmentExtendsFrom = validatedEnvironmentName(env.extends);
     if (environmentExtendsFrom) {
       ocEnv.extends = environmentExtendsFrom;
     }

--- a/packages/bruno-converters/src/opencollection/environment.ts
+++ b/packages/bruno-converters/src/opencollection/environment.ts
@@ -1,4 +1,4 @@
-import { validatedEnvironmentExtendsFrom } from '@usebruno/common/utils';
+import { validateName } from '@usebruno/common/utils';
 import { uuid } from '../common/index.js';
 import {
   isTypedValue,
@@ -20,6 +20,15 @@ interface OCVariable extends Omit<Variable, 'value'> {
   secret?: boolean;
   disabled?: boolean;
 }
+
+const validatedEnvironmentExtendsFrom = (environmentExtendsFrom: unknown): string | undefined => {
+  if (typeof environmentExtendsFrom !== 'string') {
+    return undefined;
+  }
+
+  const name = environmentExtendsFrom.trim();
+  return validateName(name) ? name : undefined;
+};
 
 export const fromOpenCollectionEnvironments = (environments: Environment[] | undefined): BrunoEnvironment[] => {
   if (!environments?.length) {

--- a/packages/bruno-converters/src/opencollection/environment.ts
+++ b/packages/bruno-converters/src/opencollection/environment.ts
@@ -1,3 +1,4 @@
+import { validatedEnvironmentExtendsFrom } from '@usebruno/common/utils';
 import { uuid } from '../common/index.js';
 import {
   isTypedValue,
@@ -71,7 +72,8 @@ export const fromOpenCollectionEnvironments = (environments: Environment[] | und
 
       return result;
     }),
-    color: env.color || null
+    color: env.color || null,
+    extends: validatedEnvironmentExtendsFrom(env.extends) || null
   }));
 };
 
@@ -106,6 +108,11 @@ export const toOpenCollectionEnvironments = (environments: BrunoEnvironment[] | 
         return ocVar;
       }) as Variable[]
     };
+
+    const environmentExtendsFrom = validatedEnvironmentExtendsFrom(env.extends);
+    if (environmentExtendsFrom) {
+      ocEnv.extends = environmentExtendsFrom;
+    }
 
     return ocEnv;
   });

--- a/packages/bruno-converters/tests/opencollection/environment.spec.js
+++ b/packages/bruno-converters/tests/opencollection/environment.spec.js
@@ -159,22 +159,6 @@ describe('OpenCollection environment round-trip — inheritance', () => {
     expect(toOpenCollectionEnvironments([env])).toEqual(ocEnvs);
   });
 
-  it('keeps a list of parents when converting OpenCollection to Bruno and back', () => {
-    const ocEnvs = [
-      {
-        name: 'prod',
-        color: undefined,
-        extends: ['base', 'shared'],
-        variables: [{ name: 'host', value: 'prod.example.com' }]
-      }
-    ];
-
-    const [env] = fromOpenCollectionEnvironments(ocEnvs);
-    expect(env.extends).toEqual(['base', 'shared']);
-
-    expect(toOpenCollectionEnvironments([env])).toEqual(ocEnvs);
-  });
-
   it('reports no parent for an environment that does not declare one', () => {
     const [env] = fromOpenCollectionEnvironments([{ name: 'prod', variables: [] }]);
 

--- a/packages/bruno-converters/tests/opencollection/environment.spec.js
+++ b/packages/bruno-converters/tests/opencollection/environment.spec.js
@@ -141,3 +141,44 @@ describe('OpenCollection environment round-trip — variable descriptions', () =
     expect(out).toEqual(ocEnvs);
   });
 });
+
+describe('OpenCollection environment round-trip — inheritance', () => {
+  it('keeps the parent environment when converting OpenCollection to Bruno and back', () => {
+    const ocEnvs = [
+      {
+        name: 'prod',
+        color: undefined,
+        extends: 'base',
+        variables: [{ name: 'host', value: 'prod.example.com' }]
+      }
+    ];
+
+    const [env] = fromOpenCollectionEnvironments(ocEnvs);
+    expect(env.extends).toBe('base');
+
+    expect(toOpenCollectionEnvironments([env])).toEqual(ocEnvs);
+  });
+
+  it('keeps a list of parents when converting OpenCollection to Bruno and back', () => {
+    const ocEnvs = [
+      {
+        name: 'prod',
+        color: undefined,
+        extends: ['base', 'shared'],
+        variables: [{ name: 'host', value: 'prod.example.com' }]
+      }
+    ];
+
+    const [env] = fromOpenCollectionEnvironments(ocEnvs);
+    expect(env.extends).toEqual(['base', 'shared']);
+
+    expect(toOpenCollectionEnvironments([env])).toEqual(ocEnvs);
+  });
+
+  it('reports no parent for an environment that does not declare one', () => {
+    const [env] = fromOpenCollectionEnvironments([{ name: 'prod', variables: [] }]);
+
+    expect(env.extends).toBeNull();
+    expect(toOpenCollectionEnvironments([env])[0]).not.toHaveProperty('extends');
+  });
+});

--- a/packages/bruno-electron/src/ipc/collection.js
+++ b/packages/bruno-electron/src/ipc/collection.js
@@ -22,6 +22,7 @@ const {
 } = require('@usebruno/filestore');
 const { dotenvToJson } = require('@usebruno/lang');
 const { utils } = require('@usebruno/common');
+const { resolveEnvironmentInheritance } = require('@usebruno/common/utils');
 const brunoConverters = require('@usebruno/converters');
 const { postmanToBruno } = brunoConverters;
 const { cookiesStore } = require('../store/cookies');
@@ -87,6 +88,7 @@ const { transformBrunoConfigBeforeSave, transformBrunoConfigAfterRead } = requir
 const { REQUEST_TYPES } = require('../utils/constants');
 const { cancelOAuth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } = require('../utils/oauth2-protocol-handler');
 const { findUniqueFolderName } = require('../utils/collection-import');
+const { renameEnvironmentExtendsReferences } = require('../utils/environments');
 const { saveSpecAndUpdateMetadata, cleanupSpecFilesForCollection } = require('./openapi-sync');
 const {
   validateWorkspacePath,
@@ -743,7 +745,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
   });
 
   // create environment
-  ipcMain.handle('renderer:create-environment', async (event, collectionPathname, name, variables, color) => {
+  ipcMain.handle('renderer:create-environment', async (event, collectionPathname, name, variables, color, inheritedEnvironmentName) => {
     try {
       validatePathIsInsideCollection(collectionPathname);
 
@@ -771,6 +773,10 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         variables: variables || [],
         color
       };
+
+      if (inheritedEnvironmentName) {
+        environment.extends = inheritedEnvironmentName;
+      }
 
       if (envHasSecrets(environment)) {
         environmentSecretsStore.storeEnvSecrets(collectionPathname, environment);
@@ -837,7 +843,25 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       moveRequestUid(envFilePath, newEnvFilePath);
       fs.renameSync(envFilePath, newEnvFilePath);
 
+      // only the yml format persists the name; bru derives it from the filename
+      if (format === 'yml') {
+        await withFileLock(newEnvFilePath, async () => {
+          const environment = parseEnvironment(fs.readFileSync(newEnvFilePath, 'utf8'), { format });
+          if (environment.name === newName) return;
+
+          environment.name = newName;
+          await writeFile(newEnvFilePath, stringifyEnvironment(environment, { format }));
+        });
+      }
+
       environmentSecretsStore.renameEnvironment(collectionPathname, environmentName, newName);
+
+      await renameEnvironmentExtendsReferences({
+        environmentsDirPath: path.join(collectionPathname, 'environments'),
+        format,
+        oldName: environmentName,
+        newName
+      });
     } catch (error) {
       return Promise.reject(error);
     }
@@ -946,6 +970,34 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
     }
   });
 
+  // save the environment this environment inherits its variables from
+  ipcMain.handle('renderer:save-environment-extends', async (event, collectionPathname, environmentName, inheritedEnvironmentName) => {
+    try {
+      const format = getCollectionFormat(collectionPathname);
+      const envFilePath = resolveEnvironmentFilePath(collectionPathname, environmentName, format);
+
+      if (!fs.existsSync(envFilePath)) {
+        throw new Error(`environment: ${envFilePath} does not exist`);
+      }
+
+      await withFileLock(envFilePath, async () => {
+        const fileContent = fs.readFileSync(envFilePath, 'utf8');
+        const environment = parseEnvironment(fileContent, { format });
+
+        if (inheritedEnvironmentName) {
+          environment.extends = inheritedEnvironmentName;
+        } else {
+          delete environment.extends;
+        }
+
+        const updatedContent = stringifyEnvironment(environment, { format });
+        await writeFile(envFilePath, updatedContent);
+      });
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+
   // update environment color
   ipcMain.handle('renderer:update-environment-color', async (event, collectionPathname, environmentName, color) => {
     try {
@@ -989,6 +1041,7 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
         name: environment.name,
         variables: environment.variables,
         color: environment.color ?? undefined,
+        extends: environment.extends ?? undefined,
         info: {
           type: 'bruno-environment',
           exportedAt: new Date().toISOString(),
@@ -2001,7 +2054,10 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       if (request.oauth2) {
         const requestCopy = _.cloneDeep(request);
         const { uid: collectionUid, pathname: collectionPath, runtimeVariables, environments = [], activeEnvironmentUid } = collection;
-        const environment = _.find(environments, (e) => e.uid === activeEnvironmentUid);
+        const environment = resolveEnvironmentInheritance({
+          environments,
+          targetEnvironment: _.find(environments, (e) => e.uid === activeEnvironmentUid)
+        });
         const envVars = getEnvVars(environment);
         const processEnvVars = getProcessEnvVars(collectionUid);
         const partialItem = { uid: itemUid };
@@ -2132,7 +2188,10 @@ const registerRendererEventHandlers = (mainWindow, watcher) => {
       if (request.oauth2) {
         const requestCopy = _.cloneDeep(request);
         const { uid: collectionUid, pathname: collectionPath, runtimeVariables, environments = [], activeEnvironmentUid } = collection;
-        const environment = _.find(environments, (e) => e.uid === activeEnvironmentUid);
+        const environment = resolveEnvironmentInheritance({
+          environments,
+          targetEnvironment: _.find(environments, (e) => e.uid === activeEnvironmentUid)
+        });
         const envVars = getEnvVars(environment);
         const processEnvVars = getProcessEnvVars(collectionUid);
         const partialItem = { uid: itemUid };

--- a/packages/bruno-electron/src/ipc/global-environments.js
+++ b/packages/bruno-electron/src/ipc/global-environments.js
@@ -50,7 +50,7 @@ const migrateActiveGlobalEnvironmentUid = async (workspacePath) => {
 };
 
 const registerGlobalEnvironmentsIpc = (mainWindow, workspaceEnvironmentsManager) => {
-  ipcMain.handle('renderer:create-global-environment', async (event, { uid, name, variables, color, workspaceUid, workspacePath }) => {
+  ipcMain.handle('renderer:create-global-environment', async (event, { uid, name, variables, color, extends: inheritedGlobalEnvironmentName, workspaceUid, workspacePath }) => {
     try {
       // If workspace path provided, use workspace environments manager
       if (workspacePath && workspaceEnvironmentsManager) {
@@ -60,7 +60,7 @@ const registerGlobalEnvironmentsIpc = (mainWindow, workspaceEnvironmentsManager)
         const sanitizedName = sanitizeName(name);
         const uniqueName = generateUniqueName(sanitizedName, (name) => existingNames.includes(name));
 
-        return await workspaceEnvironmentsManager.addGlobalEnvironmentByPath(workspacePath, { uid, name: uniqueName, variables, color });
+        return await workspaceEnvironmentsManager.addGlobalEnvironmentByPath(workspacePath, { uid, name: uniqueName, variables, color, extends: inheritedGlobalEnvironmentName });
       }
 
       const existingGlobalEnvironments = globalEnvironmentsStore.getGlobalEnvironments();
@@ -69,7 +69,7 @@ const registerGlobalEnvironmentsIpc = (mainWindow, workspaceEnvironmentsManager)
       const sanitizedName = sanitizeName(name);
       const uniqueName = generateUniqueName(sanitizedName, (name) => existingNames.includes(name));
 
-      globalEnvironmentsStore.addGlobalEnvironment({ uid, name: uniqueName, variables, color });
+      globalEnvironmentsStore.addGlobalEnvironment({ uid, name: uniqueName, variables, color, extends: inheritedGlobalEnvironmentName });
 
       return { name: uniqueName, color };
     } catch (error) {
@@ -78,15 +78,28 @@ const registerGlobalEnvironmentsIpc = (mainWindow, workspaceEnvironmentsManager)
     }
   });
 
-  ipcMain.handle('renderer:save-global-environment', async (event, { environmentUid, variables, color, workspaceUid, workspacePath }) => {
+  ipcMain.handle('renderer:save-global-environment', async (event, { environmentUid, variables, color, extends: inheritedGlobalEnvironmentName, workspaceUid, workspacePath }) => {
     try {
       if (workspacePath && workspaceEnvironmentsManager) {
-        return await workspaceEnvironmentsManager.saveGlobalEnvironmentByPath(workspacePath, { environmentUid, variables, color });
+        return await workspaceEnvironmentsManager.saveGlobalEnvironmentByPath(workspacePath, { environmentUid, variables, color, extends: inheritedGlobalEnvironmentName });
       }
 
-      globalEnvironmentsStore.saveGlobalEnvironment({ environmentUid, variables, color });
+      globalEnvironmentsStore.saveGlobalEnvironment({ environmentUid, variables, color, extends: inheritedGlobalEnvironmentName });
     } catch (error) {
       console.error('Error in renderer:save-global-environment:', error);
+      return Promise.reject(error);
+    }
+  });
+
+  ipcMain.handle('renderer:save-global-environment-extends', async (event, { environmentUid, extends: inheritedGlobalEnvironmentName, workspaceUid, workspacePath }) => {
+    try {
+      if (workspacePath && workspaceEnvironmentsManager) {
+        return await workspaceEnvironmentsManager.saveGlobalEnvironmentExtendsByPath(workspacePath, { environmentUid, extends: inheritedGlobalEnvironmentName });
+      }
+
+      globalEnvironmentsStore.saveGlobalEnvironmentExtends({ environmentUid, extends: inheritedGlobalEnvironmentName });
+    } catch (error) {
+      console.error('Error in renderer:save-global-environment-extends:', error);
       return Promise.reject(error);
     }
   });

--- a/packages/bruno-electron/src/ipc/openapi-sync.js
+++ b/packages/bruno-electron/src/ipc/openapi-sync.js
@@ -12,6 +12,7 @@ const {
   stringifyFolder
 } = require('@usebruno/filestore');
 const { openApiToBruno } = require('@usebruno/converters');
+const { resolveEnvironmentInheritance } = require('@usebruno/common/utils');
 const { writeFile, sanitizeName, getCollectionFormat, posixifyPath } = require('../utils/filesystem');
 
 const RESERVED_FOLDER_NAMES = ['node_modules', '.git', 'environments', 'mocks'];
@@ -187,7 +188,10 @@ const fetchSpecFromSource = async ({ collectionUid, collectionPath, sourceUrl, e
       ? `${sourceUrl}&_=${Date.now()}`
       : `${sourceUrl}?_=${Date.now()}`;
 
-    const environment = _.find(environments, (e) => e.uid === activeEnvironmentUid);
+    const environment = resolveEnvironmentInheritance({
+      environments,
+      targetEnvironment: _.find(environments, (e) => e.uid === activeEnvironmentUid)
+    });
     const envVars = getEnvVars(environment);
     const processEnvVars = getProcessEnvVars(collectionUid);
     const { proxyMode, proxyConfig, httpsAgentRequestFields, interpolationOptions } = await getCertsAndProxyConfig({

--- a/packages/bruno-electron/src/store/default-workspace.js
+++ b/packages/bruno-electron/src/store/default-workspace.js
@@ -364,7 +364,7 @@ class DefaultWorkspaceManager {
           }
 
           const envFilePath = path.join(environmentsDir, `${env.name}.yml`);
-          const environment = { name: env.name, variables: env.variables || [] };
+          const environment = { name: env.name, variables: env.variables || [], extends: env.extends };
           const content = stringifyEnvironment(environment, { format: 'yml' });
           await writeFile(envFilePath, content);
 

--- a/packages/bruno-electron/src/store/default-workspace.js
+++ b/packages/bruno-electron/src/store/default-workspace.js
@@ -353,18 +353,25 @@ class DefaultWorkspaceManager {
         }
         const existingEnvs = new Set(existingEnvNames);
 
-        for (const env of globalEnvironments) {
-          if (!env || !env.name || typeof env.name !== 'string') {
-            continue;
-          }
+        const isMigratable = (env) => env && typeof env.name === 'string' && env.name && !existingEnvs.has(env.name);
 
-          // Skip if environment already exists from recovery
-          if (existingEnvs.has(env.name)) {
+        // `extends` is resolved by name against the workspace.
+        const resolvableEnvironmentNames = new Set([
+          ...existingEnvs,
+          ...globalEnvironments.filter(isMigratable).map((env) => env.name)
+        ]);
+
+        for (const env of globalEnvironments) {
+          if (!isMigratable(env)) {
             continue;
           }
 
           const envFilePath = path.join(environmentsDir, `${env.name}.yml`);
-          const environment = { name: env.name, variables: env.variables || [], extends: env.extends };
+          const environment = {
+            name: env.name,
+            variables: env.variables || [],
+            extends: resolvableEnvironmentNames.has(env.extends) ? env.extends : undefined
+          };
           const content = stringifyEnvironment(environment, { format: 'yml' });
           await writeFile(envFilePath, content);
 

--- a/packages/bruno-electron/src/store/global-environments.js
+++ b/packages/bruno-electron/src/store/global-environments.js
@@ -128,7 +128,7 @@ class GlobalEnvironmentsStore {
     return this.store.set('environments', globalEnvironments);
   }
 
-  addGlobalEnvironment({ uid, name, variables = [], color }) {
+  addGlobalEnvironment({ uid, name, variables = [], color, extends: inheritedGlobalEnvironmentName }) {
     let globalEnvironments = this.getGlobalEnvironments();
     const existingEnvironment = globalEnvironments.find((env) => env?.name == name);
     if (existingEnvironment) {
@@ -138,12 +138,13 @@ class GlobalEnvironmentsStore {
       uid,
       name,
       variables,
-      color
+      color,
+      extends: inheritedGlobalEnvironmentName
     });
     this.setGlobalEnvironments(globalEnvironments);
   }
 
-  saveGlobalEnvironment({ environmentUid: globalEnvironmentUid, variables, color }) {
+  saveGlobalEnvironment({ environmentUid: globalEnvironmentUid, variables, color, extends: inheritedGlobalEnvironmentName }) {
     let globalEnvironments = this.getGlobalEnvironments();
     const environment = globalEnvironments.find((env) => env?.uid == globalEnvironmentUid);
     globalEnvironments = globalEnvironments.filter((env) => env?.uid !== globalEnvironmentUid);
@@ -151,6 +152,9 @@ class GlobalEnvironmentsStore {
       environment.variables = variables;
       if (color !== undefined) {
         environment.color = color;
+      }
+      if (inheritedGlobalEnvironmentName !== undefined) {
+        environment.extends = inheritedGlobalEnvironmentName;
       }
     }
     globalEnvironments.push(environment);
@@ -162,7 +166,13 @@ class GlobalEnvironmentsStore {
     const environment = globalEnvironments.find((env) => env?.uid == globalEnvironmentUid);
     globalEnvironments = globalEnvironments.filter((env) => env?.uid !== globalEnvironmentUid);
     if (environment) {
+      const oldName = environment.name;
       environment.name = name;
+      globalEnvironments.forEach((env) => {
+        if (env?.extends === oldName) {
+          env.extends = name;
+        }
+      });
     }
     globalEnvironments.push(environment);
     this.setGlobalEnvironments(globalEnvironments);
@@ -194,6 +204,19 @@ class GlobalEnvironmentsStore {
     globalEnvironments = globalEnvironments.filter((env) => env?.uid !== environmentUid);
     if (environmentUid == activeGlobalEnvironmentUid) {
       this.setActiveGlobalEnvironmentUid(null);
+    }
+    this.setGlobalEnvironments(globalEnvironments);
+  }
+
+  saveGlobalEnvironmentExtends({ environmentUid, extends: inheritedGlobalEnvironmentName }) {
+    let globalEnvironments = this.getGlobalEnvironments();
+    const environment = globalEnvironments.find((env) => env?.uid == environmentUid);
+    if (environment) {
+      if (inheritedGlobalEnvironmentName) {
+        environment.extends = inheritedGlobalEnvironmentName;
+      } else {
+        delete environment.extends;
+      }
     }
     this.setGlobalEnvironments(globalEnvironments);
   }

--- a/packages/bruno-electron/src/store/tests/default-workspace.spec.js
+++ b/packages/bruno-electron/src/store/tests/default-workspace.spec.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { parseEnvironment } = require('@usebruno/filestore');
+
+let mockGlobalEnvironments;
+let mockUserDataPath;
+
+jest.mock('electron', () => ({
+  app: { getPath: () => mockUserDataPath }
+}));
+
+jest.mock('electron-store', () =>
+  jest.fn().mockImplementation(() => ({
+    get: (key, defaultValue) => defaultValue,
+    set: jest.fn()
+  }))
+);
+
+jest.mock('../global-environments', () => ({
+  globalEnvironmentsStore: {
+    getGlobalEnvironments: () => mockGlobalEnvironments,
+    getActiveGlobalEnvironmentUid: () => null,
+    setActiveGlobalEnvironmentUidForWorkspace: jest.fn()
+  }
+}));
+
+const readMigratedEnvironment = (workspacePath, name) => {
+  const content = fs.readFileSync(path.join(workspacePath, 'environments', `${name}.yml`), 'utf8');
+  return parseEnvironment(content, { format: 'yml' });
+};
+
+describe('default workspace migration of global environments', () => {
+  let workspacePath;
+  let manager;
+
+  beforeEach(() => {
+    mockUserDataPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-userdata-'));
+    workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-workspace-'));
+    fs.mkdirSync(path.join(workspacePath, 'environments'));
+
+    const { DefaultWorkspaceManager } = require('../default-workspace');
+    manager = new DefaultWorkspaceManager();
+  });
+
+  afterEach(() => {
+    fs.rmSync(mockUserDataPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    fs.rmSync(workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('keeps the extends reference when the parent environment is also migrated', async () => {
+    mockGlobalEnvironments = [
+      { uid: 'dev-uid', name: 'Dev', variables: [], extends: 'Base' },
+      { uid: 'base-uid', name: 'Base', variables: [] }
+    ];
+
+    await manager.migrateFromPreferences(workspacePath, { collections: [] });
+
+    expect(readMigratedEnvironment(workspacePath, 'Dev').extends).toBe('Base');
+  });
+
+  it('leaves the recovered environment in place and still extends it when a legacy parent shares its name', async () => {
+    fs.writeFileSync(
+      path.join(workspacePath, 'environments', 'Base.yml'),
+      'name: Base\ntype: environment\nvariables:\n  - name: host\n    value: recovered\n',
+      'utf8'
+    );
+    mockGlobalEnvironments = [
+      { uid: 'dev-uid', name: 'Dev', variables: [], extends: 'Base' },
+      { uid: 'base-uid', name: 'Base', variables: [{ name: 'host', value: 'legacy', enabled: true }] }
+    ];
+
+    await manager.migrateFromPreferences(workspacePath, { collections: [] });
+
+    expect(readMigratedEnvironment(workspacePath, 'Base').variables).toEqual([
+      expect.objectContaining({ name: 'host', value: 'recovered' })
+    ]);
+    expect(readMigratedEnvironment(workspacePath, 'Dev').extends).toBe('Base');
+  });
+
+  it('keeps the extends reference when only the recovered environment exists', async () => {
+    fs.writeFileSync(
+      path.join(workspacePath, 'environments', 'Base.yml'),
+      'name: Base\ntype: environment\n',
+      'utf8'
+    );
+    mockGlobalEnvironments = [{ uid: 'dev-uid', name: 'Dev', variables: [], extends: 'Base' }];
+
+    await manager.migrateFromPreferences(workspacePath, { collections: [] });
+
+    expect(readMigratedEnvironment(workspacePath, 'Dev').extends).toBe('Base');
+  });
+
+  it('drops the extends reference when the parent is absent from the legacy environments', async () => {
+    mockGlobalEnvironments = [{ uid: 'dev-uid', name: 'Dev', variables: [], extends: 'Base' }];
+
+    await manager.migrateFromPreferences(workspacePath, { collections: [] });
+
+    expect(readMigratedEnvironment(workspacePath, 'Dev').extends).toBeUndefined();
+  });
+});

--- a/packages/bruno-electron/src/store/tests/workspace-environments.spec.js
+++ b/packages/bruno-electron/src/store/tests/workspace-environments.spec.js
@@ -1,0 +1,137 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+jest.mock('../env-secrets', () =>
+  class EnvironmentSecretsStoreStub {
+    getEnvSecrets() {
+      return [];
+    }
+
+    storeEnvSecrets() {}
+  }
+);
+
+const { GlobalEnvironmentsManager } = require('../workspace-environments');
+
+describe('workspace environments - saveGlobalEnvironment', () => {
+  let workspacePath;
+  let manager;
+
+  const findEnvironment = async (name) => {
+    const { globalEnvironments } = await manager.getGlobalEnvironments(workspacePath);
+    return globalEnvironments.find((env) => env.name === name);
+  };
+
+  beforeEach(async () => {
+    workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-workspace-envs-'));
+    manager = new GlobalEnvironmentsManager();
+
+    await manager.createGlobalEnvironment(workspacePath, {
+      name: 'Child',
+      variables: [{ name: 'host', value: 'localhost', enabled: true }],
+      color: '#ff0000',
+      extends: 'Base'
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('keeps the existing parent when the save omits extends', async () => {
+    const { uid } = await findEnvironment('Child');
+
+    await manager.saveGlobalEnvironment(workspacePath, {
+      environmentUid: uid,
+      variables: [{ name: 'host', value: '127.0.0.1', enabled: true }]
+    });
+
+    const saved = await findEnvironment('Child');
+    expect(saved.extends).toBe('Base');
+    expect(saved.variables[0].value).toBe('127.0.0.1');
+  });
+
+  it('replaces the parent when the save sets extends', async () => {
+    const { uid } = await findEnvironment('Child');
+
+    await manager.saveGlobalEnvironment(workspacePath, {
+      environmentUid: uid,
+      variables: [],
+      extends: 'OtherBase'
+    });
+
+    const saved = await findEnvironment('Child');
+    expect(saved.extends).toBe('OtherBase');
+  });
+
+  it('clears the parent when the save passes an empty extends', async () => {
+    const { uid } = await findEnvironment('Child');
+
+    await manager.saveGlobalEnvironment(workspacePath, {
+      environmentUid: uid,
+      variables: [],
+      extends: null
+    });
+
+    const saved = await findEnvironment('Child');
+    expect(saved.extends).toBeUndefined();
+  });
+
+  it('keeps the existing color when the save omits color', async () => {
+    const { uid } = await findEnvironment('Child');
+
+    await manager.saveGlobalEnvironment(workspacePath, {
+      environmentUid: uid,
+      variables: []
+    });
+
+    const saved = await findEnvironment('Child');
+    expect(saved.color).toBe('#ff0000');
+  });
+
+  it('clears the color when the save passes an empty color', async () => {
+    const { uid } = await findEnvironment('Child');
+
+    await manager.saveGlobalEnvironment(workspacePath, {
+      environmentUid: uid,
+      variables: [],
+      color: null
+    });
+
+    const saved = await findEnvironment('Child');
+    expect(saved.color).toBeNull();
+  });
+
+  it('keeps external secrets when the save omits them', async () => {
+    const environmentsDir = path.join(workspacePath, 'environments');
+    fs.writeFileSync(
+      path.join(environmentsDir, 'External.yml'),
+      [
+        'name: External',
+        'externalSecrets:',
+        '  type: vault',
+        '  variables:',
+        '    - name: token',
+        '      path: secret/data/app',
+        'variables:',
+        '  - name: host',
+        '    value: localhost'
+      ].join('\n')
+    );
+
+    const { uid } = await findEnvironment('External');
+
+    await manager.saveGlobalEnvironment(workspacePath, {
+      environmentUid: uid,
+      variables: [{ name: 'host', value: '127.0.0.1', enabled: true }]
+    });
+
+    const saved = await findEnvironment('External');
+    expect(saved.externalSecrets).toEqual({
+      type: 'vault',
+      variables: [{ name: 'token', path: 'secret/data/app' }]
+    });
+    expect(saved.variables[0].value).toBe('127.0.0.1');
+  });
+});

--- a/packages/bruno-electron/src/store/workspace-environments.js
+++ b/packages/bruno-electron/src/store/workspace-environments.js
@@ -179,23 +179,29 @@ class GlobalEnvironmentsManager {
         throw new Error(`Environment file not found for uid: ${environmentUid}`);
       }
 
-      const environment = {
-        name: envFile.name,
-        variables: variables
-      };
-
-      if (color) {
-        environment.color = color;
-      }
-
-      if (inheritedGlobalEnvironmentName) {
-        environment.extends = inheritedGlobalEnvironmentName;
-      }
-
       // Serialize concurrent writes per env file. Two rapid scripted
       // bru.setGlobalEnvVar() persist calls can otherwise overlap and the
       // second writer's stringify+write can land before the first, dropping it.
       await withFileLock(envFile.filePath, async () => {
+        const savedEnvironment = await this.parseEnvironmentFile(envFile.filePath, workspacePath);
+
+        // The whole file is rewritten, so start from what is on disk and overlay only
+        // the fields this save carries. Callers that just persist variables omit the
+        // rest, and anything omitted must survive the write.
+        const environment = {
+          ...savedEnvironment,
+          name: envFile.name,
+          variables: variables
+        };
+
+        if (color !== undefined) {
+          environment.color = color;
+        }
+
+        if (inheritedGlobalEnvironmentName !== undefined) {
+          environment.extends = inheritedGlobalEnvironmentName;
+        }
+
         if (this.envHasSecrets(environment)) {
           environmentSecretsStore.storeEnvSecrets(workspacePath, environment);
         }

--- a/packages/bruno-electron/src/store/workspace-environments.js
+++ b/packages/bruno-electron/src/store/workspace-environments.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const { parseEnvironment, stringifyEnvironment } = require('@usebruno/filestore');
 const { parseValueByDataType } = require('@usebruno/common/utils');
 const { writeFile, createDirectory, withFileLock } = require('../utils/filesystem');
+const { renameEnvironmentExtendsReferences } = require('../utils/environments');
 const { generateUidBasedOnHash, uuid } = require('../utils/common');
 const { decryptStringSafe } = require('../utils/encryption');
 const EnvironmentSecretsStore = require('./env-secrets');
@@ -120,7 +121,7 @@ class GlobalEnvironmentsManager {
     }
   }
 
-  async createGlobalEnvironment(workspacePath, { uid, name, variables, color }) {
+  async createGlobalEnvironment(workspacePath, { uid, name, variables, color, extends: inheritedGlobalEnvironmentName }) {
     try {
       if (!workspacePath) {
         throw new Error('Workspace path is required');
@@ -144,6 +145,10 @@ class GlobalEnvironmentsManager {
         color
       };
 
+      if (inheritedGlobalEnvironmentName) {
+        environment.extends = inheritedGlobalEnvironmentName;
+      }
+
       if (this.envHasSecrets(environment)) {
         environmentSecretsStore.storeEnvSecrets(workspacePath, environment);
       }
@@ -162,7 +167,7 @@ class GlobalEnvironmentsManager {
     }
   }
 
-  async saveGlobalEnvironment(workspacePath, { environmentUid, variables, color }) {
+  async saveGlobalEnvironment(workspacePath, { environmentUid, variables, color, extends: inheritedGlobalEnvironmentName }) {
     try {
       if (!workspacePath) {
         throw new Error('Workspace path is required');
@@ -181,6 +186,10 @@ class GlobalEnvironmentsManager {
 
       if (color) {
         environment.color = color;
+      }
+
+      if (inheritedGlobalEnvironmentName) {
+        environment.extends = inheritedGlobalEnvironmentName;
       }
 
       // Serialize concurrent writes per env file. Two rapid scripted
@@ -240,6 +249,13 @@ class GlobalEnvironmentsManager {
         fs.unlinkSync(envFile.filePath);
       }
 
+      await renameEnvironmentExtendsReferences({
+        environmentsDirPath: this.getEnvironmentsDir(workspacePath),
+        format: 'yml',
+        oldName,
+        newName
+      });
+
       const newUid = generateUidBasedOnHash(newFilePath);
       return { uid: newUid, name: newName };
     } catch (error) {
@@ -293,6 +309,37 @@ class GlobalEnvironmentsManager {
     }
   }
 
+  async saveGlobalEnvironmentExtends(workspacePath, environmentUid, inheritedGlobalEnvironmentName) {
+    try {
+      if (!workspacePath) {
+        throw new Error('Workspace path is required');
+      }
+
+      const envFile = this.findEnvironmentFileByUid(workspacePath, environmentUid);
+
+      if (!envFile) {
+        throw new Error(`Environment file not found for uid: ${environmentUid}`);
+      }
+
+      await withFileLock(envFile.filePath, async () => {
+        const environment = await this.parseEnvironmentFile(envFile.filePath, workspacePath);
+
+        if (inheritedGlobalEnvironmentName) {
+          environment.extends = inheritedGlobalEnvironmentName;
+        } else {
+          delete environment.extends;
+        }
+
+        const content = stringifyEnvironment(environment, { format: 'yml' });
+        await writeFile(envFile.filePath, content);
+      });
+
+      return true;
+    } catch (error) {
+      throw error;
+    }
+  }
+
   async getGlobalEnvironmentsByPath(workspacePath) {
     return this.getGlobalEnvironments(workspacePath);
   }
@@ -315,6 +362,10 @@ class GlobalEnvironmentsManager {
 
   async updateGlobalEnvironmentColorByPath(workspacePath, { environmentUid, color }) {
     return this.updateGlobalEnvironmentColor(workspacePath, environmentUid, color);
+  }
+
+  async saveGlobalEnvironmentExtendsByPath(workspacePath, { environmentUid, extends: inheritedGlobalEnvironmentName }) {
+    return this.saveGlobalEnvironmentExtends(workspacePath, environmentUid, inheritedGlobalEnvironmentName);
   }
 }
 

--- a/packages/bruno-electron/src/utils/collection.js
+++ b/packages/bruno-electron/src/utils/collection.js
@@ -820,8 +820,8 @@ const getAllRequestsInFolderRecursively = (folder = {}) => {
 };
 
 const getEnvVars = (environment = {}) => {
-  const variables = environment.variables;
-  if (!variables || !variables.length) {
+  const variables = [...(environment?.inheritedVariables || []), ...(environment?.variables || [])];
+  if (!variables.length) {
     return {
       __name__: environment.name
     };

--- a/packages/bruno-electron/src/utils/environments.js
+++ b/packages/bruno-electron/src/utils/environments.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const { parseEnvironment, stringifyEnvironment } = require('@usebruno/filestore');
+const { writeFile, withFileLock } = require('./filesystem');
+
+/**
+ * Rewrites the `extends` references that pointed at `oldName` before it was renamed to `newName`.
+ * References are matched exactly, the way the inheritance resolver reads them, so a differently-cased
+ * reference the resolver never followed is not claimed by this rename either.
+ */
+const renameEnvironmentExtendsReferences = async ({ environmentsDirPath, format, oldName, newName }) => {
+  if (!fs.existsSync(environmentsDirPath)) {
+    return;
+  }
+
+  const extension = `.${format}`;
+  const fileNames = fs.readdirSync(environmentsDirPath).filter((fileName) => fileName.endsWith(extension));
+
+  for (const fileName of fileNames) {
+    const filePath = path.join(environmentsDirPath, fileName);
+
+    await withFileLock(filePath, async () => {
+      const environment = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format });
+
+      if (environment.extends !== oldName) {
+        return;
+      }
+
+      environment.extends = newName;
+      environment.name = path.basename(fileName, extension);
+
+      await writeFile(filePath, stringifyEnvironment(environment, { format }));
+    });
+  }
+};
+
+module.exports = {
+  renameEnvironmentExtendsReferences
+};

--- a/packages/bruno-electron/src/utils/environments.js
+++ b/packages/bruno-electron/src/utils/environments.js
@@ -19,18 +19,22 @@ const renameEnvironmentExtendsReferences = async ({ environmentsDirPath, format,
   for (const fileName of fileNames) {
     const filePath = path.join(environmentsDirPath, fileName);
 
-    await withFileLock(filePath, async () => {
-      const environment = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format });
+    try {
+      await withFileLock(filePath, async () => {
+        const environment = parseEnvironment(fs.readFileSync(filePath, 'utf8'), { format });
 
-      if (environment.extends !== oldName) {
-        return;
-      }
+        if (environment.extends !== oldName) {
+          return;
+        }
 
-      environment.extends = newName;
-      environment.name = path.basename(fileName, extension);
+        environment.extends = newName;
+        environment.name = path.basename(fileName, extension);
 
-      await writeFile(filePath, stringifyEnvironment(environment, { format }));
-    });
+        await writeFile(filePath, stringifyEnvironment(environment, { format }));
+      });
+    } catch (error) {
+      console.error(`Failed to update the extends reference in ${fileName}:`, error);
+    }
   }
 };
 

--- a/packages/bruno-electron/src/utils/tests/environments.spec.js
+++ b/packages/bruno-electron/src/utils/tests/environments.spec.js
@@ -1,0 +1,70 @@
+const path = require('path');
+const fs = require('fs/promises');
+const os = require('os');
+const { parseEnvironment, stringifyEnvironment } = require('@usebruno/filestore');
+const { renameEnvironmentExtendsReferences } = require('../environments');
+
+const format = 'yml';
+
+describe('environment extends references', () => {
+  let environmentsDirPath;
+
+  const environmentFilePath = (name) => path.join(environmentsDirPath, `${name}.yml`);
+
+  const writeEnvironment = (name, contents) => fs.writeFile(environmentFilePath(name), contents);
+
+  const readExtends = async (name) => {
+    const contents = await fs.readFile(environmentFilePath(name), 'utf8');
+    return parseEnvironment(contents, { format }).extends;
+  };
+
+  // Mirrors the rename the app performs: the file moves and the name it carries moves with it.
+  const renameEnvironment = async (oldName, newName) => {
+    const environment = parseEnvironment(await fs.readFile(environmentFilePath(oldName), 'utf8'), { format });
+    environment.name = newName;
+
+    await fs.writeFile(environmentFilePath(newName), stringifyEnvironment(environment, { format }));
+    await fs.rm(environmentFilePath(oldName));
+  };
+
+  beforeEach(async () => {
+    environmentsDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'bruno-environments-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(environmentsDirPath, { recursive: true, force: true });
+  });
+
+  describe('renameEnvironmentExtendsReferences', () => {
+    it('leaves a reference that differs only in case untouched', async () => {
+      await writeEnvironment('base', 'name: base\nvariables: []\n');
+      await writeEnvironment('prod', 'name: prod\nextends: BASE\nvariables: []\n');
+      await renameEnvironment('base', 'shared');
+
+      await renameEnvironmentExtendsReferences({ environmentsDirPath, format, oldName: 'base', newName: 'shared' });
+
+      expect(await readExtends('prod')).toBe('BASE');
+    });
+
+    it('leaves a non-string reference untouched', async () => {
+      await writeEnvironment('base', 'name: base\nvariables: []\n');
+      await writeEnvironment('prod', 'name: prod\nextends:\n  - base\nvariables: []\n');
+      await renameEnvironment('base', 'shared');
+
+      await renameEnvironmentExtendsReferences({ environmentsDirPath, format, oldName: 'base', newName: 'shared' });
+
+      expect(await readExtends('prod')).toEqual(['base']);
+    });
+
+    it('leaves a reference to another environment untouched', async () => {
+      await writeEnvironment('base', 'name: base\nvariables: []\n');
+      await writeEnvironment('common', 'name: common\nvariables: []\n');
+      await writeEnvironment('prod', 'name: prod\nextends: common\nvariables: []\n');
+      await renameEnvironment('base', 'shared');
+
+      await renameEnvironmentExtendsReferences({ environmentsDirPath, format, oldName: 'base', newName: 'shared' });
+
+      expect(await readExtends('prod')).toBe('common');
+    });
+  });
+});

--- a/packages/bruno-electron/src/utils/tests/environments.spec.js
+++ b/packages/bruno-electron/src/utils/tests/environments.spec.js
@@ -56,6 +56,17 @@ describe('environment extends references', () => {
       expect(await readExtends('prod')).toEqual(['base']);
     });
 
+    it('updates the remaining references when a sibling file cannot be parsed', async () => {
+      await writeEnvironment('base', 'name: base\nvariables: []\n');
+      await writeEnvironment('broken', 'name: broken\nvariables: [\n');
+      await writeEnvironment('prod', 'name: prod\nextends: base\nvariables: []\n');
+      await renameEnvironment('base', 'shared');
+
+      await renameEnvironmentExtendsReferences({ environmentsDirPath, format, oldName: 'base', newName: 'shared' });
+
+      expect(await readExtends('prod')).toBe('shared');
+    });
+
     it('leaves a reference to another environment untouched', async () => {
       await writeEnvironment('base', 'name: base\nvariables: []\n');
       await writeEnvironment('common', 'name: common\nvariables: []\n');

--- a/packages/bruno-filestore/src/formats/yml/parseEnvironment.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseEnvironment.spec.ts
@@ -96,4 +96,53 @@ variables:
     expect(env.name).toBe('Untitled Environment');
     expect(env.variables).toEqual([]);
   });
+
+  describe('extends', () => {
+    it('parses the parent environment name', () => {
+      const env = parseEnvironment(`name: prod
+extends: base
+variables: []
+`);
+
+      expect(env.extends).toBe('base');
+    });
+
+    it('leaves extends absent for an environment that does not declare it', () => {
+      const env = parseEnvironment(`name: prod
+variables: []
+`);
+
+      expect(env).not.toHaveProperty('extends');
+    });
+
+    it('ignores a parent reference that names nothing', () => {
+      const env = parseEnvironment(`name: prod
+extends: "   "
+variables: []
+`);
+
+      expect(env).not.toHaveProperty('extends');
+    });
+
+    it('parses a list of parents unresolved so that a save does not delete it', () => {
+      const env = parseEnvironment(`name: prod
+extends:
+  - base
+  - shared
+variables: []
+`);
+
+      expect(env.extends).toEqual(['base', 'shared']);
+    });
+
+    it('ignores a parent reference that is neither a name nor a list', () => {
+      const env = parseEnvironment(`name: prod
+extends:
+  parent: base
+variables: []
+`);
+
+      expect(env).not.toHaveProperty('extends');
+    });
+  });
 });

--- a/packages/bruno-filestore/src/formats/yml/parseEnvironment.ts
+++ b/packages/bruno-filestore/src/formats/yml/parseEnvironment.ts
@@ -4,6 +4,7 @@ import type { Variable, SecretVariable } from '@opencollection/types/common/vari
 import { parseYml } from './utils';
 import { uuid, ensureString } from '../../utils';
 import { isTypedValue, fromOpenCollectionTypedValue } from './common/datatype';
+import { validatedEnvironmentExtendsFrom } from '@usebruno/common/utils';
 
 const isSecretVariable = (v: Variable | SecretVariable): v is SecretVariable => {
   return 'secret' in v && v.secret === true;
@@ -89,6 +90,11 @@ const parseEnvironment = (ymlString: string): BrunoEnvironment => {
       variables: toBrunoEnvironmentVariables(ocEnvironment.variables),
       color: ocEnvironment.color || null
     };
+
+    const ocEnvironmentExtendsFrom = validatedEnvironmentExtendsFrom(ocEnvironment.extends);
+    if (ocEnvironmentExtendsFrom) {
+      brunoEnvironment.extends = ocEnvironmentExtendsFrom;
+    }
 
     const externalSecrets = toBrunoExternalSecrets((ocEnvironment as any).externalSecrets);
     if (externalSecrets) {

--- a/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.spec.ts
@@ -88,4 +88,62 @@ describe('stringifyEnvironment', () => {
     const reparsed = parseEnvironment(stringifyEnvironment(env));
     expect(reparsed.color).toBe('#ff0000');
   });
+
+  describe('extends', () => {
+    it('round-trips the parent environment name', () => {
+      const env = {
+        uid: 'env-uid',
+        name: 'prod',
+        extends: 'base',
+        variables: [{ uid: 'u1', name: 'host', value: 'prod.example.com', type: 'text', enabled: true, secret: false }]
+      } as any;
+
+      const reparsed = parseEnvironment(stringifyEnvironment(env));
+
+      expect(reparsed.extends).toBe('base');
+      expect(reparsed.variables[0]).toMatchObject({ name: 'host', value: 'prod.example.com' });
+    });
+
+    it('omits extends when no parent is set', () => {
+      const env = { uid: 'env-uid', name: 'prod', variables: [] } as any;
+
+      expect(stringifyEnvironment(env)).not.toContain('extends');
+    });
+
+    it('omits extends when the parent names nothing', () => {
+      const env = { uid: 'env-uid', name: 'prod', extends: '  ', variables: [] } as any;
+
+      expect(stringifyEnvironment(env)).not.toContain('extends');
+    });
+
+    it('round-trips a list of parents', () => {
+      const env = { uid: 'env-uid', name: 'prod', extends: ['base', 'shared'], variables: [] } as any;
+
+      const reparsed = parseEnvironment(stringifyEnvironment(env));
+
+      expect(reparsed.extends).toEqual(['base', 'shared']);
+    });
+
+    it('omits extends when the list of parents is empty', () => {
+      const env = { uid: 'env-uid', name: 'prod', extends: [], variables: [] } as any;
+
+      expect(stringifyEnvironment(env)).not.toContain('extends');
+    });
+
+    it('never writes the inheritedFrom provenance of a resolved variable', () => {
+      const env = {
+        uid: 'env-uid',
+        name: 'prod',
+        extends: 'base',
+        variables: [
+          { uid: 'u1', name: 'host', value: 'base.example.com', type: 'text', enabled: true, secret: false, inheritedFrom: 'base' }
+        ]
+      } as any;
+
+      const yml = stringifyEnvironment(env);
+
+      expect(yml).not.toContain('inheritedFrom');
+      expect(parseEnvironment(yml).variables[0]).not.toHaveProperty('inheritedFrom');
+    });
+  });
 });

--- a/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.ts
+++ b/packages/bruno-filestore/src/formats/yml/stringifyEnvironment.ts
@@ -3,6 +3,7 @@ import type { Environment } from '@opencollection/types/config/environments';
 import type { Variable, SecretVariable } from '@opencollection/types/common/variables';
 import { stringifyYml } from './utils';
 import { hasTypedMetadata, toOpenCollectionTypedValue, serializeVariableValue } from './common/datatype';
+import { validatedEnvironmentExtendsFrom } from '@usebruno/common/utils';
 
 export const toOpenCollectionEnvironmentVariables = (variables: BrunoEnvironmentVariable[]): (Variable | SecretVariable)[] | undefined => {
   if (!variables?.length) {
@@ -54,6 +55,11 @@ const stringifyEnvironment = (environment: BrunoEnvironment): string => {
     const ocEnvironment: Environment = {
       name: environment.name
     };
+
+    const environmentExtendsFrom = validatedEnvironmentExtendsFrom(environment.extends);
+    if (environmentExtendsFrom) {
+      (ocEnvironment as any).extends = environmentExtendsFrom;
+    }
 
     if (environment.color) {
       ocEnvironment.color = environment.color;

--- a/packages/bruno-js/src/bru.js
+++ b/packages/bruno-js/src/bru.js
@@ -7,6 +7,15 @@ const CookieList = require('./cookie-list');
 
 const variableNameRegex = /^[\w-.]*$/;
 
+const assertValidVariableName = (key) => {
+  if (variableNameRegex.test(key) === false) {
+    throw new Error(
+      `Variable name: "${key}" contains invalid characters!`
+      + ' Names must only contain alpha-numeric characters, "-", "_", "."'
+    );
+  }
+};
+
 class Bru {
   /**
    * @param {object} options - Single options object (destructured)
@@ -200,11 +209,7 @@ class Bru {
       throw new Error('Creating a env variable without specifying a name is not allowed.');
     }
 
-    if (variableNameRegex.test(key) === false) {
-      throw new Error(
-        `Variable name: "${key}" contains invalid characters! Names must only contain alpha-numeric characters, "-", "_", "."`
-      );
-    }
+    assertValidVariableName(key);
 
     // Deep-equal compare so object/array writes that mutate in place
     // (e.g. `const c = bru.getEnvVar('cfg'); c.port = 4000; bru.setEnvVar('cfg', c);`)
@@ -253,6 +258,8 @@ class Bru {
     if (!key) {
       throw new Error('Creating a env variable without specifying a name is not allowed.');
     }
+
+    assertValidVariableName(key);
 
     if (!Object.hasOwn(this.globalEnvironmentVariables, key) || !isEqual(this.globalEnvironmentVariables[key], value)) {
       this.globalEnvironmentVariables[key] = value;
@@ -311,12 +318,7 @@ class Bru {
       throw new Error('Creating a variable without specifying a name is not allowed.');
     }
 
-    if (variableNameRegex.test(key) === false) {
-      throw new Error(
-        `Variable name: "${key}" contains invalid characters!`
-        + ' Names must only contain alpha-numeric characters, "-", "_", "."'
-      );
-    }
+    assertValidVariableName(key);
 
     if (!Object.hasOwn(this.runtimeVariables, key) || !isEqual(this.runtimeVariables[key], value)) {
       this.runtimeVariables[key] = value;
@@ -325,12 +327,7 @@ class Bru {
   }
 
   getVar(key) {
-    if (variableNameRegex.test(key) === false) {
-      throw new Error(
-        `Variable name: "${key}" contains invalid characters!`
-        + ' Names must only contain alpha-numeric characters, "-", "_", "."'
-      );
-    }
+    assertValidVariableName(key);
 
     return this.interpolate(this.runtimeVariables[key]);
   }
@@ -364,12 +361,7 @@ class Bru {
       throw new Error('Creating a variable without specifying a name is not allowed.');
     }
 
-    if (variableNameRegex.test(key) === false) {
-      throw new Error(
-        `Variable name: "${key}" contains invalid characters!`
-        + ' Names must only contain alpha-numeric characters, "-", "_", "."'
-      );
-    }
+    assertValidVariableName(key);
 
     if (!Object.hasOwn(this.collectionVariables, key) || !isEqual(this.collectionVariables[key], value)) {
       this.collectionVariables[key] = value;

--- a/packages/bruno-js/tests/globalEnvVar.spec.js
+++ b/packages/bruno-js/tests/globalEnvVar.spec.js
@@ -39,6 +39,12 @@ describe('Global Environment Variable APIs', () => {
       expect(() => bru.setGlobalEnvVar('', 'v')).toThrow(/without specifying a name/);
     });
 
+    test('rejects key with invalid characters', () => {
+      const bru = makeBru();
+      expect(() => bru.setGlobalEnvVar('invalid key', 'v')).toThrow(/contains invalid characters/);
+      expect(bru.globalEnvironmentVariables).not.toHaveProperty('invalid key');
+    });
+
     test('re-run: setting same key twice does not throw', () => {
       const bru = makeBru();
       bru.setGlobalEnvVar('key', 'first');

--- a/packages/bruno-lang/v2/src/envToJson.js
+++ b/packages/bruno-lang/v2/src/envToJson.js
@@ -4,7 +4,8 @@ const {
   parseAnnotationMultilineTextBlock,
   unescapeAnnotationDoubleQuotedArg,
   applyDescriptionFromAnnotations,
-  extractTypedAnnotations
+  extractTypedAnnotations,
+  validatedEnvironmentExtendsFrom
 } = require('./utils');
 
 // this is done to avoid breaking existing pairlist mapping so
@@ -22,7 +23,7 @@ const ANNOTATIONS_KEY = Symbol('annotations');
 // }
 const indentLevel = 4;
 const grammar = ohm.grammar(`Bru {
-  BruEnvFile = (vars | secretvars | externalsecrets | color)*
+  BruEnvFile = (vars | secretvars | externalsecrets | extends | color)*
 
   nl = "\\r"? "\\n"
   st = " " | "\\t"
@@ -31,6 +32,7 @@ const grammar = ohm.grammar(`Bru {
   optionalnl = ~tagend nl
   keychar = ~(tagend | st | nl | ":") any
   valuechar = ~(nl | tagend | multilinetextblockstart) any
+  singlelinechar = ~nl any
 
   multilinetextblockdelimiter = "'''"
   multilinetextblockstart = "'''" nl
@@ -76,7 +78,20 @@ const grammar = ohm.grammar(`Bru {
   externalsecretsname = externalsecretsnamechar+
   externalsecretsnamechar = ~(st | nl | "{") any
   vars = "vars" dictionary
-  color = "color:" any*
+  extends = "extends" (extendslist | extendsname)
+  extendslist = st* "[" stnl* extendsvaluelist stnl* "]"
+  extendsvaluelist = stnl* extendsvalue stnl* ("," stnl* extendsvalue)*
+  // A name containing a list delimiter or a quote is written quoted; every other name stays bare.
+  extendsvalue = quotedextendsvalue | unquotedextendsvalue
+  quotedextendsvalue = "\\"" quotedextendsvaluechar* "\\""
+  quotedextendsvaluechar = quotedextendsvalueesc | quotedextendsvaluenorm
+  quotedextendsvalueesc = "\\\\" any
+  quotedextendsvaluenorm = ~("\\"" | nl) any
+  // Environment names may contain spaces, so unlike arrayvaluechar this stops only at a delimiter.
+  unquotedextendsvalue = unquotedextendsvaluechar*
+  unquotedextendsvaluechar = ~(nl | "[" | "]" | ",") any
+  extendsname = ":" singlelinechar*
+  color = "color:" singlelinechar*
 }`);
 
 const mapPairListToKeyValPairs = (pairList = []) => {
@@ -327,6 +342,31 @@ const sem = grammar.createSemantics().addAttribute('ast', {
   },
   externalsecretsname(chars) {
     return chars.sourceString;
+  },
+  extends: (_1, reference) => {
+    const extendedEnvironmentReference = validatedEnvironmentExtendsFrom(reference.ast);
+    if (extendedEnvironmentReference) {
+      return { extends: extendedEnvironmentReference };
+    }
+    return {};
+  },
+  extendsname(_1, reference) {
+    return reference.sourceString.trim();
+  },
+  extendslist(_1, _2, _3, valuelist, _4, _5) {
+    return valuelist.ast.filter((name) => name.length > 0);
+  },
+  extendsvaluelist(_1, value, _2, _3, _4, rest) {
+    return [value.ast, ...rest.ast];
+  },
+  extendsvalue(value) {
+    return value.ast;
+  },
+  quotedextendsvalue(_1, chars, _2) {
+    return unescapeAnnotationDoubleQuotedArg(chars.sourceString);
+  },
+  unquotedextendsvalue(chars) {
+    return chars.sourceString.trim();
   },
   color: (_1, anystring) => {
     return {

--- a/packages/bruno-lang/v2/src/jsonToEnv.js
+++ b/packages/bruno-lang/v2/src/jsonToEnv.js
@@ -1,10 +1,27 @@
 const _ = require('lodash');
-const { getValueString, indentString, serializeAnnotations, buildAnnotationsFromVariable } = require('./utils');
+const {
+  getValueString,
+  indentString,
+  serializeAnnotations,
+  buildAnnotationsFromVariable,
+  escapeAnnotationDoubleQuotedArg,
+  validatedEnvironmentExtendsFrom
+} = require('./utils');
 
-const envToJson = (json) => {
+// Bare list entries end at a delimiter and are trimmed, so a name carrying one of these
+// characters — or edge whitespace — only survives the round-trip quoted.
+const quotableExtendsCharacters = ['[', ']', ',', '"'];
+
+const serializeExtendsListValue = (name) => {
+  const needsQuotes = quotableExtendsCharacters.some((character) => name.includes(character)) || name.trim() !== name;
+  return needsQuotes ? `"${escapeAnnotationDoubleQuotedArg(name)}"` : name;
+};
+
+const jsonToEnv = (json) => {
   const variables = _.get(json, 'variables', []);
   const externalSecrets = _.get(json, 'externalSecrets', null);
   const color = _.get(json, 'color', null);
+  const environmentExtendsFrom = validatedEnvironmentExtendsFrom(_.get(json, 'extends', null));
 
   const vars = variables
     .filter((variable) => !variable.secret)
@@ -26,6 +43,18 @@ const envToJson = (json) => {
     });
 
   let output = '';
+
+  if (typeof environmentExtendsFrom === 'string') {
+    output += `extends: ${environmentExtendsFrom}
+`;
+  }
+
+  if (Array.isArray(environmentExtendsFrom)) {
+    output += `extends [
+${environmentExtendsFrom.map((reference) => indentString(serializeExtendsListValue(reference))).join(',\n')}
+]
+`;
+  }
 
   if (!variables || !variables.length) {
     output += `vars {
@@ -66,4 +95,4 @@ ${serializedVariables.join('\n')}
   return output;
 };
 
-module.exports = envToJson;
+module.exports = jsonToEnv;

--- a/packages/bruno-lang/v2/src/utils.js
+++ b/packages/bruno-lang/v2/src/utils.js
@@ -238,10 +238,45 @@ const buildAnnotationsFromKVItem = (item) => {
   return [...descArr, ...other];
 };
 
+const invalidNameCharacters = /[<>:"/\\|?*\x00-\x1F]/;
+const reservedDeviceNames = /^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])$/i;
+const maximumNameLength = 255;
+
+const isValidEnvironmentName = (name) => {
+  if (!name || name.length > maximumNameLength) return false;
+  if (reservedDeviceNames.test(name)) return false;
+  if (invalidNameCharacters.test(name)) return false;
+
+  return !/^[\s\-]/.test(name) && !/[.\s]$/.test(name);
+};
+
+const validatedEnvironmentName = (reference) => {
+  if (typeof reference !== 'string') {
+    return undefined;
+  }
+
+  const name = reference.trim();
+  return isValidEnvironmentName(name) ? name : undefined;
+};
+
+const validatedEnvironmentExtendsFrom = (environmentExtendsReference) => {
+  if (typeof environmentExtendsReference === 'string') {
+    return validatedEnvironmentName(environmentExtendsReference);
+  }
+
+  if (!Array.isArray(environmentExtendsReference) || !environmentExtendsReference.length) {
+    return undefined;
+  }
+
+  const names = environmentExtendsReference.map(validatedEnvironmentName);
+  return names.every((name) => name !== undefined) ? names : undefined;
+};
+
 module.exports = {
   safeParseJson,
   indentString,
   outdentString,
+  escapeAnnotationDoubleQuotedArg,
   unescapeAnnotationDoubleQuotedArg,
   escapeMultilineDescription,
   unescapeMultilineDescription,
@@ -254,5 +289,6 @@ module.exports = {
   buildAnnotationsFromVariable,
   serializeVar,
   applyDescriptionFromAnnotations,
-  buildAnnotationsFromKVItem
+  buildAnnotationsFromKVItem,
+  validatedEnvironmentExtendsFrom
 };

--- a/packages/bruno-lang/v2/tests/envToJson.spec.js
+++ b/packages/bruno-lang/v2/tests/envToJson.spec.js
@@ -772,4 +772,254 @@ vars {
       expect(output.variables[0].value).toBe(3000);
     });
   });
+
+  describe('extends', () => {
+    it('should parse the parent environment declared before the vars block', () => {
+      const input = `
+extends: base
+vars {
+  url: http://localhost:3000
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).toEqual({
+        extends: 'base',
+        variables: [{ name: 'url', value: 'http://localhost:3000', enabled: true, secret: false }]
+      });
+    });
+
+    it('should parse the parent environment declared after the vars block', () => {
+      const input = `
+vars {
+  url: http://localhost:3000
+}
+extends: base
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toBe('base');
+    });
+
+    it('should parse the parent environment declared after the color', () => {
+      const input = `
+vars {
+  url: http://localhost:3000
+}
+color: blue
+extends: base
+`;
+
+      const output = parser(input);
+
+      expect(output.color).toBe('blue');
+      expect(output.extends).toBe('base');
+    });
+
+    it('should parse the blocks declared after the color', () => {
+      const input = `
+color: blue
+extends: base
+vars {
+  url: http://localhost:3000
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).toEqual({
+        color: 'blue',
+        extends: 'base',
+        variables: [
+          {
+            name: 'url',
+            value: 'http://localhost:3000',
+            enabled: true,
+            secret: false
+          }
+        ]
+      });
+    });
+
+    it('should parse a parent name containing spaces', () => {
+      const input = `
+extends: Base Environment
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toBe('Base Environment');
+    });
+
+    it('should omit extends when no parent is named', () => {
+      const input = `
+extends:
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).toEqual({ variables: [] });
+    });
+
+    it('should leave extends absent for a file that does not declare it', () => {
+      const input = `
+vars {
+  url: http://localhost:3000
+}
+color: blue
+`;
+
+      const output = parser(input);
+
+      expect(output).not.toHaveProperty('extends');
+    });
+
+    it('should keep the last parent when extends is declared more than once', () => {
+      const input = `
+extends: base
+extends: staging
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toBe('staging');
+    });
+
+    it('should read a list of parents unresolved so that a save does not delete it', () => {
+      const input = `
+extends [
+  base,
+  staging
+]
+vars {
+  url: http://localhost:3000
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toEqual(['base', 'staging']);
+    });
+
+    it('should read a list of parents whose names contain spaces', () => {
+      const input = `
+extends [
+  Base Environment,
+  staging server
+]
+vars {
+  url: http://localhost:3000
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toEqual(['Base Environment', 'staging server']);
+    });
+
+    it('should read a quoted list entry whose name contains a comma as a single parent', () => {
+      const input = `
+extends [
+  "acme, inc",
+  staging
+]
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toEqual(['acme, inc', 'staging']);
+    });
+
+    it('should read a quoted list entry whose name contains brackets', () => {
+      const input = `
+extends [
+  "env[1]",
+  "[bracketed]",
+  "list]end"
+]
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toEqual(['env[1]', '[bracketed]', 'list]end']);
+    });
+
+    it('should omit a quoted list entry whose escaped quote no environment name could carry', () => {
+      const input = `
+extends [
+  "say \\"hi\\", ok"
+]
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).not.toHaveProperty('extends');
+    });
+
+    it('should omit the whole list when a bare entry carries a quote no environment name could carry', () => {
+      const input = `
+extends [
+  a"b,
+  staging
+]
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).not.toHaveProperty('extends');
+    });
+
+    it('should omit a parent named something no environment could be called', () => {
+      const input = `
+extends: reports/weekly
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).not.toHaveProperty('extends');
+    });
+
+    it('should omit an empty list of parents', () => {
+      const input = `
+extends [
+]
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output).not.toHaveProperty('extends');
+    });
+
+    it('should read a bracketed value after the colon as a parent name, the list form taking no colon', () => {
+      const input = `
+extends: [base, staging]
+vars {
+}
+`;
+
+      const output = parser(input);
+
+      expect(output.extends).toBe('[base, staging]');
+    });
+  });
 });

--- a/packages/bruno-lang/v2/tests/jsonToEnv.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToEnv.spec.js
@@ -1,4 +1,5 @@
 const parser = require('../src/jsonToEnv');
+const envParser = require('../src/envToJson');
 
 describe('jsonToEnv', () => {
   it('should stringify empty vars', () => {
@@ -475,6 +476,171 @@ vars:secret [
       const output = parser(input);
       expect(output).toContain('port: 8080');
       expect(output).toContain('flag: false');
+    });
+  });
+
+  describe('extends', () => {
+    it('should stringify the parent environment ahead of the vars block', () => {
+      const input = {
+        extends: 'base',
+        variables: [{ name: 'url', value: 'http://localhost:3000', enabled: true }]
+      };
+
+      const output = parser(input);
+
+      expect(output).toEqual(`extends: base
+vars {
+  url: http://localhost:3000
+}
+`);
+    });
+
+    it('should stringify the parent environment ahead of the color', () => {
+      const input = {
+        extends: 'base',
+        variables: [],
+        color: 'blue'
+      };
+
+      const output = parser(input);
+
+      expect(output).toEqual(`extends: base
+vars {
+}
+color: blue
+`);
+    });
+
+    it('should omit extends when no parent is set', () => {
+      const input = {
+        variables: [{ name: 'url', value: 'http://localhost:3000', enabled: true }]
+      };
+
+      const output = parser(input);
+
+      expect(output).not.toContain('extends');
+    });
+
+    it('should omit extends when the parent is an empty string', () => {
+      const input = {
+        extends: '',
+        variables: []
+      };
+
+      const output = parser(input);
+
+      expect(output).not.toContain('extends');
+    });
+
+    it('should never write the inheritedFrom provenance of a resolved variable', () => {
+      const input = {
+        extends: 'base',
+        variables: [{ name: 'url', value: 'http://base', enabled: true, inheritedFrom: 'base' }]
+      };
+
+      const output = parser(input);
+
+      expect(output).not.toContain('inheritedFrom');
+      expect(envParser(output).variables[0]).not.toHaveProperty('inheritedFrom');
+    });
+
+    it('should write a list of parents as a list rather than a fabricated name', () => {
+      const input = {
+        extends: ['base', 'staging'],
+        variables: []
+      };
+
+      const output = parser(input);
+
+      expect(output).toEqual(`extends [
+  base,
+  staging
+]
+vars {
+}
+`);
+    });
+
+    it('should round-trip a list of parents through the parser', () => {
+      const input = {
+        extends: ['base', 'staging'],
+        variables: []
+      };
+
+      expect(envParser(parser(input)).extends).toEqual(['base', 'staging']);
+    });
+
+    it('should round-trip a list of parents whose names contain spaces', () => {
+      const input = {
+        extends: ['Base Environment', 'staging server'],
+        variables: []
+      };
+
+      expect(envParser(parser(input)).extends).toEqual(['Base Environment', 'staging server']);
+    });
+
+    it('should quote a list entry whose name carries a list delimiter', () => {
+      const input = {
+        extends: ['acme, inc', 'env[1]', 'plain'],
+        variables: []
+      };
+
+      const output = parser(input);
+
+      expect(output).toEqual(`extends [
+  "acme, inc",
+  "env[1]",
+  plain
+]
+vars {
+}
+`);
+    });
+
+    it('should round-trip list entries whose names carry list delimiters', () => {
+      const input = {
+        extends: ['acme, inc', 'env[1]', '[bracketed]', 'list]end'],
+        variables: []
+      };
+
+      expect(envParser(parser(input)).extends).toEqual(input.extends);
+    });
+
+    it('should omit the whole list when an entry is named something no environment could be called', () => {
+      const input = {
+        extends: ['base', 'say "hi"'],
+        variables: []
+      };
+
+      const output = parser(input);
+
+      expect(output).not.toContain('extends');
+    });
+
+    it('should omit an empty list of parents', () => {
+      const input = {
+        extends: [],
+        variables: []
+      };
+
+      const output = parser(input);
+
+      expect(output).not.toContain('extends');
+    });
+
+    it('should round-trip a parent environment through the parser', () => {
+      const input = {
+        extends: 'base',
+        variables: [
+          { name: 'url', value: 'http://localhost:3000', enabled: true, secret: false },
+          { name: 'token', value: '', enabled: true, secret: true }
+        ],
+        color: 'blue'
+      };
+
+      const output = envParser(parser(input));
+
+      expect(output).toEqual(input);
     });
   });
 });

--- a/packages/bruno-schema-types/src/collection/environment.ts
+++ b/packages/bruno-schema-types/src/collection/environment.ts
@@ -30,6 +30,7 @@ export interface Environment {
   variables: EnvironmentVariable[];
   externalSecrets?: ExternalSecrets;
   color?: string | null;
+  extends?: string | string[] | null;
 }
 
 export type Environments = Environment[];

--- a/packages/bruno-schema/src/collections/environmentSchema.spec.js
+++ b/packages/bruno-schema/src/collections/environmentSchema.spec.js
@@ -36,6 +36,37 @@ describe('Environment Schema Validation', () => {
     });
   });
 
+  describe('extends', () => {
+    it('preserves the parent environment name after validation', async () => {
+      const env = buildEnvironment({ extends: 'base' });
+
+      const validated = await environmentSchema.validate(env);
+
+      expect(validated.extends).toBe('base');
+    });
+
+    it('validates an environment with no parent', async () => {
+      await expect(environmentSchema.validate(buildEnvironment())).resolves.toBeTruthy();
+    });
+
+    it('validates an environment whose parent was cleared', async () => {
+      await expect(environmentSchema.validate(buildEnvironment({ extends: null }))).resolves.toBeTruthy();
+    });
+
+    it('preserves a list of parents after validation', async () => {
+      const env = buildEnvironment({ extends: ['base', 'shared'] });
+
+      const validated = await environmentSchema.validate(env);
+
+      expect(validated.extends).toEqual(['base', 'shared']);
+    });
+
+    it('rejects a parent reference that is neither a name nor a list of names', async () => {
+      await expect(environmentSchema.validate(buildEnvironment({ extends: { parent: 'base' } }))).rejects.toThrow();
+      await expect(environmentSchema.validate(buildEnvironment({ extends: [42] }))).rejects.toThrow();
+    });
+  });
+
   describe('external secrets', () => {
     it('preserves externalSecrets with provider-specific variable keys after validation', async () => {
       const externalSecrets = {

--- a/packages/bruno-schema/src/collections/index.js
+++ b/packages/bruno-schema/src/collections/index.js
@@ -47,6 +47,18 @@ const environmentSchema = Yup.object({
   variables: Yup.array().of(environmentVariablesSchema).required('variables are required'),
   externalSecrets: externalSecretsSchema.nullable().optional(),
   color: Yup.string().nullable().optional(),
+  extends: Yup.mixed()
+    .test(
+      'is-environment-reference',
+      'extends must be an environment name or a list of environment names',
+      (value) =>
+        value === undefined ||
+        value === null ||
+        typeof value === 'string' ||
+        (Array.isArray(value) && value.every((reference) => typeof reference === 'string'))
+    )
+    .nullable()
+    .optional(),
   pathname: Yup.string().nullable()
 })
   .noUnknown(true)

--- a/tests/environments/environment-inheritance/collection-env-inheritance-from-fixture.spec.ts
+++ b/tests/environments/environment-inheritance/collection-env-inheritance-from-fixture.spec.ts
@@ -1,0 +1,512 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect, Page } from '../../../playwright';
+import {
+  addEnvironmentVariable,
+  addEnvironmentVariables,
+  closeEnvironmentPanel,
+  copyEnvironment,
+  createCollection,
+  createEnvironment,
+  deleteEnvironment,
+  expectResponseContains,
+  getResponseBody,
+  openCollection,
+  openEnvironmentConfigTab,
+  openEnvironmentInSettings,
+  openRequest,
+  openUrlVarTooltip,
+  renameEnvironment,
+  runCollection,
+  saveEnvironment,
+  searchEnvironmentVariables,
+  selectEnvironment,
+  selectResponsePaneTab,
+  sendRequest,
+  setEnvironmentInheritance,
+  setEnvironmentSecrets,
+  setEnvironmentVariableValue,
+  validateRunnerResults
+} from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+import {
+  BASE_SECRETS,
+  DEV_SECRETS,
+  SECRET_REDECLARED_AS_NON_SECRET,
+  seedEchoSecrets,
+  seedWorkspaceVarsSecrets
+} from './secrets';
+
+const YML_COLLECTION = 'Inheritance YML';
+
+const STAGING_SECRETS = { api_key: 'api-key-from-staging' };
+
+const INHERITED_TYPE_LABELS: Array<[string, string]> = [
+  ['base_only', 'string'],
+  ['base_number', 'number'],
+  ['base_boolean', 'boolean'],
+  ['base_object', 'object']
+];
+
+const ECHO_TEST_COUNT = 1;
+const COLLECTION_REQUEST_COUNT = 4;
+
+type EnvironmentFormat = 'bru' | 'yml';
+const FORMATS: EnvironmentFormat[] = ['yml', 'bru'];
+
+const LEVEL_1 = {
+  name: 'inherit-level-1',
+  renamedName: 'inherit-level-1-renamed',
+  variables: {
+    url: { name: 'shared_url', value: 'https://level-1.example.com' },
+    region: { name: 'level_1_region', value: 'region-from-level-1' },
+    token: { name: 'level_1_token', value: 'token-from-level-1', isSecret: true }
+  }
+};
+
+const LEVEL_2 = {
+  name: 'inherit-level-2',
+  copyName: 'inherit-level-2-copy',
+  variables: {
+    own: { name: 'level_2_only', value: 'value-from-level-2' }
+  },
+  // Typed in after the chain is built, redeclaring level 1's names to retire the inherited twins.
+  overrides: {
+    region: { name: LEVEL_1.variables.region.name, value: 'region-from-level-2' },
+    token: { name: LEVEL_1.variables.token.name, value: 'token-from-level-2', isSecret: true }
+  }
+};
+
+const environmentFile = (collectionsDir: string, collectionName: string, format: EnvironmentFormat, envName: string) =>
+  path.join(collectionsDir, collectionName, 'environments', `${envName}.${format}`);
+
+/**
+ * Build a collection holding a populated level 1 environment and a level 2 that inherits
+ * nothing yet, and leave the latter open in the environment settings tab.
+ */
+const createTwoLevelChain = async (
+  page: Page,
+  collectionsDir: string,
+  collectionName: string,
+  format: EnvironmentFormat
+) => {
+  const { environment } = buildCommonLocators(page);
+
+  await createCollection(page, collectionName, collectionsDir, format);
+
+  await createEnvironment(page, LEVEL_1.name);
+  await addEnvironmentVariables(page, Object.values(LEVEL_1.variables));
+  await saveEnvironment(page);
+
+  // The only environment in the collection has nothing to inherit from, so the picker is
+  // not offered at all.
+  await expect(environment.inheritsFromAction()).toHaveCount(0);
+
+  await createEnvironment(page, LEVEL_2.name);
+  await addEnvironmentVariables(page, Object.values(LEVEL_2.variables));
+  await saveEnvironment(page);
+};
+
+test.describe('Collection environment inheritance', () => {
+  test('an environment shows its ancestor rows, with their values and data types', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment, dataTypeSelector } = buildCommonLocators(page);
+
+    await openCollection(page, YML_COLLECTION);
+    await openEnvironmentConfigTab(page);
+    await setEnvironmentSecrets(page, 'base', BASE_SECRETS);
+    await openEnvironmentInSettings(page, 'dev');
+
+    await expect(environment.inheritedSection()).toBeVisible();
+    await expect(environment.inheritedVarValue('base_only')).toHaveText('base_only_value');
+    await expect(environment.inheritedVarValue('host')).toHaveText('http://localhost:8081');
+
+    // An own row of the same name replaces the ancestor's, rather than adding a second row.
+    await expect(environment.inheritedVarRow('api_url')).toHaveCount(0);
+    await expect(environment.varRowLine('api_url')).toHaveText('https://dev.example.com');
+
+    await expect(environment.inheritedVarRow('disabled_in_base')).toHaveCount(0);
+
+    await test.step('An inherited row cannot be edited', async () => {
+      await expect(environment.inheritedVarEnabledCheckbox('base_only')).toBeChecked();
+      await expect(environment.inheritedVarEnabledCheckbox('base_only')).toBeDisabled();
+      await expect(environment.inheritedVarEditableFields('base_only')).toHaveCount(0);
+    });
+
+    await test.step('An inherited row carries the data type of the variable it came from', async () => {
+      for (const [name, label] of INHERITED_TYPE_LABELS) {
+        await expect(environment.inheritedVarDataType(name)).toHaveText(label);
+      }
+
+      await expect(environment.inheritedVarValue('base_number')).toHaveText('42');
+      await expect(environment.inheritedVarValue('base_boolean')).toHaveText('true');
+      // Object values are pretty-printed over several lines, so match the shape.
+      await expect(environment.inheritedVarValue('base_object')).toHaveText(/"region":\s*"eu"/);
+    });
+
+    await test.step('An own row replaces the inherited data type, not just the value', async () => {
+      await expect(environment.inheritedVarRow('typed_override')).toHaveCount(0);
+      await expect(environment.varRowLine('typed_override')).toHaveText('overridden_in_dev');
+      await expect(dataTypeSelector.typeLabel(environment.varRow('typed_override'))).toHaveAttribute(
+        'data-selected-type',
+        'string'
+      );
+    });
+
+    await test.step('An inherited secret arrives masked and reveals its ancestor value', async () => {
+      await environment.secretsTab().click();
+      await expect(environment.inheritedVarValue('base_token')).toHaveText('*'.repeat(BASE_SECRETS.base_token.length));
+      await expect(environment.inheritedVarDataType('base_secret_object')).toHaveText('object');
+      await expect(environment.inheritedVarDataType('base_token')).toHaveText('string');
+      await expect(environment.inheritedVarValue('base_secret_object')).not.toContainText('admin');
+
+      await environment.inheritedVarEyeToggle('base_token').click();
+      await environment.inheritedVarEyeToggle('base_secret_object').click();
+
+      await expect(environment.inheritedVarValue('base_token')).toHaveText(BASE_SECRETS.base_token);
+      await expect(environment.inheritedVarValue('base_secret_object')).toHaveText(/"scope":\s*"admin"/);
+      await expect(environment.inheritedVarSource('base_token')).toHaveAttribute('title', 'Inherited from base');
+    });
+
+    await closeEnvironmentPanel(page);
+  });
+
+  test('the inherited section collapses, filters with the search, and links to its source', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment } = buildCommonLocators(page);
+
+    await openCollection(page, YML_COLLECTION);
+    await openEnvironmentConfigTab(page);
+    await openEnvironmentInSettings(page, 'dev');
+
+    await test.step('Collapsing the section hides the inherited rows', async () => {
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow('base_only')).toHaveCount(0);
+
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow('base_only')).toBeVisible();
+    });
+
+    await test.step('The search filters inherited rows and own rows independently', async () => {
+      await searchEnvironmentVariables(page, 'base_only');
+      await expect(environment.inheritedVarRow('base_only')).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(1)');
+      await expect(environment.sectionCount('own')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, 'dev_only');
+      await expect(environment.varRow('dev_only')).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, 'matches_nothing_at_all');
+      await expect(environment.varsNoResults()).toBeVisible();
+
+      await searchEnvironmentVariables(page, '');
+      await expect(environment.inheritedVarRow('base_only')).toBeVisible();
+    });
+
+    await test.step('The source arrow opens the environment the row came from', async () => {
+      await environment.inheritedVarSource('base_only').click();
+
+      await expect(environment.detailsTitle()).toHaveText('base');
+      await expect(environment.varRowLine('base_only')).toHaveText('base_only_value');
+    });
+
+    await closeEnvironmentPanel(page);
+  });
+
+  test('the source arrow warns about unsaved changes instead of switching environments', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment, modal } = buildCommonLocators(page);
+
+    await openCollection(page, YML_COLLECTION);
+    await openEnvironmentConfigTab(page);
+    await openEnvironmentInSettings(page, 'dev');
+
+    await setEnvironmentVariableValue(page, 'dev_only', 'edited_but_unsaved');
+    await expect(environment.tabCount('variables')).toHaveClass(/unsaved/);
+
+    await environment.inheritedVarSource('base_only').click();
+
+    await expect(modal.byTitle('Unsaved changes')).toBeVisible();
+    await expect(environment.detailsTitle()).toHaveText('dev');
+    await expect(environment.varRowLine('dev_only')).toHaveText('edited_but_unsaved');
+
+    await modal.closeButton().click();
+    await environment.resetTab().click();
+    await closeEnvironmentPanel(page);
+  });
+
+  test('a request interpolates the variables its environment inherits, as their own data type', async ({
+    pageWithUserData: page
+  }) => {
+    // Two environments are edited and saved before the request goes out.
+    test.setTimeout(90000);
+
+    const { response } = buildCommonLocators(page);
+
+    await openCollection(page, YML_COLLECTION);
+    await openRequest(page, YML_COLLECTION, 'echo', { persist: true });
+    await seedEchoSecrets(page);
+    await selectEnvironment(page, 'dev');
+
+    // `host` carries the echo endpoint and is only defined in `base`, so the request
+    // cannot reach the server at all unless inheritance resolved.
+    await sendRequest(page, 200);
+
+    await expectResponseContains(page, [
+      'base_only_value',
+      'https://dev.example.com',
+      'dev_only_value',
+      // `dev` declares this one too, but disabled, so the inherited row still applies.
+      'from_base',
+      // Disabled in `base`, so it is never inherited and stays uninterpolated.
+      '{{disabled_in_base}}'
+    ]);
+
+    await test.step('The request asserts the whole environment it resolved', async () => {
+      // `echo` deep-equals the body it sent against every row `dev` resolves, typed rows and
+      // secrets included — the CLI suite runs the same request and reads that verdict from the
+      // exit code.
+      await selectResponsePaneTab(page, 'Tests');
+
+      await expect(response.testSummary()).toContainText(
+        `Tests (${ECHO_TEST_COUNT}), Passed: ${ECHO_TEST_COUNT}, Failed: 0`
+      );
+      await expect(response.testFailures()).toHaveCount(0);
+    });
+  });
+
+  test('an inherited secret reaches the request and outranks a plain row of the same name', async ({
+    pageWithUserData: page
+  }) => {
+    // Three environments are edited and saved before either request goes out.
+    test.setTimeout(120000);
+
+    await openCollection(page, YML_COLLECTION);
+    await openEnvironmentConfigTab(page);
+
+    await setEnvironmentSecrets(page, 'base', { ...BASE_SECRETS, ...SECRET_REDECLARED_AS_NON_SECRET });
+    await setEnvironmentSecrets(page, 'dev', DEV_SECRETS);
+    await setEnvironmentSecrets(page, 'staging', STAGING_SECRETS);
+
+    await openRequest(page, YML_COLLECTION, 'echo');
+    await closeEnvironmentPanel(page);
+
+    await test.step('A three-level chain resolves the secrets it inherits from either ancestor', async () => {
+      await selectEnvironment(page, 'qa');
+      await sendRequest(page, 200);
+      await selectResponsePaneTab(page, 'Response');
+
+      await expectResponseContains(page, [BASE_SECRETS.base_token, STAGING_SECRETS.api_key]);
+      // `base` declares `api_key` plain and `staging` redeclares it secret, so both are
+      // inherited by `qa` — the secret is the one that must reach the request.
+      expect(await getResponseBody(page)).not.toContain('plain_api_key');
+    });
+
+    await test.step('A name inherited as a secret and redeclared as a non-secret resolves to the secret', async () => {
+      await selectEnvironment(page, 'dev');
+      await sendRequest(page, 200);
+
+      // `dev` redeclares the secret `overridden_secret` it inherits as a non-secret, and the
+      // non-secret `overridden_plain` as a secret. Both ancestor rows survive the redeclaration,
+      // and in each pair the secret is the one that reaches the request.
+      await expectResponseContains(page, [
+        SECRET_REDECLARED_AS_NON_SECRET.overridden_secret,
+        DEV_SECRETS.overridden_plain
+      ]);
+      const body = await getResponseBody(page);
+      expect(body).not.toContain('plain_wins_in_dev');
+      expect(body).not.toContain('plain_from_base');
+    });
+  });
+
+  test('a script write only overrides an inherited variable when the value differs', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment } = buildCommonLocators(page);
+
+    await openCollection(page, YML_COLLECTION);
+    await selectEnvironment(page, 'scripted');
+    await openRequest(page, YML_COLLECTION, 'set-env-var');
+    await sendRequest(page, 200);
+
+    await openEnvironmentConfigTab(page);
+    await openEnvironmentInSettings(page, 'scripted');
+
+    // The script rewrote `base_only` with the value it already inherits, so the write is a
+    // no-op and the row stays inherited.
+    await expect(environment.inheritedVarValue('base_only')).toHaveText('base_only_value');
+    await expect(environment.varRow('base_only')).toHaveCount(0);
+
+    // `session_id` was written with a different value, so it becomes a row of its own.
+    await expect(environment.varRowLine('session_id')).toHaveText('script_session');
+    await expect(environment.inheritedVarRow('session_id')).toHaveCount(0);
+
+    await closeEnvironmentPanel(page);
+  });
+
+  test('an inherited variable is read-only in the variable tooltip', async ({ pageWithUserData: page }) => {
+    const { varInfoPopup } = buildCommonLocators(page);
+
+    await openCollection(page, YML_COLLECTION);
+    await selectEnvironment(page, 'dev');
+    await openRequest(page, YML_COLLECTION, 'echo');
+
+    const tooltip = await openUrlVarTooltip(page, 'host');
+
+    await expect(varInfoPopup.readonlyNote(tooltip)).toHaveText('Inherited from base (read-only)');
+    await expect(varInfoPopup.editableValue(tooltip)).toHaveCount(0);
+  });
+
+  test('a collection run interpolates the variables the environment inherits', async ({ pageWithUserData: page }) => {
+    // Four environments are edited and saved before the run starts.
+    test.setTimeout(120000);
+
+    await openCollection(page, YML_COLLECTION);
+    await openRequest(page, YML_COLLECTION, 'echo', { persist: true });
+    await seedEchoSecrets(page);
+    // The run covers the whole collection, so the workspace-scoped request alongside `echo`
+    // needs its own environment — and its own secrets — as well.
+    await seedWorkspaceVarsSecrets(page);
+    await selectEnvironment(page, 'dev');
+    await selectEnvironment(page, 'workspace_dev', 'global');
+
+    await runCollection(page, YML_COLLECTION);
+
+    await validateRunnerResults(page, {
+      totalRequests: COLLECTION_REQUEST_COUNT,
+      passed: COLLECTION_REQUEST_COUNT,
+      failed: 0,
+      skipped: 0
+    });
+  });
+
+  for (const format of FORMATS) {
+    test(`inheritance is written, cleared, copied, and follows a parent rename and delete in ${format}`, async ({
+      pageWithUserData: page,
+      createTmpDir
+    }) => {
+      const { environment } = buildCommonLocators(page);
+      const collectionName = `Lifecycle ${format.toUpperCase()}`;
+      const collectionsDir = await createTmpDir(`inheritance-lifecycle-${format}`);
+      const readEnvironmentFile = (name: string) =>
+        fs.readFileSync(environmentFile(collectionsDir, collectionName, format, name), 'utf8');
+
+      await test.step('Create a collection with two environments', async () => {
+        await createTwoLevelChain(page, collectionsDir, collectionName, format);
+      });
+
+      await test.step('Picking a parent writes extends and merges its rows in', async () => {
+        await setEnvironmentInheritance(page, LEVEL_1.name);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.name}`);
+
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+
+        // The rows arrived from the parent rather than from an edit, so the tab stays saved.
+        await expect(environment.tabCount('variables')).not.toHaveClass(/unsaved/);
+
+        await environment.secretsTab().click();
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.token.name)).toHaveText(
+          '*'.repeat(LEVEL_1.variables.token.value.length)
+        );
+        await environment.inheritedVarEyeToggle(LEVEL_1.variables.token.name).click();
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.token.name)).toHaveText(LEVEL_1.variables.token.value);
+
+        await environment.variablesTab().click();
+      });
+
+      await test.step('Choosing no environment removes extends again', async () => {
+        await setEnvironmentInheritance(page, null);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).not.toContain('extends');
+        await expect(environment.inheritedSection()).toHaveCount(0);
+      });
+
+      await test.step('A copy of an inheriting environment keeps its parent', async () => {
+        await setEnvironmentInheritance(page, LEVEL_1.name);
+        await copyEnvironment(page, LEVEL_2.copyName);
+
+        await expect(environment.detailsTitle()).toHaveText(LEVEL_2.copyName);
+
+        await expect.poll(() =>
+          fs.existsSync(environmentFile(collectionsDir, collectionName, format, LEVEL_2.copyName))
+        ).toBe(true);
+        expect(readEnvironmentFile(LEVEL_2.copyName)).toContain(`extends: ${LEVEL_1.name}`);
+      });
+
+      await test.step('Renaming the parent rewrites the references to it', async () => {
+        await openEnvironmentInSettings(page, LEVEL_1.name);
+        await renameEnvironment(page, LEVEL_1.renamedName);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.renamedName}`);
+
+        await openEnvironmentInSettings(page, LEVEL_2.name);
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+      });
+
+      await test.step('Deleting the parent keeps the references to it and warns about them', async () => {
+        await openEnvironmentInSettings(page, LEVEL_1.renamedName);
+        await deleteEnvironment(page);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.renamedName}`);
+
+        await openEnvironmentInSettings(page, LEVEL_2.name);
+        await expect(environment.missingInheritedEnvironment()).toContainText(LEVEL_1.renamedName);
+        await expect(environment.inheritedSection()).toHaveCount(0);
+      });
+    });
+  }
+
+  test('an own row replaces its inherited twin as it is typed, and only own rows are saved', async ({
+    pageWithUserData: page,
+    createTmpDir
+  }) => {
+    const { environment } = buildCommonLocators(page);
+    const collectionName = 'Inherited Override';
+    const collectionsDir = await createTmpDir('inheritance-override');
+    const readLevel2File = () =>
+      fs.readFileSync(environmentFile(collectionsDir, collectionName, 'yml', LEVEL_2.name), 'utf8');
+
+    await createTwoLevelChain(page, collectionsDir, collectionName, 'yml');
+    await setEnvironmentInheritance(page, LEVEL_1.name);
+
+    await test.step('Typing an own row of the same name retires the inherited one before the save', async () => {
+      await expect(environment.inheritedVarValue(LEVEL_1.variables.region.name)).toHaveText(LEVEL_1.variables.region.value);
+
+      await addEnvironmentVariable(page, LEVEL_2.overrides.region);
+
+      await expect(environment.inheritedVarRow(LEVEL_2.overrides.region.name)).toHaveCount(0);
+      await expect(environment.varRowLine(LEVEL_2.overrides.region.name)).toHaveText(LEVEL_2.overrides.region.value);
+    });
+
+    await test.step('Saving the tab writes the own rows and leaves the inherited ones behind', async () => {
+      await environment.saveTab().click();
+
+      await expect.poll(() => readLevel2File()).toContain(LEVEL_2.overrides.region.name);
+      const saved = readLevel2File();
+      expect(saved).toContain(`extends: ${LEVEL_1.name}`);
+      expect(saved).toContain(LEVEL_2.overrides.region.value);
+      expect(saved).not.toContain(LEVEL_1.variables.url.name);
+      expect(saved).not.toContain(LEVEL_1.variables.token.name);
+    });
+
+    await test.step('Save all writes the own secrets and leaves the inherited ones behind', async () => {
+      await environment.secretsTab().click();
+      await expect(environment.inheritedVarRow(LEVEL_1.variables.token.name)).toBeVisible();
+
+      await addEnvironmentVariable(page, LEVEL_2.overrides.token);
+      await expect(environment.inheritedVarRow(LEVEL_2.overrides.token.name)).toHaveCount(0);
+
+      await environment.saveAll().click();
+
+      await expect.poll(() => readLevel2File()).toContain(LEVEL_2.overrides.token.name);
+      expect(readLevel2File()).not.toContain(LEVEL_1.variables.url.name);
+    });
+  });
+});

--- a/tests/environments/environment-inheritance/collection-env-inheritance-via-ui.spec.ts
+++ b/tests/environments/environment-inheritance/collection-env-inheritance-via-ui.spec.ts
@@ -1,0 +1,794 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { test, expect, Page } from '../../../playwright';
+import {
+  addEnvironmentVariable,
+  addEnvironmentVariables,
+  addPostResponseScript,
+  closeAllCollections,
+  closeEnvironmentPanel,
+  copyEnvironment,
+  createCollection,
+  createEnvironment,
+  createRequest,
+  deleteEnvironment,
+  disableEnvironmentVariable,
+  expectResponseContains,
+  getResponseBody,
+  openEnvironmentConfigTab,
+  openEnvironmentInSettings,
+  openRequest,
+  openUrlVarTooltip,
+  renameEnvironment,
+  runCollection,
+  saveEnvironment,
+  saveRequest,
+  searchEnvironmentVariables,
+  selectEnvironment,
+  selectRequestBodyMode,
+  selectRequestPaneTab,
+  selectResponsePaneTab,
+  sendRequest,
+  setCodeMirrorEditorValue,
+  setEnvironmentInheritance,
+  setEnvironmentVariableValue,
+  setRequestUrlAndSave,
+  validateRunnerResults,
+  type EnvironmentVariable
+} from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+// Every environment, variable and request this suite asserts on is authored through the app
+// itself, so nothing here reads the committed inheritance workspace fixture — a secret gets
+// its value as it is typed in, rather than being seeded into the secret store afterwards.
+
+type InheritanceVariable = EnvironmentVariable & { disabled?: boolean };
+
+type EnvironmentDefinition = {
+  name: string;
+  extends?: string;
+  variables: Record<string, InheritanceVariable>;
+};
+
+const BASE: EnvironmentDefinition = {
+  name: 'base',
+  variables: {
+    host: { name: 'host', value: 'http://localhost:8081' },
+    apiUrl: { name: 'api_url', value: 'https://base.example.com' },
+    baseOnly: { name: 'base_only', value: 'base_only_value' },
+    apiKey: { name: 'api_key', value: 'plain_api_key' },
+    sessionId: { name: 'session_id', value: 'base_session' },
+    shadowedByDisabled: { name: 'shadowed_by_disabled', value: 'from_base' },
+    overriddenPlain: { name: 'overridden_plain', value: 'plain_from_base' },
+    number: { name: 'base_number', value: '42', dataType: 'number' },
+    boolean: { name: 'base_boolean', value: 'true', dataType: 'boolean' },
+    object: { name: 'base_object', value: '{"region":"eu"}', dataType: 'object' },
+    typedOverride: { name: 'typed_override', value: '1', dataType: 'number' },
+    disabledInBase: { name: 'disabled_in_base', value: 'should_not_resolve', disabled: true },
+    token: { name: 'base_token', value: 'token-from-base', isSecret: true },
+    secretObject: { name: 'base_secret_object', value: '{"scope":"admin"}', isSecret: true, dataType: 'object' },
+    overriddenSecret: { name: 'overridden_secret', value: 'secret-from-base', isSecret: true }
+  }
+};
+
+const DEV: EnvironmentDefinition = {
+  name: 'dev',
+  extends: BASE.name,
+  variables: {
+    apiUrl: { name: 'api_url', value: 'https://dev.example.com' },
+    devOnly: { name: 'dev_only', value: 'dev_only_value' },
+    typedOverride: { name: 'typed_override', value: 'overridden_in_dev' },
+    overriddenSecret: { name: 'overridden_secret', value: 'plain_wins_in_dev' },
+    shadowedByDisabled: { name: 'shadowed_by_disabled', value: 'never_applied', disabled: true },
+    overriddenPlain: { name: 'overridden_plain', value: 'secret-from-dev', isSecret: true }
+  }
+};
+
+const STAGING: EnvironmentDefinition = {
+  name: 'staging',
+  extends: BASE.name,
+  variables: {
+    apiKey: { name: 'api_key', value: 'api-key-from-staging', isSecret: true }
+  }
+};
+
+const QA: EnvironmentDefinition = {
+  name: 'qa',
+  extends: STAGING.name,
+  variables: {
+    apiUrl: { name: 'api_url', value: 'https://qa.example.com' }
+  }
+};
+
+const SCRIPTED: EnvironmentDefinition = {
+  name: 'scripted',
+  extends: BASE.name,
+  variables: {
+    own: { name: 'scripted_only', value: 'scripted_only_value' }
+  }
+};
+
+const ECHO_REQUEST = { name: 'echo', method: 'POST', url: '{{host}}/api/echo/everything' };
+const SET_ENV_VAR_REQUEST = { name: 'set-env-var', url: '{{host}}/ping' };
+const PING_REQUEST = { name: 'ping', url: '{{host}}/ping' };
+
+// The typed rows are interpolated unquoted, so they only parse back as a number, boolean and
+// object if their data type survived the merge.
+const ECHO_BODY = `{
+  "api_url": "{{api_url}}",
+  "base_only": "{{base_only}}",
+  "dev_only": "{{dev_only}}",
+  "disabled_in_base": "{{disabled_in_base}}",
+  "shadowed_by_disabled": "{{shadowed_by_disabled}}",
+  "base_number": {{base_number}},
+  "base_boolean": {{base_boolean}},
+  "base_object": {{base_object}},
+  "typed_override": "{{typed_override}}",
+  "base_token": "{{base_token}}",
+  "api_key": "{{api_key}}",
+  "overridden_plain": "{{overridden_plain}}",
+  "overridden_secret": "{{overridden_secret}}"
+}`;
+
+const ECHO_TESTS = `// The echo endpoint hands the request body back as a raw string.
+const sent = () => JSON.parse(res.getBody().body);
+
+test("every kind of row the environment inherits resolves under dev", function() {
+  expect(sent()).to.eql({
+    api_url: "https://dev.example.com",
+    base_only: "base_only_value",
+    dev_only: "dev_only_value",
+    // Disabled in \`base\`, so it is never inherited and stays uninterpolated.
+    disabled_in_base: "{{disabled_in_base}}",
+    // \`dev\` declares this one too, but disabled, so the inherited row still applies.
+    shadowed_by_disabled: "from_base",
+    api_key: "plain_api_key",
+    base_number: 42,
+    base_boolean: true,
+    base_object: { region: "eu" },
+    // An own row replaces the data type it inherited, not just the value.
+    typed_override: "overridden_in_dev",
+    base_token: "token-from-base",
+    // In each redeclared pair the secret is the one that reaches the request.
+    overridden_plain: "secret-from-dev",
+    overridden_secret: "secret-from-base"
+  });
+});`;
+
+const SET_ENV_VAR_SCRIPT = [
+  `bru.setEnvVar('${BASE.variables.baseOnly.name}', '${BASE.variables.baseOnly.value}');`,
+  `bru.setEnvVar('${BASE.variables.sessionId.name}', 'script_session');`
+].join('\n');
+
+const INHERITED_TYPE_LABELS: Array<[string, string]> = [
+  [BASE.variables.baseOnly.name, 'string'],
+  [BASE.variables.number.name, 'number'],
+  [BASE.variables.boolean.name, 'boolean'],
+  [BASE.variables.object.name, 'object']
+];
+
+const ECHO_TEST_COUNT = 1;
+
+/**
+ * Create an environment, fill in its rows, disable the ones declared disabled, and point it at
+ * the environment it inherits from.
+ */
+const createEnvironmentFromDefinition = async (page: Page, environment: EnvironmentDefinition) => {
+  await test.step(`Create environment "${environment.name}"`, async () => {
+    const { environment: locators } = buildCommonLocators(page);
+    const variables = Object.values(environment.variables);
+
+    await createEnvironment(page, environment.name);
+    await addEnvironmentVariables(page, variables);
+
+    const disabledVariables = variables.filter((variable) => variable.disabled);
+    if (disabledVariables.length) {
+      // The last row added may have landed on the Secrets tab; every disabled row is a plain one.
+      await locators.variablesTab().click();
+      for (const variable of disabledVariables) {
+        await disableEnvironmentVariable(page, variable.name);
+      }
+    }
+
+    await saveEnvironment(page);
+
+    if (environment.extends) {
+      await setEnvironmentInheritance(page, environment.extends);
+    }
+  });
+};
+
+/**
+ * Create a collection holding the given environment chain, in the order the definitions are
+ * listed — a parent has to exist before the environment extending it is created.
+ */
+const createCollectionWithEnvironments = async (
+  page: Page,
+  collectionName: string,
+  collectionsDir: string,
+  environments: EnvironmentDefinition[]
+) => {
+  await createCollection(page, collectionName, collectionsDir);
+  for (const environment of environments) {
+    await createEnvironmentFromDefinition(page, environment);
+  }
+};
+
+/**
+ * Create a request in the collection, open it as a permanent tab, and point it at its URL.
+ */
+const createRequestForUrl = async (
+  page: Page,
+  collectionName: string,
+  request: { name: string; method?: string; url: string }
+) => {
+  await createRequest(page, request.name, collectionName, { method: request.method });
+  await openRequest(page, collectionName, request.name, { persist: true });
+  await setRequestUrlAndSave(page, request.url);
+};
+
+/**
+ * Create the request that echoes every row its environment resolves and asserts the whole
+ * resolved environment in its tests.
+ */
+const createEchoRequest = async (page: Page, collectionName: string) => {
+  await test.step(`Create request "${ECHO_REQUEST.name}"`, async () => {
+    await createRequestForUrl(page, collectionName, ECHO_REQUEST);
+
+    await selectRequestBodyMode(page, 'JSON');
+    await setCodeMirrorEditorValue(page, 'request-body-editor', ECHO_BODY);
+
+    await selectRequestPaneTab(page, 'Tests');
+    await setCodeMirrorEditorValue(page, 'test-script-editor', ECHO_TESTS);
+
+    await saveRequest(page);
+  });
+};
+
+/**
+ * Create the request whose post-response script writes to the selected environment — once with
+ * the value that environment already inherits, once with a different one.
+ */
+const createSetEnvVarRequest = async (page: Page, collectionName: string) => {
+  await test.step(`Create request "${SET_ENV_VAR_REQUEST.name}"`, async () => {
+    await createRequestForUrl(page, collectionName, SET_ENV_VAR_REQUEST);
+    await addPostResponseScript(page, SET_ENV_VAR_SCRIPT);
+    await saveRequest(page);
+  });
+};
+
+test.describe.configure({ timeout: 180_000 });
+
+test.describe('Collection environment inheritance, authored in the app', () => {
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await closeAllCollections(page);
+    }
+  });
+
+  test('an environment shows its ancestor rows, with their values and data types', async ({ page, createTmpDir }) => {
+    const collectionName = 'Inherited Rows';
+    const { environment, dataTypeSelector } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-rows'), [BASE, DEV]);
+    await openEnvironmentInSettings(page, DEV.name);
+
+    await expect(environment.inheritedSection()).toBeVisible();
+    await expect(environment.inheritedVarValue(BASE.variables.baseOnly.name)).toHaveText(BASE.variables.baseOnly.value);
+    await expect(environment.inheritedVarValue(BASE.variables.host.name)).toHaveText(BASE.variables.host.value);
+
+    // An own row of the same name replaces the ancestor's, rather than adding a second row.
+    await expect(environment.inheritedVarRow(DEV.variables.apiUrl.name)).toHaveCount(0);
+    await expect(environment.varRowLine(DEV.variables.apiUrl.name)).toHaveText(DEV.variables.apiUrl.value);
+
+    await expect(environment.inheritedVarRow(BASE.variables.disabledInBase.name)).toHaveCount(0);
+
+    await test.step('An inherited row cannot be edited', async () => {
+      await expect(environment.inheritedVarEnabledCheckbox(BASE.variables.baseOnly.name)).toBeChecked();
+      await expect(environment.inheritedVarEnabledCheckbox(BASE.variables.baseOnly.name)).toBeDisabled();
+      await expect(environment.inheritedVarEditableFields(BASE.variables.baseOnly.name)).toHaveCount(0);
+    });
+
+    await test.step('An inherited row carries the data type of the variable it came from', async () => {
+      for (const [name, label] of INHERITED_TYPE_LABELS) {
+        await expect(environment.inheritedVarDataType(name)).toHaveText(label);
+      }
+
+      await expect(environment.inheritedVarValue(BASE.variables.number.name)).toHaveText(BASE.variables.number.value);
+      await expect(environment.inheritedVarValue(BASE.variables.boolean.name)).toHaveText(BASE.variables.boolean.value);
+      // Object values are pretty-printed over several lines, so match the shape.
+      await expect(environment.inheritedVarValue(BASE.variables.object.name)).toHaveText(/"region":\s*"eu"/);
+    });
+
+    await test.step('An own row replaces the inherited data type, not just the value', async () => {
+      await expect(environment.inheritedVarRow(DEV.variables.typedOverride.name)).toHaveCount(0);
+      await expect(environment.varRowLine(DEV.variables.typedOverride.name)).toHaveText(
+        DEV.variables.typedOverride.value
+      );
+      await expect(
+        dataTypeSelector.typeLabel(environment.varRow(DEV.variables.typedOverride.name))
+      ).toHaveAttribute('data-selected-type', 'string');
+    });
+
+    await test.step('An inherited secret arrives masked and reveals its ancestor value', async () => {
+      await environment.secretsTab().click();
+      await expect(environment.inheritedVarValue(BASE.variables.token.name)).toHaveText(
+        '*'.repeat(BASE.variables.token.value.length)
+      );
+      await expect(environment.inheritedVarDataType(BASE.variables.secretObject.name)).toHaveText('object');
+      await expect(environment.inheritedVarDataType(BASE.variables.token.name)).toHaveText('string');
+      await expect(environment.inheritedVarValue(BASE.variables.secretObject.name)).not.toContainText('admin');
+
+      await environment.inheritedVarEyeToggle(BASE.variables.token.name).click();
+      await environment.inheritedVarEyeToggle(BASE.variables.secretObject.name).click();
+
+      await expect(environment.inheritedVarValue(BASE.variables.token.name)).toHaveText(BASE.variables.token.value);
+      await expect(environment.inheritedVarValue(BASE.variables.secretObject.name)).toHaveText(/"scope":\s*"admin"/);
+      await expect(environment.inheritedVarSource(BASE.variables.token.name)).toHaveAttribute(
+        'title',
+        `Inherited from ${BASE.name}`
+      );
+    });
+
+    await closeEnvironmentPanel(page);
+  });
+
+  test('the inherited section collapses, filters with the search, and links to its source', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Inherited Section';
+    const { environment } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-section'), [BASE, DEV]);
+    await openEnvironmentInSettings(page, DEV.name);
+
+    await test.step('Collapsing the section hides the inherited rows', async () => {
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toHaveCount(0);
+
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toBeVisible();
+    });
+
+    await test.step('The search filters inherited rows and own rows independently', async () => {
+      await searchEnvironmentVariables(page, BASE.variables.baseOnly.name);
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(1)');
+      await expect(environment.sectionCount('own')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, DEV.variables.devOnly.name);
+      await expect(environment.varRow(DEV.variables.devOnly.name)).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, 'matches_nothing_at_all');
+      await expect(environment.varsNoResults()).toBeVisible();
+
+      await searchEnvironmentVariables(page, '');
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toBeVisible();
+    });
+
+    await test.step('The source arrow opens the environment the row came from', async () => {
+      await environment.inheritedVarSource(BASE.variables.baseOnly.name).click();
+
+      await expect(environment.detailsTitle()).toHaveText(BASE.name);
+      await expect(environment.varRowLine(BASE.variables.baseOnly.name)).toHaveText(BASE.variables.baseOnly.value);
+    });
+
+    await closeEnvironmentPanel(page);
+  });
+
+  test('the source arrow warns about unsaved changes instead of switching environments', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Inherited Source Guard';
+    const { environment, modal } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-source-guard'), [
+      BASE,
+      DEV
+    ]);
+    await openEnvironmentInSettings(page, DEV.name);
+
+    await setEnvironmentVariableValue(page, DEV.variables.devOnly.name, 'edited_but_unsaved');
+    await expect(environment.tabCount('variables')).toHaveClass(/unsaved/);
+
+    await environment.inheritedVarSource(BASE.variables.baseOnly.name).click();
+
+    await expect(modal.byTitle('Unsaved changes')).toBeVisible();
+    await expect(environment.detailsTitle()).toHaveText(DEV.name);
+    await expect(environment.varRowLine(DEV.variables.devOnly.name)).toHaveText('edited_but_unsaved');
+
+    await modal.closeButton().click();
+    await environment.resetTab().click();
+    await closeEnvironmentPanel(page);
+  });
+
+  test('a request interpolates the variables its environment inherits, as their own data type', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Inherited Request';
+    const { response } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-request'), [BASE, DEV]);
+    await createEchoRequest(page, collectionName);
+    await selectEnvironment(page, DEV.name);
+
+    // `host` carries the echo endpoint and is only defined in `base`, so the request cannot
+    // reach the server at all unless inheritance resolved.
+    await sendRequest(page, 200);
+
+    await expectResponseContains(page, [
+      BASE.variables.baseOnly.value,
+      DEV.variables.apiUrl.value,
+      DEV.variables.devOnly.value,
+      // `dev` declares this one too, but disabled, so the inherited row still applies.
+      BASE.variables.shadowedByDisabled.value,
+      // Disabled in `base`, so it is never inherited and stays uninterpolated.
+      `{{${BASE.variables.disabledInBase.name}}}`
+    ]);
+
+    await test.step('The request asserts the whole environment it resolved', async () => {
+      await selectResponsePaneTab(page, 'Tests');
+
+      await expect(response.testSummary()).toContainText(
+        `Tests (${ECHO_TEST_COUNT}), Passed: ${ECHO_TEST_COUNT}, Failed: 0`
+      );
+      await expect(response.testFailures()).toHaveCount(0);
+    });
+  });
+
+  test('an inherited secret reaches the request and outranks a plain row of the same name', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Inherited Secrets';
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-secrets'), [
+      BASE,
+      DEV,
+      STAGING,
+      QA
+    ]);
+    await createEchoRequest(page, collectionName);
+
+    await test.step('A three-level chain resolves the secrets it inherits from either ancestor', async () => {
+      await selectEnvironment(page, QA.name);
+      await sendRequest(page, 200);
+      await selectResponsePaneTab(page, 'Response');
+
+      await expectResponseContains(page, [BASE.variables.token.value, STAGING.variables.apiKey.value]);
+      // `base` declares `api_key` plain and `staging` redeclares it secret, so both are inherited
+      // by `qa` — the secret is the one that must reach the request.
+      expect(await getResponseBody(page)).not.toContain(BASE.variables.apiKey.value);
+    });
+
+    await test.step('A name inherited as a secret and redeclared as a non-secret resolves to the secret', async () => {
+      await selectEnvironment(page, DEV.name);
+      await sendRequest(page, 200);
+
+      // `dev` redeclares the secret `overridden_secret` it inherits as a non-secret, and the
+      // non-secret `overridden_plain` as a secret. Both ancestor rows survive the redeclaration,
+      // and in each pair the secret is the one that reaches the request.
+      await expectResponseContains(page, [
+        BASE.variables.overriddenSecret.value,
+        DEV.variables.overriddenPlain.value
+      ]);
+      const body = await getResponseBody(page);
+      expect(body).not.toContain(DEV.variables.overriddenSecret.value);
+      expect(body).not.toContain(BASE.variables.overriddenPlain.value);
+    });
+  });
+
+  test('a script write only overrides an inherited variable when the value differs', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Inherited Script Write';
+    const { environment } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-script-write'), [
+      BASE,
+      SCRIPTED
+    ]);
+    await createSetEnvVarRequest(page, collectionName);
+    await selectEnvironment(page, SCRIPTED.name);
+    await sendRequest(page, 200);
+
+    await openEnvironmentConfigTab(page);
+    await openEnvironmentInSettings(page, SCRIPTED.name);
+
+    // The script rewrote `base_only` with the value it already inherits, so the write is a no-op
+    // and the row stays inherited.
+    await expect(environment.inheritedVarValue(BASE.variables.baseOnly.name)).toHaveText(
+      BASE.variables.baseOnly.value
+    );
+    await expect(environment.varRow(BASE.variables.baseOnly.name)).toHaveCount(0);
+
+    // `session_id` was written with a different value, so it becomes a row of its own.
+    await expect(environment.varRowLine(BASE.variables.sessionId.name)).toHaveText('script_session');
+    await expect(environment.inheritedVarRow(BASE.variables.sessionId.name)).toHaveCount(0);
+
+    await closeEnvironmentPanel(page);
+  });
+
+  test('an inherited variable is read-only in the variable tooltip', async ({ page, createTmpDir }) => {
+    const collectionName = 'Inherited Tooltip';
+    const { varInfoPopup } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-tooltip'), [BASE, DEV]);
+    await createRequestForUrl(page, collectionName, PING_REQUEST);
+    await selectEnvironment(page, DEV.name);
+
+    const tooltip = await openUrlVarTooltip(page, BASE.variables.host.name);
+
+    await expect(varInfoPopup.readonlyNote(tooltip)).toHaveText(`Inherited from ${BASE.name} (read-only)`);
+    await expect(varInfoPopup.editableValue(tooltip)).toHaveCount(0);
+  });
+
+  test('a collection run interpolates the variables the environment inherits', async ({ page, createTmpDir }) => {
+    const collectionName = 'Inherited Runner';
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('inherited-runner'), [BASE, DEV]);
+    await createEchoRequest(page, collectionName);
+    await selectEnvironment(page, DEV.name);
+
+    await runCollection(page, collectionName);
+
+    await validateRunnerResults(page, {
+      totalRequests: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0
+    });
+  });
+});
+
+type EnvironmentFormat = 'bru' | 'yml';
+const FORMATS: EnvironmentFormat[] = ['yml', 'bru'];
+
+type SavedVariable = { name: string; value?: unknown; secret?: boolean; disabled?: boolean };
+type SavedEnvironment = { name: string; extends?: string; variables?: SavedVariable[] };
+
+const LEVEL_1 = {
+  name: 'ui-inherit-level-1',
+  renamedName: 'ui-inherit-level-1-renamed',
+  variables: {
+    url: { name: 'shared_url', value: 'https://level-1.example.com' },
+    region: { name: 'level_1_region', value: 'region-from-level-1' },
+    count: { name: 'level_1_count', value: '3', dataType: 'number' as const },
+    token: { name: 'level_1_token', value: 'token-from-level-1', isSecret: true }
+  }
+};
+
+const LEVEL_2 = {
+  name: 'ui-inherit-level-2',
+  copyName: 'ui-inherit-level-2-copy',
+  variables: {
+    own: { name: 'level_2_only', value: 'value-from-level-2' }
+  },
+  // Typed in after the chain is built, redeclaring level 1's names to retire the inherited twins.
+  overrides: {
+    region: { name: LEVEL_1.variables.region.name, value: 'region-from-level-2' },
+    // Redeclared without a data type, so the number it inherits has to give way to a string.
+    count: { name: LEVEL_1.variables.count.name, value: 'recounted-in-level-2' },
+    token: { name: LEVEL_1.variables.token.name, value: 'token-from-level-2', isSecret: true }
+  }
+};
+
+const environmentFile = (collectionsDir: string, collectionName: string, format: EnvironmentFormat, envName: string) =>
+  path.join(collectionsDir, collectionName, 'environments', `${envName}.${format}`);
+
+const savedVariableNames = (environment: SavedEnvironment) =>
+  (environment.variables ?? []).map((variable) => variable.name).sort();
+
+const savedVariable = (environment: SavedEnvironment, name: string) =>
+  (environment.variables ?? []).find((variable) => variable.name === name);
+
+/**
+ * Build a collection holding a populated level 1 environment and a level 2 that inherits
+ * nothing yet, and leave the latter open in the environment settings tab.
+ */
+const createTwoLevelChain = async (
+  page: Page,
+  collectionsDir: string,
+  collectionName: string,
+  format: EnvironmentFormat
+) => {
+  const { environment } = buildCommonLocators(page);
+
+  await createCollection(page, collectionName, collectionsDir, format);
+
+  await createEnvironment(page, LEVEL_1.name);
+  await addEnvironmentVariables(page, Object.values(LEVEL_1.variables));
+  await saveEnvironment(page);
+
+  // The only environment in the collection has nothing to inherit from, so the picker is
+  // not offered at all.
+  await expect(environment.inheritsFromAction()).toHaveCount(0);
+
+  await createEnvironment(page, LEVEL_2.name);
+  await addEnvironmentVariables(page, Object.values(LEVEL_2.variables));
+  await saveEnvironment(page);
+};
+
+test.describe('Collection environment inheritance lifecycle, authored in the app', () => {
+  test.afterEach(async ({ page }) => {
+    if (!page.isClosed()) {
+      await closeAllCollections(page);
+    }
+  });
+
+  for (const format of FORMATS) {
+    test(`inheritance is written, cleared, copied, and follows a parent rename and delete in ${format}`, async ({
+      page,
+      createTmpDir
+    }) => {
+      const { environment } = buildCommonLocators(page);
+      const collectionName = `Lifecycle UI ${format.toUpperCase()}`;
+      const collectionsDir = await createTmpDir(`inheritance-lifecycle-ui-${format}`);
+      const readEnvironmentFile = (name: string) =>
+        fs.readFileSync(environmentFile(collectionsDir, collectionName, format, name), 'utf8');
+
+      await test.step('Create a collection with two environments', async () => {
+        await createTwoLevelChain(page, collectionsDir, collectionName, format);
+      });
+
+      await test.step('Picking a parent writes extends and merges its rows in', async () => {
+        await setEnvironmentInheritance(page, LEVEL_1.name);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.name}`);
+
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+
+        // The rows arrived from the parent rather than from an edit, so the tab stays saved.
+        await expect(environment.tabCount('variables')).not.toHaveClass(/unsaved/);
+
+        await environment.secretsTab().click();
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.token.name)).toHaveText(
+          '*'.repeat(LEVEL_1.variables.token.value.length)
+        );
+        await environment.inheritedVarEyeToggle(LEVEL_1.variables.token.name).click();
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.token.name)).toHaveText(
+          LEVEL_1.variables.token.value
+        );
+
+        await environment.variablesTab().click();
+      });
+
+      await test.step('Choosing no environment removes extends again', async () => {
+        await setEnvironmentInheritance(page, null);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).not.toContain('extends');
+        await expect(environment.inheritedSection()).toHaveCount(0);
+      });
+
+      await test.step('A copy of an inheriting environment keeps its parent', async () => {
+        await setEnvironmentInheritance(page, LEVEL_1.name);
+        await copyEnvironment(page, LEVEL_2.copyName);
+
+        await expect(environment.detailsTitle()).toHaveText(LEVEL_2.copyName);
+
+        await expect
+          .poll(() => fs.existsSync(environmentFile(collectionsDir, collectionName, format, LEVEL_2.copyName)))
+          .toBe(true);
+        expect(readEnvironmentFile(LEVEL_2.copyName)).toContain(`extends: ${LEVEL_1.name}`);
+      });
+
+      await test.step('Renaming the parent rewrites the references to it', async () => {
+        await openEnvironmentInSettings(page, LEVEL_1.name);
+        await renameEnvironment(page, LEVEL_1.renamedName);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.renamedName}`);
+
+        await openEnvironmentInSettings(page, LEVEL_2.name);
+        await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+      });
+
+      await test.step('Deleting the parent keeps the references to it and warns about them', async () => {
+        await openEnvironmentInSettings(page, LEVEL_1.renamedName);
+        await deleteEnvironment(page);
+
+        await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.renamedName}`);
+
+        await openEnvironmentInSettings(page, LEVEL_2.name);
+        await expect(environment.missingInheritedEnvironment()).toContainText(LEVEL_1.renamedName);
+        await expect(environment.inheritedSection()).toHaveCount(0);
+      });
+    });
+  }
+
+  test('an own row overwrites the variable it inherits, and only own rows reach the file', async ({
+    page,
+    createTmpDir
+  }) => {
+    const { environment } = buildCommonLocators(page);
+    const collectionName = 'Inheritance Overwrite';
+    const collectionsDir = await createTmpDir('inheritance-overwrite');
+    const readEnvironment = (name: string) =>
+      yaml.load(fs.readFileSync(environmentFile(collectionsDir, collectionName, 'yml', name), 'utf8')) as SavedEnvironment;
+
+    await createTwoLevelChain(page, collectionsDir, collectionName, 'yml');
+    await setEnvironmentInheritance(page, LEVEL_1.name);
+
+    await test.step('The inherited rows carry the parent values until an own row redeclares them', async () => {
+      await expect(environment.inheritedVarValue(LEVEL_2.overrides.region.name)).toHaveText(
+        LEVEL_1.variables.region.value
+      );
+      await expect(environment.inheritedVarDataType(LEVEL_2.overrides.count.name)).toHaveText('number');
+    });
+
+    await test.step('Typing an own row of the same name retires the inherited twin', async () => {
+      await addEnvironmentVariable(page, LEVEL_2.overrides.region);
+      await addEnvironmentVariable(page, LEVEL_2.overrides.count);
+
+      for (const override of [LEVEL_2.overrides.region, LEVEL_2.overrides.count]) {
+        await expect(environment.inheritedVarRow(override.name)).toHaveCount(0);
+        await expect(environment.varRowLine(override.name)).toHaveText(override.value);
+      }
+    });
+
+    await test.step('Saving the tab writes the own rows and leaves the inherited ones behind', async () => {
+      await environment.saveTab().click();
+
+      await expect
+        .poll(() => savedVariableNames(readEnvironment(LEVEL_2.name)))
+        .toContain(LEVEL_2.overrides.region.name);
+
+      const saved = readEnvironment(LEVEL_2.name);
+      expect(saved.extends).toBe(LEVEL_1.name);
+      expect(savedVariableNames(saved)).toEqual(
+        [LEVEL_2.variables.own.name, LEVEL_2.overrides.region.name, LEVEL_2.overrides.count.name].sort()
+      );
+      expect(savedVariable(saved, LEVEL_2.overrides.region.name)?.value).toBe(LEVEL_2.overrides.region.value);
+      // Redeclared as a plain string, so the parent's number type is gone from the file too.
+      expect(savedVariable(saved, LEVEL_2.overrides.count.name)?.value).toBe(LEVEL_2.overrides.count.value);
+    });
+
+    await test.step('Save all writes the own secret and still leaves the inherited ones behind', async () => {
+      await environment.secretsTab().click();
+      await expect(environment.inheritedVarRow(LEVEL_2.overrides.token.name)).toBeVisible();
+
+      await addEnvironmentVariable(page, LEVEL_2.overrides.token);
+      await expect(environment.inheritedVarRow(LEVEL_2.overrides.token.name)).toHaveCount(0);
+
+      await environment.saveAll().click();
+
+      await expect
+        .poll(() => savedVariableNames(readEnvironment(LEVEL_2.name)))
+        .toContain(LEVEL_2.overrides.token.name);
+
+      const saved = readEnvironment(LEVEL_2.name);
+      expect(savedVariableNames(saved)).toEqual(
+        [
+          LEVEL_2.variables.own.name,
+          LEVEL_2.overrides.region.name,
+          LEVEL_2.overrides.count.name,
+          LEVEL_2.overrides.token.name
+        ].sort()
+      );
+      // A secret's value never reaches the file, whether it is inherited or own.
+      expect(savedVariable(saved, LEVEL_2.overrides.token.name)?.secret).toBe(true);
+      expect(savedVariable(saved, LEVEL_2.overrides.token.name)?.value).toBeUndefined();
+      // Rows only the parent declares stay in the parent file.
+      expect(savedVariableNames(saved)).not.toContain(LEVEL_1.variables.url.name);
+    });
+
+    await test.step('The parent keeps the values its child overwrote', async () => {
+      const parent = readEnvironment(LEVEL_1.name);
+
+      expect(parent.extends).toBeUndefined();
+      expect(savedVariable(parent, LEVEL_1.variables.region.name)?.value).toBe(LEVEL_1.variables.region.value);
+      expect(savedVariable(parent, LEVEL_1.variables.count.name)?.value).toEqual({
+        type: 'number',
+        data: LEVEL_1.variables.count.value
+      });
+      expect(savedVariable(parent, LEVEL_1.variables.url.name)?.value).toBe(LEVEL_1.variables.url.value);
+    });
+  });
+});

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/bruno.json
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "Inheritance BRU",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/echo.bru
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/echo.bru
@@ -1,0 +1,63 @@
+meta {
+  name: echo
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{host}}/api/echo/everything
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "api_url": "{{api_url}}",
+    "base_only": "{{base_only}}",
+    "dev_only": "{{dev_only}}",
+    "disabled_in_base": "{{disabled_in_base}}",
+    "shadowed_by_disabled": "{{shadowed_by_disabled}}",
+    "base_number": {{base_number}},
+    "base_boolean": {{base_boolean}},
+    "base_object": {{base_object}},
+    "typed_override": "{{typed_override}}",
+    "base_token": "{{base_token}}",
+    "api_key": "{{api_key}}",
+    "overridden_plain": "{{overridden_plain}}",
+    "overridden_secret": "{{overridden_secret}}"
+  }
+}
+
+tests {
+  // The echo endpoint hands the request body back as a raw string.
+  const sent = () => JSON.parse(res.getBody().body);
+
+  test("every kind of row the environment inherits resolves under dev", function() {
+    expect(sent()).to.eql({
+      api_url: "https://dev.example.com",
+      base_only: "base_only_value",
+      dev_only: "dev_only_value",
+      // Disabled in `base`, so it is never inherited and stays uninterpolated.
+      disabled_in_base: "{{disabled_in_base}}",
+      // `dev` declares this one too, but disabled, so the inherited row still applies.
+      shadowed_by_disabled: "from_base",
+      api_key: "plain_api_key",
+      // The body interpolates the typed rows unquoted, so they only parse back as a number,
+      // boolean and object if the data type survived the merge.
+      base_number: 42,
+      base_boolean: true,
+      base_object: { region: "eu" },
+      // An own row replaces the data type it inherited, not just the value.
+      typed_override: "overridden_in_dev",
+      // A secret carries no value on disk, so both runners give it one before the request goes
+      // out: the app through its secret store, `bru run` through --env-var.
+      base_token: "token-from-base",
+      // `dev` redeclares the inherited plain `overridden_plain` as a secret, and the inherited
+      // secret `overridden_secret` as plain. Both ancestor rows survive, and in each pair the
+      // secret is the one that reaches the request — never the plain row's `plain_from_base` or
+      // `plain_wins_in_dev`.
+      overridden_plain: "secret-from-dev",
+      overridden_secret: "secret-from-base"
+    });
+  });
+}

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/environments/base.bru
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/environments/base.bru
@@ -1,0 +1,26 @@
+vars {
+  host: http://localhost:8081
+  api_url: https://base.example.com
+  base_only: base_only_value
+  api_key: plain_api_key
+  session_id: base_session
+  ~disabled_in_base: should_not_resolve
+  shadowed_by_disabled: from_base
+  overridden_plain: plain_from_base
+  @number
+  base_number: 42
+  @boolean
+  base_boolean: true
+  @object
+  base_object: '''
+    {"region":"eu"}
+  '''
+  @number
+  typed_override: 1
+}
+vars:secret [
+  base_token,
+  @object
+  base_secret_object,
+  overridden_secret
+]

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/environments/dev.bru
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/bru/environments/dev.bru
@@ -1,0 +1,11 @@
+extends: base
+vars {
+  api_url: https://dev.example.com
+  dev_only: dev_only_value
+  typed_override: overridden_in_dev
+  ~shadowed_by_disabled: never_applied
+  overridden_secret: plain_wins_in_dev
+}
+vars:secret [
+  overridden_plain
+]

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/echo.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/echo.yml
@@ -1,0 +1,66 @@
+info:
+  name: echo
+  type: http
+  seq: 1
+
+http:
+  method: POST
+  url: '{{host}}/api/echo/everything'
+  body:
+    type: json
+    data: |-
+      {
+        "api_url": "{{api_url}}",
+        "base_only": "{{base_only}}",
+        "dev_only": "{{dev_only}}",
+        "disabled_in_base": "{{disabled_in_base}}",
+        "shadowed_by_disabled": "{{shadowed_by_disabled}}",
+        "base_number": {{base_number}},
+        "base_boolean": {{base_boolean}},
+        "base_object": {{base_object}},
+        "typed_override": "{{typed_override}}",
+        "base_token": "{{base_token}}",
+        "api_key": "{{api_key}}",
+        "overridden_plain": "{{overridden_plain}}",
+        "overridden_secret": "{{overridden_secret}}"
+      }
+  auth: none
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        // The echo endpoint hands the request body back as a raw string.
+        const sent = () => JSON.parse(res.getBody().body);
+
+        test("every kind of row the environment inherits resolves under dev", function() {
+          expect(sent()).to.eql({
+            api_url: "https://dev.example.com",
+            base_only: "base_only_value",
+            dev_only: "dev_only_value",
+            // Disabled in `base`, so it is never inherited and stays uninterpolated.
+            disabled_in_base: "{{disabled_in_base}}",
+            // `dev` declares this one too, but disabled, so the inherited row still applies.
+            shadowed_by_disabled: "from_base",
+            api_key: "plain_api_key",
+            // The body interpolates the typed rows unquoted, so they only parse back as a number,
+            // boolean and object if the data type survived the merge.
+            base_number: 42,
+            base_boolean: true,
+            base_object: { region: "eu" },
+            // An own row replaces the data type it inherited, not just the value.
+            typed_override: "overridden_in_dev",
+            // A secret carries no value on disk, so both runners give it one before the request
+            // goes out: the app through its secret store, `bru run` through --env-var.
+            base_token: "token-from-base",
+            // `dev` redeclares the inherited plain `overridden_plain` as a secret, and the
+            // inherited secret `overridden_secret` as plain. Both ancestor rows survive, and in
+            // each pair the secret is the one that reaches the request — never the plain row's
+            // `plain_from_base` or `plain_wins_in_dev`.
+            overridden_plain: "secret-from-dev",
+            overridden_secret: "secret-from-base"
+          });
+        });
+
+settings:
+  encodeUrl: true

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/base.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/base.yml
@@ -1,0 +1,42 @@
+name: base
+variables:
+  - name: host
+    value: http://localhost:8081
+  - name: api_url
+    value: https://base.example.com
+  - name: base_only
+    value: base_only_value
+  - name: api_key
+    value: plain_api_key
+  - name: session_id
+    value: base_session
+  - name: disabled_in_base
+    value: should_not_resolve
+    disabled: true
+  - name: shadowed_by_disabled
+    value: from_base
+  - name: overridden_plain
+    value: plain_from_base
+  - name: base_number
+    value:
+      type: number
+      data: "42"
+  - name: base_boolean
+    value:
+      type: boolean
+      data: "true"
+  - name: base_object
+    value:
+      type: object
+      data: '{"region":"eu"}'
+  - name: typed_override
+    value:
+      type: number
+      data: "1"
+  - secret: true
+    name: base_token
+  - secret: true
+    name: base_secret_object
+    type: object
+  - secret: true
+    name: overridden_secret

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/dev.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/dev.yml
@@ -1,0 +1,16 @@
+name: dev
+extends: base
+variables:
+  - name: api_url
+    value: https://dev.example.com
+  - name: dev_only
+    value: dev_only_value
+  - name: typed_override
+    value: overridden_in_dev
+  - name: shadowed_by_disabled
+    value: never_applied
+    disabled: true
+  - name: overridden_secret
+    value: plain_wins_in_dev
+  - secret: true
+    name: overridden_plain

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/qa.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/qa.yml
@@ -1,0 +1,5 @@
+name: qa
+extends: staging
+variables:
+  - name: api_url
+    value: https://qa.example.com

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/scripted.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/scripted.yml
@@ -1,0 +1,5 @@
+name: scripted
+extends: base
+variables:
+  - name: scripted_only
+    value: scripted_only_value

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/staging.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/environments/staging.yml
@@ -1,0 +1,5 @@
+name: staging
+extends: base
+variables:
+  - secret: true
+    name: api_key

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/opencollection.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: Inheritance YML

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/set-env-var.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/set-env-var.yml
@@ -1,0 +1,19 @@
+info:
+  name: set-env-var
+  type: http
+  seq: 3
+
+http:
+  method: GET
+  url: '{{host}}/ping'
+  auth: none
+
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        bru.setEnvVar('base_only', 'base_only_value');
+        bru.setEnvVar('session_id', 'script_session');
+
+settings:
+  encodeUrl: true

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/set-global-env-var.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/set-global-env-var.yml
@@ -1,0 +1,19 @@
+info:
+  name: set-global-env-var
+  type: http
+  seq: 4
+
+http:
+  method: GET
+  url: '{{workspace_host}}/ping'
+  auth: none
+
+runtime:
+  scripts:
+    - type: after-response
+      code: |-
+        bru.setGlobalEnvVar('workspace_base_only', 'from_workspace_base');
+        bru.setGlobalEnvVar('workspace_session_id', 'script_session');
+
+settings:
+  encodeUrl: true

--- a/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/workspace-vars.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/collections/yml/workspace-vars.yml
@@ -1,0 +1,66 @@
+info:
+  name: workspace-vars
+  type: http
+  seq: 2
+
+http:
+  method: POST
+  url: '{{workspace_host}}/api/echo/everything'
+  body:
+    type: json
+    data: |-
+      {
+        "workspace_base_only": "{{workspace_base_only}}",
+        "workspace_overridden": "{{workspace_overridden}}",
+        "workspace_dev_only": "{{workspace_dev_only}}",
+        "workspace_disabled": "{{workspace_disabled}}",
+        "workspace_shadowed_by_disabled": "{{workspace_shadowed_by_disabled}}",
+        "workspace_number": {{workspace_number}},
+        "workspace_boolean": {{workspace_boolean}},
+        "workspace_object": {{workspace_object}},
+        "workspace_typed_override": "{{workspace_typed_override}}",
+        "workspace_token": "{{workspace_token}}",
+        "workspace_api_key": "{{workspace_api_key}}",
+        "workspace_overridden_plain": "{{workspace_overridden_plain}}",
+        "workspace_overridden_secret": "{{workspace_overridden_secret}}"
+      }
+  auth: none
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        // The echo endpoint hands the request body back as a raw string.
+        const sent = () => JSON.parse(res.getBody().body);
+
+        test("every kind of row the workspace environment inherits resolves under workspace_dev", function() {
+          expect(sent()).to.eql({
+            workspace_base_only: "from_workspace_base",
+            workspace_overridden: "from_workspace_dev",
+            workspace_dev_only: "workspace_dev_only_value",
+            // Disabled in `workspace_base`, so it is never inherited and stays uninterpolated.
+            workspace_disabled: "{{workspace_disabled}}",
+            // `workspace_dev` declares this one too, but disabled, so the inherited row still applies.
+            workspace_shadowed_by_disabled: "shadowed_from_workspace_base",
+            workspace_api_key: "plain_workspace_api_key",
+            // The body interpolates the typed rows unquoted, so they only parse back as a number,
+            // boolean and object if the data type survived the merge.
+            workspace_number: 7,
+            workspace_boolean: true,
+            workspace_object: { tier: "free" },
+            // An own row replaces the data type it inherited, not just the value.
+            workspace_typed_override: "overridden_in_workspace_dev",
+            // A secret carries no value on disk, so both runners give it one before the request
+            // goes out: the app through its secret store, `bru run` through --global-env-var.
+            workspace_token: "token-from-workspace-base",
+            // `workspace_dev` redeclares the inherited plain `workspace_overridden_plain` as a
+            // secret, and the inherited secret `workspace_overridden_secret` as plain. Both ancestor
+            // rows survive, and in each pair the secret is the one that reaches the request — never
+            // the plain row's `plain_from_workspace_base` or `plain_wins_in_workspace_dev`.
+            workspace_overridden_plain: "secret-from-workspace-dev",
+            workspace_overridden_secret: "secret-from-workspace-base"
+          });
+        });
+
+settings:
+  encodeUrl: true

--- a/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_base.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_base.yml
@@ -1,0 +1,42 @@
+name: workspace_base
+variables:
+  - name: workspace_host
+    value: http://localhost:8081
+  - name: workspace_base_only
+    value: from_workspace_base
+  - name: workspace_session_id
+    value: workspace_base_session
+  - name: workspace_overridden
+    value: from_workspace_base
+  - name: workspace_api_key
+    value: plain_workspace_api_key
+  - name: workspace_disabled
+    value: should_not_resolve
+    disabled: true
+  - name: workspace_shadowed_by_disabled
+    value: shadowed_from_workspace_base
+  - name: workspace_overridden_plain
+    value: plain_from_workspace_base
+  - name: workspace_number
+    value:
+      type: number
+      data: "7"
+  - name: workspace_boolean
+    value:
+      type: boolean
+      data: "true"
+  - name: workspace_object
+    value:
+      type: object
+      data: '{"tier":"free"}'
+  - name: workspace_typed_override
+    value:
+      type: number
+      data: "1"
+  - secret: true
+    name: workspace_token
+  - secret: true
+    name: workspace_secret_object
+    type: object
+  - secret: true
+    name: workspace_overridden_secret

--- a/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_dev.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_dev.yml
@@ -1,0 +1,16 @@
+name: workspace_dev
+extends: workspace_base
+variables:
+  - name: workspace_overridden
+    value: from_workspace_dev
+  - name: workspace_dev_only
+    value: workspace_dev_only_value
+  - name: workspace_typed_override
+    value: overridden_in_workspace_dev
+  - name: workspace_shadowed_by_disabled
+    value: never_applied
+    disabled: true
+  - name: workspace_overridden_secret
+    value: plain_wins_in_workspace_dev
+  - secret: true
+    name: workspace_overridden_plain

--- a/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_qa.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_qa.yml
@@ -1,0 +1,5 @@
+name: workspace_qa
+extends: workspace_staging
+variables:
+  - name: workspace_overridden
+    value: from_workspace_qa

--- a/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_scripted.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_scripted.yml
@@ -1,0 +1,5 @@
+name: workspace_scripted
+extends: workspace_base
+variables:
+  - name: workspace_scripted_only
+    value: workspace_scripted_only_value

--- a/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_staging.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/environments/workspace_staging.yml
@@ -1,0 +1,5 @@
+name: workspace_staging
+extends: workspace_base
+variables:
+  - secret: true
+    name: workspace_api_key

--- a/tests/environments/environment-inheritance/fixtures/workspace/workspace.yml
+++ b/tests/environments/environment-inheritance/fixtures/workspace/workspace.yml
@@ -1,0 +1,14 @@
+opencollection: 1.0.0
+info:
+  name: "Environment Inheritance"
+  type: workspace
+
+collections:
+  - name: "Inheritance BRU"
+    path: "collections/bru"
+  - name: "Inheritance YML"
+    path: "collections/yml"
+
+specs:
+
+docs: ''

--- a/tests/environments/environment-inheritance/init-user-data/collection-security.json
+++ b/tests/environments/environment-inheritance/init-user-data/collection-security.json
@@ -1,0 +1,16 @@
+{
+  "collections": [
+    {
+      "path": "{{workspacePath}}/collections/bru",
+      "securityConfig": {
+        "jsSandboxMode": "safe"
+      }
+    },
+    {
+      "path": "{{workspacePath}}/collections/yml",
+      "securityConfig": {
+        "jsSandboxMode": "safe"
+      }
+    }
+  ]
+}

--- a/tests/environments/environment-inheritance/init-user-data/preferences.json
+++ b/tests/environments/environment-inheritance/init-user-data/preferences.json
@@ -1,0 +1,11 @@
+{
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    },
+    "general": {
+      "defaultWorkspacePath": "{{workspacePath}}"
+    }
+  }
+}

--- a/tests/environments/environment-inheritance/secrets.ts
+++ b/tests/environments/environment-inheritance/secrets.ts
@@ -1,0 +1,38 @@
+import type { Page } from '@playwright/test';
+import { closeEnvironmentPanel, openEnvironmentConfigTab, setEnvironmentSecrets } from '../../utils/page';
+
+// `echo` and `workspace-vars` assert the whole environment they resolved, secret rows included, so
+// the values below have to be in the secret store before either request goes out. The CLI suite
+// runs the same two requests and injects the same values with `--env-var` / `--global-env-var`,
+// which is the only way a `bru run` can give a secret a value.
+export const BASE_SECRETS = { base_token: 'token-from-base', base_secret_object: '{"scope":"admin"}' };
+export const SECRET_REDECLARED_AS_NON_SECRET = { overridden_secret: 'secret-from-base' };
+export const DEV_SECRETS = { overridden_plain: 'secret-from-dev' };
+
+export const WORKSPACE_BASE_SECRETS = {
+  workspace_token: 'token-from-workspace-base',
+  workspace_secret_object: '{"scope":"admin"}'
+};
+export const WORKSPACE_SECRET_REDECLARED_AS_NON_SECRET = {
+  workspace_overridden_secret: 'secret-from-workspace-base'
+};
+export const WORKSPACE_DEV_SECRETS = { workspace_overridden_plain: 'secret-from-workspace-dev' };
+
+export const seedEchoSecrets = async (page: Page) => {
+  await openEnvironmentConfigTab(page);
+  await setEnvironmentSecrets(page, 'base', { ...BASE_SECRETS, ...SECRET_REDECLARED_AS_NON_SECRET });
+  await setEnvironmentSecrets(page, 'dev', DEV_SECRETS);
+  await closeEnvironmentPanel(page);
+};
+
+export const seedWorkspaceVarsSecrets = async (page: Page) => {
+  await openEnvironmentConfigTab(page, 'global');
+  await setEnvironmentSecrets(
+    page,
+    'workspace_base',
+    { ...WORKSPACE_BASE_SECRETS, ...WORKSPACE_SECRET_REDECLARED_AS_NON_SECRET },
+    'global'
+  );
+  await setEnvironmentSecrets(page, 'workspace_dev', WORKSPACE_DEV_SECRETS, 'global');
+  await closeEnvironmentPanel(page, 'global');
+};

--- a/tests/environments/environment-inheritance/workspace-env-inheritance-from-fixture.spec.ts
+++ b/tests/environments/environment-inheritance/workspace-env-inheritance-from-fixture.spec.ts
@@ -1,0 +1,450 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from '../../../playwright';
+import {
+  addEnvironmentVariables,
+  closeEnvironmentPanel,
+  copyEnvironment,
+  createEnvironment,
+  deleteEnvironment,
+  expectResponseContains,
+  getResponseBody,
+  openCollection,
+  openEnvironmentConfigTab,
+  openEnvironmentInSettings,
+  openRequest,
+  openUrlVarTooltip,
+  renameEnvironment,
+  runCollection,
+  saveEnvironment,
+  searchEnvironmentVariables,
+  selectEnvironment,
+  selectResponsePaneTab,
+  sendRequest,
+  setEnvironmentInheritance,
+  setEnvironmentSecrets,
+  setEnvironmentVariableValue,
+  validateRunnerResults
+} from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+import {
+  seedEchoSecrets,
+  seedWorkspaceVarsSecrets,
+  WORKSPACE_BASE_SECRETS,
+  WORKSPACE_DEV_SECRETS,
+  WORKSPACE_SECRET_REDECLARED_AS_NON_SECRET
+} from './secrets';
+
+const COLLECTION = 'Inheritance YML';
+
+const WORKSPACE_STAGING_SECRETS = { workspace_api_key: 'api-key-from-workspace-staging' };
+
+const INHERITED_TYPE_LABELS: Array<[string, string]> = [
+  ['workspace_base_only', 'string'],
+  ['workspace_number', 'number'],
+  ['workspace_boolean', 'boolean'],
+  ['workspace_object', 'object']
+];
+
+const WORKSPACE_VARS_TEST_COUNT = 1;
+const COLLECTION_REQUEST_COUNT = 4;
+
+const LEVEL_1 = {
+  name: 'shared-inherit-level-1',
+  renamedName: 'shared-inherit-level-1-renamed',
+  variables: {
+    url: { name: 'shared_url', value: 'https://shared.example.com' }
+  }
+};
+
+const LEVEL_2 = {
+  name: 'shared-inherit-level-2',
+  copyName: 'shared-inherit-level-2-copy',
+  variables: {
+    own: { name: 'level_2_only', value: 'value-from-level-2' }
+  }
+};
+
+test.describe('Workspace environment inheritance', () => {
+  test('a workspace environment shows its ancestor rows, with their values and data types', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment, dataTypeSelector } = buildCommonLocators(page);
+
+    await openCollection(page, COLLECTION);
+    await openEnvironmentConfigTab(page, 'global');
+    await setEnvironmentSecrets(page, 'workspace_base', WORKSPACE_BASE_SECRETS, 'global');
+    await openEnvironmentInSettings(page, 'workspace_dev', 'global');
+
+    await expect(environment.inheritedSection()).toBeVisible();
+    await expect(environment.inheritedVarValue('workspace_base_only')).toHaveText('from_workspace_base');
+    await expect(environment.inheritedVarValue('workspace_host')).toHaveText('http://localhost:8081');
+
+    // An own row of the same name replaces the ancestor's, rather than adding a second row.
+    await expect(environment.inheritedVarRow('workspace_overridden')).toHaveCount(0);
+    await expect(environment.varRowLine('workspace_overridden')).toHaveText('from_workspace_dev');
+
+    await expect(environment.inheritedVarRow('workspace_disabled')).toHaveCount(0);
+
+    await test.step('An inherited row cannot be edited', async () => {
+      await expect(environment.inheritedVarEnabledCheckbox('workspace_base_only')).toBeChecked();
+      await expect(environment.inheritedVarEnabledCheckbox('workspace_base_only')).toBeDisabled();
+      await expect(environment.inheritedVarEditableFields('workspace_base_only')).toHaveCount(0);
+    });
+
+    await test.step('An inherited row carries the data type of the variable it came from', async () => {
+      for (const [name, label] of INHERITED_TYPE_LABELS) {
+        await expect(environment.inheritedVarDataType(name)).toHaveText(label);
+      }
+
+      await expect(environment.inheritedVarValue('workspace_number')).toHaveText('7');
+      await expect(environment.inheritedVarValue('workspace_boolean')).toHaveText('true');
+      // Object values are pretty-printed over several lines, so match the shape.
+      await expect(environment.inheritedVarValue('workspace_object')).toHaveText(/"tier":\s*"free"/);
+    });
+
+    await test.step('An own row replaces the inherited data type, not just the value', async () => {
+      await expect(environment.inheritedVarRow('workspace_typed_override')).toHaveCount(0);
+      await expect(environment.varRowLine('workspace_typed_override')).toHaveText('overridden_in_workspace_dev');
+      await expect(
+        dataTypeSelector.typeLabel(environment.varRow('workspace_typed_override'))
+      ).toHaveAttribute('data-selected-type', 'string');
+    });
+
+    await test.step('An inherited secret arrives masked and reveals its ancestor value', async () => {
+      await environment.secretsTab().click();
+      await expect(environment.inheritedVarValue('workspace_token')).toHaveText(
+        '*'.repeat(WORKSPACE_BASE_SECRETS.workspace_token.length)
+      );
+      await expect(environment.inheritedVarDataType('workspace_secret_object')).toHaveText('object');
+      await expect(environment.inheritedVarDataType('workspace_token')).toHaveText('string');
+      await expect(environment.inheritedVarValue('workspace_secret_object')).not.toContainText('admin');
+
+      await environment.inheritedVarEyeToggle('workspace_token').click();
+      await environment.inheritedVarEyeToggle('workspace_secret_object').click();
+
+      await expect(environment.inheritedVarValue('workspace_token')).toHaveText(
+        WORKSPACE_BASE_SECRETS.workspace_token
+      );
+      await expect(environment.inheritedVarValue('workspace_secret_object')).toHaveText(/"scope":\s*"admin"/);
+      await expect(environment.inheritedVarSource('workspace_token')).toHaveAttribute(
+        'title',
+        'Inherited from workspace_base'
+      );
+    });
+
+    await closeEnvironmentPanel(page, 'global');
+  });
+
+  test('the inherited section collapses, filters with the search, and links to its source', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment } = buildCommonLocators(page);
+
+    await openCollection(page, COLLECTION);
+    await openEnvironmentConfigTab(page, 'global');
+    await openEnvironmentInSettings(page, 'workspace_dev', 'global');
+
+    await test.step('Collapsing the section hides the inherited rows', async () => {
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow('workspace_base_only')).toHaveCount(0);
+
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow('workspace_base_only')).toBeVisible();
+    });
+
+    await test.step('The search filters inherited rows and own rows independently', async () => {
+      await searchEnvironmentVariables(page, 'workspace_base_only');
+      await expect(environment.inheritedVarRow('workspace_base_only')).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(1)');
+      await expect(environment.sectionCount('own')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, 'workspace_dev_only');
+      await expect(environment.varRow('workspace_dev_only')).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, 'matches_nothing_at_all');
+      await expect(environment.varsNoResults()).toBeVisible();
+
+      await searchEnvironmentVariables(page, '');
+      await expect(environment.inheritedVarRow('workspace_base_only')).toBeVisible();
+    });
+
+    await test.step('The source arrow opens the environment the row came from', async () => {
+      await environment.inheritedVarSource('workspace_base_only').click();
+
+      await expect(environment.detailsTitle()).toHaveText('workspace_base');
+      await expect(environment.varRowLine('workspace_base_only')).toHaveText('from_workspace_base');
+    });
+
+    await closeEnvironmentPanel(page, 'global');
+  });
+
+  test('the source arrow warns about unsaved changes instead of switching environments', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment, modal } = buildCommonLocators(page);
+
+    await openCollection(page, COLLECTION);
+    await openEnvironmentConfigTab(page, 'global');
+    await openEnvironmentInSettings(page, 'workspace_dev', 'global');
+
+    await setEnvironmentVariableValue(page, 'workspace_overridden', 'edited_but_unsaved');
+    await expect(environment.tabCount('variables')).toHaveClass(/unsaved/);
+
+    await environment.inheritedVarSource('workspace_base_only').click();
+
+    await expect(modal.byTitle('Unsaved changes')).toBeVisible();
+    await expect(environment.detailsTitle()).toHaveText('workspace_dev');
+    await expect(environment.varRowLine('workspace_overridden')).toHaveText('edited_but_unsaved');
+
+    await modal.closeButton().click();
+    await environment.resetTab().click();
+    await closeEnvironmentPanel(page, 'global');
+  });
+
+  test('a request interpolates the workspace variables its environment inherits, as their own data type', async ({
+    pageWithUserData: page
+  }) => {
+    // Two environments are edited and saved before the request goes out.
+    test.setTimeout(90000);
+
+    const { response } = buildCommonLocators(page);
+
+    await openCollection(page, COLLECTION);
+    await openRequest(page, COLLECTION, 'workspace-vars', { persist: true });
+    await seedWorkspaceVarsSecrets(page);
+    await selectEnvironment(page, 'workspace_dev', 'global');
+
+    // `workspace_host` carries the echo endpoint and is only defined in `workspace_base`, so the
+    // request cannot reach the server at all unless inheritance resolved.
+    await sendRequest(page, 200);
+
+    await expectResponseContains(page, [
+      'from_workspace_base',
+      'from_workspace_dev',
+      'workspace_dev_only_value',
+      // `workspace_dev` declares this one too, but disabled, so the inherited row still applies.
+      'shadowed_from_workspace_base',
+      // Disabled in `workspace_base`, so it is never inherited and stays uninterpolated.
+      '{{workspace_disabled}}'
+    ]);
+
+    await test.step('The request asserts the whole workspace environment it resolved', async () => {
+      // `workspace-vars` deep-equals the body it sent against every row `workspace_dev` resolves,
+      // typed rows and secrets included — the CLI suite runs the same request and reads that
+      // verdict from the exit code.
+      await selectResponsePaneTab(page, 'Tests');
+
+      await expect(response.testSummary()).toContainText(
+        `Tests (${WORKSPACE_VARS_TEST_COUNT}), Passed: ${WORKSPACE_VARS_TEST_COUNT}, Failed: 0`
+      );
+      await expect(response.testFailures()).toHaveCount(0);
+    });
+  });
+
+  test('an inherited workspace secret reaches the request and outranks a plain row of the same name', async ({
+    pageWithUserData: page
+  }) => {
+    // Three environments are edited and saved before either request goes out.
+    test.setTimeout(120000);
+
+    await openCollection(page, COLLECTION);
+    await openEnvironmentConfigTab(page, 'global');
+
+    await setEnvironmentSecrets(
+      page,
+      'workspace_base',
+      { ...WORKSPACE_BASE_SECRETS, ...WORKSPACE_SECRET_REDECLARED_AS_NON_SECRET },
+      'global'
+    );
+    await setEnvironmentSecrets(page, 'workspace_dev', WORKSPACE_DEV_SECRETS, 'global');
+    await setEnvironmentSecrets(page, 'workspace_staging', WORKSPACE_STAGING_SECRETS, 'global');
+
+    await openRequest(page, COLLECTION, 'workspace-vars');
+    await closeEnvironmentPanel(page, 'global');
+
+    await test.step('A three-level chain resolves the secrets it inherits from either ancestor', async () => {
+      await selectEnvironment(page, 'workspace_qa', 'global');
+      await sendRequest(page, 200);
+      await selectResponsePaneTab(page, 'Response');
+
+      await expectResponseContains(page, [
+        WORKSPACE_BASE_SECRETS.workspace_token,
+        WORKSPACE_STAGING_SECRETS.workspace_api_key
+      ]);
+      // `workspace_base` declares `workspace_api_key` plain and `workspace_staging` redeclares it
+      // secret, so both are inherited by `workspace_qa` — the secret is the one that must reach the
+      // request.
+      expect(await getResponseBody(page)).not.toContain('plain_workspace_api_key');
+    });
+
+    await test.step('A name inherited as a secret and redeclared as a non-secret resolves to the secret', async () => {
+      await selectEnvironment(page, 'workspace_dev', 'global');
+      await sendRequest(page, 200);
+      await selectResponsePaneTab(page, 'Response');
+
+      // `workspace_dev` redeclares the secret `workspace_overridden_secret` it inherits as a
+      // non-secret, and the non-secret `workspace_overridden_plain` as a secret. Both ancestor rows
+      // survive the redeclaration, and in each pair the secret is the one that reaches the request.
+      await expectResponseContains(page, [
+        WORKSPACE_SECRET_REDECLARED_AS_NON_SECRET.workspace_overridden_secret,
+        WORKSPACE_DEV_SECRETS.workspace_overridden_plain
+      ]);
+      const body = await getResponseBody(page);
+      expect(body).not.toContain('plain_wins_in_workspace_dev');
+      expect(body).not.toContain('plain_from_workspace_base');
+    });
+  });
+
+  test('a script write only overrides an inherited workspace variable when the value differs', async ({
+    pageWithUserData: page
+  }) => {
+    const { environment } = buildCommonLocators(page);
+
+    await openCollection(page, COLLECTION);
+    await selectEnvironment(page, 'workspace_scripted', 'global');
+    await openRequest(page, COLLECTION, 'set-global-env-var');
+    // The request's own URL comes from `workspace_host`, which only the ancestor declares.
+    await sendRequest(page, 200);
+
+    await openEnvironmentConfigTab(page, 'global');
+    await openEnvironmentInSettings(page, 'workspace_scripted', 'global');
+
+    // The script rewrote `workspace_base_only` with the value it already inherits, so the
+    // write is a no-op and the row stays inherited.
+    await expect(environment.inheritedVarValue('workspace_base_only')).toHaveText('from_workspace_base');
+    await expect(environment.varRow('workspace_base_only')).toHaveCount(0);
+
+    // `workspace_session_id` was written with a different value, so it becomes a row of its own.
+    await expect(environment.varRowLine('workspace_session_id')).toHaveText('script_session');
+    await expect(environment.inheritedVarRow('workspace_session_id')).toHaveCount(0);
+
+    await closeEnvironmentPanel(page, 'global');
+  });
+
+  test('an inherited workspace variable is read-only in the variable tooltip', async ({
+    pageWithUserData: page
+  }) => {
+    const { varInfoPopup } = buildCommonLocators(page);
+
+    await openCollection(page, COLLECTION);
+    await selectEnvironment(page, 'workspace_dev', 'global');
+    await openRequest(page, COLLECTION, 'workspace-vars');
+
+    const tooltip = await openUrlVarTooltip(page, 'workspace_host');
+
+    await expect(varInfoPopup.name(tooltip)).toHaveText('workspace_host');
+    await expect(varInfoPopup.scopeBadge(tooltip)).toHaveText('Global');
+    await expect(varInfoPopup.valueDisplay(tooltip)).toContainText('http://localhost:8081');
+    await expect(varInfoPopup.readonlyNote(tooltip)).toHaveText('Inherited from workspace_base (read-only)');
+    await expect(varInfoPopup.editableValue(tooltip)).toHaveCount(0);
+  });
+
+  test('a collection run interpolates the workspace variables the environment inherits', async ({
+    pageWithUserData: page
+  }) => {
+    // Four environments are edited and saved before the run starts.
+    test.setTimeout(120000);
+
+    await openCollection(page, COLLECTION);
+    await openRequest(page, COLLECTION, 'workspace-vars', { persist: true });
+    await seedWorkspaceVarsSecrets(page);
+    // The run covers the whole collection, so the collection-scoped requests alongside
+    // `workspace-vars` need their own environment — and their own secrets — as well.
+    await seedEchoSecrets(page);
+    await selectEnvironment(page, 'workspace_dev', 'global');
+    await selectEnvironment(page, 'dev');
+
+    await runCollection(page, COLLECTION);
+
+    await validateRunnerResults(page, {
+      totalRequests: COLLECTION_REQUEST_COUNT,
+      passed: COLLECTION_REQUEST_COUNT,
+      failed: 0,
+      skipped: 0
+    });
+  });
+
+  test('a workspace environment records its parent, copies it, and follows the parent rename and delete', async ({
+    restartApp,
+    workspaceFixturePath
+  }) => {
+    // Booting a fresh electron and then editing five environments through the UI takes a while.
+    test.setTimeout(120000);
+
+    // Workspace ("global") environments are written by their own store, so the collection-scoped
+    // lifecycle says nothing about them. Asserting on the files the app writes needs an app bound
+    // to *this* test's workspace copy — the shared `pageWithUserData` app binds to whichever test
+    // in this file launched it first.
+    expect(workspaceFixturePath).not.toBeNull();
+    const environmentFile = (name: string) => path.join(workspaceFixturePath!, 'environments', `${name}.yml`);
+    const readEnvironmentFile = (name: string) => fs.readFileSync(environmentFile(name), 'utf8');
+
+    const app = await restartApp({});
+    const page = await app.firstWindow();
+    await page.locator('[data-app-state="loaded"]').waitFor({ timeout: 30000 });
+
+    const { environment } = buildCommonLocators(page);
+
+    await openCollection(page, COLLECTION);
+    await openEnvironmentConfigTab(page, 'global');
+
+    await test.step('Create a parent and a child workspace environment', async () => {
+      await createEnvironment(page, LEVEL_1.name, 'global');
+      await addEnvironmentVariables(page, Object.values(LEVEL_1.variables));
+      await saveEnvironment(page);
+
+      await createEnvironment(page, LEVEL_2.name, 'global');
+      await addEnvironmentVariables(page, Object.values(LEVEL_2.variables));
+      await saveEnvironment(page);
+    });
+
+    await test.step('Picking a parent writes extends and merges its rows in', async () => {
+      await setEnvironmentInheritance(page, LEVEL_1.name);
+
+      await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.name}`);
+      await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+    });
+
+    await test.step('Choosing no environment removes extends again', async () => {
+      await setEnvironmentInheritance(page, null);
+
+      await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).not.toContain('extends');
+      await expect(environment.inheritedSection()).toHaveCount(0);
+    });
+
+    await test.step('A copy of an inheriting environment keeps its parent', async () => {
+      await setEnvironmentInheritance(page, LEVEL_1.name);
+      await copyEnvironment(page, LEVEL_2.copyName);
+
+      await expect(environment.detailsTitle()).toHaveText(LEVEL_2.copyName);
+
+      await expect.poll(() => fs.existsSync(environmentFile(LEVEL_2.copyName))).toBe(true);
+      expect(readEnvironmentFile(LEVEL_2.copyName)).toContain(`extends: ${LEVEL_1.name}`);
+    });
+
+    await test.step('Renaming the parent rewrites the references to it', async () => {
+      await openEnvironmentInSettings(page, LEVEL_1.name, 'global');
+      await renameEnvironment(page, LEVEL_1.renamedName);
+
+      await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.renamedName}`);
+
+      await openEnvironmentInSettings(page, LEVEL_2.name, 'global');
+      await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+    });
+
+    await test.step('Deleting the parent keeps the references to it and warns about them', async () => {
+      await openEnvironmentInSettings(page, LEVEL_1.renamedName, 'global');
+      await deleteEnvironment(page);
+
+      await expect.poll(() => readEnvironmentFile(LEVEL_2.name)).toContain(`extends: ${LEVEL_1.renamedName}`);
+
+      await openEnvironmentInSettings(page, LEVEL_2.name, 'global');
+      await expect(environment.missingInheritedEnvironment()).toContainText(LEVEL_1.renamedName);
+      await expect(environment.inheritedSection()).toHaveCount(0);
+    });
+  });
+});

--- a/tests/environments/environment-inheritance/workspace-env-inheritance-via-ui.spec.ts
+++ b/tests/environments/environment-inheritance/workspace-env-inheritance-via-ui.spec.ts
@@ -1,0 +1,852 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { test, expect, closeElectronApp, ElectronApplication, Page } from '../../../playwright';
+import {
+  addEnvironmentVariable,
+  addEnvironmentVariables,
+  addPostResponseScript,
+  closeAllCollections,
+  closeEnvironmentPanel,
+  copyEnvironment,
+  createCollection,
+  createEnvironment,
+  createRequest,
+  createWorkspace,
+  deleteAllGlobalEnvironments,
+  deleteEnvironment,
+  disableEnvironmentVariable,
+  expectResponseContains,
+  getResponseBody,
+  openEnvironmentConfigTab,
+  openEnvironmentInSettings,
+  openRequest,
+  openUrlVarTooltip,
+  renameEnvironment,
+  runCollection,
+  saveEnvironment,
+  saveRequest,
+  searchEnvironmentVariables,
+  selectEnvironment,
+  selectRequestBodyMode,
+  selectRequestPaneTab,
+  selectResponsePaneTab,
+  sendRequest,
+  setCodeMirrorEditorValue,
+  setEnvironmentInheritance,
+  setEnvironmentVariableValue,
+  setRequestUrlAndSave,
+  validateRunnerResults,
+  waitForReadyPage,
+  type EnvironmentVariable
+} from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+// The workspace ("global") environments this suite asserts on are authored through the app
+// itself, so nothing here reads the committed inheritance workspace fixture — a secret gets its
+// value as it is typed in, rather than being seeded into the secret store afterwards.
+
+const SCOPE = 'global' as const;
+
+type InheritanceVariable = EnvironmentVariable & { disabled?: boolean };
+
+type EnvironmentDefinition = {
+  name: string;
+  extends?: string;
+  variables: Record<string, InheritanceVariable>;
+};
+
+const BASE: EnvironmentDefinition = {
+  name: 'workspace_base',
+  variables: {
+    host: { name: 'workspace_host', value: 'http://localhost:8081' },
+    overridden: { name: 'workspace_overridden', value: 'from_workspace_base' },
+    baseOnly: { name: 'workspace_base_only', value: 'from_workspace_base' },
+    apiKey: { name: 'workspace_api_key', value: 'plain_workspace_api_key' },
+    sessionId: { name: 'workspace_session_id', value: 'workspace_base_session' },
+    shadowedByDisabled: { name: 'workspace_shadowed_by_disabled', value: 'shadowed_from_workspace_base' },
+    overriddenPlain: { name: 'workspace_overridden_plain', value: 'plain_from_workspace_base' },
+    number: { name: 'workspace_number', value: '7', dataType: 'number' },
+    boolean: { name: 'workspace_boolean', value: 'true', dataType: 'boolean' },
+    object: { name: 'workspace_object', value: '{"tier":"free"}', dataType: 'object' },
+    typedOverride: { name: 'workspace_typed_override', value: '1', dataType: 'number' },
+    disabledInBase: { name: 'workspace_disabled', value: 'should_not_resolve', disabled: true },
+    token: { name: 'workspace_token', value: 'token-from-workspace-base', isSecret: true },
+    secretObject: {
+      name: 'workspace_secret_object',
+      value: '{"scope":"admin"}',
+      isSecret: true,
+      dataType: 'object'
+    },
+    overriddenSecret: {
+      name: 'workspace_overridden_secret',
+      value: 'secret-from-workspace-base',
+      isSecret: true
+    }
+  }
+};
+
+const DEV: EnvironmentDefinition = {
+  name: 'workspace_dev',
+  extends: BASE.name,
+  variables: {
+    overridden: { name: 'workspace_overridden', value: 'from_workspace_dev' },
+    devOnly: { name: 'workspace_dev_only', value: 'workspace_dev_only_value' },
+    typedOverride: { name: 'workspace_typed_override', value: 'overridden_in_workspace_dev' },
+    overriddenSecret: { name: 'workspace_overridden_secret', value: 'plain_wins_in_workspace_dev' },
+    shadowedByDisabled: { name: 'workspace_shadowed_by_disabled', value: 'never_applied', disabled: true },
+    overriddenPlain: { name: 'workspace_overridden_plain', value: 'secret-from-workspace-dev', isSecret: true }
+  }
+};
+
+const STAGING: EnvironmentDefinition = {
+  name: 'workspace_staging',
+  extends: BASE.name,
+  variables: {
+    apiKey: { name: 'workspace_api_key', value: 'api-key-from-workspace-staging', isSecret: true }
+  }
+};
+
+const QA: EnvironmentDefinition = {
+  name: 'workspace_qa',
+  extends: STAGING.name,
+  variables: {
+    overridden: { name: 'workspace_overridden', value: 'from_workspace_qa' }
+  }
+};
+
+const SCRIPTED: EnvironmentDefinition = {
+  name: 'workspace_scripted',
+  extends: BASE.name,
+  variables: {
+    own: { name: 'workspace_scripted_only', value: 'workspace_scripted_only_value' }
+  }
+};
+
+const WORKSPACE_VARS_REQUEST = { name: 'workspace-vars', method: 'POST', url: '{{workspace_host}}/api/echo/everything' };
+const SET_GLOBAL_ENV_VAR_REQUEST = { name: 'set-global-env-var', url: '{{workspace_host}}/ping' };
+const PING_REQUEST = { name: 'ping', url: '{{workspace_host}}/ping' };
+
+// The typed rows are interpolated unquoted, so they only parse back as a number, boolean and
+// object if their data type survived the merge.
+const WORKSPACE_VARS_BODY = `{
+  "workspace_overridden": "{{workspace_overridden}}",
+  "workspace_base_only": "{{workspace_base_only}}",
+  "workspace_dev_only": "{{workspace_dev_only}}",
+  "workspace_disabled": "{{workspace_disabled}}",
+  "workspace_shadowed_by_disabled": "{{workspace_shadowed_by_disabled}}",
+  "workspace_number": {{workspace_number}},
+  "workspace_boolean": {{workspace_boolean}},
+  "workspace_object": {{workspace_object}},
+  "workspace_typed_override": "{{workspace_typed_override}}",
+  "workspace_token": "{{workspace_token}}",
+  "workspace_api_key": "{{workspace_api_key}}",
+  "workspace_overridden_plain": "{{workspace_overridden_plain}}",
+  "workspace_overridden_secret": "{{workspace_overridden_secret}}"
+}`;
+
+const WORKSPACE_VARS_TESTS = `// The echo endpoint hands the request body back as a raw string.
+const sent = () => JSON.parse(res.getBody().body);
+
+test("every kind of row the workspace environment inherits resolves under workspace_dev", function() {
+  expect(sent()).to.eql({
+    workspace_overridden: "from_workspace_dev",
+    workspace_base_only: "from_workspace_base",
+    workspace_dev_only: "workspace_dev_only_value",
+    // Disabled in \`workspace_base\`, so it is never inherited and stays uninterpolated.
+    workspace_disabled: "{{workspace_disabled}}",
+    // \`workspace_dev\` declares this one too, but disabled, so the inherited row still applies.
+    workspace_shadowed_by_disabled: "shadowed_from_workspace_base",
+    workspace_api_key: "plain_workspace_api_key",
+    workspace_number: 7,
+    workspace_boolean: true,
+    workspace_object: { tier: "free" },
+    // An own row replaces the data type it inherited, not just the value.
+    workspace_typed_override: "overridden_in_workspace_dev",
+    workspace_token: "token-from-workspace-base",
+    // In each redeclared pair the secret is the one that reaches the request.
+    workspace_overridden_plain: "secret-from-workspace-dev",
+    workspace_overridden_secret: "secret-from-workspace-base"
+  });
+});`;
+
+const SET_GLOBAL_ENV_VAR_SCRIPT = [
+  `bru.setGlobalEnvVar('${BASE.variables.baseOnly.name}', '${BASE.variables.baseOnly.value}');`,
+  `bru.setGlobalEnvVar('${BASE.variables.sessionId.name}', 'script_session');`
+].join('\n');
+
+const INHERITED_TYPE_LABELS: Array<[string, string]> = [
+  [BASE.variables.baseOnly.name, 'string'],
+  [BASE.variables.number.name, 'number'],
+  [BASE.variables.boolean.name, 'boolean'],
+  [BASE.variables.object.name, 'object']
+];
+
+const WORKSPACE_VARS_TEST_COUNT = 1;
+
+/**
+ * Create a workspace environment, fill in its rows, disable the ones declared disabled, and
+ * point it at the environment it inherits from.
+ */
+const createEnvironmentFromDefinition = async (page: Page, environment: EnvironmentDefinition) => {
+  await test.step(`Create workspace environment "${environment.name}"`, async () => {
+    const { environment: locators } = buildCommonLocators(page);
+    const variables = Object.values(environment.variables);
+
+    await createEnvironment(page, environment.name, SCOPE);
+    await addEnvironmentVariables(page, variables);
+
+    const disabledVariables = variables.filter((variable) => variable.disabled);
+    if (disabledVariables.length) {
+      // The last row added may have landed on the Secrets tab; every disabled row is a plain one.
+      await locators.variablesTab().click();
+      for (const variable of disabledVariables) {
+        await disableEnvironmentVariable(page, variable.name);
+      }
+    }
+
+    await saveEnvironment(page);
+
+    if (environment.extends) {
+      await setEnvironmentInheritance(page, environment.extends);
+    }
+  });
+};
+
+/**
+ * Create the collection the workspace environments are exercised from — the environment
+ * selector lives in the collection header — and then the environment chain, in the order the
+ * definitions are listed: a parent has to exist before the environment extending it is created.
+ */
+const createCollectionWithEnvironments = async (
+  page: Page,
+  collectionName: string,
+  collectionsDir: string,
+  environments: EnvironmentDefinition[]
+) => {
+  await createCollection(page, collectionName, collectionsDir);
+  for (const environment of environments) {
+    await createEnvironmentFromDefinition(page, environment);
+  }
+};
+
+/**
+ * Create a request in the collection, open it as a permanent tab, and point it at its URL.
+ */
+const createRequestForUrl = async (
+  page: Page,
+  collectionName: string,
+  request: { name: string; method?: string; url: string }
+) => {
+  await createRequest(page, request.name, collectionName, { method: request.method });
+  await openRequest(page, collectionName, request.name, { persist: true });
+  await setRequestUrlAndSave(page, request.url);
+};
+
+/**
+ * Create the request that echoes every row its workspace environment resolves and asserts the
+ * whole resolved environment in its tests.
+ */
+const createWorkspaceVarsRequest = async (page: Page, collectionName: string) => {
+  await test.step(`Create request "${WORKSPACE_VARS_REQUEST.name}"`, async () => {
+    await createRequestForUrl(page, collectionName, WORKSPACE_VARS_REQUEST);
+
+    await selectRequestBodyMode(page, 'JSON');
+    await setCodeMirrorEditorValue(page, 'request-body-editor', WORKSPACE_VARS_BODY);
+
+    await selectRequestPaneTab(page, 'Tests');
+    await setCodeMirrorEditorValue(page, 'test-script-editor', WORKSPACE_VARS_TESTS);
+
+    await saveRequest(page);
+  });
+};
+
+/**
+ * Create the request whose post-response script writes to the selected workspace environment —
+ * once with the value that environment already inherits, once with a different one.
+ */
+const createSetGlobalEnvVarRequest = async (page: Page, collectionName: string) => {
+  await test.step(`Create request "${SET_GLOBAL_ENV_VAR_REQUEST.name}"`, async () => {
+    await createRequestForUrl(page, collectionName, SET_GLOBAL_ENV_VAR_REQUEST);
+    await addPostResponseScript(page, SET_GLOBAL_ENV_VAR_SCRIPT);
+    await saveRequest(page);
+  });
+};
+
+test.describe.configure({ timeout: 180_000 });
+
+test.describe('Workspace environment inheritance, authored in the app', () => {
+  // Workspace environments outlive a collection, so they have to be cleared before the next test
+  // authors the same chain again. Tests leave a tab open on purpose: the selector this cleanup
+  // goes through lives in the collection header, which is gone once nothing is open.
+  test.afterEach(async ({ page }) => {
+    if (page.isClosed()) {
+      return;
+    }
+    await deleteAllGlobalEnvironments(page);
+    await closeAllCollections(page);
+  });
+
+  test('a workspace environment shows its ancestor rows, with their values and data types', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Workspace Inherited Rows';
+    const { environment, dataTypeSelector } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('workspace-inherited-rows'), [
+      BASE,
+      DEV
+    ]);
+    await openEnvironmentInSettings(page, DEV.name, SCOPE);
+
+    await expect(environment.inheritedSection()).toBeVisible();
+    await expect(environment.inheritedVarValue(BASE.variables.baseOnly.name)).toHaveText(
+      BASE.variables.baseOnly.value
+    );
+    await expect(environment.inheritedVarValue(BASE.variables.host.name)).toHaveText(BASE.variables.host.value);
+
+    // An own row of the same name replaces the ancestor's, rather than adding a second row.
+    await expect(environment.inheritedVarRow(DEV.variables.overridden.name)).toHaveCount(0);
+    await expect(environment.varRowLine(DEV.variables.overridden.name)).toHaveText(DEV.variables.overridden.value);
+
+    await expect(environment.inheritedVarRow(BASE.variables.disabledInBase.name)).toHaveCount(0);
+
+    await test.step('An inherited row cannot be edited', async () => {
+      await expect(environment.inheritedVarEnabledCheckbox(BASE.variables.baseOnly.name)).toBeChecked();
+      await expect(environment.inheritedVarEnabledCheckbox(BASE.variables.baseOnly.name)).toBeDisabled();
+      await expect(environment.inheritedVarEditableFields(BASE.variables.baseOnly.name)).toHaveCount(0);
+    });
+
+    await test.step('An inherited row carries the data type of the variable it came from', async () => {
+      for (const [name, label] of INHERITED_TYPE_LABELS) {
+        await expect(environment.inheritedVarDataType(name)).toHaveText(label);
+      }
+
+      await expect(environment.inheritedVarValue(BASE.variables.number.name)).toHaveText(BASE.variables.number.value);
+      await expect(environment.inheritedVarValue(BASE.variables.boolean.name)).toHaveText(BASE.variables.boolean.value);
+      // Object values are pretty-printed over several lines, so match the shape.
+      await expect(environment.inheritedVarValue(BASE.variables.object.name)).toHaveText(/"tier":\s*"free"/);
+    });
+
+    await test.step('An own row replaces the inherited data type, not just the value', async () => {
+      await expect(environment.inheritedVarRow(DEV.variables.typedOverride.name)).toHaveCount(0);
+      await expect(environment.varRowLine(DEV.variables.typedOverride.name)).toHaveText(
+        DEV.variables.typedOverride.value
+      );
+      await expect(
+        dataTypeSelector.typeLabel(environment.varRow(DEV.variables.typedOverride.name))
+      ).toHaveAttribute('data-selected-type', 'string');
+    });
+
+    await test.step('An inherited secret arrives masked and reveals its ancestor value', async () => {
+      await environment.secretsTab().click();
+      await expect(environment.inheritedVarValue(BASE.variables.token.name)).toHaveText(
+        '*'.repeat(BASE.variables.token.value.length)
+      );
+      await expect(environment.inheritedVarDataType(BASE.variables.secretObject.name)).toHaveText('object');
+      await expect(environment.inheritedVarDataType(BASE.variables.token.name)).toHaveText('string');
+      await expect(environment.inheritedVarValue(BASE.variables.secretObject.name)).not.toContainText('admin');
+
+      await environment.inheritedVarEyeToggle(BASE.variables.token.name).click();
+      await environment.inheritedVarEyeToggle(BASE.variables.secretObject.name).click();
+
+      await expect(environment.inheritedVarValue(BASE.variables.token.name)).toHaveText(BASE.variables.token.value);
+      await expect(environment.inheritedVarValue(BASE.variables.secretObject.name)).toHaveText(/"scope":\s*"admin"/);
+      await expect(environment.inheritedVarSource(BASE.variables.token.name)).toHaveAttribute(
+        'title',
+        `Inherited from ${BASE.name}`
+      );
+    });
+  });
+
+  test('the inherited section collapses, filters with the search, and links to its source', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Workspace Inherited Section';
+    const { environment } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('workspace-inherited-section'), [
+      BASE,
+      DEV
+    ]);
+    await openEnvironmentInSettings(page, DEV.name, SCOPE);
+
+    await test.step('Collapsing the section hides the inherited rows', async () => {
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toHaveCount(0);
+
+      await environment.inheritedSectionToggle().click();
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toBeVisible();
+    });
+
+    await test.step('The search filters inherited rows and own rows independently', async () => {
+      await searchEnvironmentVariables(page, BASE.variables.baseOnly.name);
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(1)');
+      await expect(environment.sectionCount('own')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, DEV.variables.devOnly.name);
+      await expect(environment.varRow(DEV.variables.devOnly.name)).toBeVisible();
+      await expect(environment.sectionCount('inherited')).toHaveText('(0)');
+      await expect(environment.varsNoResults()).toHaveCount(0);
+
+      await searchEnvironmentVariables(page, 'matches_nothing_at_all');
+      await expect(environment.varsNoResults()).toBeVisible();
+
+      await searchEnvironmentVariables(page, '');
+      await expect(environment.inheritedVarRow(BASE.variables.baseOnly.name)).toBeVisible();
+    });
+
+    await test.step('The source arrow opens the environment the row came from', async () => {
+      await environment.inheritedVarSource(BASE.variables.baseOnly.name).click();
+
+      await expect(environment.detailsTitle()).toHaveText(BASE.name);
+      await expect(environment.varRowLine(BASE.variables.baseOnly.name)).toHaveText(BASE.variables.baseOnly.value);
+    });
+  });
+
+  test('the source arrow warns about unsaved changes instead of switching environments', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Workspace Inherited Source Guard';
+    const { environment, modal } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(
+      page,
+      collectionName,
+      await createTmpDir('workspace-inherited-source-guard'),
+      [BASE, DEV]
+    );
+    await openEnvironmentInSettings(page, DEV.name, SCOPE);
+
+    await setEnvironmentVariableValue(page, DEV.variables.overridden.name, 'edited_but_unsaved');
+    await expect(environment.tabCount('variables')).toHaveClass(/unsaved/);
+
+    await environment.inheritedVarSource(BASE.variables.baseOnly.name).click();
+
+    await expect(modal.byTitle('Unsaved changes')).toBeVisible();
+    await expect(environment.detailsTitle()).toHaveText(DEV.name);
+    await expect(environment.varRowLine(DEV.variables.overridden.name)).toHaveText('edited_but_unsaved');
+
+    await modal.closeButton().click();
+    await environment.resetTab().click();
+  });
+
+  test('a request interpolates the workspace variables its environment inherits, as their own data type', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Workspace Inherited Request';
+    const { response } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('workspace-inherited-request'), [
+      BASE,
+      DEV
+    ]);
+    await createWorkspaceVarsRequest(page, collectionName);
+    await selectEnvironment(page, DEV.name, SCOPE);
+
+    // `workspace_host` carries the echo endpoint and is only defined in `workspace_base`, so the
+    // request cannot reach the server at all unless inheritance resolved.
+    await sendRequest(page, 200);
+
+    await expectResponseContains(page, [
+      BASE.variables.baseOnly.value,
+      DEV.variables.overridden.value,
+      DEV.variables.devOnly.value,
+      // `workspace_dev` declares this one too, but disabled, so the inherited row still applies.
+      BASE.variables.shadowedByDisabled.value,
+      // Disabled in `workspace_base`, so it is never inherited and stays uninterpolated.
+      `{{${BASE.variables.disabledInBase.name}}}`
+    ]);
+
+    await test.step('The request asserts the whole workspace environment it resolved', async () => {
+      await selectResponsePaneTab(page, 'Tests');
+
+      await expect(response.testSummary()).toContainText(
+        `Tests (${WORKSPACE_VARS_TEST_COUNT}), Passed: ${WORKSPACE_VARS_TEST_COUNT}, Failed: 0`
+      );
+      await expect(response.testFailures()).toHaveCount(0);
+    });
+  });
+
+  test('an inherited workspace secret reaches the request and outranks a plain row of the same name', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Workspace Inherited Secrets';
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('workspace-inherited-secrets'), [
+      BASE,
+      DEV,
+      STAGING,
+      QA
+    ]);
+    await createWorkspaceVarsRequest(page, collectionName);
+
+    await test.step('A three-level chain resolves the secrets it inherits from either ancestor', async () => {
+      await selectEnvironment(page, QA.name, SCOPE);
+      await sendRequest(page, 200);
+      await selectResponsePaneTab(page, 'Response');
+
+      await expectResponseContains(page, [BASE.variables.token.value, STAGING.variables.apiKey.value]);
+      // `workspace_base` declares `workspace_api_key` plain and `workspace_staging` redeclares it
+      // secret, so both are inherited by `workspace_qa` — the secret is the one that must reach the
+      // request.
+      expect(await getResponseBody(page)).not.toContain(BASE.variables.apiKey.value);
+    });
+
+    await test.step('A name inherited as a secret and redeclared as a non-secret resolves to the secret', async () => {
+      await selectEnvironment(page, DEV.name, SCOPE);
+      await sendRequest(page, 200);
+      await selectResponsePaneTab(page, 'Response');
+
+      // `workspace_dev` redeclares the secret `workspace_overridden_secret` it inherits as a
+      // non-secret, and the non-secret `workspace_overridden_plain` as a secret. Both ancestor rows
+      // survive the redeclaration, and in each pair the secret is the one that reaches the request.
+      await expectResponseContains(page, [
+        BASE.variables.overriddenSecret.value,
+        DEV.variables.overriddenPlain.value
+      ]);
+      const body = await getResponseBody(page);
+      expect(body).not.toContain(DEV.variables.overriddenSecret.value);
+      expect(body).not.toContain(BASE.variables.overriddenPlain.value);
+    });
+  });
+
+  test('a script write only overrides an inherited workspace variable when the value differs', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Workspace Inherited Script Write';
+    const { environment } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(
+      page,
+      collectionName,
+      await createTmpDir('workspace-inherited-script-write'),
+      [BASE, SCRIPTED]
+    );
+    await createSetGlobalEnvVarRequest(page, collectionName);
+    await selectEnvironment(page, SCRIPTED.name, SCOPE);
+    // The request's own URL comes from `workspace_host`, which only the ancestor declares.
+    await sendRequest(page, 200);
+
+    await openEnvironmentConfigTab(page, SCOPE);
+    await openEnvironmentInSettings(page, SCRIPTED.name, SCOPE);
+
+    // The script rewrote `workspace_base_only` with the value it already inherits, so the write is
+    // a no-op and the row stays inherited.
+    await expect(environment.inheritedVarValue(BASE.variables.baseOnly.name)).toHaveText(
+      BASE.variables.baseOnly.value
+    );
+    await expect(environment.varRow(BASE.variables.baseOnly.name)).toHaveCount(0);
+
+    // `workspace_session_id` was written with a different value, so it becomes a row of its own.
+    await expect(environment.varRowLine(BASE.variables.sessionId.name)).toHaveText('script_session');
+    await expect(environment.inheritedVarRow(BASE.variables.sessionId.name)).toHaveCount(0);
+
+    await closeEnvironmentPanel(page, SCOPE);
+  });
+
+  test('an inherited workspace variable is read-only in the variable tooltip', async ({ page, createTmpDir }) => {
+    const collectionName = 'Workspace Inherited Tooltip';
+    const { varInfoPopup } = buildCommonLocators(page);
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('workspace-inherited-tooltip'), [
+      BASE,
+      DEV
+    ]);
+    await createRequestForUrl(page, collectionName, PING_REQUEST);
+    await selectEnvironment(page, DEV.name, SCOPE);
+
+    const tooltip = await openUrlVarTooltip(page, BASE.variables.host.name);
+
+    await expect(varInfoPopup.name(tooltip)).toHaveText(BASE.variables.host.name);
+    await expect(varInfoPopup.scopeBadge(tooltip)).toHaveText('Global');
+    await expect(varInfoPopup.valueDisplay(tooltip)).toContainText(BASE.variables.host.value);
+    await expect(varInfoPopup.readonlyNote(tooltip)).toHaveText(`Inherited from ${BASE.name} (read-only)`);
+    await expect(varInfoPopup.editableValue(tooltip)).toHaveCount(0);
+  });
+
+  test('a collection run interpolates the workspace variables the environment inherits', async ({
+    page,
+    createTmpDir
+  }) => {
+    const collectionName = 'Workspace Inherited Runner';
+
+    await createCollectionWithEnvironments(page, collectionName, await createTmpDir('workspace-inherited-runner'), [
+      BASE,
+      DEV
+    ]);
+    await createWorkspaceVarsRequest(page, collectionName);
+    await selectEnvironment(page, DEV.name, SCOPE);
+
+    await runCollection(page, collectionName);
+
+    await validateRunnerResults(page, {
+      totalRequests: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0
+    });
+  });
+});
+
+const WORKSPACE = 'Inheritance UI Workspace';
+const LIFECYCLE_COLLECTION = 'Inheritance UI Collection';
+// The app's own workspace, which it creates in the same location.
+const DEFAULT_WORKSPACE_DIRECTORY = 'default-workspace';
+
+type SavedVariable = { name: string; value?: unknown; secret?: boolean; disabled?: boolean };
+type SavedEnvironment = { name: string; extends?: string; variables?: SavedVariable[] };
+
+const LEVEL_1 = {
+  name: 'ui-workspace-level-1',
+  renamedName: 'ui-workspace-level-1-renamed',
+  variables: {
+    url: { name: 'shared_workspace_url', value: 'https://workspace-level-1.example.com' },
+    region: { name: 'workspace_level_1_region', value: 'region-from-workspace-level-1' },
+    count: { name: 'workspace_level_1_count', value: '3', dataType: 'number' as const },
+    token: { name: 'workspace_level_1_token', value: 'token-from-workspace-level-1', isSecret: true }
+  }
+};
+
+const LEVEL_2 = {
+  name: 'ui-workspace-level-2',
+  copyName: 'ui-workspace-level-2-copy',
+  variables: {
+    own: { name: 'workspace_level_2_only', value: 'value-from-workspace-level-2' }
+  },
+  // Typed in after the chain is built, redeclaring level 1's names to retire the inherited twins.
+  overrides: {
+    region: { name: LEVEL_1.variables.region.name, value: 'region-from-workspace-level-2' },
+    // Redeclared without a data type, so the number it inherits has to give way to a string.
+    count: { name: LEVEL_1.variables.count.name, value: 'recounted-in-workspace-level-2' },
+    token: { name: LEVEL_1.variables.token.name, value: 'token-from-workspace-level-2', isSecret: true }
+  }
+};
+
+const savedVariableNames = (environment: SavedEnvironment) =>
+  (environment.variables ?? []).map((variable) => variable.name).sort();
+
+const savedVariable = (environment: SavedEnvironment, name: string) =>
+  (environment.variables ?? []).find((variable) => variable.name === name);
+
+/**
+ * The directory the app created for the workspace, found by the workspace file it holds.
+ */
+const workspaceDirectory = (workspacesLocation: string) => {
+  const directories = fs
+    .readdirSync(workspacesLocation)
+    .filter((entry) => entry !== DEFAULT_WORKSPACE_DIRECTORY)
+    .filter((entry) => fs.existsSync(path.join(workspacesLocation, entry, 'workspace.yml')));
+
+  expect(directories).toHaveLength(1);
+  return path.join(workspacesLocation, directories[0]);
+};
+
+/**
+ * Launch the app against a temp workspaces location, create a workspace in it, and open a
+ * collection — the environment selector lives in the collection header, so workspace
+ * environments can only be reached with one open.
+ */
+const launchWithWorkspace = async (
+  launchElectronApp: (options?: { initUserDataPath?: string }) => Promise<ElectronApplication>,
+  createTmpDir: (tag?: string) => Promise<string>,
+  tag: string
+) => {
+  const workspacesLocation = await createTmpDir(`${tag}-workspaces`);
+  const initUserDataPath = await createTmpDir(`${tag}-user-data`);
+  fs.writeFileSync(
+    path.join(initUserDataPath, 'preferences.json'),
+    JSON.stringify({ preferences: { general: { defaultLocation: workspacesLocation } } }, null, 2)
+  );
+
+  const app = await launchElectronApp({ initUserDataPath });
+  const page = await waitForReadyPage(app);
+
+  await createWorkspace(page, WORKSPACE);
+  await createCollection(page, LIFECYCLE_COLLECTION, await createTmpDir(`${tag}-collection`));
+
+  return { app, page, workspacePath: workspaceDirectory(workspacesLocation) };
+};
+
+/**
+ * Create a populated level 1 workspace environment and a level 2 that inherits nothing yet,
+ * leaving the latter open in the environment settings tab.
+ */
+const createTwoLevelChain = async (page: Page) => {
+  await createEnvironment(page, LEVEL_1.name, SCOPE);
+  await addEnvironmentVariables(page, Object.values(LEVEL_1.variables));
+  await saveEnvironment(page);
+
+  await createEnvironment(page, LEVEL_2.name, SCOPE);
+  await addEnvironmentVariables(page, Object.values(LEVEL_2.variables));
+  await saveEnvironment(page);
+};
+
+test.describe('Workspace environment inheritance lifecycle, authored in the app', () => {
+  test('a workspace environment records its parent, copies it, and follows the parent rename and delete', async ({
+    launchElectronApp,
+    createTmpDir
+  }) => {
+    const { app, page, workspacePath } = await launchWithWorkspace(
+      launchElectronApp,
+      createTmpDir,
+      'workspace-lifecycle-ui'
+    );
+    const { environment } = buildCommonLocators(page);
+    const environmentFile = (name: string) => path.join(workspacePath, 'environments', `${name}.yml`);
+    const readEnvironment = (name: string) =>
+      yaml.load(fs.readFileSync(environmentFile(name), 'utf8')) as SavedEnvironment;
+
+    await test.step('Create a parent and a child workspace environment', async () => {
+      await createTwoLevelChain(page);
+    });
+
+    await test.step('Picking a parent writes extends and merges its rows in', async () => {
+      await setEnvironmentInheritance(page, LEVEL_1.name);
+
+      await expect.poll(() => readEnvironment(LEVEL_2.name).extends).toBe(LEVEL_1.name);
+      await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+
+      // The rows arrived from the parent rather than from an edit, so the tab stays saved.
+      await expect(environment.tabCount('variables')).not.toHaveClass(/unsaved/);
+    });
+
+    await test.step('Choosing no environment removes extends again', async () => {
+      await setEnvironmentInheritance(page, null);
+
+      await expect.poll(() => readEnvironment(LEVEL_2.name).extends).toBeUndefined();
+      await expect(environment.inheritedSection()).toHaveCount(0);
+    });
+
+    await test.step('A copy of an inheriting environment keeps its parent', async () => {
+      await setEnvironmentInheritance(page, LEVEL_1.name);
+      await copyEnvironment(page, LEVEL_2.copyName);
+
+      await expect(environment.detailsTitle()).toHaveText(LEVEL_2.copyName);
+
+      await expect.poll(() => fs.existsSync(environmentFile(LEVEL_2.copyName))).toBe(true);
+      expect(readEnvironment(LEVEL_2.copyName).extends).toBe(LEVEL_1.name);
+    });
+
+    await test.step('Renaming the parent rewrites the references to it', async () => {
+      await openEnvironmentInSettings(page, LEVEL_1.name, SCOPE);
+      await renameEnvironment(page, LEVEL_1.renamedName);
+
+      await expect.poll(() => readEnvironment(LEVEL_2.name).extends).toBe(LEVEL_1.renamedName);
+
+      await openEnvironmentInSettings(page, LEVEL_2.name, SCOPE);
+      await expect(environment.inheritedVarValue(LEVEL_1.variables.url.name)).toHaveText(LEVEL_1.variables.url.value);
+    });
+
+    await test.step('Deleting the parent keeps the references to it and warns about them', async () => {
+      await openEnvironmentInSettings(page, LEVEL_1.renamedName, SCOPE);
+      await deleteEnvironment(page);
+
+      await expect.poll(() => readEnvironment(LEVEL_2.name).extends).toBe(LEVEL_1.renamedName);
+
+      await openEnvironmentInSettings(page, LEVEL_2.name, SCOPE);
+      await expect(environment.missingInheritedEnvironment()).toContainText(LEVEL_1.renamedName);
+      await expect(environment.inheritedSection()).toHaveCount(0);
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('an own row overwrites the workspace variable it inherits, and only own rows reach the file', async ({
+    launchElectronApp,
+    createTmpDir
+  }) => {
+    const { app, page, workspacePath } = await launchWithWorkspace(
+      launchElectronApp,
+      createTmpDir,
+      'workspace-overwrite-ui'
+    );
+    const { environment } = buildCommonLocators(page);
+    const readEnvironment = (name: string) =>
+      yaml.load(fs.readFileSync(path.join(workspacePath, 'environments', `${name}.yml`), 'utf8')) as SavedEnvironment;
+
+    await createTwoLevelChain(page);
+    await setEnvironmentInheritance(page, LEVEL_1.name);
+
+    await test.step('The inherited rows carry the parent values until an own row redeclares them', async () => {
+      await expect(environment.inheritedVarValue(LEVEL_2.overrides.region.name)).toHaveText(
+        LEVEL_1.variables.region.value
+      );
+      await expect(environment.inheritedVarDataType(LEVEL_2.overrides.count.name)).toHaveText('number');
+    });
+
+    await test.step('Typing an own row of the same name retires the inherited twin', async () => {
+      await addEnvironmentVariable(page, LEVEL_2.overrides.region);
+      await addEnvironmentVariable(page, LEVEL_2.overrides.count);
+
+      for (const override of [LEVEL_2.overrides.region, LEVEL_2.overrides.count]) {
+        await expect(environment.inheritedVarRow(override.name)).toHaveCount(0);
+        await expect(environment.varRowLine(override.name)).toHaveText(override.value);
+      }
+    });
+
+    await test.step('Saving the tab writes the own rows and leaves the inherited ones behind', async () => {
+      await environment.saveTab().click();
+
+      await expect
+        .poll(() => savedVariableNames(readEnvironment(LEVEL_2.name)))
+        .toContain(LEVEL_2.overrides.region.name);
+
+      const saved = readEnvironment(LEVEL_2.name);
+      expect(saved.extends).toBe(LEVEL_1.name);
+      expect(savedVariableNames(saved)).toEqual(
+        [LEVEL_2.variables.own.name, LEVEL_2.overrides.region.name, LEVEL_2.overrides.count.name].sort()
+      );
+      expect(savedVariable(saved, LEVEL_2.overrides.region.name)?.value).toBe(LEVEL_2.overrides.region.value);
+      // Redeclared as a plain string, so the parent's number type is gone from the file too.
+      expect(savedVariable(saved, LEVEL_2.overrides.count.name)?.value).toBe(LEVEL_2.overrides.count.value);
+    });
+
+    await test.step('Save all writes the own secret and still leaves the inherited ones behind', async () => {
+      await environment.secretsTab().click();
+      await expect(environment.inheritedVarRow(LEVEL_2.overrides.token.name)).toBeVisible();
+
+      await addEnvironmentVariable(page, LEVEL_2.overrides.token);
+      await expect(environment.inheritedVarRow(LEVEL_2.overrides.token.name)).toHaveCount(0);
+
+      await environment.saveAll().click();
+
+      await expect
+        .poll(() => savedVariableNames(readEnvironment(LEVEL_2.name)))
+        .toContain(LEVEL_2.overrides.token.name);
+
+      const saved = readEnvironment(LEVEL_2.name);
+      expect(savedVariableNames(saved)).toEqual(
+        [
+          LEVEL_2.variables.own.name,
+          LEVEL_2.overrides.region.name,
+          LEVEL_2.overrides.count.name,
+          LEVEL_2.overrides.token.name
+        ].sort()
+      );
+      // A secret's value never reaches the file, whether it is inherited or own.
+      expect(savedVariable(saved, LEVEL_2.overrides.token.name)?.secret).toBe(true);
+      expect(savedVariable(saved, LEVEL_2.overrides.token.name)?.value).toBeUndefined();
+      // Rows only the parent declares stay in the parent file.
+      expect(savedVariableNames(saved)).not.toContain(LEVEL_1.variables.url.name);
+    });
+
+    await test.step('The parent keeps the values its child overwrote', async () => {
+      const parent = readEnvironment(LEVEL_1.name);
+
+      expect(parent.extends).toBeUndefined();
+      expect(savedVariable(parent, LEVEL_1.variables.region.name)?.value).toBe(LEVEL_1.variables.region.value);
+      expect(savedVariable(parent, LEVEL_1.variables.url.name)?.value).toBe(LEVEL_1.variables.url.value);
+    });
+
+    await closeElectronApp(app);
+  });
+});

--- a/tests/environments/export-environment/collection-env-export/collection-env-export.spec.ts
+++ b/tests/environments/export-environment/collection-env-export/collection-env-export.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from '../../../../playwright';
 import path from 'path';
 import fs from 'fs';
 
-import { readExportedJson } from '../../../utils/helpers';
+import { findEnvironmentByName, readExportedJson } from '../../../utils/helpers';
+import { openCollection, openEnvironmentConfigTab } from '../../../utils/page';
+import { buildCommonLocators } from '../../../utils/page/locators';
 
 // Helper function to load expected fixtures
 function loadExpectedFixture(fixturePath: string) {
@@ -180,7 +182,7 @@ test.describe.serial('Collection Environment Export Tests', () => {
 
       await test.step('Execute export and close modal', async () => {
         // Export should succeed with unique names
-        await page.getByRole('button', { name: 'Export 2 Environment' }).click();
+        await page.getByRole('button', { name: 'Export 3 Environments' }).click();
       });
 
       await test.step('Verify unique naming and file content', async () => {
@@ -292,7 +294,7 @@ test.describe.serial('Collection Environment Export Tests', () => {
 
       await test.step('Execute export and verify success', async () => {
         // Export the environments
-        await page.getByRole('button', { name: 'Export 2 Environments' }).click();
+        await page.getByRole('button', { name: 'Export 3 Environments' }).click();
 
         // Verify success message
         await expect(page.getByText('Environment(s) exported successfully', { exact: false }).first()).toBeVisible();
@@ -370,6 +372,49 @@ test.describe.serial('Collection Environment Export Tests', () => {
         const expectedContent = loadExpectedFixture('local.json');
         expect(normalizeExportedContent(exportedContent)).toEqual(expectedContent);
       });
+    });
+  });
+
+  test('should warn about a left-out parent environment and export the chain once it is selected', async ({
+    pageWithUserData: page,
+    createTmpDir
+  }) => {
+    const exportDir = await createTmpDir('collection-env-export-extends');
+    const { environment } = buildCommonLocators(page);
+
+    await test.step('Open collection and navigate to environment settings', async () => {
+      await openCollection(page, 'Environment Export Test Collection');
+      await openEnvironmentConfigTab(page);
+    });
+
+    await test.step('Selecting only the inheriting environment warns about its parent', async () => {
+      await environment.exportAction().click();
+      await expect(environment.exportModal.root()).toBeVisible();
+
+      await environment.exportModal.deselectAll().click();
+      await environment.exportModal.environmentCheckbox('derived').check();
+
+      await expect(environment.exportModal.inheritanceWarning()).toHaveText('inherits local');
+    });
+
+    await test.step('Selecting the parent clears the warning', async () => {
+      await environment.exportModal.environmentCheckbox('local').check();
+
+      await expect(environment.exportModal.inheritanceWarning()).toHaveCount(0);
+    });
+
+    await test.step('The exported environment names the one it extends', async () => {
+      await environment.exportModal.location().fill(exportDir);
+      await environment.exportModal.submit().click();
+      await expect(environment.exportModal.root()).toBeHidden();
+
+      const exported = await readExportedJson(path.join(exportDir, 'bruno-collection-environments.json'));
+      const expected = loadExpectedFixture('bruno-collection-environments.json');
+
+      expect(findEnvironmentByName(exported.environments, 'derived')).toEqual(
+        findEnvironmentByName(expected.environments, 'derived')
+      );
+      expect(findEnvironmentByName(exported.environments, 'local').extends).toBeUndefined();
     });
   });
 

--- a/tests/environments/export-environment/collection-env-export/fixtures/collection/environments/derived.bru
+++ b/tests/environments/export-environment/collection-env-export/fixtures/collection/environments/derived.bru
@@ -1,0 +1,5 @@
+extends: local
+
+vars {
+  region: eu-west-1
+}

--- a/tests/environments/export-environment/global-env-export/global-env-export.spec.ts
+++ b/tests/environments/export-environment/global-env-export/global-env-export.spec.ts
@@ -24,6 +24,11 @@ function normalizeExportedContent(content: any) {
     content.info.exportedAt = '2024-01-01T00:00:00.000Z';
     content.info.exportedUsing = 'Bruno/v1.0.0';
   }
+  // Global environments are read back with fs.readdirSync, whose order differs per filesystem,
+  // so compare against the name-sorted fixture.
+  if (Array.isArray(content.environments)) {
+    content.environments.sort((a, b) => a.name.localeCompare(b.name));
+  }
   return content;
 }
 

--- a/tests/environments/export-environment/global-env-export/global-env-export.spec.ts
+++ b/tests/environments/export-environment/global-env-export/global-env-export.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from '../../../../playwright';
 import path from 'path';
 import fs from 'fs';
 
-import { readExportedJson } from '../../../utils/helpers';
+import { findEnvironmentByName, readExportedJson } from '../../../utils/helpers';
+import { openCollection, openEnvironmentConfigTab } from '../../../utils/page';
+import { buildCommonLocators } from '../../../utils/page/locators';
 
 // Helper function to load expected fixtures
 function loadExpectedFixture(fixturePath: string) {
@@ -184,7 +186,7 @@ test.describe.serial('Global Environment Export Tests', () => {
 
       await test.step('Execute export and close modal', async () => {
         // Export should succeed with unique names
-        await page.getByRole('button', { name: 'Export 2 Environment' }).click();
+        await page.getByRole('button', { name: 'Export 3 Environments' }).click();
       });
 
       await test.step('Verify unique naming and file content', async () => {
@@ -298,7 +300,7 @@ test.describe.serial('Global Environment Export Tests', () => {
 
       await test.step('Execute export and verify success', async () => {
         // Export the environments
-        await page.getByRole('button', { name: 'Export 2 Environments' }).click();
+        await page.getByRole('button', { name: 'Export 3 Environments' }).click();
         await page.waitForTimeout(200);
         // Verify success message
         await expect(page.getByText('Environment(s) exported successfully', { exact: false }).first()).toBeVisible();
@@ -378,6 +380,49 @@ test.describe.serial('Global Environment Export Tests', () => {
         const expectedContent = loadExpectedFixture('local.json');
         expect(normalizeExportedContent(exportedContent)).toEqual(expectedContent);
       });
+    });
+  });
+
+  test('should warn about a left-out parent environment and export the chain once it is selected', async ({
+    pageWithUserData: page,
+    createTmpDir
+  }) => {
+    const exportDir = await createTmpDir('global-env-export-extends');
+    const { environment } = buildCommonLocators(page);
+
+    await test.step('Open collection and navigate to global environment settings', async () => {
+      await openCollection(page, 'Environment Export Test Collection');
+      await openEnvironmentConfigTab(page, 'global');
+    });
+
+    await test.step('Selecting only the inheriting environment warns about its parent', async () => {
+      await environment.exportAction().click();
+      await expect(environment.exportModal.root()).toBeVisible();
+
+      await environment.exportModal.deselectAll().click();
+      await environment.exportModal.environmentCheckbox('derived').check();
+
+      await expect(environment.exportModal.inheritanceWarning()).toHaveText('inherits local');
+    });
+
+    await test.step('Selecting the parent clears the warning', async () => {
+      await environment.exportModal.environmentCheckbox('local').check();
+
+      await expect(environment.exportModal.inheritanceWarning()).toHaveCount(0);
+    });
+
+    await test.step('The exported environment names the one it extends', async () => {
+      await environment.exportModal.location().fill(exportDir);
+      await environment.exportModal.submit().click();
+      await expect(environment.exportModal.root()).toBeHidden();
+
+      const exported = await readExportedJson(path.join(exportDir, 'bruno-global-environments.json'));
+      const expected = loadExpectedFixture('bruno-global-environments.json');
+
+      expect(findEnvironmentByName(exported.environments, 'derived')).toEqual(
+        findEnvironmentByName(expected.environments, 'derived')
+      );
+      expect(findEnvironmentByName(exported.environments, 'local').extends).toBeUndefined();
     });
   });
 

--- a/tests/environments/export-environment/global-env-export/init-user-data/global-environments.json
+++ b/tests/environments/export-environment/global-env-export/init-user-data/global-environments.json
@@ -47,6 +47,21 @@
           "description": "Secret line one\nSecret line two"
         }
       ]
+    },
+    {
+      "uid": "Kq2vDdmTzXaLm4hRpWs8N",
+      "name": "derived",
+      "extends": "local",
+      "variables": [
+        {
+          "uid": "9bMxQnv3RtYWk1cLdEuZ7",
+          "name": "region",
+          "value": "eu-west-1",
+          "type": "text",
+          "enabled": true,
+          "secret": false
+        }
+      ]
     }
   ],
   "activeGlobalEnvironmentUid": "FfmX1qYW2EaOpLWeNPLKM"

--- a/tests/environments/fixtures/environment-exports/bruno-collection-environments.json
+++ b/tests/environments/fixtures/environment-exports/bruno-collection-environments.json
@@ -6,6 +6,19 @@
   },
   "environments": [
     {
+      "name": "derived",
+      "extends": "local",
+      "variables": [
+        {
+          "name": "region",
+          "value": "eu-west-1",
+          "type": "text",
+          "enabled": true,
+          "secret": false
+        }
+      ]
+    },
+    {
       "name": "local",
       "variables": [
         {

--- a/tests/environments/fixtures/environment-exports/bruno-global-environments.json
+++ b/tests/environments/fixtures/environment-exports/bruno-global-environments.json
@@ -6,6 +6,19 @@
   },
   "environments": [
     {
+      "name": "derived",
+      "extends": "local",
+      "variables": [
+        {
+          "name": "region",
+          "value": "eu-west-1",
+          "type": "text",
+          "enabled": true,
+          "secret": false
+        }
+      ]
+    },
+    {
       "name": "local",
       "variables": [
         {

--- a/tests/environments/import-environment/bruno-env-import/collection-env-import/collection-env-import.spec.ts
+++ b/tests/environments/import-environment/bruno-env-import/collection-env-import/collection-env-import.spec.ts
@@ -137,6 +137,8 @@ test.describe.serial('Collection Environment Import Tests', () => {
 
       // Verify prod environment variables
       const locators = buildCommonLocators(page);
+      await locators.environment.settingsListItem('prod').click();
+
       await expect(locators.environment.varRowValueCell('host')).toBeVisible();
 
       // secretToken was imported as a secret, so it lives on the Secrets tab, not Variables.

--- a/tests/environments/rename-environment/fixtures/collections/bru/bruno.json
+++ b/tests/environments/rename-environment/fixtures/collections/bru/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "Rename Env BRU",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/tests/environments/rename-environment/fixtures/collections/bru/environments/Local.bru
+++ b/tests/environments/rename-environment/fixtures/collections/bru/environments/Local.bru
@@ -1,0 +1,3 @@
+vars {
+  host: https://echo.usebruno.com
+}

--- a/tests/environments/rename-environment/fixtures/collections/yml/environments/Local.yml
+++ b/tests/environments/rename-environment/fixtures/collections/yml/environments/Local.yml
@@ -1,0 +1,5 @@
+name: Local
+
+variables:
+  - name: host
+    value: https://echo.usebruno.com

--- a/tests/environments/rename-environment/fixtures/collections/yml/opencollection.yml
+++ b/tests/environments/rename-environment/fixtures/collections/yml/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: Rename Env YML

--- a/tests/environments/rename-environment/init-user-data/preferences.json
+++ b/tests/environments/rename-environment/init-user-data/preferences.json
@@ -1,0 +1,12 @@
+{
+  "lastOpenedCollections": [
+    "{{collectionPath}}/bru",
+    "{{collectionPath}}/yml"
+  ],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/environments/rename-environment/rename-environment.spec.ts
+++ b/tests/environments/rename-environment/rename-environment.spec.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect, Page } from '../../../playwright';
+import { openEnvironmentConfigTab, renameEnvironment } from '../../utils/page';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+// A rename must move the environment file *and* keep the name stored inside it in
+// sync. Only the yml format persists a name; bru derives it from the filename.
+const ORIGINAL_ENV_NAME = 'Local';
+const NEW_ENV_NAME = 'Staging';
+const HOST_VALUE = 'https://echo.usebruno.com';
+
+const environmentFile = (collectionPath: string, format: string, envName: string) =>
+  path.join(collectionPath, format, 'environments', `${envName}.${format}`);
+
+const renameEnvironmentInCollection = async (page: Page, collectionName: string) => {
+  const locators = buildCommonLocators(page);
+
+  await locators.sidebar.collection(collectionName).click();
+  await openEnvironmentConfigTab(page);
+  await expect(locators.environment.sidebarListItemExact('collection', ORIGINAL_ENV_NAME)).toBeVisible();
+
+  await renameEnvironment(page, NEW_ENV_NAME);
+
+  await expect(locators.environment.sidebarListItemExact('collection', NEW_ENV_NAME)).toBeVisible();
+  await expect(locators.environment.sidebarListItemExact('collection', ORIGINAL_ENV_NAME)).toHaveCount(0);
+};
+
+test.describe('Rename environment', () => {
+  test('renames the environment file and keeps the stored name in sync in both formats', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    await test.step('Rename in a bru collection', async () => {
+      await renameEnvironmentInCollection(page, 'Rename Env BRU');
+
+      const renamedFile = environmentFile(collectionFixturePath, 'bru', NEW_ENV_NAME);
+      await expect.poll(async () => fs.existsSync(renamedFile)).toBe(true);
+      expect(fs.existsSync(environmentFile(collectionFixturePath, 'bru', ORIGINAL_ENV_NAME))).toBe(false);
+      // bru stores no name, so the rename must leave the file byte-identical.
+      expect(fs.readFileSync(renamedFile, 'utf8')).toBe(`vars {\n  host: ${HOST_VALUE}\n}\n`);
+    });
+
+    await test.step('Rename in a yml collection', async () => {
+      await renameEnvironmentInCollection(page, 'Rename Env YML');
+
+      const renamedFile = environmentFile(collectionFixturePath, 'yml', NEW_ENV_NAME);
+      await expect.poll(async () => fs.existsSync(renamedFile)).toBe(true);
+      expect(fs.existsSync(environmentFile(collectionFixturePath, 'yml', ORIGINAL_ENV_NAME))).toBe(false);
+
+      await expect.poll(async () => fs.readFileSync(renamedFile, 'utf8')).toContain(`name: ${NEW_ENV_NAME}`);
+      const content = fs.readFileSync(renamedFile, 'utf8');
+      expect(content).not.toContain(`name: ${ORIGINAL_ENV_NAME}`);
+      expect(content).toContain(HOST_VALUE);
+    });
+  });
+});

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -2,6 +2,9 @@ import fs from 'fs';
 
 export const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+export const findEnvironmentByName = (environments: any[], name: string) =>
+  environments.find((environment) => environment.name === name);
+
 /**
  * Read and JSON-parse a file, retrying until it has parseable content.
  *

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -957,6 +957,106 @@ const createEnvironment = async (
   });
 };
 
+/**
+ * Rename the environment currently open in the environment settings tab
+ * @param page - The page object
+ * @param newName - The new name for the environment
+ * @returns void
+ */
+const renameEnvironment = async (page: Page, newName: string) => {
+  await test.step(`Rename environment to "${newName}"`, async () => {
+    const locators = buildCommonLocators(page);
+    await locators.environment.renameAction().click();
+
+    const nameInput = locators.environment.renameInput();
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill(newName);
+    await nameInput.press('Enter');
+
+    await expect(nameInput).toBeHidden();
+  });
+};
+
+/**
+ * Open an environment from the list in the environment settings tab
+ * @param page - The page object
+ * @param environmentName - The environment to open
+ * @param type - The environment scope the settings tab is showing
+ * @returns void
+ */
+const openEnvironmentInSettings = async (
+  page: Page,
+  environmentName: string,
+  type: EnvironmentType = 'collection'
+) => {
+  await test.step(`Open environment "${environmentName}" in the settings tab`, async () => {
+    const { environment } = buildCommonLocators(page);
+
+    await environment.sidebarListItemExact(type, environmentName).click();
+    await expect(environment.detailsTitle()).toHaveText(environmentName);
+  });
+};
+
+/**
+ * Pick the environment that the currently open environment inherits its variables from
+ * @param page - The page object
+ * @param parentEnvironmentName - The environment to inherit from, or null to stop inheriting
+ * @returns void
+ */
+const setEnvironmentInheritance = async (page: Page, parentEnvironmentName: string | null) => {
+  await test.step(
+    parentEnvironmentName ? `Inherit variables from "${parentEnvironmentName}"` : 'Stop inheriting variables',
+    async () => {
+      const locators = buildCommonLocators(page);
+      await locators.environment.inheritsFromAction().click();
+
+      const option = parentEnvironmentName
+        ? locators.environment.inheritsFromOption(parentEnvironmentName)
+        : locators.environment.inheritsFromNoneOption();
+      await option.click();
+
+      const toastText = parentEnvironmentName
+        ? `Inheriting variables from ${parentEnvironmentName}`
+        : 'Stopped inheriting variables';
+      await expect(page.getByText(toastText).last()).toBeVisible();
+    }
+  );
+};
+
+/**
+ * Copy the environment currently open in the environment settings tab
+ * @param page - The page object
+ * @param newName - Name for the copy
+ * @returns void
+ */
+const copyEnvironment = async (page: Page, newName: string) => {
+  await test.step(`Copy environment to "${newName}"`, async () => {
+    const locators = buildCommonLocators(page);
+    await locators.environment.copyAction().click();
+
+    const modal = page.locator('.bruno-modal').filter({ hasText: 'Copy Environment' });
+    await modal.locator('#environment-name').fill(newName);
+    await modal.getByRole('button', { name: 'Copy', exact: true }).click();
+    await modal.waitFor({ state: 'hidden' });
+  });
+};
+
+/**
+ * Delete the environment currently open in the environment settings tab
+ * @param page - The page object
+ * @returns void
+ */
+const deleteEnvironment = async (page: Page) => {
+  await test.step('Delete the open environment', async () => {
+    const locators = buildCommonLocators(page);
+    await locators.environment.deleteAction().click();
+
+    const modal = page.locator('.bruno-modal').filter({ hasText: 'Delete Environment' });
+    await modal.getByRole('button', { name: 'Delete', exact: true }).click();
+    await modal.waitFor({ state: 'hidden' });
+  });
+};
+
 type EnvironmentVariable = {
   name: string;
   value: string;
@@ -970,9 +1070,14 @@ type EnvironmentVariable = {
  * plain variable to the Variables tab before the row is added.
  * @param page - The page object
  * @param variable - The variable to add (name, value, and optional secret flag)
+ * @param options - `valueFirst` types the value into the row before naming it
  * @returns void
  */
-const addEnvironmentVariable = async (page: Page, variable: EnvironmentVariable) => {
+const addEnvironmentVariable = async (
+  page: Page,
+  variable: EnvironmentVariable,
+  options: AddRowOptions = {}
+) => {
   await test.step(`Add environment ${variable.isSecret ? 'secret' : 'variable'} "${variable.name}"`, async () => {
     const tab = variable.isSecret
       ? page.getByTestId('responsive-tab-secrets')
@@ -980,7 +1085,7 @@ const addEnvironmentVariable = async (page: Page, variable: EnvironmentVariable)
     await tab.click();
     await expect(tab).toHaveClass(/active/);
 
-    await addRowToActiveTab(page, variable.name, variable.value, variable.dataType);
+    await addRowToActiveTab(page, variable.name, variable.value, variable.dataType, options);
   });
 };
 
@@ -999,6 +1104,8 @@ const addEnvironmentVariables = async (page: Page, variables: EnvironmentVariabl
   });
 };
 
+type AddRowOptions = { valueFirst?: boolean };
+
 /**
  * Add a variable or secret to whichever environment tab (Variables / Secrets) is
  * currently active. The active tab determines the row's type, so select the tab
@@ -1007,40 +1114,150 @@ const addEnvironmentVariables = async (page: Page, variables: EnvironmentVariabl
  * @param name - The variable/secret name
  * @param value - The variable/secret value
  * @param dataType - Optional non-string dataType to assign (default `string`)
+ * @param options - `valueFirst` types the value into the row before naming it
  * @returns void
  */
 const addRowToActiveTab = async (
   page: Page,
   name: string,
   value: string,
-  dataType?: 'number' | 'boolean' | 'object'
+  dataType?: 'number' | 'boolean' | 'object',
+  options: AddRowOptions = {}
 ) => {
   await test.step(`Add row "${name}" to the active environment tab`, async () => {
-    const nameInput = page.locator('input[placeholder="Name"]').last();
-    await nameInput.waitFor({ state: 'visible' });
-    await nameInput.fill(name);
+    const { environment, dataTypeSelector } = buildCommonLocators(page);
+
+    if (options.valueFirst) {
+      const emptyRowNameInput = page.locator('input[placeholder="Name"]').last();
+      await emptyRowNameInput.waitFor({ state: 'visible' });
+      // Filling the value appends another empty row, so the row being filled in stops being the
+      // last one — its formik index is what stays put until it has a name to be found by.
+      const rowIndex = Number((await emptyRowNameInput.getAttribute('name')).split('.')[0]);
+
+      const emptyRowEditor = environment.variableValueEditor(rowIndex);
+      await emptyRowEditor.scrollIntoViewIfNeeded();
+      await emptyRowEditor.click({ position: { x: 5, y: 5 } });
+      await expect(emptyRowEditor).toHaveClass(/CodeMirror-focused/);
+      await page.keyboard.type(value);
+      await expect(emptyRowEditor).toContainText(value);
+
+      await environment.variableNameInput(rowIndex).fill(name);
+    } else {
+      const nameInput = page.locator('input[placeholder="Name"]').last();
+      await nameInput.waitFor({ state: 'visible' });
+      await nameInput.fill(name);
+    }
 
     const row = page.getByTestId(`env-var-row-${name}`);
     await row.waitFor({ state: 'visible' });
 
     const codeMirror = row.getByTestId(/^test-multiline-editor-\d+\.value$/).locator('.CodeMirror').first();
     await codeMirror.scrollIntoViewIfNeeded();
-    // Target the editor's left edge: when the value column is narrow the DataTypeSelector
-    // renders as a compact overlay pinned to the cell's right side, which otherwise
-    // intercepts a centered click/hover.
-    await codeMirror.click({ position: { x: 5, y: 5 } });
-    if (dataType) {
-      await expect(codeMirror).toHaveClass(/CodeMirror-focused/);
-      await page.keyboard.insertText(value);
+    if (!options.valueFirst) {
+      // Target the editor's left edge: when the value column is narrow the DataTypeSelector
+      // renders as a compact overlay pinned to the cell's right side, which otherwise
+      // intercepts a centered click/hover.
+      await codeMirror.click({ position: { x: 5, y: 5 } });
+      if (dataType) {
+        await expect(codeMirror).toHaveClass(/CodeMirror-focused/);
+        await page.keyboard.insertText(value);
+      } else {
+        await page.keyboard.type(value);
+      }
+    }
 
-      const { dataTypeSelector } = buildCommonLocators(page);
+    if (dataType) {
       await codeMirror.hover({ position: { x: 5, y: 5 } });
       await dataTypeSelector.typeLabel(row).click();
       await dataTypeSelector.menuItem(dataType).click();
       await expect(dataTypeSelector.typeLabel(row)).toHaveAttribute('data-selected-type', dataType);
-    } else {
-      await page.keyboard.type(value);
     }
+  });
+};
+
+/**
+ * Replace the value of an existing environment variable row. The row must already be on the
+ * active tab; a secret keeps its value masked, so reveal it with the row's eye toggle
+ * before asserting on the displayed text. Whatever the row holds is cleared first, so the
+ * same call can be repeated against an app instance a previous test already wrote to.
+ * @param page - The page object
+ * @param name - The name of the row to fill
+ * @param value - The value to type
+ * @returns void
+ */
+const setEnvironmentVariableValue = async (page: Page, name: string, value: string) => {
+  await test.step(`Set environment variable "${name}" to "${value}"`, async () => {
+    const editor = buildCommonLocators(page).environment.varRowValueEditor(name);
+    await editor.scrollIntoViewIfNeeded();
+    await editor.click({ position: { x: 5, y: 5 } });
+    await expect(editor).toHaveClass(/CodeMirror-focused/);
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+a' : 'Control+a');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.type(value);
+    await expect(editor).not.toHaveClass(/CodeMirror-empty/);
+  });
+};
+
+/**
+ * Uncheck the enabled checkbox of an environment variable row. The row must already be on the
+ * active tab.
+ * @param page - The page object
+ * @param name - The name of the row to disable
+ * @returns void
+ */
+const disableEnvironmentVariable = async (page: Page, name: string) => {
+  await test.step(`Disable environment variable "${name}"`, async () => {
+    const checkbox = buildCommonLocators(page).environment.varRowEnabledCheckbox(name);
+    await checkbox.click();
+    await expect(checkbox).not.toBeChecked();
+  });
+};
+
+/**
+ * Give an environment's secret rows their values and save. A secret's value never lives in the
+ * environment file, so a fixture can only declare the rows — a test that needs a secret
+ * resolved has to type the values in through the editor first.
+ * @param page - The page object
+ * @param environmentName - The environment holding the secret rows
+ * @param secrets - Secret name to value
+ * @param type - The environment scope the settings tab is showing
+ * @returns void
+ */
+const setEnvironmentSecrets = async (
+  page: Page,
+  environmentName: string,
+  secrets: Record<string, string>,
+  type: EnvironmentType = 'collection'
+) => {
+  await test.step(`Set the secrets of environment "${environmentName}"`, async () => {
+    const { environment } = buildCommonLocators(page);
+
+    await openEnvironmentInSettings(page, environmentName, type);
+    await environment.secretsTab().click();
+
+    for (const [name, value] of Object.entries(secrets)) {
+      await setEnvironmentVariableValue(page, name, value);
+    }
+
+    await saveEnvironment(page);
+    await environment.variablesTab().click();
+  });
+};
+
+/**
+ * Filter the open environment's rows through the editor's search box, opening it first
+ * when it is still collapsed behind the search icon.
+ * @param page - The page object
+ * @param query - The text to filter by
+ * @returns void
+ */
+const searchEnvironmentVariables = async (page: Page, query: string) => {
+  await test.step(`Filter environment variables by "${query}"`, async () => {
+    const { environment } = buildCommonLocators(page);
+    if (!(await environment.searchInput().isVisible())) {
+      await environment.searchAction().click();
+    }
+    await environment.searchInput().fill(query);
   });
 };
 
@@ -2147,6 +2364,28 @@ const editCodeMirrorEditor = async (page: Page, editorTestId: string, newContent
     await page.keyboard.press(selectAll);
     await page.keyboard.press('Backspace');
     await page.keyboard.type(newContent, { delay: 5 });
+  });
+};
+
+/**
+ * Replace a CodeMirror editor's content through the CodeMirror API instead of typing it.
+ * Auto-close-bracket and auto-indent handling corrupts content typed character by character,
+ * so anything holding `{{var}}` tokens or several lines of braces goes through here.
+ * @param page - The page object
+ * @param editorTestId - The test ID of the editor container
+ * @param content - The content to write
+ */
+const setCodeMirrorEditorValue = async (page: Page, editorTestId: string, content: string) => {
+  await test.step(`Set CodeMirror editor "${editorTestId}"`, async () => {
+    const editor = buildCommonLocators(page).codeMirror.byTestId(editorTestId);
+    await editor.waitFor({ state: 'visible' });
+    await editor.evaluate((el, value) => {
+      const cm = (el as any).CodeMirror;
+      if (!cm) {
+        throw new Error('CodeMirror instance not found');
+      }
+      cm.setValue(value);
+    }, content);
   });
 };
 
@@ -3359,12 +3598,21 @@ export {
   openEnvironmentConfigTab,
   importEnvironment,
   createEnvironment,
+  renameEnvironment,
+  openEnvironmentInSettings,
+  setEnvironmentInheritance,
+  copyEnvironment,
+  deleteEnvironment,
   addEnvironmentVariable,
   addEnvironmentVariables,
   addRowToActiveTab,
   cycleVariableSort,
   getVisibleVariableNames,
   dragVariableRow,
+  setEnvironmentVariableValue,
+  disableEnvironmentVariable,
+  setEnvironmentSecrets,
+  searchEnvironmentVariables,
   deleteAllGlobalEnvironments,
   saveEnvironment,
   closeEnvironmentPanel,
@@ -3412,6 +3660,7 @@ export {
   switchWorkspace,
   selectScriptSubTab,
   editCodeMirrorEditor,
+  setCodeMirrorEditorValue,
   addPreRequestScript,
   addPostResponseScript,
   writeScriptContent,

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1173,7 +1173,11 @@ const addRowToActiveTab = async (
       const nameInput = await emptyRowNameInput(page);
       // Filling the value appends another empty row, so the row being filled in stops being the
       // last one — its formik index is what stays put until it has a name to be found by.
-      const rowIndex = Number((await nameInput.getAttribute('name')).split('.')[0]);
+      const formikName = await nameInput.getAttribute('name');
+      if (formikName === null) {
+        throw new Error('Empty environment row is missing its formik "name" attribute');
+      }
+      const rowIndex = Number(formikName.split('.')[0]);
 
       const emptyRowEditor = environment.variableValueEditor(rowIndex);
       await emptyRowEditor.scrollIntoViewIfNeeded();

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -1107,6 +1107,48 @@ const addEnvironmentVariables = async (page: Page, variables: EnvironmentVariabl
 type AddRowOptions = { valueFirst?: boolean };
 
 /**
+ * Bring part of the environment table into view. The table is virtualized, so a row outside the
+ * rendered window is absent from the DOM altogether, and waiting on the target alone never
+ * resolves. Walks the scroller a viewport at a time until the target renders, leaving the list
+ * wherever that happened.
+ * @param page - The page object
+ * @param target - The row, or a control within a row, to scroll to
+ * @returns void
+ */
+const scrollEnvironmentTableTo = async (page: Page, target: Locator) => {
+  const isRendered = () => target.isVisible().catch(() => false);
+  if (await isRendered()) {
+    return;
+  }
+
+  const scroller = buildCommonLocators(page).environment.variablesScroller();
+  await scroller.waitFor({ state: 'visible' });
+
+  const viewports = await scroller.evaluate((element) => Math.ceil(element.scrollHeight / element.clientHeight));
+  for (let viewport = 0; viewport <= viewports; viewport++) {
+    await scroller.evaluate((element, offset) => element.scrollTo({ top: offset * element.clientHeight }), viewport);
+    if (await isRendered()) {
+      return;
+    }
+  }
+};
+
+/**
+ * The trailing empty row's Name input, scrolled into the rendered window first. Only the empty
+ * row carries the `Name` placeholder, so a match is always the row a new variable goes into.
+ * @param page - The page object
+ * @returns The empty row's Name input
+ */
+const emptyRowNameInput = async (page: Page) => {
+  const nameInput = page.locator('input[placeholder="Name"]').last();
+
+  await scrollEnvironmentTableTo(page, nameInput);
+  await nameInput.waitFor({ state: 'visible' });
+
+  return nameInput;
+};
+
+/**
  * Add a variable or secret to whichever environment tab (Variables / Secrets) is
  * currently active. The active tab determines the row's type, so select the tab
  * before calling. When `dataType` is given, its type is set via the DataTypeSelector.
@@ -1128,11 +1170,10 @@ const addRowToActiveTab = async (
     const { environment, dataTypeSelector } = buildCommonLocators(page);
 
     if (options.valueFirst) {
-      const emptyRowNameInput = page.locator('input[placeholder="Name"]').last();
-      await emptyRowNameInput.waitFor({ state: 'visible' });
+      const nameInput = await emptyRowNameInput(page);
       // Filling the value appends another empty row, so the row being filled in stops being the
       // last one — its formik index is what stays put until it has a name to be found by.
-      const rowIndex = Number((await emptyRowNameInput.getAttribute('name')).split('.')[0]);
+      const rowIndex = Number((await nameInput.getAttribute('name')).split('.')[0]);
 
       const emptyRowEditor = environment.variableValueEditor(rowIndex);
       await emptyRowEditor.scrollIntoViewIfNeeded();
@@ -1143,8 +1184,7 @@ const addRowToActiveTab = async (
 
       await environment.variableNameInput(rowIndex).fill(name);
     } else {
-      const nameInput = page.locator('input[placeholder="Name"]').last();
-      await nameInput.waitFor({ state: 'visible' });
+      const nameInput = await emptyRowNameInput(page);
       await nameInput.fill(name);
     }
 
@@ -1188,6 +1228,7 @@ const addRowToActiveTab = async (
 const setEnvironmentVariableValue = async (page: Page, name: string, value: string) => {
   await test.step(`Set environment variable "${name}" to "${value}"`, async () => {
     const editor = buildCommonLocators(page).environment.varRowValueEditor(name);
+    await scrollEnvironmentTableTo(page, editor);
     await editor.scrollIntoViewIfNeeded();
     await editor.click({ position: { x: 5, y: 5 } });
     await expect(editor).toHaveClass(/CodeMirror-focused/);
@@ -1208,6 +1249,7 @@ const setEnvironmentVariableValue = async (page: Page, name: string, value: stri
 const disableEnvironmentVariable = async (page: Page, name: string) => {
   await test.step(`Disable environment variable "${name}"`, async () => {
     const checkbox = buildCommonLocators(page).environment.varRowEnabledCheckbox(name);
+    await scrollEnvironmentTableTo(page, checkbox);
     await checkbox.click();
     await expect(checkbox).not.toBeChecked();
   });

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -52,6 +52,10 @@ export const buildEnvironmentLocators = (page: Page) => ({
   varErrors: () => page.getByTestId('env-var-name-error'),
   // The trailing empty "add new variable" row's name input.
   addRowNameInput: () => page.getByTestId('env-var-name-input').last(),
+  // The variables table's scroll container. The table is virtualized, so rows outside the
+  // rendered window reach the DOM only once this element is scrolled to them.
+  variablesScroller: () =>
+    page.locator('.table-container').filter({ has: page.locator('tr[data-testid^="env-var-row-"]') }),
   // A row addressed by its formik index rather than its name — the only handle on a row that
   // has no name yet, and one that survives the empty row the table appends while it is filled in.
   variableValueEditor: (index: number) =>

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -2,6 +2,7 @@ import { expect, Page, test } from '../../../../playwright';
 import { buildCollectionHeaderLocators } from '../collection/collection-header';
 
 const environmentItemLocator = (page: Page, name: string) => page.locator('.environment-item').filter({ hasText: name });
+const exportModalRoot = (page: Page) => page.locator('.bruno-modal').filter({ hasText: 'Export Environments' });
 
 export const buildEnvironmentLocators = (page: Page) => ({
   selector: () => page.getByTestId('environment-selector-trigger'),
@@ -51,6 +52,10 @@ export const buildEnvironmentLocators = (page: Page) => ({
   varErrors: () => page.getByTestId('env-var-name-error'),
   // The trailing empty "add new variable" row's name input.
   addRowNameInput: () => page.getByTestId('env-var-name-input').last(),
+  // A row addressed by its formik index rather than its name — the only handle on a row that
+  // has no name yet, and one that survives the empty row the table appends while it is filled in.
+  variableValueEditor: (index: number) =>
+    page.locator(`[data-testid="test-multiline-editor-${index}.value"]`).locator('.CodeMirror').first(),
   addVariableButton: () => page.getByTestId('add-variable'),
   variableNameInput: (index: number) => page.locator(`input[name="${index}.name"]`),
   variableSecretCheckbox: (index: number) => page.locator(`input[name="${index}.secret"]`),
@@ -84,13 +89,42 @@ export const buildEnvironmentLocators = (page: Page) => ({
   // measurement copy (which carries no responsive-tab testid) is excluded.
   tabCount: (tab: string) => page.getByTestId(`responsive-tab-${tab}`).getByTestId('env-tab-count'),
   saveTab: () => page.getByTestId('save-env'),
+  resetTab: () => page.getByTestId('reset-env'),
   saveAll: () => page.getByTestId('save-all-env'),
   searchInput: () => page.getByTestId('env-search-input'),
   searchClearBtn: () => page.locator('.env-list-search .close-icon'),
   listItem: (name?: string) => name ? page.getByTestId('env-list-item').filter({ hasText: name }) : page.getByTestId('env-list-item'),
+  // "Inherits from" picker in the environment editor header, and its menu options.
+  // Menu item ids are the parent environment names, lowercased by MenuDropdown.
+  inheritsFromAction: () => page.getByTestId('env-inherits-from-action'),
+  inheritsFromName: () => page.getByTestId('env-inherits-from-action').locator('.inherits-from-name'),
+  inheritsFromOption: (name: string) => page.getByTestId(`env-inherits-from-${name.toLowerCase()}`),
+  inheritsFromNoneOption: () => page.getByTestId('env-inherits-from-no-environment'),
+  missingInheritedEnvironment: () => page.getByTestId('env-missing-inherited-environment'),
+  // Rows merged in from an ancestor environment; they are read-only.
+  inheritedSection: () => page.getByTestId('env-var-section-inherited'),
+  inheritedSectionToggle: () => page.getByTestId('env-var-section-toggle-inherited'),
+  sectionCount: (section: string) => page.getByTestId(`env-var-section-${section}`).locator('.section-count'),
+  inheritedVarRow: (name: string) => page.getByTestId(`env-inherited-var-row-${name}`),
+  inheritedVarValue: (name: string) => page.getByTestId(`env-inherited-var-row-${name}`).locator('.inherited-value'),
+  inheritedVarDataType: (name: string) =>
+    page.getByTestId(`env-inherited-var-row-${name}`).getByTestId('inherited-data-type'),
+  inheritedVarSource: (name: string) => page.getByTestId(`env-inherited-var-row-${name}`).getByTestId('inherited-source'),
+  inheritedVarEyeToggle: (name: string) =>
+    page.getByTestId(`env-inherited-var-row-${name}`).getByTestId('inherited-secret-reveal-toggle'),
+  inheritedVarEnabledCheckbox: (name: string) =>
+    page.getByTestId(`env-inherited-var-row-${name}`).locator('input[type="checkbox"]'),
+  inheritedVarEditableFields: (name: string) =>
+    page.getByTestId(`env-inherited-var-row-${name}`).locator('input:not([type="checkbox"]), .CodeMirror'),
+  detailsTitle: () => page.getByTestId('env-details-title'),
+  copyAction: () => page.getByTestId('env-copy-action'),
+  deleteAction: () => page.getByTestId('env-delete-action'),
   noResults: () => page.getByTestId('env-no-results'),
+  varsNoResults: () => page.getByTestId('env-vars-no-results'),
   noEnvironmentItem: () => page.getByTestId('env-no-environment-item'),
   searchAction: () => page.getByTestId('env-search-action'),
+  renameAction: () => page.getByTestId('env-rename-action'),
+  renameInput: () => page.getByTestId('env-rename-input'),
   savedToast: () => page.getByText('Changes saved successfully').last(),
   collectionEnvTab: () => page.locator('.request-tab').filter({ hasText: /^Environments$/ }),
   globalEnvTab: () => page.locator('.request-tab').filter({ hasText: /^Global Environments$/ }),
@@ -115,6 +149,19 @@ export const buildEnvironmentLocators = (page: Page) => ({
     page
       .getByTestId(scope === 'global' ? 'workspace-env-list-item' : 'collection-env-list-item')
       .filter({ has: page.getByText(name, { exact: true }) }),
+  exportAction: () => page.locator('button[title="Export environment"]'),
+  exportModal: {
+    root: () => exportModalRoot(page),
+    deselectAll: () => exportModalRoot(page).getByRole('button', { name: 'Deselect All' }),
+    environmentCheckbox: (name: string) =>
+      exportModalRoot(page)
+        .locator('label.environment-item')
+        .filter({ has: page.getByText(name, { exact: true }) })
+        .locator('input[type="checkbox"]'),
+    inheritanceWarning: () => exportModalRoot(page).getByTestId('env-export-inheritance-warning'),
+    location: () => exportModalRoot(page).locator('#export-location'),
+    submit: () => exportModalRoot(page).getByRole('button', { name: /^Export \d+ Environments?$/ })
+  },
   varRowEnabledCheckbox: (name: string) =>
     page.getByTestId(`env-var-row-${name}`).getByTestId('env-var-enabled-checkbox'),
   importSubmitButton: (scope: 'collection' | 'global') =>


### PR DESCRIPTION
### Description

Adds support for environment inheritance: an environment can inherit another environment's variables and override only the names it redefines. Works for collection environments and workspace environments, in both `.bru` and `.yml`, in the app and in the CLI.

### Problem

Environment variables are duplicated across environments, and there's no way to layer them — define common values once, inherit them, and override only what differs.

### Screenshots

https://github.com/user-attachments/assets/a141d950-dbcd-45f9-8d96-a670841675aa

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment inheritance for collection and workspace environments.
  * View inherited variables with types, sources, collapsible sections, search, and read-only status.
  * Select, change, copy, rename, and remove inherited environments.
  * Preserve inheritance when importing, exporting, and saving environments.
  * Resolve inherited variables in requests, scripts, collection runs, code generation, and CLI execution.
  * Added warnings for missing or excluded parent environments.
* **Bug Fixes**
  * Prevented unchanged inherited values and secrets from being unnecessarily written to environment files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->