### PR TITLE
fix(collection-settings): save presets using shortcuts

### DIFF
--- a/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
+++ b/packages/bruno-app/src/components/CollectionSettings/Presets/index.js
@@ -90,7 +90,7 @@ const PresetsSettings = ({ collection }) => {
             type="text"
             name="requestUrl"
             placeholder="Request URL"
-            className="block textbox preset-input"
+            className="block textbox preset-input mousetrap"
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"

--- a/packages/bruno-app/src/ui/SegmentedControl/components/Segment.jsx
+++ b/packages/bruno-app/src/ui/SegmentedControl/components/Segment.jsx
@@ -32,7 +32,7 @@ const Segment = forwardRef(({ value, label, icon, disabled = false, className = 
         {...rest}
         ref={ref}
         type="radio"
-        className="segment-input"
+        className="segment-input mousetrap"
         name={name}
         value={value}
         checked={checked}


### PR DESCRIPTION
### Description

As this is small task under transient requests presets hence taken care for - BRU-2070

Changing presets and saving using shortcuts is not saving until we click somewhere else and press the save shortcut again

### Problem

When changing presets and pressing shortcuts it is not saving - reason `mousetrap` class is not being passed to the respective `<input/>` tag

### Fix

Pass `mousetrap` class to the respective `<input/>` tag in preset settings

### Before vs After

https://github.com/user-attachments/assets/1e392c27-4b3e-4b04-8f61-419363f5bbe2

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard shortcut handling for the default base URL field.
  * Enabled keyboard shortcut support for segmented control options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->