### PR TITLE
fix(test): add dataTestId to delete collection item modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItems/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItems/index.js
@@ -76,6 +76,7 @@ const DeleteCollectionItems = ({ entries, onClose }) => {
       confirmButtonColor="danger"
       handleConfirm={onConfirm}
       handleCancel={onClose}
+      dataTestId="delete-collection-item-modal"
     >
       Are you sure you want to delete {description}?
     </Modal>


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Fixes the test failure for Delete collection modal, by adding data-test-id `delete-collection-item-modal` for the modal.
### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a stable identifier to the collection-item deletion confirmation modal, improving UI test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->