### PR TITLE
feat(preferences): add docs URL for Mock Server

### DIFF
--- a/packages/bruno-app/src/components/Preferences/Beta/index.js
+++ b/packages/bruno-app/src/components/Preferences/Beta/index.js
@@ -65,7 +65,8 @@ const BETA_FEATURES = [
     id: BETA_FEATURE_IDS.MOCK_SERVER,
     label: 'Mock Server',
     description: 'Run a local mock server using response examples defined in your collection. Serve mock API responses for frontend development without a real backend.',
-    toggle: true
+    toggle: true,
+    docsUrl: 'https://link.usebruno.com/docs/mock-server'
   }
 ];
 


### PR DESCRIPTION
### Description

The Mock Server entry in Preferences → Beta was the only beta feature without a
"View docs" link. This adds one, pointing to the Mock Server documentation.
### Changes
- Added `docsUrl` to the Mock Server beta feature so the existing "View docs"
  link renders alongside the other beta features.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “View docs” link for the Mock Server feature in the Beta preferences tab, providing quick access to related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->