### PR TITLE
fix(collection-docs): Include git repo url toggle is hidden when there is no git remote url

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
@@ -47,6 +47,8 @@ export const StyledWrapper = styled.div`
   .docs-tag-item {
     display: inline-flex;
     align-items: center;
+    box-sizing: border-box;
+    height: 1.75rem;
     gap: 0.25rem;
     max-width: 100%;
     padding: 0.25rem;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.jsx
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.jsx
@@ -14,7 +14,8 @@ const Advanced = ({
   availableTags,
   onTagsChange,
   includeGitLink,
-  onGitLinkToggle
+  onGitLinkToggle,
+  hasGitUrl
 }) => {
   const [open, setOpen] = useState(false);
   const requestsLabelId = useId();
@@ -83,19 +84,21 @@ const Advanced = ({
               )}
             </section>
 
-            <section className="adv-section">
-              <div className="adv-row">
-                <div className="adv-label mb-0">
-                  <IconGitBranch size={16} className="adv-label-icon" aria-hidden="true" />
-                  <span>Include git repo URL</span>
+            {hasGitUrl && (
+              <section className="adv-section" data-testid="docs-git-link">
+                <div className="adv-row">
+                  <div className="adv-label mb-0">
+                    <IconGitBranch size={16} className="adv-label-icon" aria-hidden="true" />
+                    <span>Include git repo URL</span>
+                  </div>
+                  <label className="adv-toggle" data-testid="docs-git-link-toggle">
+                    <span className="toggle-label">Show</span>
+                    <ToggleSwitch isOn={includeGitLink} handleToggle={onGitLinkToggle} size="xs" />
+                  </label>
                 </div>
-                <label className="adv-toggle">
-                  <span className="toggle-label">Show</span>
-                  <ToggleSwitch isOn={includeGitLink} handleToggle={onGitLinkToggle} size="xs" />
-                </label>
-              </div>
-              <p className="adv-desc">Adds the repository link so readers can clone your collection in Bruno.</p>
-            </section>
+                <p className="adv-desc">Adds the repository link so readers can clone your collection in Bruno.</p>
+              </section>
+            )}
           </div>
         </div>
       </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.spec.js
@@ -12,7 +12,8 @@ const defaultProps = {
   availableTags: ['prod', 'wip'],
   onTagsChange: jest.fn(),
   includeGitLink: true,
-  onGitLinkToggle: jest.fn()
+  onGitLinkToggle: jest.fn(),
+  hasGitUrl: true
 };
 
 const renderAdvanced = (props = {}) =>
@@ -72,12 +73,25 @@ describe('Advanced (Generate Documentation)', () => {
 
   it('toggles the git repo link when the switch is clicked', () => {
     const onGitLinkToggle = jest.fn();
-    const { getByText, getByRole, getByTestId } = renderAdvanced({ onGitLinkToggle });
+    const { getByTestId } = renderAdvanced({ onGitLinkToggle });
     expand(getByTestId);
 
-    expect(getByText('Include git repo URL')).toBeInTheDocument();
-    fireEvent.click(getByRole('checkbox'));
+    expect(getByTestId('docs-git-link')).toBeInTheDocument();
+    fireEvent.click(getByTestId('docs-git-link-toggle').querySelector('input[type="checkbox"]'));
     expect(onGitLinkToggle).toHaveBeenCalled();
+  });
+
+  it('renders the git repo URL section only when a git url is present', () => {
+    const { getByTestId, queryByTestId, rerender } = renderAdvanced({ hasGitUrl: false });
+    expand(getByTestId);
+    expect(queryByTestId('docs-git-link')).not.toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={themes.light}>
+        <Advanced {...defaultProps} hasGitUrl={true} />
+      </ThemeProvider>
+    );
+    expect(queryByTestId('docs-git-link')).toBeInTheDocument();
   });
 
   it('keeps the collapsible body out of the a11y tree and tab order until expanded', () => {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -90,6 +90,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
   const [docTags, setDocTags] = useState({ include: [], exclude: [] });
   const [includeGitLink, setIncludeGitLink] = useState(true);
   const { gitCollectionUrl, isResolved: gitUrlLoaded } = useCollectionGitRemoteUrl(collection?.pathname);
+  const hasGitUrl = gitUrlLoaded && Boolean(gitCollectionUrl);
 
   const handleGenerate = useCallback(() => {
     try {
@@ -192,6 +193,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
                   onTagsChange={setDocTags}
                   includeGitLink={includeGitLink}
                   onGitLinkToggle={() => setIncludeGitLink((prev) => !prev)}
+                  hasGitUrl={hasGitUrl}
                 />
               </div>
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.spec.js
@@ -128,11 +128,30 @@ describe('GenerateDocumentation', () => {
     renderModal(buildCollection());
 
     fireEvent.click(screen.getByTestId('docs-advanced-toggle'));
-    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByTestId('docs-git-link-toggle').querySelector('input[type="checkbox"]'));
 
     fireEvent.click(screen.getByTestId('generate-btn'));
 
     const [, options] = generateApiDocsHtml.mock.calls[0];
     expect(options.gitCollectionUrl).toBeUndefined();
+  });
+
+  it('hides the git repo URL toggle when the collection has no git url', () => {
+    mockGitRemote = { gitCollectionUrl: null, isResolved: true };
+    renderModal(buildCollection());
+
+    fireEvent.click(screen.getByTestId('docs-advanced-toggle'));
+
+    expect(screen.queryByTestId('docs-git-link')).not.toBeInTheDocument();
+  });
+
+  it('shows the git repo URL toggle switched on by default when a git url is present', () => {
+    mockGitRemote = { gitCollectionUrl: 'https://github.com/org/repo.git', isResolved: true };
+    renderModal(buildCollection());
+
+    fireEvent.click(screen.getByTestId('docs-advanced-toggle'));
+
+    expect(screen.getByTestId('docs-git-link')).toBeInTheDocument();
+    expect(screen.getByTestId('docs-git-link-toggle').querySelector('input[type="checkbox"]')).toBeChecked();
   });
 });

--- a/tests/collection/generate-docs/generate-docs-git-link.spec.ts
+++ b/tests/collection/generate-docs/generate-docs-git-link.spec.ts
@@ -1,0 +1,30 @@
+import { execSync } from 'child_process';
+import { test, expect } from '../../../playwright';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const COLLECTION_NAME = 'GenerateDocsOrder';
+
+test.describe('Generate Documentation - git link', () => {
+  test('shows the git-link control under Advanced when the collection has a git remote', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    execSync('git init', { cwd: collectionFixturePath!, stdio: 'pipe' });
+    execSync('git remote add origin https://github.com/org/repo.git', { cwd: collectionFixturePath!, stdio: 'pipe' });
+
+    const locators = buildCommonLocators(page);
+
+    await locators.sidebar.collection(COLLECTION_NAME).hover();
+    await locators.actions.collectionActions(COLLECTION_NAME).click();
+    await locators.generateDocs.menuItem().click();
+
+    const modal = locators.generateDocs.modal();
+    await expect(modal).toBeVisible();
+
+    await locators.generateDocs.advancedToggle().click();
+    await expect(locators.generateDocs.gitLinkLabel()).toBeVisible();
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+});

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -1,4 +1,3 @@
-import { execSync } from 'child_process';
 import jsyaml from 'js-yaml';
 import { test, expect, Page } from '../../../playwright';
 import { generateCollectionDocs } from '../../utils/page';
@@ -372,30 +371,6 @@ test.describe('Generate Documentation', () => {
     await expect(locators.generateDocs.excludeTagsInput()).toBeVisible();
 
     await expect(locators.generateDocs.gitLinkLabel()).toBeHidden();
-
-    await locators.generateDocs.cancelButton().click();
-    await expect(modal).toBeHidden();
-  });
-
-  test('shows the git-link control under Advanced when the collection has a git remote', async ({
-    pageWithUserData: page,
-    collectionFixturePath
-  }) => {
-    execSync('git init', { cwd: collectionFixturePath!, stdio: 'ignore' });
-    execSync('git remote add origin https://github.com/org/repo.git', { cwd: collectionFixturePath!, stdio: 'ignore' });
-
-    const locators = buildCommonLocators(page);
-
-    await locators.sidebar.collection(COLLECTION_NAME).hover();
-    await locators.actions.collectionActions(COLLECTION_NAME).click();
-    await locators.generateDocs.menuItem().click();
-
-    const modal = locators.generateDocs.modal();
-    await expect(modal).toBeVisible();
-
-    await locators.generateDocs.advancedToggle().click();
-
-    await expect(locators.generateDocs.gitLinkLabel()).toBeVisible();
 
     await locators.generateDocs.cancelButton().click();
     await expect(modal).toBeHidden();

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import jsyaml from 'js-yaml';
 import { test, expect, Page } from '../../../playwright';
 import { generateCollectionDocs } from '../../utils/page';
@@ -348,7 +349,7 @@ test.describe('Generate Documentation', () => {
     expect(generatedEnvironmentNames(content).sort()).toEqual([...EXPECTED_ENVIRONMENTS].sort());
   });
 
-  test('reveals request filtering and the git-link control under Advanced', async ({
+  test('reveals request filtering under Advanced, and hides the git-link control when the collection has no git remote', async ({
     pageWithUserData: page
   }) => {
     const locators = buildCommonLocators(page);
@@ -369,6 +370,30 @@ test.describe('Generate Documentation', () => {
     await expect(locators.generateDocs.filterByTagsButton()).toHaveAttribute('aria-pressed', 'true');
     await expect(locators.generateDocs.includeTagsInput()).toBeVisible();
     await expect(locators.generateDocs.excludeTagsInput()).toBeVisible();
+
+    await expect(locators.generateDocs.gitLinkLabel()).toBeHidden();
+
+    await locators.generateDocs.cancelButton().click();
+    await expect(modal).toBeHidden();
+  });
+
+  test('shows the git-link control under Advanced when the collection has a git remote', async ({
+    pageWithUserData: page,
+    collectionFixturePath
+  }) => {
+    execSync('git init', { cwd: collectionFixturePath!, stdio: 'ignore' });
+    execSync('git remote add origin https://github.com/org/repo.git', { cwd: collectionFixturePath!, stdio: 'ignore' });
+
+    const locators = buildCommonLocators(page);
+
+    await locators.sidebar.collection(COLLECTION_NAME).hover();
+    await locators.actions.collectionActions(COLLECTION_NAME).click();
+    await locators.generateDocs.menuItem().click();
+
+    const modal = locators.generateDocs.modal();
+    await expect(modal).toBeVisible();
+
+    await locators.generateDocs.advancedToggle().click();
 
     await expect(locators.generateDocs.gitLinkLabel()).toBeVisible();
 

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -240,7 +240,7 @@ export const buildCommonLocators = (page: Page) => ({
     includeTagsInput: () => page.locator('.bruno-modal').getByLabel('Include tags'),
     excludeTagsInput: () => page.locator('.bruno-modal').getByLabel('Exclude tags'),
     tagChip: (name: string) => page.locator('.bruno-modal .docs-tag-item').filter({ hasText: name }),
-    gitLinkLabel: () => page.locator('.bruno-modal').getByText('Include git repo URL')
+    gitLinkLabel: () => page.locator('.bruno-modal').getByTestId('docs-git-link')
   },
   runnerResults: {
     itemPath: (name: string) => page.getByTestId('runner-result-item').filter({ hasText: name })


### PR DESCRIPTION
Ref: BRU-4022

### Description

In the Generate Documentation modal, the "Include git repo URL" toggle now appears only when the collection actually has a git remote, and it is switched on by default when a URL is present.

### Problem

The toggle was shown for every collection, even ones with no git remote, so users saw a switch that did nothing because there was no repo URL to include.

### Fix

Only render the toggle when a git remote URL is resolved for the collection (on by default), and hide it entirely when there is none.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | 
<img width="1578" height="1460" alt="image" src="https://github.com/user-attachments/assets/74442865-46f8-44de-a589-07b909a3ffdf" />
| After |
<img width="1612" height="1358" alt="image" src="https://github.com/user-attachments/assets/a4f36c78-fb10-456a-9f5c-55326462dc4e" />

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The “Include git repo URL” option now appears only when a collection has an available Git repository URL.
  * Improved the layout and sizing of documentation tag items.

* **Tests**
  * Added coverage for showing and hiding the Git repository URL option based on repository availability.
  * Updated documentation-generation checks to validate the toggle reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->