### PR TITLE
fix(request): creating a new request from sidebar add request pre fils the preset url

### DIFF
--- a/packages/bruno-app/src/utils/collections/emptyStateRequest.js
+++ b/packages/bruno-app/src/utils/collections/emptyStateRequest.js
@@ -10,11 +10,12 @@ const createRequest = async ({ dispatch, collection, itemUid, requestType }) => 
   try {
     const uniqueName = await generateUniqueRequestName(collection, 'Untitled', itemUid);
     const filename = sanitizeName(uniqueName);
+    const presets = collection?.draft?.brunoConfig?.presets ?? collection?.brunoConfig?.presets;
 
     const baseParams = {
       requestName: uniqueName,
       filename,
-      requestUrl: '',
+      requestUrl: presets?.requestUrl || '',
       collectionUid: collection.uid,
       itemUid
     };

--- a/tests/collection/presets-base-url.spec.ts
+++ b/tests/collection/presets-base-url.spec.ts
@@ -1,15 +1,35 @@
-import { test, expect } from '../../playwright';
-import { buildCommonLocators, closeAllCollections, createCollection, setRequestUrlPreset } from '../utils/page';
+import { test, expect, Page } from '../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  deleteRequest,
+  setRequestUrlPreset
+} from '../utils/page';
 
 const COLLECTION_NAME = 'presets-base-url';
 const BASE_URL = 'https://api.example.com';
+const REQUEST_NAME = 'Untitled';
+
+type Locators = ReturnType<typeof buildCommonLocators>;
+
+const createHttpRequestFromEmptyStateCta = async (page: Page, locators: Locators) => {
+  await test.step('Create an HTTP request from the "+ Add request" CTA', async () => {
+    await locators.sidebar.collection(COLLECTION_NAME).click();
+    await locators.sidebar.collectionScope(COLLECTION_NAME).getByTestId('add-request-cta').click();
+    await page.getByTestId('add-request-cta-http').click();
+  });
+};
 
 test.describe('New requests inherit the collection presets Base URL', () => {
   test.afterEach(async ({ page }) => {
     await closeAllCollections(page);
   });
 
-  test('the empty-collection "+ Add request" CTA pre-fills the preset Base URL', async ({ page, createTmpDir }) => {
+  test('the "+ Add request" CTA follows the Base URL preset as it is set and cleared', async ({
+    page,
+    createTmpDir
+  }) => {
     const locators = buildCommonLocators(page);
 
     await test.step('Create a fresh collection', async () => {
@@ -22,23 +42,27 @@ test.describe('New requests inherit the collection presets Base URL', () => {
       await expect(locators.presets.requestUrl()).toHaveValue(BASE_URL);
     });
 
-    const cta = locators.sidebar.collectionScope(COLLECTION_NAME).getByTestId('add-request-cta');
-
-    await test.step('Open the empty-collection CTA', async () => {
-      if (!(await cta.isVisible())) {
-        await locators.sidebar.collection(COLLECTION_NAME).click();
-      }
-      await expect(cta).toBeVisible();
-      await cta.click();
-    });
-
-    await test.step('Create an HTTP request from the CTA', async () => {
-      await page.getByTestId('add-request-cta-http').click();
-    });
+    await createHttpRequestFromEmptyStateCta(page, locators);
 
     await test.step('Verify the new request opens with the preset Base URL', async () => {
-      await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, 'Untitled')).toBeVisible();
+      await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, REQUEST_NAME)).toBeVisible();
       await expect(locators.requestUrl.editor()).toContainText(BASE_URL);
+    });
+
+    await test.step('Clear the Base URL preset', async () => {
+      await setRequestUrlPreset(page, COLLECTION_NAME, '');
+      await expect(locators.presets.requestUrl()).toHaveValue('');
+    });
+
+    await test.step('Delete the request so the collection is empty again', async () => {
+      await deleteRequest(page, REQUEST_NAME, COLLECTION_NAME);
+    });
+
+    await createHttpRequestFromEmptyStateCta(page, locators);
+
+    await test.step('Verify the new request opens with an empty URL', async () => {
+      await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, REQUEST_NAME)).toBeVisible();
+      await expect(locators.requestUrl.line()).toHaveText('');
     });
   });
 });

--- a/tests/collection/presets-base-url.spec.ts
+++ b/tests/collection/presets-base-url.spec.ts
@@ -1,8 +1,9 @@
-import { test, expect, Page } from '../../playwright';
+import { test, expect } from '../../playwright';
 import {
   buildCommonLocators,
   closeAllCollections,
   createCollection,
+  createRequestFromEmptyStateCta,
   deleteRequest,
   setRequestUrlPreset
 } from '../utils/page';
@@ -10,16 +11,6 @@ import {
 const COLLECTION_NAME = 'presets-base-url';
 const BASE_URL = 'https://api.example.com';
 const REQUEST_NAME = 'Untitled';
-
-type Locators = ReturnType<typeof buildCommonLocators>;
-
-const createHttpRequestFromEmptyStateCta = async (page: Page, locators: Locators) => {
-  await test.step('Create an HTTP request from the "+ Add request" CTA', async () => {
-    await locators.sidebar.collection(COLLECTION_NAME).click();
-    await locators.sidebar.collectionScope(COLLECTION_NAME).getByTestId('add-request-cta').click();
-    await page.getByTestId('add-request-cta-http').click();
-  });
-};
 
 test.describe('New requests inherit the collection presets Base URL', () => {
   test.afterEach(async ({ page }) => {
@@ -42,7 +33,7 @@ test.describe('New requests inherit the collection presets Base URL', () => {
       await expect(locators.presets.requestUrl()).toHaveValue(BASE_URL);
     });
 
-    await createHttpRequestFromEmptyStateCta(page, locators);
+    await createRequestFromEmptyStateCta(page, COLLECTION_NAME);
 
     await test.step('Verify the new request opens with the preset Base URL', async () => {
       await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, REQUEST_NAME)).toBeVisible();
@@ -58,7 +49,7 @@ test.describe('New requests inherit the collection presets Base URL', () => {
       await deleteRequest(page, REQUEST_NAME, COLLECTION_NAME);
     });
 
-    await createHttpRequestFromEmptyStateCta(page, locators);
+    await createRequestFromEmptyStateCta(page, COLLECTION_NAME);
 
     await test.step('Verify the new request opens with an empty URL', async () => {
       await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, REQUEST_NAME)).toBeVisible();

--- a/tests/collection/presets-base-url.spec.ts
+++ b/tests/collection/presets-base-url.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../../playwright';
+import { buildCommonLocators, closeAllCollections, createCollection, setRequestUrlPreset } from '../utils/page';
+
+const COLLECTION_NAME = 'presets-base-url';
+const BASE_URL = 'https://api.example.com';
+
+test.describe('New requests inherit the collection presets Base URL', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('the empty-collection "+ Add request" CTA pre-fills the preset Base URL', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+
+    await test.step('Create a fresh collection', async () => {
+      await createCollection(page, COLLECTION_NAME, await createTmpDir(COLLECTION_NAME));
+      await expect(locators.sidebar.collection(COLLECTION_NAME)).toBeVisible();
+    });
+
+    await test.step('Save a Base URL in the collection presets', async () => {
+      await setRequestUrlPreset(page, COLLECTION_NAME, BASE_URL);
+      await expect(locators.presets.requestUrl()).toHaveValue(BASE_URL);
+    });
+
+    const cta = locators.sidebar.collectionScope(COLLECTION_NAME).getByTestId('add-request-cta');
+
+    await test.step('Open the empty-collection CTA', async () => {
+      if (!(await cta.isVisible())) {
+        await locators.sidebar.collection(COLLECTION_NAME).click();
+      }
+      await expect(cta).toBeVisible();
+      await cta.click();
+    });
+
+    await test.step('Create an HTTP request from the CTA', async () => {
+      await page.getByTestId('add-request-cta-http').click();
+    });
+
+    await test.step('Verify the new request opens with the preset Base URL', async () => {
+      await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, 'Untitled')).toBeVisible();
+      await expect(locators.requestUrl.editor()).toContainText(BASE_URL);
+    });
+  });
+});

--- a/tests/collection/presets-base-url.spec.ts
+++ b/tests/collection/presets-base-url.spec.ts
@@ -46,7 +46,7 @@ test.describe('New requests inherit the collection presets Base URL', () => {
 
     await test.step('Verify the new request opens with the preset Base URL', async () => {
       await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, REQUEST_NAME)).toBeVisible();
-      await expect(locators.requestUrl.editor()).toContainText(BASE_URL);
+      await expect(locators.request.urlLine().first()).toContainText(BASE_URL);
     });
 
     await test.step('Clear the Base URL preset', async () => {
@@ -62,7 +62,7 @@ test.describe('New requests inherit the collection presets Base URL', () => {
 
     await test.step('Verify the new request opens with an empty URL', async () => {
       await expect(locators.sidebar.itemRowIn(COLLECTION_NAME, REQUEST_NAME)).toBeVisible();
-      await expect(locators.requestUrl.line()).toHaveText('');
+      await expect(locators.request.urlLine().first()).toHaveText('');
     });
   });
 });

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import { buildCommonLocators, buildScriptErrorLocators, buildGrpcCommonLocators, PresetRequestType } from './locators';
 import { waitForCollectionMount } from './mounting';
 import { buildPreferencesLocators, openPreferences, selectPreferencesTab } from './preferences';
+import { EmptyStateRequestType } from './sidebar';
 
 type SandboxMode = 'safe' | 'developer';
 
@@ -409,6 +410,27 @@ const setRequestUrlPreset = async (page: Page, collectionName: string, requestUr
     await locators.presets.saveBtn().click();
 
     await locators.tabs.tabDraftIndicator(locators.tabs.collectionSettingsTab()).waitFor({ state: 'hidden' });
+  });
+};
+
+/**
+ * Create a request from the "+ Add request" CTA shown inside an empty collection.
+ * @param page - The page object
+ * @param collectionName - The name of the collection
+ * @param requestType - The request type to pick from the CTA menu (defaults to http)
+ * @returns void
+ */
+const createRequestFromEmptyStateCta = async (
+  page: Page,
+  collectionName: string,
+  requestType: EmptyStateRequestType = 'http'
+) => {
+  await test.step(`Create a ${requestType} request from the "+ Add request" CTA`, async () => {
+    const { sidebar } = buildCommonLocators(page);
+
+    await sidebar.collection(collectionName).click();
+    await sidebar.emptyStateCta(collectionName).click();
+    await sidebar.emptyStateCtaItem(requestType).click();
   });
 };
 
@@ -3226,6 +3248,7 @@ export {
   createTransientRequestFromPreset,
   setRequestTypePreset,
   setRequestUrlPreset,
+  createRequestFromEmptyStateCta,
   fillRequestUrl,
   deleteRequest,
   deleteCollectionFromOverview,

--- a/tests/utils/page/actions.ts
+++ b/tests/utils/page/actions.ts
@@ -389,6 +389,30 @@ const setRequestTypePreset = async (page: Page, collectionName: string, requestT
 };
 
 /**
+ * Set the Base URL preset for a collection.
+ * New requests created in the collection inherit this as their starting URL.
+ * @param page - The page object
+ * @param collectionName - The name of the collection
+ * @param requestUrl - The Base URL to save as the preset
+ * @returns void
+ */
+const setRequestUrlPreset = async (page: Page, collectionName: string, requestUrl: string) => {
+  await test.step(`Set the Base URL preset to "${requestUrl}"`, async () => {
+    const locators = buildCommonLocators(page);
+
+    await openCollectionSettings(page, collectionName);
+    await selectCollectionPaneTab(page, 'presets');
+
+    const urlInput = locators.presets.requestUrl();
+    await urlInput.waitFor({ state: 'visible' });
+    await urlInput.fill(requestUrl);
+    await locators.presets.saveBtn().click();
+
+    await locators.tabs.tabDraftIndicator(locators.tabs.collectionSettingsTab()).waitFor({ state: 'hidden' });
+  });
+};
+
+/**
  * Fill the URL field in the currently active request
  * Works with HTTP, GraphQL, gRPC, and WebSocket requests
  * @param page - The page object
@@ -3201,6 +3225,7 @@ export {
   createTransientRequest,
   createTransientRequestFromPreset,
   setRequestTypePreset,
+  setRequestUrlPreset,
   fillRequestUrl,
   deleteRequest,
   deleteCollectionFromOverview,

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -193,12 +193,6 @@ export const buildCommonLocators = (page: Page) => ({
     inheritedMode: () => page.getByTestId('inherited-auth-mode'),
     dropdownItem: (id: string) => page.getByTestId(`auth-mode-dropdown-${id}`)
   },
-  requestUrl: {
-    container: () => page.getByTestId('request-url'),
-    editor: () => page.getByTestId('request-url').locator('.CodeMirror'),
-    /** The URL editor's rendered text. An empty URL renders an empty first line. */
-    line: () => page.getByTestId('request-url').locator('.CodeMirror-line').first()
-  },
   presets: {
     requestType: (type: PresetRequestType) =>
       page.getByTestId(`presets-request-type-${type}`),

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -193,6 +193,10 @@ export const buildCommonLocators = (page: Page) => ({
     inheritedMode: () => page.getByTestId('inherited-auth-mode'),
     dropdownItem: (id: string) => page.getByTestId(`auth-mode-dropdown-${id}`)
   },
+  requestUrl: {
+    container: () => page.getByTestId('request-url'),
+    editor: () => page.getByTestId('request-url').locator('.CodeMirror')
+  },
   presets: {
     requestType: (type: PresetRequestType) =>
       page.getByTestId(`presets-request-type-${type}`),

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -195,7 +195,9 @@ export const buildCommonLocators = (page: Page) => ({
   },
   requestUrl: {
     container: () => page.getByTestId('request-url'),
-    editor: () => page.getByTestId('request-url').locator('.CodeMirror')
+    editor: () => page.getByTestId('request-url').locator('.CodeMirror'),
+    /** The URL editor's rendered text. An empty URL renders an empty first line. */
+    line: () => page.getByTestId('request-url').locator('.CodeMirror-line').first()
   },
   presets: {
     requestType: (type: PresetRequestType) =>

--- a/tests/utils/page/sidebar/index.ts
+++ b/tests/utils/page/sidebar/index.ts
@@ -1,5 +1,7 @@
 import { Locator, Page } from '../../../../playwright';
 
+export type EmptyStateRequestType = 'http' | 'graphql' | 'grpc' | 'websocket';
+
 /**
  * Locators for the sidebar (collections tree) section.
  */
@@ -34,6 +36,13 @@ export const buildSidebarLocators = (page: Page) => {
       collectionScope(collectionName).locator('.item-name').and(page.getByTitle(name, { exact: true })),
     itemRowIn: (collectionName: string, name: string): Locator =>
       collectionScope(collectionName).getByTestId('sidebar-collection-item-row').filter({ has: itemByName(name) }),
+
+    // "+ Add request" cta inside the empty collection
+    emptyStateCta: (collectionName: string): Locator =>
+      collectionScope(collectionName).getByTestId('add-request-cta'),
+    emptyStateCtaItem: (requestType: EmptyStateRequestType): Locator =>
+      page.getByTestId(`add-request-cta-${requestType}`),
+
     // The "..." menu on a sidebar row. `type` picks the row and the testid prefix:
     // 'item' for a collection item row (`collection-item-menu-*`), 'collection' for a
     // top-level collection row (`collection-actions-*`). Trigger is in the row; items


### PR DESCRIPTION
### Description
closes - https://github.com/usebruno/bruno/issues/9095
BRU-4411

Pre fills the request url when creating a new request from the `+ Add request` option in sidebar.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
When clicking the `+ Add request`  to create a new request we are not filling the request url with the default url set in the collections preset.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- Added the preset url when creating a request.
- Added e2e test for setting the base url and testing when 

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

https://github.com/user-attachments/assets/7003eb34-fe10-4438-a96f-cc0498ed9357

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New requests use the configured Base URL preset from draft or standard collection settings when available.
  * Added support for selecting HTTP, GraphQL, gRPC, or WebSocket request types from an empty collection’s “Add request” menu.

* **Bug Fixes**
  * New requests now start with the preset URL instead of always using a blank URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->