### PR TITLE
perf(runner): remove redundant deep clones of the runner results tree

### DIFF
--- a/packages/bruno-app/src/components/RunnerResults/index.jsx
+++ b/packages/bruno-app/src/components/RunnerResults/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import path from 'utils/common/path';
 import { useDispatch } from 'react-redux';
-import { get, cloneDeep } from 'lodash';
+import { get } from 'lodash';
 import { runCollectionFolder, cancelRunnerExecution, mountCollection, updateRunnerConfiguration } from 'providers/ReduxStore/slices/collections/actions';
 import { resetCollectionRunner } from 'providers/ReduxStore/slices/collections';
 import { findItemInCollection, getTotalRequestCountInCollection, areItemsLoading } from 'utils/collections';
@@ -85,7 +85,7 @@ export default function RunnerResults({ collection }) {
   // ref for the runner output body
   const runnerBodyRef = useRef();
 
-  const collectionCopy = cloneDeep(collection);
+  const collectionCopy = collection;
   const runnerInfo = get(collection, 'runnerResult.info', {});
 
   // tags for the collection run
@@ -94,7 +94,7 @@ export default function RunnerResults({ collection }) {
   // have tags been added for the collection run
   const areTagsAdded = tags.include.length > 0 || tags.exclude.length > 0;
 
-  const items = cloneDeep(get(collection, 'runnerResult.items', []))
+  const items = get(collection, 'runnerResult.items', [])
     .map((item) => {
       const info = findItemInCollection(collectionCopy, item.uid);
       if (!info) {


### PR DESCRIPTION
Our renderer process has a lot of deepclones on the collection and items that is filling up the heap space. Most of the calls are in read-only paths and it is safe to reuse the objects than creating new ones.

In the runner view, `collectionCopy` only feeds `findItemInCollection` and `getTotalRequestCountInCollection`, and the runner result items are spread into fresh objects before anything is set on them. Neither path mutates its input, so the clones were pure allocation.

Ticket: BRU-4086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined result processing by removing unnecessary data duplication.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->