### PR TITLE
fix(app): the status bar is shown for smaller bodies as well

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -668,13 +668,15 @@ class CodeEditor extends React.Component {
             ref={(node) => { this._node = node; }}
           />
         </div>
-        <StatusBar
-          value={this.cachedValue}
-          mode={this.props.mode}
-          longLineDetected={this.state.longLineDetected}
-          longLineMode={this.state.longLineMode}
-          onToggle={this._handleToggleFullMode}
-        />
+        {this.state.longLineDetected && (
+          <StatusBar
+            value={this.cachedValue}
+            mode={this.props.mode}
+            longLineDetected={this.state.longLineDetected}
+            longLineMode={this.state.longLineMode}
+            onToggle={this._handleToggleFullMode}
+          />
+        )}
       </StyledWrapper>
     );
   }

--- a/packages/bruno-app/src/components/CodeEditor/index.spec.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.spec.js
@@ -264,7 +264,7 @@ describe('CodeEditor', () => {
   });
 
   it('loads a normal external value before restoring enhanced features', () => {
-    const { rerender } = setupEditorWithRef({
+    const { rerender, queryByTestId } = setupEditorWithRef({
       value: 'x'.repeat(LONG_LINE_LIMIT + 1),
       mode: 'application/json'
     });
@@ -280,13 +280,13 @@ describe('CodeEditor', () => {
     expect(editor.setValue).toHaveBeenCalledWith('short');
     expect(editor.setValue.mock.invocationCallOrder[0])
       .toBeLessThan(editor.setOption.mock.invocationCallOrder[modeCallIndex]);
+    expect(queryByTestId('editor-status-bar')).not.toBeInTheDocument();
   });
 
-  it('shows the size and mode in the status bar, with no toggle for short content', () => {
+  it('hides the status bar for short content', () => {
     const view = setupEditorWithRef({ value: 'short', mode: 'application/json' });
 
-    expect(view.getByTestId('editor-status-bar')).toHaveTextContent('json mode');
-    expect(view.queryByTestId('editor-status-bar-toggle')).not.toBeInTheDocument();
+    expect(view.queryByTestId('editor-status-bar')).not.toBeInTheDocument();
   });
 
   describe('link-aware reconfiguration', () => {


### PR DESCRIPTION
### Problem

BRU-4469

Status bar was added in the editor for larger single line bodies in https://github.com/usebruno/bruno/pull/8867, it isn't needed for cases where there's nothing effecting the perf of the editor. 

### Fix

- Adds the longline flag as a check
- Updates the needed test for it

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The code editor’s status bar is now hidden when content does not contain long lines.
  * Updated behavior ensures the status bar appears only when relevant to the editor content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->