### PR TITLE
fix(app): labelled cloned items by type in the clone modal and toast

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CloneCollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CloneCollectionItem/index.js
@@ -5,6 +5,7 @@ import * as Yup from 'yup';
 import Modal from 'components/Modal';
 import { useDispatch, useSelector } from 'react-redux';
 import { isItemAFolder } from 'utils/tabs';
+import { getItemTypeLabel } from 'utils/collections';
 import { cloneItem } from 'providers/ReduxStore/slices/collections/actions';
 import { IconArrowBackUp, IconEdit, IconCaretDown } from '@tabler/icons';
 import { sanitizeName, validateName, validateNameError } from 'utils/common/regex';
@@ -24,6 +25,7 @@ const CloneCollectionItem = ({ collectionUid, item, onClose }) => {
   const [isEditing, toggleEditing] = useState(false);
   const itemName = item?.name;
   const itemType = item?.type;
+  const itemTypeLabel = getItemTypeLabel(item);
   const [showFilesystemName, toggleShowFilesystemName] = useState(false);
 
   const dropdownTippyRef = useRef();
@@ -53,11 +55,11 @@ const CloneCollectionItem = ({ collectionUid, item, onClose }) => {
     onSubmit: (values) => {
       dispatch(cloneItem(values.name, values.filename, item.uid, collectionUid))
         .then(() => {
-          toast.success('Request cloned!');
+          toast.success(`${itemTypeLabel} cloned!`);
           onClose();
         })
         .catch((err) => {
-          toast.error(err ? err.message : 'An error occurred while cloning the request');
+          toast.error(err ? err.message : `An error occurred while cloning the ${itemTypeLabel.toLowerCase()}`);
         });
     }
   });
@@ -87,14 +89,14 @@ const CloneCollectionItem = ({ collectionUid, item, onClose }) => {
       <StyledWrapper>
         <Modal
           size="md"
-          title={`Clone ${isFolder ? 'Folder' : 'Request'}`}
+          title={`Clone ${itemTypeLabel}`}
           handleCancel={onClose}
           hideFooter
         >
           <form className="bruno-form" onSubmit={formik.handleSubmit}>
             <div>
               <label htmlFor="name" className="block font-medium">
-                {isFolder ? 'Folder' : 'Request'} Name
+                {itemTypeLabel} Name
               </label>
               <input
                 id="collection-item-name"

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -696,8 +696,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
   const handleCloneItem = () => {
     if (!isCloneable) return;
     dispatch(cloneItem(`${item.name} copy`, sanitizeName(`${item.name} copy`), item.uid, collectionUid))
-      .then(() => toast.success(`${isFolder ? 'Folder' : 'Request'} cloned!`))
-      .catch((err) => toast.error(formatIpcError(err) || `An error occurred while cloning the ${isFolder ? 'folder' : 'request'}`));
+      .then(() => toast.success(`${getItemTypeLabel(item)} cloned!`))
+      .catch((err) => toast.error(formatIpcError(err) || `An error occurred while cloning the ${getItemTypeLabel(item).toLowerCase()}`));
   };
 
   const handlePasteItem = () => {


### PR DESCRIPTION
### Description
Cloning an app called it a request in the clone dialog and the toast message.

### Problem
Apps became cloneable again, but clone still said "Request". Cloning a folder also wrongly said "Request cloned!".

### Fix
Clone now names the item correctly `App, Folder, or Request ` in its dialog and its messages.

### Screenshots
Before:

<img width="1454" height="349" alt="Screenshot 2026-09-02 at 3 10 35 PM" src="https://github.com/user-attachments/assets/3f88e9c4-3b89-480a-8be6-63e5b6a391af" />

After:

<img width="1455" height="361" alt="Screenshot 2026-09-02 at 3 09 33 PM" src="https://github.com/user-attachments/assets/6a417ef9-082d-477e-9bce-113790e55069" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**
