### PR TITLE
fix(variable-scope): collection env in variable scope should not present if active env is deleted

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -401,6 +401,10 @@ export const collectionsSlice = createSlice({
         if (collection.environmentsDraft?.environmentUid === environment.uid) {
           collection.environmentsDraft = null;
         }
+
+        // TODO: if the deleted environment was the active one, clear activeEnvironmentUid here
+        // (set it to null). Right now it's left pointing at a uid no longer present
+        // in `environments`. _deleteGlobalEnvironment already does correctly for global environments.
       }
     },
     saveEnvironment: (state, action) => {

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -57,14 +57,12 @@ const submitCreateEnvironment = ({
   nameInput,
   createButton,
   actions,
-  revert
+  onSuccess
 }) => {
   const {
-    handleScopeSwitch,
     onCreateEnvironment,
     showError,
-    clearError,
-    unregisterActiveCreateForm
+    clearError
   } = actions;
 
   const name = nameInput.value.trim();
@@ -82,9 +80,7 @@ const submitCreateEnvironment = ({
 
   onCreateEnvironment(scope, name)
     .then(() => {
-      unregisterActiveCreateForm(revert);
-      // once new env is created, add the variable to it and save immediately
-      handleScopeSwitch(scope, { immediate: true });
+      onSuccess();
     })
     .catch((err) => {
       showError(err?.message || 'Failed to create environment');
@@ -100,7 +96,9 @@ const renderCreateEnvironment = (row, scope, actions) => {
 
   const {
     registerActiveCreateForm,
-    unregisterActiveCreateForm
+    unregisterActiveCreateForm,
+    clearError,
+    handleScopeSwitch
   } = actions;
 
   const nameInput = document.createElement('input');
@@ -127,6 +125,7 @@ const renderCreateEnvironment = (row, scope, actions) => {
   // Restores this row back to the "No Environment" state.
   const revert = () => {
     unregisterActiveCreateForm(revert);
+    clearError();
     renderNoEnvironmentInline(row, scope, actions);
   };
 
@@ -134,13 +133,20 @@ const renderCreateEnvironment = (row, scope, actions) => {
   // can restore this row via `revert`.
   registerActiveCreateForm(revert, row);
 
+  // restore the created env as a dropdown option.
+  const onSuccess = () => {
+    unregisterActiveCreateForm(revert);
+    renderScopeOption(row, scope, actions);
+    handleScopeSwitch(scope, { keepDropdownOpen: true });
+  };
+
   const submit = () =>
     submitCreateEnvironment({
       scope,
       nameInput,
       createButton,
       actions,
-      revert
+      onSuccess
     });
 
   createButton.addEventListener('click', (e) => {
@@ -446,9 +452,8 @@ function createSecretController({ secretLabel, secretCheckbox, onSecretChange })
  * @param {{type: string, label: string, enabled: boolean, supportsSecret: boolean}} initialScope -
  *   The scope currently active before any switch (the guessed scope). used to set the secret
  *   checkbox's initial visibility.
- * @param {(scope: Object, options?: {immediate?: boolean}) => void} onSwitchScope - Repoints the
- *   pending target scope. When `immediate` is true (after creating a brand new environment),
- *   the caller should save right away rather than waiting for the next blur.
+ * @param {(scope: Object) => void} onSwitchScope - Repoints the pending target scope (including
+ *   right after creating a brand new environment); the caller saves later, on the next blur.
  * @param {(scope: Object, name: string) => Promise<void>} onCreateEnvironment
  * @param {(secret: boolean) => void} [onSecretChange] - Called whenever the Secret checkbox is toggled or the active scope changes.
  */
@@ -474,14 +479,18 @@ export const createAddToScopeSwitcher = ({
 
   let activeRowTracker = null;
 
-  const handleScopeSwitch = (scope, options) => {
-    dropdown.close();
+  const handleScopeSwitch = (scope, { keepDropdownOpen = false } = {}) => {
+    // Creating a new environment inline keeps the dropdown open so the newly active option
+    // stays visible.
+    if (!keepDropdownOpen) {
+      dropdown.close();
+    }
     error.clear();
     secretController.setCurrentScope(scope);
     if (activeRowTracker) {
       activeRowTracker.setActiveScope(scope);
     }
-    onSwitchScope(scope, options);
+    onSwitchScope(scope);
   };
 
   const rowsByType = renderScopeRows({

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -377,6 +377,7 @@ export const renderVarInfo = (token, options) => {
   const displayScopeType = hasRuntimeVariable ? 'runtime' : (scopeInfo ? scopeInfo.type : 'Unknown');
   const scopeLabel = getScopeLabel(displayScopeType);
   const isNewVariable = scopeInfo.data && scopeInfo.data.variable === null;
+
   const canGoToDefinition = !!collection && !isNewVariable && !hasRuntimeVariable && ['request', 'folder', 'collection', 'environment', 'global'].includes(scopeInfo.type);
 
   // If the variable is not new and has a valid scope, make the variable name clickable to go to its definition
@@ -846,20 +847,13 @@ export const renderVarInfo = (token, options) => {
           });
       };
 
-      const onSwitchScope = (scope, { immediate = false } = {}) => {
+      const onSwitchScope = (scope) => {
         const newScopeInfo = buildScopeInfoForSwitch(scope);
         if (!newScopeInfo) {
           return;
         }
         scopeInfo = newScopeInfo;
         scopeBadge.textContent = getScopeLabel(newScopeInfo.type);
-
-        // for inline create environment flow, the new variable is persisted immediately after the environment is created and selected.
-        if (immediate) {
-          persistNewVariable(getPendingSecret()).catch((err) => {
-            toast.error(err?.message || 'Failed to save variable');
-          });
-        }
       };
 
       const onCreateEnvironment = (scope, name) => {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -784,7 +784,8 @@ export const renderVarInfo = (token, options) => {
         (env) => env.uid === globalEnvironmentsState.activeGlobalEnvironmentUid
       )?.name;
       const addToScopes = getAvailableAddToScopes({
-        activeEnvironmentUid: freshCollectionForScopes?.activeEnvironmentUid,
+        // add activeEnvironmentUid only if activeEnvironmentName is there with the active id
+        activeEnvironmentUid: activeEnvironmentName ? freshCollectionForScopes?.activeEnvironmentUid : undefined,
         activeEnvironmentName,
         activeGlobalEnvironmentUid: globalEnvironmentsState.activeGlobalEnvironmentUid,
         activeGlobalEnvironmentName,

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -691,7 +691,7 @@ describe('renderVarInfo', () => {
       expect(updateVariableInScope).not.toHaveBeenCalled();
     });
 
-    it('shows "Create One" when no environment exists, and saves the variable immediately once it is created', async () => {
+    it('shows "Create One" when no environment exists, creates and selects the environment, and saves the variable once the tooltip is dismissed', async () => {
       getVariableScope.mockReturnValue(null);
       getAvailableAddToScopes.mockReturnValue([
         { type: 'collection', label: 'Collection Variable', enabled: true, supportsSecret: false },
@@ -731,6 +731,7 @@ describe('renderVarInfo', () => {
       );
 
       const switcher = result.querySelector('.var-add-to-switcher');
+      const valueContainer = result.querySelector('.var-value-container');
       switcher.querySelector('.var-add-to-toggle').click();
 
       const createLink = switcher.querySelector('[data-testid="var-info-add-to-create-env-button"]');
@@ -746,7 +747,21 @@ describe('renderVarInfo', () => {
       await Promise.resolve();
 
       expect(addEnvironment).toHaveBeenCalledWith('Dev', 'col-1');
-      expect(updateVariableInScope).toHaveBeenCalled();
+      // Creating and selecting the environment only repoints the pending scope. it doesn't
+      // save the variable.
+      expect(updateVariableInScope).not.toHaveBeenCalled();
+      // adding a new env will not close the switcher
+      expect(switcher.querySelector('.var-add-to-list').style.display).toBe('block');
+
+      valueContainer._cmEditor.getValue = () => 'a-new-value';
+      await valueContainer._persistNewVariable();
+
+      expect(updateVariableInScope).toHaveBeenCalledWith(
+        'missingVar',
+        'a-new-value',
+        expect.objectContaining({ type: 'environment' }),
+        'col-1'
+      );
     });
 
     it('adds variable as a secret if secret is selected when creating the environment, instead of always saving as a plain variable', async () => {
@@ -786,6 +801,7 @@ describe('renderVarInfo', () => {
       );
 
       const switcher = result.querySelector('.var-add-to-switcher');
+      const valueContainer = result.querySelector('.var-value-container');
       switcher.querySelector('.var-add-to-toggle').click();
 
       const createLink = switcher.querySelector('[data-testid="var-info-add-to-create-env-button"]');
@@ -803,6 +819,9 @@ describe('renderVarInfo', () => {
       await jest.runAllTimersAsync();
       await Promise.resolve();
       await Promise.resolve();
+
+      valueContainer._cmEditor.getValue = () => 'a-secret-value';
+      await valueContainer._persistNewVariable();
 
       expect(updateVariableInScope).toHaveBeenCalledWith(
         'missingVar',

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -603,16 +603,21 @@ describe('renderVarInfo', () => {
       expect(activeRow.querySelector('[data-testid="var-info-add-to-option-request"]')).not.toBeNull();
     });
 
-    it('resolves the Environment scope against the real active environment, not whichever environment is merely being displayed', () => {
+    it('resolves the Environment scope against the real active environment, not whichever environment is being displayed', () => {
       getVariableScope.mockReturnValue(null);
       getAvailableAddToScopes.mockReturnValue([]);
+      const freshCollection = {
+        uid: 'col-1',
+        activeEnvironmentUid: 'env-prod',
+        environments: [{ uid: 'env-prod', name: 'Prod' }]
+      };
       store.getState.mockReturnValue({
         globalEnvironments: { globalEnvironments: [], activeGlobalEnvironmentUid: null },
         collections: {
-          collections: [{ uid: 'col-1', activeEnvironmentUid: 'env-prod' }]
+          collections: [freshCollection]
         }
       });
-      findCollectionByUid.mockReturnValue({ uid: 'col-1', activeEnvironmentUid: 'env-prod' });
+      findCollectionByUid.mockReturnValue(freshCollection);
 
       renderVarInfo(
         { string: '{{missingVar}}' },

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.js
@@ -134,10 +134,10 @@ export const goToVariableDefinition = (scopeInfo, collection, item, variableName
       const tabsState = state.tabs || {};
       const activeTab = (tabsState.tabs || []).find((t) => t.uid === tabsState.activeTabUid);
 
-      // instead of creating a new global environment tab, check if one already exists and reuse it.
-      const existingGlobalTab = activeTab?.type === 'global-environment-settings'
+      const matchesCollection = (tab) => !collection.uid || tab.collectionUid === collection.uid;
+      const existingGlobalTab = activeTab?.type === 'global-environment-settings' && matchesCollection(activeTab)
         ? activeTab
-        : (tabsState.tabs || []).find((t) => t.type === 'global-environment-settings');
+        : (tabsState.tabs || []).find((t) => t.type === 'global-environment-settings' && matchesCollection(t));
 
       const fallbackCollectionUid = collection.uid || activeTab?.collectionUid;
       const globalEnvironmentTabUid = existingGlobalTab?.uid || `${fallbackCollectionUid}-global-environment-settings`;

--- a/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/goToVariableDefinition.spec.js
@@ -197,4 +197,24 @@ describe('goToVariableDefinition', () => {
 
     expect(addTab).toHaveBeenCalledWith(expect.objectContaining({ uid: 'col-1-global-environment-settings' }));
   });
+
+  it('does not reuse another collection Global Environment Settings tab', () => {
+    store.getState.mockReturnValueOnce({
+      globalEnvironments: { activeGlobalEnvironmentUid: undefined },
+      tabs: {
+        activeTabUid: 'col-2-global-environment-settings',
+        tabs: [
+          { uid: 'col-2-global-environment-settings', collectionUid: 'col-2', type: 'global-environment-settings' }
+        ]
+      }
+    });
+    const scopeInfo = { type: 'global', data: { variable: { name: 'apiToken', secret: false } } };
+
+    goToVariableDefinition(scopeInfo, collection, null, 'apiToken');
+
+    expect(addTab).toHaveBeenCalledWith(expect.objectContaining({
+      uid: 'col-1-global-environment-settings',
+      collectionUid: 'col-1'
+    }));
+  });
 });

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -165,6 +165,7 @@ export const buildCommonLocators = (page: Page) => ({
     // The "Add to" switcher, shown in place of an editable value for undefined variables.
     addToSwitcher: (popup: Locator) => popup.getByTestId('var-info-add-to'),
     addToToggle: (popup: Locator) => popup.getByTestId('var-info-add-to-toggle'),
+    addToList: (popup: Locator) => popup.getByTestId('var-info-add-to-list'),
     addToOption: (popup: Locator, scopeType: string) => popup.getByTestId(`var-info-add-to-option-${scopeType}`),
     addToActiveOption: (popup: Locator, scopeType?: string) => {
       const activeRow = popup.locator('.var-add-to-option-active');

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -331,6 +331,45 @@ test.describe('Variable Tooltip', () => {
     });
   });
 
+  test('should not offer environment as an available Add-to scope after the active environment is deleted', async ({ page, createTmpDir }) => {
+    const collectionName = 'deleted-active-env-scope-test';
+    const { sidebar, request, varInfoPopup } = buildCommonLocators(page);
+
+    await test.step('Create a collection environment, activate it, then delete it', async () => {
+      await createCollection(page, collectionName, await createTmpDir('deleted-active-env-scope-collection'));
+
+      await createEnvironment(page, 'Doomed Env', 'collection');
+      await addEnvironmentVariable(page, { name: 'doomedVar', value: 'doomed-value' });
+      await saveEnvironment(page);
+
+      await page.getByTestId('env-delete-action').click();
+      const deleteModal = page.locator('.bruno-modal').filter({ hasText: 'Delete Environment' });
+      await deleteModal.getByRole('button', { name: 'Delete', exact: true }).click();
+      await expect(deleteModal).toBeHidden();
+
+      await closeEnvironmentPanel(page);
+
+      await createRequest(page, 'Deleted Env Request', collectionName);
+      await sidebar.request('Deleted Env Request').click();
+      await setRequestUrlAndSave(page, 'https://api.example.com');
+    });
+
+    await test.step('Type an undefined variable into the URL', async () => {
+      await request.urlInput().click();
+      await page.keyboard.press('End');
+      await page.keyboard.type('?key={{afterDeleteVar}}');
+    });
+
+    await test.step('The Environment scope is offered as "No Environment", not as available', async () => {
+      const tooltip = await openUrlVarTooltip(page, 'afterDeleteVar', 'invalid');
+      await varInfoPopup.addToToggle(tooltip).click();
+
+      await expect(varInfoPopup.addToOption(tooltip, 'environment')).toHaveCount(0);
+      await expect(varInfoPopup.addToNoEnvNote(tooltip, 'environment')).toBeVisible();
+      await expect(varInfoPopup.addToCreateEnvButton(tooltip, 'environment')).toBeVisible();
+    });
+  });
+
   test('should repoint the scope badge on switch without saving, then save into the newly picked scope', async ({ page, createTmpDir }) => {
     const collectionName = 'add-to-switch-scope-test';
     const { sidebar, request, varInfoPopup, table } = buildCommonLocators(page);

--- a/tests/variable-tooltip/variable-tooltip.spec.ts
+++ b/tests/variable-tooltip/variable-tooltip.spec.ts
@@ -589,7 +589,7 @@ test.describe('Variable Tooltip', () => {
     });
   });
 
-  test('should create an environment inline via "Create One" and save the variable into it immediately', async ({ page, createTmpDir }) => {
+  test('should create an environment inline via "Create One" and save the variable into it once the tooltip is dismissed', async ({ page, createTmpDir }) => {
     const collectionName = 'add-to-create-env-test';
     const envName = 'Freshly Created Env';
     const { sidebar, request, varInfoPopup, environment } = buildCommonLocators(page);
@@ -626,14 +626,17 @@ test.describe('Variable Tooltip', () => {
       await varInfoPopup.addToCreateEnvSubmit(tooltip).click();
     });
 
-    await test.step('The variable is saved into the newly created environment immediately', async () => {
+    await test.step('Creating the environment only repoints the pending scope. the value is not saved', async () => {
       const tooltip = varInfoPopup.all().first();
 
       await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
       await expect(varInfoPopup.editableValue(tooltip)).toContainText('fresh-value');
-      await expect(varInfoPopup.addToSwitcher(tooltip)).toHaveCount(0);
+      await expect(varInfoPopup.addToSwitcher(tooltip)).toBeVisible();
 
-      await dismissVarTooltip(page);
+      // list should be visible after creating the new env.
+      await expect(varInfoPopup.addToList(tooltip)).toBeVisible();
+
+      await sidebar.collectionsContainer().click();
     });
 
     await test.step('Environment now exists with this variable under Variables', async () => {
@@ -694,7 +697,7 @@ test.describe('Variable Tooltip', () => {
       await expect(varInfoPopup.addToCreateEnvNameInput(tooltip)).toBeVisible();
     });
 
-    await test.step('Fixing the name and resubmitting succeeds, saving the pending value', async () => {
+    await test.step('Fixing the name and resubmitting succeeds, repointing the scope', async () => {
       const tooltip = varInfoPopup.all().first();
 
       await varInfoPopup.addToCreateEnvNameInput(tooltip).fill('Recovered Env');
@@ -702,7 +705,16 @@ test.describe('Variable Tooltip', () => {
 
       await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
       await expect(varInfoPopup.editableValue(tooltip)).toContainText('err-value');
-      await expect(varInfoPopup.addToSwitcher(tooltip)).toHaveCount(0);
+      await expect(varInfoPopup.addToSwitcher(tooltip)).toBeVisible();
+      await expect(varInfoPopup.addToList(tooltip)).toBeVisible();
+    });
+
+    await test.step('Dismissing the tooltip saves the pending value into the recovered environment', async () => {
+      await sidebar.collectionsContainer().click();
+
+      const tooltip = await openUrlVarTooltip(page, 'errEnvVar', 'valid');
+      await expect(varInfoPopup.scopeBadge(tooltip)).toContainText('Environment');
+      await expect(varInfoPopup.editableValue(tooltip)).toContainText('err-value');
     });
   });
 


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Event though we are Deleting the active collection environment, the variable tooltip shows an option to pick the Collection environment.

BRU-4474

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
when we delete a colelction environment it deletes the file on disk and the file-watcher (unlinkEnvironmentFile in the electron main process) reports back, which dispatches collectionUnlinkEnvFileEvent . Now in `collectionUnlinkEnvFileEvent` we are not setting the `collection.activeEnvironmentUid` to null. Even though env is removed  we have a `activeEnvironmentUid`.
Since we have this id the variable tooltip shows the option to pick the env.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

1. For now fix scope is just the variable scope as fixing in reducer have a large blast radius and more testing needed. 
Now checking if for the uid we have a environment name or not. 
2. Added a TODO to fix this in selector.


### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

https://github.com/user-attachments/assets/cb8a3cdd-7339-43d5-836e-6d709afc0c8e

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the variable “Add to” menu from offering an Environment option when no active environment is available.
  * The menu now clearly indicates when no environment exists and provides an option to create one.
  * Inline environment creation now keeps the menu open, selects the new environment, and saves variable values only after the update is confirmed.
  * Global environment navigation now opens the settings tab for the correct collection.

* **Tests**
  * Added coverage for deleted active environments, inline environment creation, and collection-specific environment navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->