### PR TITLE
fix(opencollection): preserve multipart form content-type on import and export

### DIFF
--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -225,6 +225,7 @@ export const transformCollectionToSaveToExportAsFile = (collection, options = {}
         type: param.type,
         name: param.name,
         value: param.value,
+        contentType: param.contentType,
         description: param.description,
         enabled: param.enabled
       };

--- a/packages/bruno-app/src/utils/tests/collections/datatype-export-import.spec.js
+++ b/packages/bruno-app/src/utils/tests/collections/datatype-export-import.spec.js
@@ -197,6 +197,71 @@ describe('Bruno JSON export/import — dataType preservation', () => {
   });
 });
 
+describe('transformCollectionToSaveToExportAsFile: multipart form contentType', () => {
+  const multipartEntries = () => [
+    { uid: UID, name: 'metadata', value: '{"tag":"v1"}', type: 'text', enabled: true, contentType: 'application/json' },
+    { uid: UID, name: 'plain', value: 'hello', type: 'text', enabled: true, contentType: '' }
+  ];
+
+  const buildMultipartRequest = () => ({
+    url: 'https://example.com',
+    method: 'POST',
+    headers: [],
+    params: [],
+    body: { mode: 'multipartForm', multipartForm: multipartEntries() },
+    auth: { mode: 'none' },
+    script: { req: null, res: null },
+    vars: { req: [], res: [] },
+    assertions: [],
+    tests: null
+  });
+
+  it('keeps contentType on request and example multipart entries', () => {
+    const collection = {
+      uid: UID,
+      name: 'Multipart Collection',
+      version: '1',
+      items: [
+        {
+          uid: UID,
+          type: 'http-request',
+          name: 'upload',
+          seq: 1,
+          request: buildMultipartRequest(),
+          examples: [
+            {
+              uid: UID,
+              itemUid: UID,
+              name: 'upload example',
+              type: 'http-request',
+              request: buildMultipartRequest(),
+              response: { status: 200, statusText: 'OK', headers: [], body: '' }
+            }
+          ]
+        }
+      ],
+      root: {
+        request: {
+          headers: [],
+          script: { req: null, res: null },
+          vars: { req: [], res: [] },
+          tests: null
+        }
+      }
+    };
+
+    const exported = transformCollectionToSaveToExportAsFile(collection);
+
+    const item = exported.items[0];
+    expect(item.request.body.multipartForm[0].contentType).toBe('application/json');
+    expect(item.request.body.multipartForm[1].contentType).toBe('');
+
+    const example = item.examples[0];
+    expect(example.request.body.multipartForm[0].contentType).toBe('application/json');
+    expect(example.request.body.multipartForm[1].contentType).toBe('');
+  });
+});
+
 describe('deleteSecretsInEnvs', () => {
   it('clears the value but preserves dataType on secret variables', () => {
     const envs = [

--- a/packages/bruno-converters/src/opencollection/common/body.ts
+++ b/packages/bruno-converters/src/opencollection/common/body.ts
@@ -202,7 +202,7 @@ export const toOpenCollectionBody = (body: BrunoHttpRequestBody | null | undefin
           entry.description = field.description;
         }
 
-        if (field.contentType && field.contentType.trim().length) {
+        if (field.contentType && typeof field.contentType === 'string' && field.contentType.trim().length) {
           entry.contentType = field.contentType;
         }
 

--- a/packages/bruno-converters/src/opencollection/common/body.ts
+++ b/packages/bruno-converters/src/opencollection/common/body.ts
@@ -115,7 +115,7 @@ export const fromOpenCollectionBody = (body: HttpRequestBody | GraphQLBody | und
               type: field.type || 'text',
               name: field.name || '',
               value: Array.isArray(field.value) ? field.value : (field.value || ''),
-              contentType: null,
+              contentType: field.contentType || null,
               enabled: field.disabled !== true
             };
             const desc = typeof field.description === 'string' ? field.description : field.description?.content;
@@ -200,6 +200,10 @@ export const toOpenCollectionBody = (body: BrunoHttpRequestBody | null | undefin
 
         if (field.description && typeof field.description === 'string' && field.description.trim().length) {
           entry.description = field.description;
+        }
+
+        if (field.contentType && field.contentType.trim().length) {
+          entry.contentType = field.contentType;
         }
 
         if (field.enabled === false) {

--- a/packages/bruno-converters/tests/opencollection/multipart-content-type.spec.js
+++ b/packages/bruno-converters/tests/opencollection/multipart-content-type.spec.js
@@ -1,8 +1,9 @@
 import { describe, it, expect } from '@jest/globals';
-import { brunoToOpenCollection, openCollectionToBruno } from '../../dist/esm/index.js';
+import { brunoToOpenCollection } from '../../src/opencollection/bruno-to-opencollection';
+import { openCollectionToBruno } from '../../src/opencollection/opencollection-to-bruno';
 
-describe('multipart-form contentType', () => {
-  it('Bruno→OC→Bruno: preserves contentType, omits when empty', () => {
+describe('multipart form contentType: export then import keeps it the same', () => {
+  it('preserves contentType and omits it when empty', () => {
     const brunoCollection = {
       uid: 'c-ct1',
       name: 'Test',
@@ -43,8 +44,10 @@ describe('multipart-form contentType', () => {
     expect(mp[2].contentType).toBe('image/png');
     expect(mp[2].value).toEqual(['/tmp/me.png']);
   });
+});
 
-  it('OC→Bruno: reads contentType from yaml, null when absent', () => {
+describe('openCollectionToBruno (import): multipart form contentType', () => {
+  it('reads contentType and defaults to null when absent', () => {
     const openCollection = {
       opencollection: '1.0.0',
       info: { name: 'Test' },

--- a/packages/bruno-converters/tests/opencollection/multipart-content-type.spec.js
+++ b/packages/bruno-converters/tests/opencollection/multipart-content-type.spec.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from '@jest/globals';
+import { brunoToOpenCollection, openCollectionToBruno } from '../../dist/esm/index.js';
+
+describe('multipart-form contentType', () => {
+  it('Bruno→OC→Bruno: preserves contentType, omits when empty', () => {
+    const brunoCollection = {
+      uid: 'c-ct1',
+      name: 'Test',
+      version: '1',
+      items: [
+        {
+          uid: 'i-ct1',
+          type: 'http-request',
+          name: 'R',
+          request: {
+            method: 'POST',
+            url: 'https://example.com',
+            headers: [],
+            body: {
+              mode: 'multipartForm',
+              multipartForm: [
+                { uid: 'm1', name: 'metadata', value: '{"tag":"v1"}', type: 'text', enabled: true, contentType: 'application/json' },
+                { uid: 'm2', name: 'plain', value: 'hello', type: 'text', enabled: true, contentType: '' },
+                { uid: 'm3', name: 'avatar', value: ['/tmp/me.png'], type: 'file', enabled: false, contentType: 'image/png' }
+              ]
+            }
+          }
+        }
+      ],
+      root: {}
+    };
+
+    const oc = brunoToOpenCollection(brunoCollection);
+    const data = oc.items[0].http.body.data;
+    expect(data[0]).toMatchObject({ name: 'metadata', contentType: 'application/json' });
+    expect(data[1]).not.toHaveProperty('contentType');
+    expect(data[2]).toMatchObject({ name: 'avatar', contentType: 'image/png', disabled: true });
+
+    const back = openCollectionToBruno(oc);
+    const mp = back.items[0].request.body.multipartForm;
+    expect(mp[0].contentType).toBe('application/json');
+    expect(mp[1].contentType).toBeNull();
+    expect(mp[2].contentType).toBe('image/png');
+    expect(mp[2].value).toEqual(['/tmp/me.png']);
+  });
+
+  it('OC→Bruno: reads contentType from yaml, null when absent', () => {
+    const openCollection = {
+      opencollection: '1.0.0',
+      info: { name: 'Test' },
+      items: [
+        {
+          info: { name: 'R', type: 'http' },
+          http: {
+            method: 'POST',
+            url: 'https://example.com',
+            body: {
+              type: 'multipart-form',
+              data: [
+                { name: 'metadata', type: 'text', value: '{}', contentType: 'application/json' },
+                { name: 'plain', type: 'text', value: 'x' }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
+    const bruno = openCollectionToBruno(openCollection);
+    const mp = bruno.items[0].request.body.multipartForm;
+    expect(mp[0].contentType).toBe('application/json');
+    expect(mp[1].contentType).toBeNull();
+  });
+});

--- a/packages/bruno-filestore/src/formats/yml/common/body.spec.ts
+++ b/packages/bruno-filestore/src/formats/yml/common/body.spec.ts
@@ -60,3 +60,61 @@ describe('file body description', () => {
     }
   });
 });
+
+describe('multipart form contentType', () => {
+  it('toOpenCollectionBody: writes contentType when set, omits when empty or whitespace-only', () => {
+    const out = toOpenCollectionBody({
+      mode: 'multipartForm',
+      multipartForm: [
+        { uid: 'm1', type: 'text', name: 'metadata', value: '{"tag":"v1"}', contentType: 'application/json', enabled: true },
+        { uid: 'm2', type: 'text', name: 'plain', value: 'hello', contentType: '', enabled: true },
+        { uid: 'm3', type: 'text', name: 'ws', value: 'x', contentType: '   ', enabled: true },
+        { uid: 'm4', type: 'file', name: 'avatar', value: ['/tmp/me.png'], contentType: 'image/png', enabled: false }
+      ]
+    } as any);
+
+    expect(out?.type).toBe('multipart-form');
+    expect(out?.data).toHaveLength(4);
+    expect(out?.data[0]).toMatchObject({ name: 'metadata', contentType: 'application/json' });
+    expect(out?.data[1]).not.toHaveProperty('contentType');
+    expect(out?.data[2]).not.toHaveProperty('contentType');
+    expect(out?.data[3]).toMatchObject({ name: 'avatar', contentType: 'image/png', disabled: true });
+  });
+
+  it('toBrunoBody: reads contentType and defaults to null when absent', () => {
+    const out = toBrunoBody({
+      type: 'multipart-form',
+      data: [
+        { name: 'metadata', type: 'text', value: '{}', contentType: 'application/json' },
+        { name: 'plain', type: 'text', value: 'x' }
+      ]
+    } as any);
+
+    expect(out?.mode).toBe('multipartForm');
+    expect(out?.multipartForm).toHaveLength(2);
+
+    if (out?.multipartForm) {
+      expect(out.multipartForm[0]).toMatchObject({ name: 'metadata', contentType: 'application/json' });
+      expect(out.multipartForm[1].contentType).toBeNull();
+    }
+  });
+
+  it('round-trips multipart contentType through OC conversion', () => {
+    const brunoBody = {
+      mode: 'multipartForm',
+      multipartForm: [
+        { uid: 'm1', type: 'text', name: 'metadata', value: '{"tag":"v1"}', contentType: 'application/json', enabled: true },
+        { uid: 'm2', type: 'file', name: 'avatar', value: ['/tmp/me.png'], contentType: 'image/png', enabled: false }
+      ]
+    } as any;
+
+    const back = toBrunoBody(toOpenCollectionBody(brunoBody));
+
+    expect(back?.multipartForm).toHaveLength(2);
+
+    if (back?.multipartForm) {
+      expect(back.multipartForm[0]).toMatchObject({ name: 'metadata', contentType: 'application/json' });
+      expect(back.multipartForm[1]).toMatchObject({ name: 'avatar', contentType: 'image/png', enabled: false });
+    }
+  });
+});

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -533,6 +533,7 @@ describe('jsonToBru stringify: multipart contentType', () => {
     const output = stringify(input);
     expect(output).toContain('@contentType(application/json)');
     expect(output).toContain('@contentType(image/png)');
+    expect(output).not.toContain('@contentType()');
 
     const parsed = parser(output);
     expect(parsed.body.multipartForm).toEqual([

--- a/packages/bruno-lang/v2/tests/jsonToBru.spec.js
+++ b/packages/bruno-lang/v2/tests/jsonToBru.spec.js
@@ -514,3 +514,31 @@ script:grpc:after-call-end {
     });
   });
 });
+
+describe('jsonToBru stringify: multipart contentType', () => {
+  const parser = require('../src/bruToJson');
+
+  it('round-trips @contentType on text and file entries and keeps empty contentType empty', () => {
+    const input = {
+      body: {
+        mode: 'multipartForm',
+        multipartForm: [
+          { name: 'metadata', value: '{"tag":"v1"}', enabled: true, type: 'text', contentType: 'application/json' },
+          { name: 'plain', value: 'hello', enabled: true, type: 'text', contentType: '' },
+          { name: 'avatar', value: ['/tmp/me.png'], enabled: false, type: 'file', contentType: 'image/png' }
+        ]
+      }
+    };
+
+    const output = stringify(input);
+    expect(output).toContain('@contentType(application/json)');
+    expect(output).toContain('@contentType(image/png)');
+
+    const parsed = parser(output);
+    expect(parsed.body.multipartForm).toEqual([
+      { name: 'metadata', value: '{"tag":"v1"}', enabled: true, type: 'text', contentType: 'application/json' },
+      { name: 'plain', value: 'hello', enabled: true, type: 'text', contentType: '' },
+      { name: 'avatar', value: ['/tmp/me.png'], enabled: false, type: 'file', contentType: 'image/png' }
+    ]);
+  });
+});


### PR DESCRIPTION
JIRA : BRU-4018
### Description

Multipart form fields in Bruno support a per part Content-Type, but it was lost when exporting or importing collections in the OpenCollection format.

### Problem

Exporting a collection as OpenCollection YAML dropped the `contentType` of multipart form entries, and importing an OpenCollection file ignored the field. Related issue: usebruno/opencollection#37

### Fix

- bruno-app: include `contentType` when copying multipart form params in `transformCollectionToSaveToExportAsFile`
- bruno-converters: map `contentType` in both directions in the OpenCollection body converter (omitted when empty on export, null when absent on import)

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Multipart form data exports now preserve each field’s content type.
- OpenCollection, YAML, and JSON conversions retain multipart content types in both directions.
- Empty or missing content types are handled consistently without adding unnecessary values.
- File paths and disabled file parts remain preserved during conversion and export.
- Multipart request and example data now maintain content type information more reliably across import and export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->