### PR TITLE
feat(CLI): added interpolation for digest auth credentials and corresponding tests

### DIFF
--- a/packages/bruno-cli/src/runner/interpolate-vars.js
+++ b/packages/bruno-cli/src/runner/interpolate-vars.js
@@ -295,6 +295,12 @@ const interpolateVars = (request, envVariables = {}, runtimeVariables = {}, proc
     request.awsv4config.profileName = _interpolate(request.awsv4config.profileName) || '';
   }
 
+  // interpolate vars for digest auth
+  if (request.digestConfig) {
+    request.digestConfig.username = _interpolate(request.digestConfig.username) || '';
+    request.digestConfig.password = _interpolate(request.digestConfig.password) || '';
+  }
+
   // interpolate vars for ntlmConfig auth
   if (request.ntlmConfig) {
     request.ntlmConfig.username = _interpolate(request.ntlmConfig.username) || '';

--- a/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/bruno.json
+++ b/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "digest-auth",
+  "type": "collection",
+  "ignore": []
+}

--- a/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/environments/local.yml
+++ b/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/environments/local.yml
@@ -1,0 +1,4 @@
+name: local
+variables:
+  - name: digestPw
+    value: passwd

--- a/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/opencollection.yml
+++ b/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/opencollection.yml
@@ -1,0 +1,3 @@
+opencollection: "1.0.0"
+info:
+  name: digest-auth

--- a/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/request-level.yml
+++ b/packages/bruno-cli/tests/integration/digest-auth/fixtures/collection/request-level.yml
@@ -1,0 +1,20 @@
+info:
+  name: request-level
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "https://www.httpfaker.org/api/auth/digest/auth/user/passwd"
+  auth:
+    type: digest
+    username: "user"
+    password: "{{digestPw}}"
+
+runtime:
+  scripts:
+    - type: tests
+      code: |-
+        test('digest auth succeeds with the resolved password', function() {
+          expect(res.getStatus()).to.equal(200);
+        });

--- a/packages/bruno-cli/tests/integration/digest-auth/run-digest-auth.spec.js
+++ b/packages/bruno-cli/tests/integration/digest-auth/run-digest-auth.spec.js
@@ -1,0 +1,33 @@
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const { runCli } = require('../helpers/run-cli');
+const { createCollectionFixture } = require('../helpers/collection-fixture');
+
+const FIXTURE_COLLECTION = path.join(__dirname, 'fixtures', 'collection');
+
+const NETWORK_TIMEOUT = 30000;
+
+// Digest credentials must be interpolated before the interceptor hashes them; the endpoint
+// answers 200 only for the resolved password, which the fixture's test checks on the response.
+describe('CLI run — digest auth credentials are interpolated', () => {
+  let collectionDir;
+
+  beforeEach(() => {
+    collectionDir = createCollectionFixture(FIXTURE_COLLECTION);
+  });
+
+  afterEach(() => {
+    fs.rmSync(collectionDir, { recursive: true, force: true });
+  });
+
+  it(
+    'resolves {{var}} in request-level digest credentials',
+    async () => {
+      const { code, stdout, stderr } = await runCli(['run', 'request-level.yml', '--env', 'local'], collectionDir);
+
+      expect({ code, stdout, stderr }).toMatchObject({ code: 0 });
+    },
+    NETWORK_TIMEOUT
+  );
+});

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -100,3 +100,30 @@ describe('interpolate-vars: api key header name sidecar', () => {
     expect(request.apiKeyHeaderName).toEqual('X-API-Key');
   });
 });
+
+describe('interpolate-vars: digest auth', () => {
+  const digestRequest = () => ({
+    digestConfig: {
+      username: 'user',
+      password: '{{digestPw}}'
+    }
+  });
+
+  it('interpolates digest credentials from environment variables', () => {
+    const request = digestRequest();
+    const envVariables = { digestPw: 'passwd' };
+
+    interpolateVars(request, envVariables, {}, {});
+
+    expect(request.digestConfig).toEqual({ username: 'user', password: 'passwd' });
+  });
+
+  it('interpolates digest credentials from runtime variables', () => {
+    const request = digestRequest();
+    const runtimeVariables = { digestPw: 'passwd' };
+
+    interpolateVars(request, {}, runtimeVariables, {});
+
+    expect(request.digestConfig).toEqual({ username: 'user', password: 'passwd' });
+  });
+});

--- a/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
+++ b/packages/bruno-cli/tests/runner/interpolate-vars.spec.js
@@ -1,5 +1,6 @@
 const { describe, it, expect } = require('@jest/globals');
 const interpolateVars = require('../../src/runner/interpolate-vars');
+const prepareRequest = require('../../src/runner/prepare-request');
 
 describe('interpolate-vars: interpolateVars', () => {
   it('keeps stream-backed JSON request bodies intact', () => {
@@ -102,15 +103,8 @@ describe('interpolate-vars: api key header name sidecar', () => {
 });
 
 describe('interpolate-vars: digest auth', () => {
-  const digestRequest = () => ({
-    digestConfig: {
-      username: 'user',
-      password: '{{digestPw}}'
-    }
-  });
-
   it('interpolates digest credentials from environment variables', () => {
-    const request = digestRequest();
+    const request = { digestConfig: { username: 'user', password: '{{digestPw}}' } };
     const envVariables = { digestPw: 'passwd' };
 
     interpolateVars(request, envVariables, {}, {});
@@ -119,10 +113,23 @@ describe('interpolate-vars: digest auth', () => {
   });
 
   it('interpolates digest credentials from runtime variables', () => {
-    const request = digestRequest();
+    const request = { digestConfig: { username: 'user', password: '{{digestPw}}' } };
     const runtimeVariables = { digestPw: 'passwd' };
 
     interpolateVars(request, {}, runtimeVariables, {});
+
+    expect(request.digestConfig).toEqual({ username: 'user', password: 'passwd' });
+  });
+
+  it('interpolates digest credentials inherited from the collection', async () => {
+    const collection = {
+      root: { request: { auth: { mode: 'digest', digest: { username: 'user', password: '{{digestPw}}' } } } }
+    };
+    const item = { request: { method: 'GET', headers: [], params: [], url: 'https://example.com', auth: { mode: 'inherit' } } };
+    const envVariables = { digestPw: 'passwd' };
+
+    const request = await prepareRequest(item, collection);
+    interpolateVars(request, envVariables, {}, {});
 
     expect(request.digestConfig).toEqual({ username: 'user', password: 'passwd' });
   });


### PR DESCRIPTION
BRU-4332

### Description

Interpolate `{{var}}` in digest auth username/password in the CLI, matching the app.

### Problem

`interpolate-vars.js` interpolates every other auth config but had no `digestConfig` block, so the literal `{{var}}` was hashed and the server returned 401. Collections that pass in the app failed in CI.

### Fix

Added the missing `digestConfig` block. Runs before the digest interceptor, covers request- and collection-level auth. Unit tests for env/runtime vars, plus an integration test against a live digest endpoint that 401s without the fix.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td style="padding: 0;">
      <video src="https://github.com/user-attachments/assets/3d70d898-d5fb-4480-8630-a9f5c0a0f765" controls width="400"></video>
    </td>
    <td style="padding: 0;">
      <video src="https://github.com/user-attachments/assets/70422ce5-b39c-4ce3-931f-8f8e1399ee4d" controls width="400"></video>
    </td>
  </tr>
</table>

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Digest authentication usernames and passwords now correctly support variable interpolation when requests run through the CLI.
  - Credentials can be resolved from environments, runtime variables, and inherited collection settings before authentication is performed.

- **Tests**
  - Added coverage for request-level digest authentication, including successful authenticated requests and credential interpolation across supported variable sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->