### PR TITLE
feat(variable-scope): added icons to variable scope list and the badge

### DIFF
--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -429,7 +429,9 @@ const GlobalStyle = createGlobalStyle`
 
   /* Scope Badge */
   .CodeMirror-brunoVarInfo .var-scope-badge {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
     padding: 0.125rem 0.375rem;
     background: ${(props) => rgba(props.theme.brand, 0.07)};
     border: 1px solid ${(props) => rgba(props.theme.brand, 0.08)};
@@ -438,6 +440,19 @@ const GlobalStyle = createGlobalStyle`
     color: ${(props) => props.theme.brand};
     letter-spacing: 0.03125rem;
     flex-shrink: 0;
+  }
+
+  .CodeMirror-brunoVarInfo .var-scope-badge-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: currentColor;
+  }
+
+  .CodeMirror-brunoVarInfo .var-scope-badge-icon svg {
+    width: 0.75rem;
+    height: 0.75rem;
   }
 
   .bruno-var-definition-target {
@@ -626,10 +641,10 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.25rem;
   }
 
-  /* "Add to" scope switcher (shown below the value editor for brand new variables) */
+   /* "Add to" scope switcher (shown below the value editor for brand new variables) */
   .CodeMirror-brunoVarInfo .var-add-to-switcher {
     margin-top: 0.5rem;
-    max-width: 18rem;
+    width: 19rem;
   }
 
   /* Toggle and Secret checkbox sit in one row. */
@@ -674,6 +689,7 @@ const GlobalStyle = createGlobalStyle`
   .CodeMirror-brunoVarInfo .var-add-to-secret-checkbox {
     margin: 0;
     cursor: pointer;
+    accent-color: ${(props) => props.theme.primary.solid};
   }
 
   .CodeMirror-brunoVarInfo .var-add-to-toggle-chevron {
@@ -709,7 +725,7 @@ const GlobalStyle = createGlobalStyle`
   .CodeMirror-brunoVarInfo .var-add-to-option-trigger {
     display: flex;
     align-items: center;
-    gap: 0.2rem;
+    gap: 0.375rem;
     width: 100%;
     height: 1.5rem;
     min-width: 0;
@@ -732,12 +748,17 @@ const GlobalStyle = createGlobalStyle`
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 0.875rem;
-    height: 0.875rem;
+    width: 1.125rem;
+    height: 1.125rem;
     border-radius: ${(props) => props.theme.border.radius.sm};
     font-size: 0.5rem;
     font-weight: 600;
     line-height: 1;
+  }
+
+  .CodeMirror-brunoVarInfo .var-add-to-option-icon svg {
+    width: 0.75rem;
+    height: 0.75rem;
   }
 
   .CodeMirror-brunoVarInfo .var-add-to-option-icon-request {
@@ -799,6 +820,7 @@ const GlobalStyle = createGlobalStyle`
     font-size: ${(props) => props.theme.font.size.xs};
     color: ${(props) => props.theme.dropdown.mutedText};
     line-height: 1.25rem;
+    white-space: nowrap;
   }
 
   .CodeMirror-brunoVarInfo .var-add-to-link-button {

--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -1,18 +1,4 @@
-import { VARIABLE_ADD_SCOPES } from 'utils/common/constants';
-
-const CHEVRON_ICON_SVG_TEXT = `
-<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <polyline points="6,9 12,15 18,9"></polyline>
-</svg>
-`;
-
-const SCOPE_ICON_LETTER = {
-  [VARIABLE_ADD_SCOPES.REQUEST]: 'R',
-  [VARIABLE_ADD_SCOPES.FOLDER]: 'F',
-  [VARIABLE_ADD_SCOPES.COLLECTION]: 'C',
-  [VARIABLE_ADD_SCOPES.ENVIRONMENT]: 'E',
-  [VARIABLE_ADD_SCOPES.GLOBAL]: 'G'
-};
+import { VARIABLE_ADD_SCOPES, CHEVRON_ICON_SVG_TEXT, SCOPE_ICON } from 'utils/common/constants';
 
 const createScopeIcon = (scope, { muted = false } = {}) => {
   const icon = document.createElement('span');
@@ -20,7 +6,9 @@ const createScopeIcon = (scope, { muted = false } = {}) => {
   if (muted) {
     icon.classList.add('var-add-to-option-icon-muted');
   }
-  icon.textContent = SCOPE_ICON_LETTER[scope.type] || scope.label?.charAt(0)?.toUpperCase() || '?';
+
+  icon.innerHTML = SCOPE_ICON[scope.type] || '';
+
   return icon;
 };
 

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -29,7 +29,7 @@ import { defineCodeMirrorBrunoVariablesMode } from 'utils/common/codemirror';
 import { MaskedEditor } from 'utils/common/masked-editor';
 import { setupAutoComplete } from 'utils/codemirror/autocomplete';
 import { variableNameRegex, validateName, validateNameError } from 'utils/common/regex';
-import { VARIABLE_ADD_SCOPES } from 'utils/common/constants';
+import { VARIABLE_ADD_SCOPES, SCOPE_ICON } from 'utils/common/constants';
 import { createAddToScopeSwitcher } from 'utils/codemirror/addToScopeSwitcher';
 import { goToVariableDefinition } from 'utils/codemirror/goToVariableDefinition';
 
@@ -98,6 +98,23 @@ const getScopeLabel = (scopeType) => {
     'pathParam': 'Path Param'
   };
   return labels[scopeType] || scopeType;
+};
+
+const setScopeBadgeContent = (scopeBadge, scopeType, label) => {
+  scopeBadge.innerHTML = '';
+
+  const scopeIcon = SCOPE_ICON[scopeType];
+  if (scopeIcon) {
+    const icon = document.createElement('span');
+    icon.className = 'var-scope-badge-icon';
+    icon.innerHTML = scopeIcon;
+    scopeBadge.appendChild(icon);
+  }
+
+  const labelSpan = document.createElement('span');
+  labelSpan.className = 'var-scope-badge-label';
+  labelSpan.textContent = label;
+  scopeBadge.appendChild(labelSpan);
 };
 
 const NEW_ENVIRONMENT_WAIT_TIMEOUT_MS = 3000;
@@ -398,7 +415,7 @@ export const renderVarInfo = (token, options) => {
 
   header.appendChild(varName);
 
-  scopeBadge.textContent = scopeLabel;
+  setScopeBadgeContent(scopeBadge, displayScopeType, scopeLabel);
   header.appendChild(scopeBadge);
 
   into.appendChild(header);
@@ -804,7 +821,7 @@ export const renderVarInfo = (token, options) => {
       // This can happen if adding variable in Global Table where collection is not available.
       if (initialScope && initialScope.type !== scopeInfo.type) {
         scopeInfo = buildScopeInfoForSwitch(initialScope);
-        scopeBadge.textContent = getScopeLabel(initialScope.type);
+        setScopeBadgeContent(scopeBadge, initialScope.type, getScopeLabel(initialScope.type));
       }
 
       const removeAddToSwitcher = () => {
@@ -833,7 +850,7 @@ export const renderVarInfo = (token, options) => {
             const updatedScopeInfo = getVariableScope(variableName, freshCollection, freshItem);
             if (updatedScopeInfo) {
               scopeInfo = updatedScopeInfo;
-              scopeBadge.textContent = getScopeLabel(updatedScopeInfo.type);
+              setScopeBadgeContent(scopeBadge, updatedScopeInfo.type, getScopeLabel(updatedScopeInfo.type));
             }
 
             const interpolatedValue = interpolate(value, allVariables);
@@ -853,7 +870,7 @@ export const renderVarInfo = (token, options) => {
           return;
         }
         scopeInfo = newScopeInfo;
-        scopeBadge.textContent = getScopeLabel(newScopeInfo.type);
+        setScopeBadgeContent(scopeBadge, newScopeInfo.type, getScopeLabel(newScopeInfo.type));
       };
 
       const onCreateEnvironment = (scope, name) => {

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -585,7 +585,7 @@ describe('renderVarInfo', () => {
 
       // Guessed scope shows up as the header badge, same as any other variable.
       const scopeBadge = result.querySelector('.var-scope-badge');
-      expect(scopeBadge.textContent).toBe('Request');
+      expect(scopeBadge.querySelector('.var-scope-badge-label').textContent).toBe('Request');
 
       const switcher = result.querySelector('.var-add-to-switcher');
       expect(switcher).not.toBeNull();
@@ -680,13 +680,14 @@ describe('renderVarInfo', () => {
       );
 
       const scopeBadge = result.querySelector('.var-scope-badge');
-      expect(scopeBadge.textContent).toBe('Request');
+      const scopeBadgeLabel = () => scopeBadge.querySelector('.var-scope-badge-label').textContent;
+      expect(scopeBadgeLabel()).toBe('Request');
 
       const switcher = result.querySelector('.var-add-to-switcher');
       switcher.querySelector('.var-add-to-toggle').click();
       switcher.querySelector('[data-testid="var-info-add-to-option-collection"]').click();
 
-      expect(scopeBadge.textContent).toBe('Collection');
+      expect(scopeBadgeLabel()).toBe('Collection');
       // Picking an existing scope only repoints where the next blur-save writes to.
       expect(updateVariableInScope).not.toHaveBeenCalled();
     });

--- a/packages/bruno-app/src/utils/common/constants.js
+++ b/packages/bruno-app/src/utils/common/constants.js
@@ -22,6 +22,65 @@ export const VARIABLE_ADD_SCOPES = {
   FOLDER: 'folder'
 };
 
+export const CHEVRON_ICON_SVG_TEXT = `
+<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="6,9 12,15 18,9"></polyline>
+</svg>
+`;
+
+// Collection Environment
+const DATABASE_ICON_SVG_TEXT = `
+<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <ellipse cx="12" cy="6" rx="8" ry="3"></ellipse>
+  <path d="M4 6v6a8 3 0 0 0 16 0v-6"></path>
+  <path d="M4 12v6a8 3 0 0 0 16 0v-6"></path>
+</svg>
+`;
+
+// Global Environment
+const WORLD_ICON_SVG_TEXT = `
+<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"></circle>
+  <line x1="3.6" y1="9" x2="20.4" y2="9"></line>
+  <line x1="3.6" y1="15" x2="20.4" y2="15"></line>
+  <path d="M11.5 3a17 17 0 0 0 0 18"></path>
+  <path d="M12.5 3a17 17 0 0 1 0 18"></path>
+</svg>
+`;
+
+// Request
+const SEND_ICON_SVG_TEXT = `
+<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="10" y1="14" x2="21" y2="3"></line>
+  <path d="M21 3l-6.5 18a0.55 .55 0 0 1 -1 0l-3.5 -7l-7 -3.5a0.55 .55 0 0 1 0 -1l18 -6.5"></path>
+</svg>
+`;
+
+// Parent Folder
+const FOLDER_ICON_SVG_TEXT = `
+<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 4h4l3 3h7a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-11a2 2 0 0 1 2 -2"></path>
+</svg>
+`;
+
+// Collection variable
+const BOX_ICON_SVG_TEXT = `
+<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="12 3 20 7.5 20 16.5 12 21 4 16.5 4 7.5 12 3"></polyline>
+  <line x1="12" y1="12" x2="20" y2="7.5"></line>
+  <line x1="12" y1="12" x2="12" y2="21"></line>
+  <line x1="12" y1="12" x2="4" y2="7.5"></line>
+</svg>
+`;
+
+export const SCOPE_ICON = {
+  [VARIABLE_ADD_SCOPES.REQUEST]: SEND_ICON_SVG_TEXT,
+  [VARIABLE_ADD_SCOPES.FOLDER]: FOLDER_ICON_SVG_TEXT,
+  [VARIABLE_ADD_SCOPES.COLLECTION]: BOX_ICON_SVG_TEXT,
+  [VARIABLE_ADD_SCOPES.ENVIRONMENT]: DATABASE_ICON_SVG_TEXT,
+  [VARIABLE_ADD_SCOPES.GLOBAL]: WORLD_ICON_SVG_TEXT
+};
+
 export const AUTH_MODES = {
   AWSV4: 'awsv4',
   BASIC: 'basic',


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Added icons for variable scope switcher list and the badge.

BRU-4475

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
Earlier we were only showing the first text icon for the variable scope option.


### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
Added icons to the items in the variable scope list

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="306" height="268" alt="image" src="https://github.com/user-attachments/assets/c0ea0b66-b020-403d-9ae7-06f649a76729" />| <img width="354" height="278" alt="image" src="https://github.com/user-attachments/assets/636842b4-d87b-4037-9011-294833651ee6" />|

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Variable information popovers now display clearer scope badges with icons.
  * Improved scope switcher sizing, spacing, icon visibility, and text layout.
  * Secret checkboxes now use an accent color for better visual feedback.
  * Added consistent icons for database, globe, send, folder, and box scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->