### PR TITLE
chore(standards): update coding standards for call site specific clones

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -132,3 +132,10 @@ For each test file:
 - Avoid single line abstractions where all that's being done is increasing the call stack with one additional function.
 - Add in meaningful comments instead of obvious ones where complex code flow is explained properly.
 - Avoid optional chaining (`?.`) where it doesn't make sense — it hides whether a value can genuinely be null and works against TypeScript's guarantees. Only use it when the null case is handled right there (fallback, early return, or guard); otherwise fix the type or narrow first.
+
+## Data Copies and Mutations
+
+- MUST: Do not use `cloneDeep` (or equivalent deep clones) in new code. Deep-cloning large objects (collections, environments, request trees) allocates huge heap copies that are often unnecessary.
+- MUST: If a mutation requires a copy, make that copy at the call site - copy only the data that will actually be mutated, as shallowly as possible.
+- Prefer in-place updates of owned draft/local state, immutable updates of the changed path only (`{ ...obj, field: next }`, array spreads, etc.), or a targeted clone of the subtree being edited — not a defensive deep clone of the whole object graph inside helpers.
+- Existing `cloneDeep` call sites may remain until touched; when modifying such code, replace the deep clone with a call-site copy of the minimal data needed.


### PR DESCRIPTION
### Description

Update coding standards instructions for call site specific clones, these are to incrementally improve our unnecessary heap usage situation where deepClones are used too often even when they aren't needed. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added coding standards for handling data copies and mutations.
  * New code should avoid deep-cloning utilities and instead create minimal, shallow copies at the call site when needed.
  * Existing deep-cloning usage may remain until the surrounding code is modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->