### PR TITLE
fix(test): cli test cases for windows

### DIFF
--- a/packages/bruno-cli/tests/integration/nodevm-async-callbacks/run-nodevm-async-callbacks.spec.js
+++ b/packages/bruno-cli/tests/integration/nodevm-async-callbacks/run-nodevm-async-callbacks.spec.js
@@ -34,7 +34,7 @@ describe('CLI run --sandbox developer - async test() callbacks are awaited befor
     );
     code = result.code;
     output = stripAnsi(`${result.stdout}\n${result.stderr}`);
-  });
+  }, 120000);
 
   afterAll(async () => {
     fs.rmSync(collectionDir, { recursive: true, force: true });

--- a/packages/bruno-cli/tests/integration/nodevm-async-callbacks/run-nodevm-async-callbacks.spec.js
+++ b/packages/bruno-cli/tests/integration/nodevm-async-callbacks/run-nodevm-async-callbacks.spec.js
@@ -34,7 +34,7 @@ describe('CLI run --sandbox developer - async test() callbacks are awaited befor
     );
     code = result.code;
     output = stripAnsi(`${result.stdout}\n${result.stderr}`);
-  }, 120000);
+  }, 4000);
 
   afterAll(async () => {
     fs.rmSync(collectionDir, { recursive: true, force: true });

--- a/packages/bruno-cli/tests/integration/nodevm-async-callbacks/run-nodevm-async-callbacks.spec.js
+++ b/packages/bruno-cli/tests/integration/nodevm-async-callbacks/run-nodevm-async-callbacks.spec.js
@@ -34,7 +34,7 @@ describe('CLI run --sandbox developer - async test() callbacks are awaited befor
     );
     code = result.code;
     output = stripAnsi(`${result.stdout}\n${result.stderr}`);
-  }, 4000);
+  }, 20000);
 
   afterAll(async () => {
     fs.rmSync(collectionDir, { recursive: true, force: true });


### PR DESCRIPTION
### Description

Test-only change: adds an explicit Jest timeout to the `beforeAll` hook in the bruno-cli `nodevm-async-callbacks` spec.

which was failing due to changes in PR #9081

### Problem

The hook runs the full `bru run`, but bruno-cli sets no `testTimeout`, so it inherited Jest's 5s default and failed on the slower Windows CI runner.

### Fix

Give the hook an explicit timeout, as the sibling `quickjs-trap-containment`spec already does for its CLI run.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the setup timeout for a CLI integration test to allow additional time for starting the HTTP server and running commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->