### PR TITLE
fix(migration): keep the call wrapping a response member in pm.sendRequest callbacks

### DIFF
--- a/packages/bruno-converters/src/utils/send-request-transformer.js
+++ b/packages/bruno-converters/src/utils/send-request-transformer.js
@@ -270,12 +270,12 @@ const resolvesToHandlerParam = (path, name, handler) => {
  * that resolve to a different binding — a nested function re-declaring the name —
  * are left alone.
  * @param {Object} j - jscodeshift API
- * @param {Object} handlerPath - Path of the `.then` fulfilled handler argument; the
- *   caller guarantees it is a function expression with an Identifier first param.
+ * @param {Object} handlerPath - Path of the function receiving the response: a `.then`
+ *   fulfilled handler or a `pm.sendRequest` callback
+ * @param {string} responseVarName - Name of the handler's response parameter
  */
-const rewriteThenHandlerResponseAccess = (j, handlerPath) => {
+const rewriteResponseAccess = (j, handlerPath, responseVarName) => {
   const handler = handlerPath.value;
-  const responseVarName = handler.params[0].name;
 
   j(handlerPath).find(j.MemberExpression, {
     object: {
@@ -386,10 +386,11 @@ const isResponseParamReassigned = (j, handlerPath) => {
 /**
  * Transform callback function to Bruno format
  * @param {Object} j - jscodeshift API
- * @param {Object} callback - Callback function expression
+ * @param {Object} callbackPath - Path of the callback argument
  * @returns {Object} - Transformed callback function
  */
-const transformCallback = (j, callback) => {
+const transformCallback = (j, callbackPath) => {
+  const callback = callbackPath.value;
   if (!callback || (callback.type !== 'FunctionExpression' && callback.type !== 'ArrowFunctionExpression')) return null;
 
   const params = callback.params;
@@ -406,41 +407,7 @@ const transformCallback = (j, callback) => {
     errorVarName = params[0].name;
   }
 
-  // Process the callback body to transform response property references
-  j(callbackBody).find(j.MemberExpression, {
-    object: {
-      type: 'Identifier',
-      name: responseVarName
-    }
-  }).forEach((memberPath) => {
-    const property = memberPath.node.property;
-
-    // Handle property access
-    if (property.type === 'Identifier' && responsePropertyMap[property.name]) {
-      const bruProperty = responsePropertyMap[property.name];
-      if (bruProperty) {
-        // Check if memberPath is part of a CallExpression
-        const parentPath = memberPath.parent;
-        if (parentPath && parentPath.node.type === 'CallExpression') {
-          // Replace the entire CallExpression with a property access
-          j(parentPath).replaceWith(
-            j.memberExpression(
-              j.identifier(responseVarName),
-              j.identifier(bruProperty)
-            )
-          );
-        } else {
-          // Regular property access replacement
-          j(memberPath).replaceWith(
-            j.memberExpression(
-              j.identifier(responseVarName),
-              j.identifier(bruProperty)
-            )
-          );
-        }
-      }
-    }
-  });
+  rewriteResponseAccess(j, callbackPath, responseVarName);
 
   // Create the callback block
   return j.functionExpression(
@@ -523,7 +490,8 @@ const sendRequestTransformer = (path, j) => {
 
   let transformedCallback = null;
   if (callback) {
-    transformedCallback = transformCallback(j, callback);
+    const callbackPath = callPath.get('arguments', 1);
+    transformedCallback = transformCallback(j, callbackPath);
 
     // Add async keyword to the callback function
     if (transformedCallback && (transformedCallback.type === 'FunctionExpression' || transformedCallback.type === 'ArrowFunctionExpression')) {
@@ -567,7 +535,7 @@ const sendRequestTransformer = (path, j) => {
     const returnsResponse = returnsParamUnchanged(j, handlerPath);
     const reassignsResponse = isResponseParamReassigned(j, handlerPath);
 
-    rewriteThenHandlerResponseAccess(j, handlerPath);
+    rewriteResponseAccess(j, handlerPath, handler.params[0].name);
 
     if (!returnsResponse) break;
     if (reassignsResponse) break;

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1534,7 +1534,6 @@ await bru.sendRequest({
           console.log(code);
           console.log(status);
         });
-
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1512,44 +1512,63 @@ await bru.sendRequest({
   describe('response members wrapped in other expressions', () => {
     it('should keep the call wrapping a response property', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({
+          url: 'https://echo.usebruno.com',
+          method: 'POST',
+          header: {
+            'Content-Type': 'application/json'
+          },
+          body: {
+            mode: 'raw',
+            raw: JSON.stringify({ hello: 'world' })
+          }
+        }, function (err, response) {
+
           const json = response.json();
           const text = response.text();
           const code = response.code;
           const status = response.status;
-        
-          console.log(response.json());
-          console.log(response.text());
-          console.log(response.code);
-          console.log(response.status);
+
+          console.log(json);
+          console.log(text);
+          console.log(code);
+          console.log(status);
         });
+
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({
+          url: 'https://echo.usebruno.com',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          data: JSON.stringify({ hello: 'world' })
+        }, async function(err, response) {
           const json = response.data;
           const text = response.data;
           const code = response.status;
           const status = response.statusText;
 
-          console.log(response.data);
-          console.log(response.data);
-          console.log(response.status);
-          console.log(response.statusText);
+          console.log(json);
+          console.log(text);
+          console.log(code);
+          console.log(status);
         });
       `);
     });
 
     it('should rewrite response properties and methods passed together as call arguments', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           console.log(response.code, response.json());
           pm.environment.set('statusText', response.status);
         });
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           console.log(response.status, response.data);
           bru.setEnvVar('statusText', response.statusText);
         });
@@ -1557,13 +1576,13 @@ await bru.sendRequest({
     });
     it('should rewrite a response member nested inside a call argument', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           console.log(response.json().data.id, response.text().length);
         });
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           console.log(response.data.data.id, response.data.length);
         });
       `);
@@ -1571,13 +1590,13 @@ await bru.sendRequest({
 
     it('should rewrite response members inside a template literal', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           console.log(\`\${response.code} \${response.status}\`);
         });
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           console.log(\`\${response.status} \${response.statusText}\`);
         });
       `);
@@ -1585,7 +1604,7 @@ await bru.sendRequest({
 
     it('should rewrite response members used in comparisons', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           if (response.code === 200 && response.status === 'OK') {
             console.log(response.json());
           }
@@ -1593,7 +1612,7 @@ await bru.sendRequest({
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           if (response.status === 200 && response.statusText === 'OK') {
             console.log(response.data);
           }
@@ -1603,13 +1622,13 @@ await bru.sendRequest({
 
     it('should rewrite response members used as an object key and value', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           const result = { [response.code]: response.json() };
         });
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           const result = { [response.status]: response.data };
         });
       `);
@@ -1617,13 +1636,13 @@ await bru.sendRequest({
 
     it('should rewrite response members accessed with a computed string key', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           console.log(response['code'], response['json']());
         });
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           console.log(response.status, response.data);
         });
       `);
@@ -1631,7 +1650,7 @@ await bru.sendRequest({
 
     it('should rewrite response members inside a nested pm.test and pm.expect', () => {
       const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           pm.test('ok', () => {
             pm.expect(response.code).to.eql(200);
             pm.expect(response.json().id).to.eql(1);
@@ -1640,7 +1659,7 @@ await bru.sendRequest({
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           test('ok', () => {
             expect(response.status).to.eql(200);
             expect(response.data.id).to.eql(1);

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -588,52 +588,6 @@ describe('Send Request Translation', () => {
       expect(translatedCode).toContain('const responseTime = response.responseTime');
       expect(translatedCode).toContain('const text = response.data');
     });
-
-    it('should keep the call wrapping a response property', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
-          console.log(response.code);
-        });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
-          console.log(response.status);
-        });
-      `);
-    });
-
-    it('should rewrite response properties and methods passed together as call arguments', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
-          console.log(response.code, response.json());
-          pm.environment.set('statusText', response.status);
-        });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
-          console.log(response.status, response.data);
-          bru.setEnvVar('statusText', response.statusText);
-        });
-      `);
-    });
-
-    it('should leave a response name re-declared by a nested function untouched', () => {
-      const code = `
-        pm.sendRequest({ url: 'https://x' }, function (err, response) {
-          console.log(response.code);
-          const inner = (response) => response.code;
-        });
-      `;
-      const translatedCode = translateCode(code);
-      expect(translatedCode).toBe(`
-        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
-          console.log(response.status);
-          const inner = (response) => response.code;
-        });
-      `);
-    });
   });
 
   describe('Async/Await', () => {
@@ -1551,6 +1505,147 @@ await bru.sendRequest({
         await bru.sendRequest({ url: 'https://echo.usebruno.com' })
           .then(() => 'done')
           .then((res) => res.json());
+      `);
+    });
+  });
+
+  describe('response members wrapped in other expressions', () => {
+    it('should keep the call wrapping a response property', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          const json = response.json();
+          const text = response.text();
+          const code = response.code;
+          const status = response.status;
+        
+          console.log(response.json());
+          console.log(response.text());
+          console.log(response.code);
+          console.log(response.status);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          const json = response.data;
+          const text = response.data;
+          const code = response.status;
+          const status = response.statusText;
+
+          console.log(response.data);
+          console.log(response.data);
+          console.log(response.status);
+          console.log(response.statusText);
+        });
+      `);
+    });
+
+    it('should rewrite response properties and methods passed together as call arguments', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          console.log(response.code, response.json());
+          pm.environment.set('statusText', response.status);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          console.log(response.status, response.data);
+          bru.setEnvVar('statusText', response.statusText);
+        });
+      `);
+    });
+    it('should rewrite a response member nested inside a call argument', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          console.log(response.json().data.id, response.text().length);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          console.log(response.data.data.id, response.data.length);
+        });
+      `);
+    });
+
+    it('should rewrite response members inside a template literal', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          console.log(\`\${response.code} \${response.status}\`);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          console.log(\`\${response.status} \${response.statusText}\`);
+        });
+      `);
+    });
+
+    it('should rewrite response members used in comparisons', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          if (response.code === 200 && response.status === 'OK') {
+            console.log(response.json());
+          }
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          if (response.status === 200 && response.statusText === 'OK') {
+            console.log(response.data);
+          }
+        });
+      `);
+    });
+
+    it('should rewrite response members used as an object key and value', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          const result = { [response.code]: response.json() };
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          const result = { [response.status]: response.data };
+        });
+      `);
+    });
+
+    it('should rewrite response members accessed with a computed string key', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          console.log(response['code'], response['json']());
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          console.log(response.status, response.data);
+        });
+      `);
+    });
+
+    it('should rewrite response members inside a nested pm.test and pm.expect', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          pm.test('ok', () => {
+            pm.expect(response.code).to.eql(200);
+            pm.expect(response.json().id).to.eql(1);
+          });
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          test('ok', () => {
+            expect(response.status).to.eql(200);
+            expect(response.data.id).to.eql(1);
+          });
+        });
       `);
     });
   });

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -588,6 +588,52 @@ describe('Send Request Translation', () => {
       expect(translatedCode).toContain('const responseTime = response.responseTime');
       expect(translatedCode).toContain('const text = response.data');
     });
+
+    it('should keep the call wrapping a response property', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          console.log(response.code);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          console.log(response.status);
+        });
+      `);
+    });
+
+    it('should rewrite response properties and methods passed together as call arguments', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          console.log(response.code, response.json());
+          pm.environment.set('statusText', response.status);
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          console.log(response.status, response.data);
+          bru.setEnvVar('statusText', response.statusText);
+        });
+      `);
+    });
+
+    it('should leave a response name re-declared by a nested function untouched', () => {
+      const code = `
+        pm.sendRequest({ url: 'https://x' }, function (err, response) {
+          console.log(response.code);
+          const inner = (response) => response.code;
+        });
+      `;
+      const translatedCode = translateCode(code);
+      expect(translatedCode).toBe(`
+        await bru.sendRequest({ url: 'https://x' }, async function(err, response) {
+          console.log(response.status);
+          const inner = (response) => response.code;
+        });
+      `);
+    });
   });
 
   describe('Async/Await', () => {

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1512,18 +1512,7 @@ await bru.sendRequest({
   describe('response members wrapped in other expressions', () => {
     it('should keep the call wrapping a response property', () => {
       const code = `
-        pm.sendRequest({
-          url: 'https://echo.usebruno.com',
-          method: 'POST',
-          header: {
-            'Content-Type': 'application/json'
-          },
-          body: {
-            mode: 'raw',
-            raw: JSON.stringify({ hello: 'world' })
-          }
-        }, function (err, response) {
-
+        pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {
           const json = response.json();
           const text = response.text();
           const code = response.code;
@@ -1537,14 +1526,7 @@ await bru.sendRequest({
       `;
       const translatedCode = translateCode(code);
       expect(translatedCode).toBe(`
-        await bru.sendRequest({
-          url: 'https://echo.usebruno.com',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          data: JSON.stringify({ hello: 'world' })
-        }, async function(err, response) {
+        await bru.sendRequest({ url: 'https://echo.usebruno.com' }, async function(err, response) {
           const json = response.data;
           const text = response.data;
           const code = response.status;
@@ -1573,6 +1555,7 @@ await bru.sendRequest({
         });
       `);
     });
+    
     it('should rewrite a response member nested inside a call argument', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {

--- a/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
+++ b/packages/bruno-converters/tests/postman/postman-translations/transpiler-tests/transformers/send-request.test.js
@@ -1555,7 +1555,7 @@ await bru.sendRequest({
         });
       `);
     });
-    
+
     it('should rewrite a response member nested inside a call argument', () => {
       const code = `
         pm.sendRequest({ url: 'https://echo.usebruno.com' }, function (err, response) {


### PR DESCRIPTION
BRU-4291

### Description

When migrating a Postman script to Bruno, the `pm.sendRequest` callback rewriter maps Postman response access to its Bruno equivalent (`response.code` → `response.status`, `response.json()` → `response.data`, ...). If a mapped response member sat inside a call as an *argument*, the rewriter replaced the entire wrapping call instead of just the member.

Example:

```js
// Postman
console.log(response.code);

// Bruno (before this fix)
response.status;

// Bruno (expected)
console.log(response.status);
```

### Problem

The rewrite was written with `response.json()` in mind. On Postman that is a method, on Bruno it is a plain property, so the call has to lose its parentheses. To do that, `transformCallback` checked whether the member's parent was a `CallExpression` and, if so, replaced the whole parent.

That check is too broad. A parent can be a `CallExpression` for two different reasons:

- the member is the **callee**: `response.json()`
- the member is an **argument** of some other call: `console.log(response.code)`

The old code treated both the same and replaced the parent in either case.

### Fix

 Before, the only check was "is the parent a CallExpression?". If yes, the whole parent was replaced.
 
 Now we check two things: the parent is a CallExpression and the member is that call's callee. Only when both hold is the whole call replaced (response.json() → response.data). Otherwise just the member itself is replaced, so whatever wraps it is kept (console.log(response.code) → console.log(response.status)).

| Statement                    | Parent is a call? | Member is the callee? | Old code                               | New code                                                 |
| ---------------------------- | ----------------- | --------------------- | -------------------------------------- | -------------------------------------------------------- |
| `response.json()`            | yes               | yes                   | replace whole call → `response.data`   | same                                                     |
| `console.log(response.code)` | yes               | no                    | replace whole call → `response.status` | replace only the member → `console.log(response.status)` |
### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved translation of response properties and methods in promise handlers and request callbacks.
  - Preserved correct behavior for nested and computed response access, shadowed variables, expressions, and template literals.
  - Improved conversion of response fields and methods to their Bruno equivalents across more Postman scripts.

- **Tests**
  - Added coverage for nested expressions, comparisons, computed keys, bracket notation, template literals, and nested test assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->