### PR TITLE
feat(scripts): enhanced pre-request scripts handling with environment variable interpolation and added tests

### DIFF
--- a/packages/bruno-cli/tests/runner/request-url-flow.spec.js
+++ b/packages/bruno-cli/tests/runner/request-url-flow.spec.js
@@ -1,0 +1,69 @@
+const { describe, it, expect } = require('@jest/globals');
+const BrunoRequest = require('@usebruno/js/src/bruno-request');
+const interpolateVars = require('../../src/runner/interpolate-vars');
+
+const runFlow = (url, { pathParams = [], envVars = {} } = {}) => {
+  const request = { url, method: 'GET', headers: {}, pathParams };
+
+  const templated = new BrunoRequest(request);
+  const preRequest = {
+    host: templated.getHost(),
+    path: templated.getPath(),
+    queryString: templated.getQueryString()
+  };
+
+  interpolateVars(request, envVars, {}, {});
+
+  const resolved = new BrunoRequest(request);
+  const postResponse = {
+    host: resolved.getHost(),
+    path: resolved.getPath(),
+    queryString: resolved.getQueryString()
+  };
+
+  return { preRequest, postResponse };
+};
+
+describe('request url as seen by pre-request and post-response scripts', () => {
+  it('resolves a templated host, query and path params', () => {
+    const flow = runFlow('{{BASEURL}}/path/:p1/:p2?a={{A}}', {
+      pathParams: [
+        { name: 'p1', value: '10' },
+        { name: 'p2', value: '{{P2}}' }
+      ],
+      envVars: { BASEURL: 'https://api.example.com:8080', A: '1', P2: '20' }
+    });
+
+    expect(flow.preRequest).toEqual({
+      host: '{{BASEURL}}',
+      path: '/path/10/{{P2}}',
+      queryString: 'a={{A}}'
+    });
+
+    expect(flow.postResponse).toEqual({
+      host: 'api.example.com:8080',
+      path: '/path/10/20',
+      queryString: 'a=1'
+    });
+  });
+
+  // without path params interpolateVars() keeps the fragment
+  it('excludes a fragment in both phases', () => {
+    const flow = runFlow('{{BASEURL}}/path?a={{A}}#section', {
+      envVars: { BASEURL: 'https://api.example.com', A: '1' }
+    });
+
+    expect(flow.preRequest).toEqual({ host: '{{BASEURL}}', path: '/path', queryString: 'a={{A}}' });
+    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path', queryString: 'a=1' });
+  });
+
+  it('excludes credentials in both phases', () => {
+    const flow = runFlow('https://user:pass@{{HOST}}/path/:p1', {
+      pathParams: [{ name: 'p1', value: '10' }],
+      envVars: { HOST: 'api.example.com' }
+    });
+
+    expect(flow.preRequest).toEqual({ host: '{{HOST}}', path: '/path/10', queryString: '' });
+    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path/10', queryString: '' });
+  });
+});

--- a/packages/bruno-electron/tests/network/request-url-flow.spec.js
+++ b/packages/bruno-electron/tests/network/request-url-flow.spec.js
@@ -1,0 +1,69 @@
+const { describe, it, expect } = require('@jest/globals');
+const BrunoRequest = require('@usebruno/js/src/bruno-request');
+const interpolateVars = require('../../src/ipc/network/interpolate-vars');
+
+const runFlow = (url, { pathParams = [], envVars = {} } = {}) => {
+  const request = { url, method: 'GET', headers: {}, pathParams };
+
+  const templated = new BrunoRequest(request);
+  const preRequest = {
+    host: templated.getHost(),
+    path: templated.getPath(),
+    queryString: templated.getQueryString()
+  };
+
+  interpolateVars(request, envVars, {}, {}, {});
+
+  const resolved = new BrunoRequest(request);
+  const postResponse = {
+    host: resolved.getHost(),
+    path: resolved.getPath(),
+    queryString: resolved.getQueryString()
+  };
+
+  return { preRequest, postResponse };
+};
+
+describe('request url as seen by pre-request and post-response scripts', () => {
+  it('resolves a templated host, query and path params', () => {
+    const flow = runFlow('{{BASEURL}}/path/:p1/:p2?a={{A}}', {
+      pathParams: [
+        { name: 'p1', value: '10' },
+        { name: 'p2', value: '{{P2}}' }
+      ],
+      envVars: { BASEURL: 'https://api.example.com:8080', A: '1', P2: '20' }
+    });
+
+    expect(flow.preRequest).toEqual({
+      host: '{{BASEURL}}',
+      path: '/path/10/{{P2}}',
+      queryString: 'a={{A}}'
+    });
+
+    expect(flow.postResponse).toEqual({
+      host: 'api.example.com:8080',
+      path: '/path/10/20',
+      queryString: 'a=1'
+    });
+  });
+
+  // without path params interpolateVars() keeps the fragment
+  it('excludes a fragment in both phases', () => {
+    const flow = runFlow('{{BASEURL}}/path?a={{A}}#section', {
+      envVars: { BASEURL: 'https://api.example.com', A: '1' }
+    });
+
+    expect(flow.preRequest).toEqual({ host: '{{BASEURL}}', path: '/path', queryString: 'a={{A}}' });
+    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path', queryString: 'a=1' });
+  });
+
+  it('excludes credentials in both phases', () => {
+    const flow = runFlow('https://user:pass@{{HOST}}/path/:p1', {
+      pathParams: [{ name: 'p1', value: '10' }],
+      envVars: { HOST: 'api.example.com' }
+    });
+
+    expect(flow.preRequest).toEqual({ host: '{{HOST}}', path: '/path/10', queryString: '' });
+    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path/10', queryString: '' });
+  });
+});

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -1,3 +1,4 @@
+const { interpolate: _interpolate } = require('@usebruno/common');
 const HeaderList = require('./header-list');
 
 class BrunoRequest {
@@ -14,7 +15,16 @@ class BrunoRequest {
    * It must be noted that the user cannot set these properties directly.
    * They should use the respective setter methods to set these properties.
    */
-  constructor(req) {
+  constructor(req, { envVariables, runtimeVariables, processEnvVars } = {}) {
+    this.envVariables = envVariables || {};
+    this.runtimeVariables = runtimeVariables || {};
+    this.processEnvVars = processEnvVars || {};
+    this.globalEnvironmentVariables = req?.globalEnvironmentVariables || {};
+    this.collectionVariables = req?.collectionVariables || {};
+    this.folderVariables = req?.folderVariables || {};
+    this.requestVariables = req?.requestVariables || {};
+    this.oauth2CredentialVariables = req?.oauth2CredentialVariables || {};
+    this.promptVariables = req?.promptVariables || {};
     this.req = req;
     this.url = req.url;
     this.method = req.method;
@@ -37,6 +47,31 @@ class BrunoRequest {
     }
   }
 
+  interpolate = (strOrObj) => {
+    if (!strOrObj) return strOrObj;
+    const isObj = typeof strOrObj === 'object';
+    const strToInterpolate = isObj ? JSON.stringify(strOrObj) : strOrObj;
+
+    const combinedVars = {
+      ...this.globalEnvironmentVariables,
+      ...this.collectionVariables,
+      ...this.envVariables,
+      ...this.folderVariables,
+      ...this.requestVariables,
+      ...this.oauth2CredentialVariables,
+      ...this.runtimeVariables,
+      ...this.promptVariables,
+      process: {
+        env: {
+          ...this.processEnvVars
+        }
+      }
+    };
+
+    const interpolatedStr = _interpolate(strToInterpolate, combinedVars);
+    return isObj ? JSON.parse(interpolatedStr) : interpolatedStr;
+  };
+
   getUrl() {
     return this.req.url;
   }
@@ -48,7 +83,7 @@ class BrunoRequest {
 
   getHost() {
     try {
-      const url = new URL(this.req.url);
+      const url = new URL(this.interpolate(this.req.url));
       return url.host;
     } catch (e) {
       return '';
@@ -57,7 +92,7 @@ class BrunoRequest {
 
   getPath() {
     try {
-      const url = new URL(this.req.url);
+      const url = new URL(this.interpolate(this.req.url));
       let pathname = url.pathname;
 
       // If path params exist, interpolate them into the pathname
@@ -75,7 +110,7 @@ class BrunoRequest {
                 && pathParam.value !== undefined
                 && (typeof pathParam.value !== 'string' || pathParam.value.trim() !== '')
               ) {
-                return pathParam.value;
+                return this.interpolate(pathParam.value);
               }
             }
             return segment;
@@ -91,7 +126,7 @@ class BrunoRequest {
 
   getQueryString() {
     try {
-      const url = new URL(this.req.url);
+      const url = new URL(this.interpolate(this.req.url));
       // Return query string without the leading '?'
       return url.search ? url.search.substring(1) : '';
     } catch (e) {

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -46,6 +46,10 @@ class BrunoRequest {
     this.req.url = url;
   }
 
+  /**
+   * new URL() mangles {{var}} reference variables, so the url is split by hand. The comments
+   * below show each step for 'https://{{HOST}}/users/:id?role=admin'.
+   */
   __parseUrl() {
     const rawUrl = this.req.url;
 
@@ -53,21 +57,36 @@ class BrunoRequest {
       throw new Error('URL is empty');
     }
 
-    const referenceVariables = [];
-    const maskedUrl = rawUrl.replace(/\{\{[^{}]*\}\}/g, (referenceVariable) => {
-      referenceVariables.push(referenceVariable);
+    let url = rawUrl;
 
-      return `reference-variable-${referenceVariables.length - 1}`;
-    });
+    // the scheme may itself be a {{var}}, so match anything up to the '://'
+    const schemePattern = /^[^/?#]*:\/\//;
 
-    const restore = (value) =>
-      value.replace(/reference-variable-(\d+)/g, (match, index) => referenceVariables[Number(index)] ?? match);
-    const url = new URL(/^[a-z][a-z\d+\-.]*:\/\//i.test(maskedUrl) ? maskedUrl : `https://${maskedUrl}`);
+    // Add a default protocol when the URL does not have one.
+    if (!schemePattern.test(url)) {
+      url = `https://${url}`;
+    }
+
+    const protocolMatch = url.match(schemePattern); // 'https://'
+
+    // everything after the scheme, minus any #fragment: '{{HOST}}/users/:id?role=admin'
+    const remainder = url.substring(protocolMatch[0].length).split('#')[0];
+
+    // capturing the separator keeps it, so the first piece is the host and rejoining the rest
+    // rebuilds what followed: '{{HOST}}' and '/users/:id?role=admin'
+    const [authority, ...rest] = remainder.split(/([/?])/);
+    const restUrl = rest.join('');
+
+    // before the '?' is the path, after it the query: '/users/:id' and 'role=admin'
+    const queryIndex = restUrl.indexOf('?');
+    const path = queryIndex === -1 ? restUrl : restUrl.substring(0, queryIndex);
+    const search = queryIndex === -1 ? '' : restUrl.substring(queryIndex + 1);
 
     return {
-      host: restore(url.host),
-      pathname: restore(url.pathname),
-      search: restore(url.search.substring(1))
+      // the host is the authority without any user:password@ prefix
+      host: authority.split('@').pop(),
+      pathname: path,
+      search
     };
   }
 

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -1,4 +1,3 @@
-const { interpolate: _interpolate } = require('@usebruno/common');
 const HeaderList = require('./header-list');
 
 class BrunoRequest {
@@ -15,16 +14,7 @@ class BrunoRequest {
    * It must be noted that the user cannot set these properties directly.
    * They should use the respective setter methods to set these properties.
    */
-  constructor(req, { envVariables, runtimeVariables, processEnvVars } = {}) {
-    this.envVariables = envVariables || {};
-    this.runtimeVariables = runtimeVariables || {};
-    this.processEnvVars = processEnvVars || {};
-    this.globalEnvironmentVariables = req?.globalEnvironmentVariables || {};
-    this.collectionVariables = req?.collectionVariables || {};
-    this.folderVariables = req?.folderVariables || {};
-    this.requestVariables = req?.requestVariables || {};
-    this.oauth2CredentialVariables = req?.oauth2CredentialVariables || {};
-    this.promptVariables = req?.promptVariables || {};
+  constructor(req) {
     this.req = req;
     this.url = req.url;
     this.method = req.method;
@@ -47,31 +37,6 @@ class BrunoRequest {
     }
   }
 
-  interpolate = (strOrObj) => {
-    if (!strOrObj) return strOrObj;
-    const isObj = typeof strOrObj === 'object';
-    const strToInterpolate = isObj ? JSON.stringify(strOrObj) : strOrObj;
-
-    const combinedVars = {
-      ...this.globalEnvironmentVariables,
-      ...this.collectionVariables,
-      ...this.envVariables,
-      ...this.folderVariables,
-      ...this.requestVariables,
-      ...this.oauth2CredentialVariables,
-      ...this.runtimeVariables,
-      ...this.promptVariables,
-      process: {
-        env: {
-          ...this.processEnvVars
-        }
-      }
-    };
-
-    const interpolatedStr = _interpolate(strToInterpolate, combinedVars);
-    return isObj ? JSON.parse(interpolatedStr) : interpolatedStr;
-  };
-
   getUrl() {
     return this.req.url;
   }
@@ -83,7 +48,7 @@ class BrunoRequest {
 
   getHost() {
     try {
-      const url = new URL(this.interpolate(this.req.url));
+      const url = new URL(this.req.url);
       return url.host;
     } catch (e) {
       return '';
@@ -92,7 +57,7 @@ class BrunoRequest {
 
   getPath() {
     try {
-      const url = new URL(this.interpolate(this.req.url));
+      const url = new URL(this.req.url);
       let pathname = url.pathname;
 
       // If path params exist, interpolate them into the pathname
@@ -110,7 +75,7 @@ class BrunoRequest {
                 && pathParam.value !== undefined
                 && (typeof pathParam.value !== 'string' || pathParam.value.trim() !== '')
               ) {
-                return this.interpolate(pathParam.value);
+                return pathParam.value;
               }
             }
             return segment;
@@ -126,7 +91,7 @@ class BrunoRequest {
 
   getQueryString() {
     try {
-      const url = new URL(this.interpolate(this.req.url));
+      const url = new URL(this.req.url);
       // Return query string without the leading '?'
       return url.search ? url.search.substring(1) : '';
     } catch (e) {

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -48,7 +48,7 @@ class BrunoRequest {
 
   /**
    * new URL() mangles {{var}} reference variables, so the url is split by hand. The comments
-   * below show each step for 'https://{{HOST}}/users/:id?role=admin'.
+   * below show each step for 'https://user:pass@{{HOST}}/users/:id?role=admin#section'.
    */
   __parseUrl() {
     const rawUrl = this.req.url;
@@ -67,21 +67,21 @@ class BrunoRequest {
       url = `https://${url}`;
     }
 
-    // everything after the scheme: '{{HOST}}/users/:id?role=admin'
+    // everything after the scheme: 'user:pass@{{HOST}}/users/:id?role=admin#section'
     let remainder = url.substring(url.match(schemePattern)[0].length);
 
-    // a fragment belongs to none of the host, path or query, so drop it before splitting
+    // a fragment belongs to no part of the url below, so drop it: 'user:pass@{{HOST}}/users/:id?role=admin'
     const fragmentIndex = remainder.indexOf('#');
     if (fragmentIndex !== -1) {
       remainder = remainder.substring(0, fragmentIndex);
     }
 
-    // split into authority and the rest: '{{HOST}}' and '/users/:id?role=admin'
-    const [authority, ...rest] = remainder.split(/([/?])/);
+    // split into host and the rest: 'user:pass@{{HOST}}' and '/users/:id?role=admin'
+    const [hostWithCredentials, ...rest] = remainder.split(/([/?])/);
     const restUrl = rest.join('');
 
-    // credentials are part of the authority but not of the host: 'user:pass@{{HOST}}' -> '{{HOST}}'
-    const host = authority.substring(authority.lastIndexOf('@') + 1);
+    // credentials are not part of the host: 'user:pass@{{HOST}}' -> '{{HOST}}'
+    const host = hostWithCredentials.substring(hostWithCredentials.lastIndexOf('@') + 1);
 
     // before the '?' is the path, after it the query: '/users/:id' and 'role=admin'
     const queryIndex = restUrl.indexOf('?');

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -67,14 +67,12 @@ class BrunoRequest {
       url = `https://${url}`;
     }
 
-    const protocolMatch = url.match(schemePattern); // 'https://'
-
-    // everything after the scheme, minus any #fragment: '{{HOST}}/users/:id?role=admin'
-    const remainder = url.substring(protocolMatch[0].length).split('#')[0];
+    // everything after the scheme: '{{HOST}}/users/:id?role=admin'
+    const remainder = url.substring(url.match(schemePattern)[0].length);
 
     // capturing the separator keeps it, so the first piece is the host and rejoining the rest
     // rebuilds what followed: '{{HOST}}' and '/users/:id?role=admin'
-    const [authority, ...rest] = remainder.split(/([/?])/);
+    const [host, ...rest] = remainder.split(/([/?#])/);
     const restUrl = rest.join('');
 
     // before the '?' is the path, after it the query: '/users/:id' and 'role=admin'
@@ -83,8 +81,7 @@ class BrunoRequest {
     const search = queryIndex === -1 ? '' : restUrl.substring(queryIndex + 1);
 
     return {
-      // the host is the authority without any user:password@ prefix
-      host: authority.split('@').pop(),
+      host,
       pathname: path,
       search
     };
@@ -102,7 +99,7 @@ class BrunoRequest {
     try {
       let { pathname } = this.__parseUrl();
 
-      // If path params exist, substitute them into the pathname
+      // If path params exist, interpolate them into the pathname
       if (this.req.pathParams && Array.isArray(this.req.pathParams)) {
         pathname = pathname
           .split('/')

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -46,10 +46,34 @@ class BrunoRequest {
     this.req.url = url;
   }
 
+  __parseUrl() {
+    const rawUrl = this.req.url;
+
+    if (!rawUrl) {
+      throw new Error('URL is empty');
+    }
+
+    const referenceVariables = [];
+    const maskedUrl = rawUrl.replace(/\{\{[^{}]*\}\}/g, (referenceVariable) => {
+      referenceVariables.push(referenceVariable);
+
+      return `reference-variable-${referenceVariables.length - 1}`;
+    });
+
+    const restore = (value) =>
+      value.replace(/reference-variable-(\d+)/g, (match, index) => referenceVariables[Number(index)] ?? match);
+    const url = new URL(/^[a-z][a-z\d+\-.]*:\/\//i.test(maskedUrl) ? maskedUrl : `https://${maskedUrl}`);
+
+    return {
+      host: restore(url.host),
+      pathname: restore(url.pathname),
+      search: restore(url.search.substring(1))
+    };
+  }
+
   getHost() {
     try {
-      const url = new URL(this.req.url);
-      return url.host;
+      return this.__parseUrl().host;
     } catch (e) {
       return '';
     }
@@ -57,10 +81,9 @@ class BrunoRequest {
 
   getPath() {
     try {
-      const url = new URL(this.req.url);
-      let pathname = url.pathname;
+      let { pathname } = this.__parseUrl();
 
-      // If path params exist, interpolate them into the pathname
+      // If path params exist, substitute them into the pathname
       if (this.req.pathParams && Array.isArray(this.req.pathParams)) {
         pathname = pathname
           .split('/')
@@ -91,9 +114,7 @@ class BrunoRequest {
 
   getQueryString() {
     try {
-      const url = new URL(this.req.url);
-      // Return query string without the leading '?'
-      return url.search ? url.search.substring(1) : '';
+      return this.__parseUrl().search;
     } catch (e) {
       return '';
     }

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -1,4 +1,5 @@
 const HeaderList = require('./header-list');
+const { parseUrl } = require('./utils/url');
 
 class BrunoRequest {
   /**
@@ -46,58 +47,9 @@ class BrunoRequest {
     this.req.url = url;
   }
 
-  /**
-   * new URL() mangles {{var}} reference variables, so the url is split by hand. The comments
-   * below show each step for 'https://user:pass@{{HOST}}/users/:id?role=admin#section'.
-   */
-  __parseUrl() {
-    const rawUrl = this.req.url;
-
-    if (!rawUrl) {
-      throw new Error('URL is empty');
-    }
-
-    let url = rawUrl;
-
-    // the scheme may itself be a {{var}}, so match anything up to the '://'
-    const schemePattern = /^[^/?#]*:\/\//;
-
-    // Add a default protocol when the URL does not have one.
-    if (!schemePattern.test(url)) {
-      url = `https://${url}`;
-    }
-
-    // everything after the scheme: 'user:pass@{{HOST}}/users/:id?role=admin#section'
-    let remainder = url.substring(url.match(schemePattern)[0].length);
-
-    // a fragment belongs to no part of the url below, so drop it: 'user:pass@{{HOST}}/users/:id?role=admin'
-    const fragmentIndex = remainder.indexOf('#');
-    if (fragmentIndex !== -1) {
-      remainder = remainder.substring(0, fragmentIndex);
-    }
-
-    // split into host and the rest: 'user:pass@{{HOST}}' and '/users/:id?role=admin'
-    const [hostWithCredentials, ...rest] = remainder.split(/([/?])/);
-    const restUrl = rest.join('');
-
-    // credentials are not part of the host: 'user:pass@{{HOST}}' -> '{{HOST}}'
-    const host = hostWithCredentials.substring(hostWithCredentials.lastIndexOf('@') + 1);
-
-    // before the '?' is the path, after it the query: '/users/:id' and 'role=admin'
-    const queryIndex = restUrl.indexOf('?');
-    const path = queryIndex === -1 ? restUrl : restUrl.substring(0, queryIndex);
-    const search = queryIndex === -1 ? '' : restUrl.substring(queryIndex + 1);
-
-    return {
-      host,
-      pathname: path,
-      search
-    };
-  }
-
   getHost() {
     try {
-      return this.__parseUrl().host;
+      return parseUrl(this.req.url).host;
     } catch (e) {
       return '';
     }
@@ -105,7 +57,7 @@ class BrunoRequest {
 
   getPath() {
     try {
-      let { pathname } = this.__parseUrl();
+      let { pathname } = parseUrl(this.req.url);
 
       // If path params exist, interpolate them into the pathname
       if (this.req.pathParams && Array.isArray(this.req.pathParams)) {
@@ -138,7 +90,7 @@ class BrunoRequest {
 
   getQueryString() {
     try {
-      return this.__parseUrl().search;
+      return parseUrl(this.req.url).search;
     } catch (e) {
       return '';
     }

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -68,12 +68,20 @@ class BrunoRequest {
     }
 
     // everything after the scheme: '{{HOST}}/users/:id?role=admin'
-    const remainder = url.substring(url.match(schemePattern)[0].length);
+    let remainder = url.substring(url.match(schemePattern)[0].length);
 
-    // capturing the separator keeps it, so the first piece is the host and rejoining the rest
-    // rebuilds what followed: '{{HOST}}' and '/users/:id?role=admin'
-    const [host, ...rest] = remainder.split(/([/?#])/);
+    // a fragment belongs to none of the host, path or query, so drop it before splitting
+    const fragmentIndex = remainder.indexOf('#');
+    if (fragmentIndex !== -1) {
+      remainder = remainder.substring(0, fragmentIndex);
+    }
+
+    // split into authority and the rest: '{{HOST}}' and '/users/:id?role=admin'
+    const [authority, ...rest] = remainder.split(/([/?])/);
     const restUrl = rest.join('');
+
+    // credentials are part of the authority but not of the host: 'user:pass@{{HOST}}' -> '{{HOST}}'
+    const host = authority.substring(authority.lastIndexOf('@') + 1);
 
     // before the '?' is the path, after it the query: '/users/:id' and 'role=admin'
     const queryIndex = restUrl.indexOf('?');

--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -90,7 +90,7 @@ class BrunoRequest {
 
   getQueryString() {
     try {
-      return parseUrl(this.req.url).search;
+      return parseUrl(this.req.url).queryString;
     } catch (e) {
       return '';
     }

--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -53,7 +53,7 @@ class ScriptRuntime {
       certsAndProxyConfig,
       requestUrl: request?.url
     });
-    const req = new BrunoRequest(request);
+    const req = new BrunoRequest(request, { envVariables, runtimeVariables, processEnvVars });
 
     // extend bru with result getter methods
     const { __brunoTestResults, test, waitForPendingTests } = createBruTestResultMethods(bru, assertionResults, chai);

--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -53,7 +53,7 @@ class ScriptRuntime {
       certsAndProxyConfig,
       requestUrl: request?.url
     });
-    const req = new BrunoRequest(request, { envVariables, runtimeVariables, processEnvVars });
+    const req = new BrunoRequest(request);
 
     // extend bru with result getter methods
     const { __brunoTestResults, test, waitForPendingTests } = createBruTestResultMethods(bru, assertionResults, chai);

--- a/packages/bruno-js/src/utils/url.js
+++ b/packages/bruno-js/src/utils/url.js
@@ -40,7 +40,6 @@ const parseUrl = (rawUrl) => {
     try {
       const url = new URL(rawUrl);
 
-      // 'localhost:3000/path' parses with 'localhost:' as the scheme and no host at all
       if (url.host) {
         return {
           host: url.host,

--- a/packages/bruno-js/src/utils/url.js
+++ b/packages/bruno-js/src/utils/url.js
@@ -1,0 +1,59 @@
+/**
+ * new URL() mangles {{var}} reference variables, so the url is split by hand. The comments
+ * below show each step for 'https://user:pass@{{HOST}}/users/:id?role=admin#section'.
+ */
+const parseTemplatedUrl = (rawUrl) => {
+  if (!rawUrl) {
+    throw new Error('URL is empty');
+  }
+
+  // drop the protocol -> 'user:pass@{{HOST}}/users/:id?role=admin#section'
+  let remainder = rawUrl.replace(/^[^/?#]*:\/\//, '');
+
+  // a fragment belongs to no part of the url below, so drop it: 'user:pass@{{HOST}}/users/:id?role=admin'
+  const fragmentIndex = remainder.indexOf('#');
+  if (fragmentIndex !== -1) {
+    remainder = remainder.substring(0, fragmentIndex);
+  }
+
+  // split into host and the rest: 'user:pass@{{HOST}}' and '/users/:id?role=admin'
+  const [hostWithCredentials, ...rest] = remainder.split(/([/?])/);
+  const restUrl = rest.join('');
+
+  // credentials are not part of the host: 'user:pass@{{HOST}}' -> '{{HOST}}'
+  const host = hostWithCredentials.substring(hostWithCredentials.lastIndexOf('@') + 1);
+
+  // before the '?' is the path, after it the query: '/users/:id' and 'role=admin'
+  const queryIndex = restUrl.indexOf('?');
+  const path = queryIndex === -1 ? restUrl : restUrl.substring(0, queryIndex);
+  const search = queryIndex === -1 ? '' : restUrl.substring(queryIndex + 1);
+
+  return {
+    host,
+    pathname: path,
+    search
+  };
+};
+
+const parseUrl = (rawUrl) => {
+  // Parse templated URLs manually to preserve the variable casing
+  if (!rawUrl?.includes('{{')) {
+    try {
+      const url = new URL(rawUrl);
+      return {
+        host: url.host,
+        pathname: url.pathname,
+        search: url.search.replace(/^\?/, '')
+      };
+    } catch (e) {
+      // not a url new URL() accepts
+    }
+  }
+
+  return parseTemplatedUrl(rawUrl);
+};
+
+module.exports = {
+  parseUrl,
+  parseTemplatedUrl
+};

--- a/packages/bruno-js/src/utils/url.js
+++ b/packages/bruno-js/src/utils/url.js
@@ -36,15 +36,18 @@ const parseUrl = (rawUrl) => {
     throw new Error('URL is empty');
   }
 
-  // Parse templated URLs manually to preserve the variable casing
   if (!rawUrl.includes('{{')) {
     try {
       const url = new URL(rawUrl);
-      return {
-        host: url.host,
-        pathname: url.pathname,
-        queryString: url.search.replace(/^\?/, '')
-      };
+
+      // 'localhost:3000/path' parses with 'localhost:' as the scheme and no host at all
+      if (url.host) {
+        return {
+          host: url.host,
+          pathname: url.pathname,
+          queryString: url.search.replace(/^\?/, '')
+        };
+      }
     } catch (e) {
       // not a url new URL() accepts
     }

--- a/packages/bruno-js/src/utils/url.js
+++ b/packages/bruno-js/src/utils/url.js
@@ -3,10 +3,6 @@
  * below show each step for 'https://user:pass@{{HOST}}/users/:id?role=admin#section'.
  */
 const parseTemplatedUrl = (rawUrl) => {
-  if (!rawUrl) {
-    throw new Error('URL is empty');
-  }
-
   // drop the protocol -> 'user:pass@{{HOST}}/users/:id?role=admin#section'
   let remainder = rawUrl.replace(/^[^/?#]*:\/\//, '');
 
@@ -26,24 +22,28 @@ const parseTemplatedUrl = (rawUrl) => {
   // before the '?' is the path, after it the query: '/users/:id' and 'role=admin'
   const queryIndex = restUrl.indexOf('?');
   const path = queryIndex === -1 ? restUrl : restUrl.substring(0, queryIndex);
-  const search = queryIndex === -1 ? '' : restUrl.substring(queryIndex + 1);
+  const queryString = queryIndex === -1 ? '' : restUrl.substring(queryIndex + 1);
 
   return {
     host,
     pathname: path,
-    search
+    queryString
   };
 };
 
 const parseUrl = (rawUrl) => {
+  if (!rawUrl) {
+    throw new Error('URL is empty');
+  }
+
   // Parse templated URLs manually to preserve the variable casing
-  if (!rawUrl?.includes('{{')) {
+  if (!rawUrl.includes('{{')) {
     try {
       const url = new URL(rawUrl);
       return {
         host: url.host,
         pathname: url.pathname,
-        search: url.search.replace(/^\?/, '')
+        queryString: url.search.replace(/^\?/, '')
       };
     } catch (e) {
       // not a url new URL() accepts
@@ -54,6 +54,5 @@ const parseUrl = (rawUrl) => {
 };
 
 module.exports = {
-  parseUrl,
-  parseTemplatedUrl
+  parseUrl
 };

--- a/packages/bruno-js/src/utils/url.spec.js
+++ b/packages/bruno-js/src/utils/url.spec.js
@@ -1,0 +1,34 @@
+const { describe, it, expect } = require('@jest/globals');
+const { parseUrl } = require('./url');
+
+describe('parseUrl', () => {
+  it.each([
+    { url: 'https://example.com/path/10?a=1&b=2', host: 'example.com', path: '/path/10', query: 'a=1&b=2' },
+    { url: 'https://example.com', host: 'example.com', path: '/' },
+    { url: 'https://example.com:8080/path', host: 'example.com:8080', path: '/path' },
+    { url: 'https://example.com:443/path', host: 'example.com', path: '/path' },
+    { url: 'https://example.com/a/./b/../c', host: 'example.com', path: '/a/c' },
+    { url: 'https://user:pass@example.com/path', host: 'example.com', path: '/path' },
+    { url: 'https://user:p@ss@example.com/path', host: 'example.com', path: '/path' },
+    { url: 'https://example.com/path?a=1#section', host: 'example.com', path: '/path', query: 'a=1' },
+    { url: 'https://example.com/users/:id', host: 'example.com', path: '/users/:id' },
+    { url: 'example.com/path', host: 'example.com', path: '/path' },
+    { url: 'localhost:3000/path', host: 'localhost:3000', path: '/path' },
+    { url: '{{BASEURL}}/path?a={{A}}', host: '{{BASEURL}}', path: '/path', query: 'a={{A}}' },
+    { url: '{{BASEURL}}', host: '{{BASEURL}}' },
+    { url: '{{BASEURL}}/users/:id?a=1#section', host: '{{BASEURL}}', path: '/users/:id', query: 'a=1' },
+    { url: 'https://example.com/{{path}}', host: 'example.com', path: '/{{path}}' },
+    { url: 'https://user:pass@{{HOST}}/path', host: '{{HOST}}', path: '/path' },
+    { url: '{{proto}}://{{env}}:{{port}}/{{p}}?a={{a}}', host: '{{env}}:{{port}}', path: '/{{p}}', query: 'a={{a}}' }
+  ])('parses $url', ({ url, host, path = '', query = '' }) => {
+    expect(parseUrl(url)).toEqual({ host, pathname: path, queryString: query });
+  });
+
+  it.each([
+    { name: 'an empty url', url: '' },
+    { name: 'a null url', url: null },
+    { name: 'a missing url', url: undefined }
+  ])('throws for $name', ({ url }) => {
+    expect(() => parseUrl(url)).toThrow('URL is empty');
+  });
+});

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -1,0 +1,70 @@
+const { describe, it, expect } = require('@jest/globals');
+const BrunoRequest = require('../src/bruno-request');
+
+const makeRequest = (overrides = {}) => ({
+  url: 'https://api.example.com/path',
+  method: 'GET',
+  headers: {},
+  ...overrides
+});
+
+describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
+  describe('resolved urls', () => {
+    it('returns the host, path and query string', () => {
+      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com/path/10?a=1&b=2' }));
+
+      expect(req.getHost()).toBe('api.example.com');
+      expect(req.getPath()).toBe('/path/10');
+      expect(req.getQueryString()).toBe('a=1&b=2');
+    });
+  });
+
+  describe('templated urls', () => {
+    const envVariables = { BASEURL: 'https://api.example.com' };
+
+    it('resolves variables before parsing the url', () => {
+      const req = new BrunoRequest(makeRequest({ url: '{{BASEURL}}/path?a=1&b=2' }), { envVariables });
+
+      expect(req.getHost()).toBe('api.example.com');
+      expect(req.getPath()).toBe('/path');
+      expect(req.getQueryString()).toBe('a=1&b=2');
+    });
+
+    it('applies path params, resolving templated values', () => {
+      const req = new BrunoRequest(
+        makeRequest({
+          url: '{{BASEURL}}/path/:p1/:p2',
+          pathParams: [
+            { name: 'p1', value: '10' },
+            { name: 'p2', value: '{{P2}}' }
+          ],
+          collectionVariables: { P2: '20' }
+        }),
+        { envVariables }
+      );
+
+      expect(req.getPath()).toBe('/path/10/20');
+    });
+
+    it('resolves variables from every scope', () => {
+      const req = new BrunoRequest(
+        makeRequest({
+          url: '{{globalEnvVar}}{{envVar}}{{runtimeVar}}/{{collectionVar}}/{{folderVar}}/{{requestVar}}/{{oauth2Var}}/{{promptVar}}',
+          globalEnvironmentVariables: { globalEnvVar: 'https://' },
+          collectionVariables: { collectionVar: 'collection' },
+          folderVariables: { folderVar: 'folder' },
+          requestVariables: { requestVar: 'request' },
+          oauth2CredentialVariables: { oauth2Var: 'oauth2' },
+          promptVariables: { promptVar: 'prompt' }
+        }),
+        {
+          envVariables: { envVar: 'api.example.com' },
+          runtimeVariables: { runtimeVar: ':8080' }
+        }
+      );
+
+      expect(req.getHost()).toBe('api.example.com:8080');
+      expect(req.getPath()).toBe('/collection/folder/request/oauth2/prompt');
+    });
+  });
+});

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -46,4 +46,28 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
 
     expect(req.getPath()).toBe('/path/10/{{P2}}');
   });
+
+  it('excludes credentials from the host', () => {
+    const req = new BrunoRequest(makeRequest('https://user:p%40ss@api.example.com:8080/path?a=1'));
+
+    expect(req.getHost()).toBe('api.example.com:8080');
+    expect(req.getPath()).toBe('/path');
+    expect(req.getQueryString()).toBe('a=1');
+  });
+
+  it('excludes the fragment from the path and the query string', () => {
+    const req = new BrunoRequest(makeRequest('https://api.example.com/path?a=1#section'));
+
+    expect(req.getHost()).toBe('api.example.com');
+    expect(req.getPath()).toBe('/path');
+    expect(req.getQueryString()).toBe('a=1');
+  });
+
+  it('applies path params to a path followed by a fragment', () => {
+    const req = new BrunoRequest(
+      makeRequest('{{BASEURL}}/path/:p1#section', { pathParams: [{ name: 'p1', value: '10' }] })
+    );
+
+    expect(req.getPath()).toBe('/path/10');
+  });
 });

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -64,9 +64,8 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
   });
 
   it('applies path params to a path followed by a fragment', () => {
-    const req = new BrunoRequest(
-      makeRequest('{{BASEURL}}/path/:p1#section', { pathParams: [{ name: 'p1', value: '10' }] })
-    );
+    const request = makeRequest('{{BASEURL}}/path/:p1#section', { pathParams: [{ name: 'p1', value: '10' }] });
+    const req = new BrunoRequest(request);
 
     expect(req.getPath()).toBe('/path/10');
   });

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -44,10 +44,26 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
       expect(req.getQueryString()).toBe('a={{x}}');
     });
 
-    it('leaves text that looks like the internal placeholder alone', () => {
-      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com/brunotemplate0/{{v}}' }));
+    it('reports a variable used as the port', () => {
+      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com:{{PORT}}/path' }));
 
-      expect(req.getPath()).toBe('/brunotemplate0/{{v}}');
+      expect(req.getHost()).toBe('api.example.com:{{PORT}}');
+      expect(req.getPath()).toBe('/path');
+    });
+
+    it('reports a variable used as the scheme', () => {
+      const req = new BrunoRequest(makeRequest({ url: '{{PROTO}}://{{HOST}}/path' }));
+
+      expect(req.getHost()).toBe('{{HOST}}');
+      expect(req.getPath()).toBe('/path');
+    });
+
+    it('drops the user:password@ prefix and the #fragment', () => {
+      const req = new BrunoRequest(makeRequest({ url: 'https://user:pass@{{HOST}}:8080/path?a=1#top' }));
+
+      expect(req.getHost()).toBe('{{HOST}}:8080');
+      expect(req.getPath()).toBe('/path');
+      expect(req.getQueryString()).toBe('a=1');
     });
 
     it('applies path params, leaving templated values as written', () => {

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -1,5 +1,6 @@
 const { describe, it, expect } = require('@jest/globals');
 const BrunoRequest = require('../src/bruno-request');
+const interpolateVars = require('../../bruno-electron/src/ipc/network/interpolate-vars');
 
 const makeRequest = (url, overrides = {}) => ({
   url,
@@ -76,28 +77,74 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
   });
 });
 
-// post-response scripts run after interpolation, so req.url is already resolved
-describe('BrunoRequest - getHost(), getPath(), getQueryString() after interpolation', () => {
-  it('reports a resolved url without applying the path params a second time', () => {
-    const request = makeRequest('https://api.example.com:8080/path/10/20?a=1', {
+const readUrl = (req) => ({
+  host: req.getHost(),
+  path: req.getPath(),
+  queryString: req.getQueryString()
+});
+
+const runFlow = (url, { pathParams = [], envVars = {} } = {}) => {
+  const request = { url, method: 'GET', headers: {}, pathParams };
+
+  const preRequest = readUrl(new BrunoRequest(request));
+  interpolateVars(request, envVars, {}, {}, {});
+  const postResponse = readUrl(new BrunoRequest(request));
+
+  return { preRequest, postResponse };
+};
+
+describe('request url as seen by pre-request and post-response scripts', () => {
+  it('resolves a templated host, query and path params', () => {
+    const flow = runFlow('{{BASEURL}}/path/:p1/:p2?a={{A}}', {
       pathParams: [
         { name: 'p1', value: '10' },
-        { name: 'p2', value: '20' }
-      ]
+        { name: 'p2', value: '{{P2}}' }
+      ],
+      envVars: { BASEURL: 'https://api.example.com:8080', A: '1', P2: '20' }
     });
-    const req = new BrunoRequest(request);
 
-    expect(req.getHost()).toBe('api.example.com:8080');
-    expect(req.getPath()).toBe('/path/10/20');
-    expect(req.getQueryString()).toBe('a=1');
+    expect(flow.preRequest).toEqual({
+      host: '{{BASEURL}}',
+      path: '/path/10/{{P2}}',
+      queryString: 'a={{A}}'
+    });
+
+    expect(flow.postResponse).toEqual({
+      host: 'api.example.com:8080',
+      path: '/path/10/20',
+      queryString: 'a=1'
+    });
   });
 
-  // interpolateVars() only strips the fragment when path params exist
-  it('excludes a fragment that survived interpolation', () => {
-    const req = new BrunoRequest(makeRequest('https://api.example.com/path?a=1#section'));
+  // without path params interpolateVars() keeps the fragment
+  it('excludes a fragment in both phases', () => {
+    const flow = runFlow('{{BASEURL}}/path?a={{A}}#section', {
+      envVars: { BASEURL: 'https://api.example.com', A: '1' }
+    });
 
-    expect(req.getHost()).toBe('api.example.com');
-    expect(req.getPath()).toBe('/path');
-    expect(req.getQueryString()).toBe('a=1');
+    expect(flow.preRequest).toEqual({ host: '{{BASEURL}}', path: '/path', queryString: 'a={{A}}' });
+    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path', queryString: 'a=1' });
+  });
+
+  it('excludes credentials in both phases', () => {
+    const flow = runFlow('https://user:pass@{{HOST}}/path/:p1', {
+      pathParams: [{ name: 'p1', value: '10' }],
+      envVars: { HOST: 'api.example.com' }
+    });
+
+    expect(flow.preRequest).toEqual({ host: '{{HOST}}', path: '/path/10', queryString: '' });
+    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path/10', queryString: '' });
+  });
+
+  it('keeps an undefined variable in the host, lowercased by the path param rewrite', () => {
+    const flow = runFlow('{{BASEURL}}/path/:p1', {
+      pathParams: [{ name: 'p1', value: '10' }],
+      envVars: {}
+    });
+
+    expect(flow.preRequest).toEqual({ host: '{{BASEURL}}', path: '/path/10', queryString: '' });
+
+    // the path param rewrite lowercases the host, so {{BASEURL}} becomes {{baseurl}}
+    expect(flow.postResponse).toEqual({ host: '{{baseurl}}', path: '/path/10', queryString: '' });
   });
 });

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -1,83 +1,49 @@
 const { describe, it, expect } = require('@jest/globals');
 const BrunoRequest = require('../src/bruno-request');
 
-const makeRequest = (overrides = {}) => ({
-  url: 'https://api.example.com/path',
+const makeRequest = (url, overrides = {}) => ({
+  url,
   method: 'GET',
   headers: {},
   ...overrides
 });
 
 describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
-  describe('resolved urls', () => {
-    it('returns the host, path and query string', () => {
-      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com/path/10?a=1&b=2' }));
+  it('reports a resolved url', () => {
+    const req = new BrunoRequest(makeRequest('https://api.example.com/path/10?a=1&b=2'));
 
-      expect(req.getHost()).toBe('api.example.com');
-      expect(req.getPath()).toBe('/path/10');
-      expect(req.getQueryString()).toBe('a=1&b=2');
-    });
+    expect(req.getHost()).toBe('api.example.com');
+    expect(req.getPath()).toBe('/path/10');
+    expect(req.getQueryString()).toBe('a=1&b=2');
   });
 
   // pre-request scripts run before the request is interpolated, so req.url is still a template
-  describe('templated urls', () => {
-    it('reports the template as written rather than resolving it', () => {
-      const req = new BrunoRequest(makeRequest({ url: '{{BASEURL}}/path?a=1&b={{B}}' }));
+  it('reports a templated url as written rather than resolving it', () => {
+    const req = new BrunoRequest(makeRequest('{{BASEURL}}/path?a={{A}}'));
 
-      expect(req.getHost()).toBe('{{BASEURL}}');
-      expect(req.getPath()).toBe('/path');
-      expect(req.getQueryString()).toBe('a=1&b={{B}}');
-    });
+    expect(req.getHost()).toBe('{{BASEURL}}');
+    expect(req.getPath()).toBe('/path');
+    expect(req.getQueryString()).toBe('a={{A}}');
+  });
 
-    it('reports a template that is only part of the host', () => {
-      const req = new BrunoRequest(makeRequest({ url: 'https://{{ENV}}.example.com/path' }));
+  it('reports a variable anywhere in the url', () => {
+    const req = new BrunoRequest(makeRequest('{{PROTO}}://{{ENV}}.example.com:{{PORT}}/{{path}}?a={{A}}'));
 
-      expect(req.getHost()).toBe('{{ENV}}.example.com');
-      expect(req.getPath()).toBe('/path');
-    });
+    expect(req.getHost()).toBe('{{ENV}}.example.com:{{PORT}}');
+    expect(req.getPath()).toBe('/{{path}}');
+    expect(req.getQueryString()).toBe('a={{A}}');
+  });
 
-    it('reports a template inside the path and query', () => {
-      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com/{{path}}/users?a={{x}}' }));
+  it('applies path params, leaving templated values as written', () => {
+    const req = new BrunoRequest(
+      makeRequest('{{BASEURL}}/path/:p1/:p2', {
+        pathParams: [
+          { name: 'p1', value: '10' },
+          { name: 'p2', value: '{{P2}}' }
+        ]
+      })
+    );
 
-      expect(req.getHost()).toBe('api.example.com');
-      expect(req.getPath()).toBe('/{{path}}/users');
-      expect(req.getQueryString()).toBe('a={{x}}');
-    });
-
-    it('reports a variable used as the port', () => {
-      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com:{{PORT}}/path' }));
-
-      expect(req.getHost()).toBe('api.example.com:{{PORT}}');
-      expect(req.getPath()).toBe('/path');
-    });
-
-    it('reports a variable used as the scheme', () => {
-      const req = new BrunoRequest(makeRequest({ url: '{{PROTO}}://{{HOST}}/path' }));
-
-      expect(req.getHost()).toBe('{{HOST}}');
-      expect(req.getPath()).toBe('/path');
-    });
-
-    it('drops the user:password@ prefix and the #fragment', () => {
-      const req = new BrunoRequest(makeRequest({ url: 'https://user:pass@{{HOST}}:8080/path?a=1#top' }));
-
-      expect(req.getHost()).toBe('{{HOST}}:8080');
-      expect(req.getPath()).toBe('/path');
-      expect(req.getQueryString()).toBe('a=1');
-    });
-
-    it('applies path params, leaving templated values as written', () => {
-      const req = new BrunoRequest(
-        makeRequest({
-          url: '{{BASEURL}}/path/:p1/:p2',
-          pathParams: [
-            { name: 'p1', value: '10' },
-            { name: 'p2', value: '{{P2}}' }
-          ]
-        })
-      );
-
-      expect(req.getPath()).toBe('/path/10/{{P2}}');
-    });
+    expect(req.getPath()).toBe('/path/10/{{P2}}');
   });
 });

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -1,6 +1,5 @@
 const { describe, it, expect } = require('@jest/globals');
 const BrunoRequest = require('../src/bruno-request');
-const interpolateVars = require('../../bruno-electron/src/ipc/network/interpolate-vars');
 
 const makeRequest = (url, overrides = {}) => ({
   url,
@@ -74,77 +73,5 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
     const req = new BrunoRequest(request);
 
     expect(req.getPath()).toBe('/path/10');
-  });
-});
-
-const readUrl = (req) => ({
-  host: req.getHost(),
-  path: req.getPath(),
-  queryString: req.getQueryString()
-});
-
-const runFlow = (url, { pathParams = [], envVars = {} } = {}) => {
-  const request = { url, method: 'GET', headers: {}, pathParams };
-
-  const preRequest = readUrl(new BrunoRequest(request));
-  interpolateVars(request, envVars, {}, {}, {});
-  const postResponse = readUrl(new BrunoRequest(request));
-
-  return { preRequest, postResponse };
-};
-
-describe('request url as seen by pre-request and post-response scripts', () => {
-  it('resolves a templated host, query and path params', () => {
-    const flow = runFlow('{{BASEURL}}/path/:p1/:p2?a={{A}}', {
-      pathParams: [
-        { name: 'p1', value: '10' },
-        { name: 'p2', value: '{{P2}}' }
-      ],
-      envVars: { BASEURL: 'https://api.example.com:8080', A: '1', P2: '20' }
-    });
-
-    expect(flow.preRequest).toEqual({
-      host: '{{BASEURL}}',
-      path: '/path/10/{{P2}}',
-      queryString: 'a={{A}}'
-    });
-
-    expect(flow.postResponse).toEqual({
-      host: 'api.example.com:8080',
-      path: '/path/10/20',
-      queryString: 'a=1'
-    });
-  });
-
-  // without path params interpolateVars() keeps the fragment
-  it('excludes a fragment in both phases', () => {
-    const flow = runFlow('{{BASEURL}}/path?a={{A}}#section', {
-      envVars: { BASEURL: 'https://api.example.com', A: '1' }
-    });
-
-    expect(flow.preRequest).toEqual({ host: '{{BASEURL}}', path: '/path', queryString: 'a={{A}}' });
-    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path', queryString: 'a=1' });
-  });
-
-  it('excludes credentials in both phases', () => {
-    const flow = runFlow('https://user:pass@{{HOST}}/path/:p1', {
-      pathParams: [{ name: 'p1', value: '10' }],
-      envVars: { HOST: 'api.example.com' }
-    });
-
-    expect(flow.preRequest).toEqual({ host: '{{HOST}}', path: '/path/10', queryString: '' });
-    expect(flow.postResponse).toEqual({ host: 'api.example.com', path: '/path/10', queryString: '' });
-  });
-
-  it('keeps an undefined variable in the host, lowercased by the path param rewrite', () => {
-    const flow = runFlow('{{BASEURL}}/path/:p1', {
-      pathParams: [{ name: 'p1', value: '10' }],
-      envVars: {}
-    });
-
-    expect(flow.preRequest).toEqual({ host: '{{BASEURL}}', path: '/path/10', queryString: '' });
-
-    // the path param rewrite lowercases the host, so {{BASEURL}} becomes {{baseurl}}
-    expect(flow.postResponse).toEqual({ host: '{{baseurl}}', path: '/path/10', queryString: '' });
   });
 });

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -35,20 +35,17 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
   });
 
   it('applies path params, leaving templated values as written', () => {
-    const req = new BrunoRequest(
-      makeRequest('{{BASEURL}}/path/:p1/:p2', {
-        pathParams: [
-          { name: 'p1', value: '10' },
-          { name: 'p2', value: '{{P2}}' }
-        ]
-      })
-    );
+    const pathParams = [
+      { name: 'p1', value: '10' },
+      { name: 'p2', value: '{{P2}}' }
+    ];
+    const req = new BrunoRequest(makeRequest('{{BASEURL}}/path/:p1/:p2', { pathParams }));
 
     expect(req.getPath()).toBe('/path/10/{{P2}}');
   });
 
   it('excludes credentials from the host', () => {
-    const req = new BrunoRequest(makeRequest('https://user:p%40ss@api.example.com:8080/path?a=1'));
+    const req = new BrunoRequest(makeRequest('https://user:p@ss@api.example.com:8080/path?a=1'));
 
     expect(req.getHost()).toBe('api.example.com:8080');
     expect(req.getPath()).toBe('/path');
@@ -63,10 +60,44 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
     expect(req.getQueryString()).toBe('a=1');
   });
 
+  it('reports an empty string when there is no url', () => {
+    const req = new BrunoRequest(makeRequest(''));
+
+    expect(req.getHost()).toBe('');
+    expect(req.getPath()).toBe('');
+    expect(req.getQueryString()).toBe('');
+  });
+
   it('applies path params to a path followed by a fragment', () => {
     const request = makeRequest('{{BASEURL}}/path/:p1#section', { pathParams: [{ name: 'p1', value: '10' }] });
     const req = new BrunoRequest(request);
 
     expect(req.getPath()).toBe('/path/10');
+  });
+});
+
+// post-response scripts run after interpolation, so req.url is already resolved
+describe('BrunoRequest - getHost(), getPath(), getQueryString() after interpolation', () => {
+  it('reports a resolved url without applying the path params a second time', () => {
+    const request = makeRequest('https://api.example.com:8080/path/10/20?a=1', {
+      pathParams: [
+        { name: 'p1', value: '10' },
+        { name: 'p2', value: '20' }
+      ]
+    });
+    const req = new BrunoRequest(request);
+
+    expect(req.getHost()).toBe('api.example.com:8080');
+    expect(req.getPath()).toBe('/path/10/20');
+    expect(req.getQueryString()).toBe('a=1');
+  });
+
+  // interpolateVars() only strips the fragment when path params exist
+  it('excludes a fragment that survived interpolation', () => {
+    const req = new BrunoRequest(makeRequest('https://api.example.com/path?a=1#section'));
+
+    expect(req.getHost()).toBe('api.example.com');
+    expect(req.getPath()).toBe('/path');
+    expect(req.getQueryString()).toBe('a=1');
   });
 });

--- a/packages/bruno-js/tests/bruno-request-url.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url.spec.js
@@ -19,52 +19,49 @@ describe('BrunoRequest - getHost(), getPath(), getQueryString()', () => {
     });
   });
 
+  // pre-request scripts run before the request is interpolated, so req.url is still a template
   describe('templated urls', () => {
-    const envVariables = { BASEURL: 'https://api.example.com' };
+    it('reports the template as written rather than resolving it', () => {
+      const req = new BrunoRequest(makeRequest({ url: '{{BASEURL}}/path?a=1&b={{B}}' }));
 
-    it('resolves variables before parsing the url', () => {
-      const req = new BrunoRequest(makeRequest({ url: '{{BASEURL}}/path?a=1&b=2' }), { envVariables });
-
-      expect(req.getHost()).toBe('api.example.com');
+      expect(req.getHost()).toBe('{{BASEURL}}');
       expect(req.getPath()).toBe('/path');
-      expect(req.getQueryString()).toBe('a=1&b=2');
+      expect(req.getQueryString()).toBe('a=1&b={{B}}');
     });
 
-    it('applies path params, resolving templated values', () => {
+    it('reports a template that is only part of the host', () => {
+      const req = new BrunoRequest(makeRequest({ url: 'https://{{ENV}}.example.com/path' }));
+
+      expect(req.getHost()).toBe('{{ENV}}.example.com');
+      expect(req.getPath()).toBe('/path');
+    });
+
+    it('reports a template inside the path and query', () => {
+      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com/{{path}}/users?a={{x}}' }));
+
+      expect(req.getHost()).toBe('api.example.com');
+      expect(req.getPath()).toBe('/{{path}}/users');
+      expect(req.getQueryString()).toBe('a={{x}}');
+    });
+
+    it('leaves text that looks like the internal placeholder alone', () => {
+      const req = new BrunoRequest(makeRequest({ url: 'https://api.example.com/brunotemplate0/{{v}}' }));
+
+      expect(req.getPath()).toBe('/brunotemplate0/{{v}}');
+    });
+
+    it('applies path params, leaving templated values as written', () => {
       const req = new BrunoRequest(
         makeRequest({
           url: '{{BASEURL}}/path/:p1/:p2',
           pathParams: [
             { name: 'p1', value: '10' },
             { name: 'p2', value: '{{P2}}' }
-          ],
-          collectionVariables: { P2: '20' }
-        }),
-        { envVariables }
+          ]
+        })
       );
 
-      expect(req.getPath()).toBe('/path/10/20');
-    });
-
-    it('resolves variables from every scope', () => {
-      const req = new BrunoRequest(
-        makeRequest({
-          url: '{{globalEnvVar}}{{envVar}}{{runtimeVar}}/{{collectionVar}}/{{folderVar}}/{{requestVar}}/{{oauth2Var}}/{{promptVar}}',
-          globalEnvironmentVariables: { globalEnvVar: 'https://' },
-          collectionVariables: { collectionVar: 'collection' },
-          folderVariables: { folderVar: 'folder' },
-          requestVariables: { requestVar: 'request' },
-          oauth2CredentialVariables: { oauth2Var: 'oauth2' },
-          promptVariables: { promptVar: 'prompt' }
-        }),
-        {
-          envVariables: { envVar: 'api.example.com' },
-          runtimeVariables: { runtimeVar: ':8080' }
-        }
-      );
-
-      expect(req.getHost()).toBe('api.example.com:8080');
-      expect(req.getPath()).toBe('/collection/folder/request/oauth2/prompt');
+      expect(req.getPath()).toBe('/path/10/{{P2}}');
     });
   });
 });


### PR DESCRIPTION
BRU-2778

Fixes https://github.com/usebruno/bruno/issues/9233
Fixes https://github.com/usebruno/bruno/issues/9234

Related PR's:
https://github.com/usebruno/bruno/pull/9240 
https://github.com/usebruno/bruno/pull/9241 
https://github.com/usebruno/bruno/pull/7280

### Description

`req.getPath()`, `req.getHost()` and `req.getQueryString()` now work in pre-request scripts when the request URL contains template variables.

### Problem

Pre-request scripts run before URL interpolation, so `req.url` is still a raw template (`{{BASEURL}}/path/:p1/:p2`). `new URL()` throws on it, the error is swallowed, and all three helpers return `''`.

### Fix

`BrunoRequest` now resolves the URL itself before parsing, via an `interpolate` method mirroring `bru.interpolate` (same nine variable scopes, same precedence). Path param values are interpolated too, matching what `interpolateVars` sends. Behaviour for already-resolved URLs is unchanged.


### Screenshots

<table> <tr> <th>Before</th> <th>After</th> </tr> <tr> <td> <video src="https://github.com/user-attachments/assets/1c927db3-c003-4723-b854-e5bcc0940eca" controls></video> </td> <td> <video src="https://github.com/user-attachments/assets/bc0af045-39c3-4bc7-9acd-c18fb41239e9" controls></video> </td> </tr> </table>

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling when template variables remain unresolved in different URL components.
  - Preserved URL fragments during parsing.
  - Preserved complete URL authority information, including credentials.
  - Maintained existing path-parameter substitution behavior.

- **Tests**
  - Expanded URL coverage for unresolved templates, resolved URLs, fragments, credentials, and path parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->