### PR TITLE
fix(collection-docs): UI improvements in advanced filtering section in generate docs modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
@@ -55,6 +55,11 @@ export const StyledWrapper = styled.div`
     background-color: transparent;
     border: 1px solid ${(props) => props.theme.border.border0};
     border-radius: ${(props) => props.theme.border.radius.base};
+    transition: background-color 0.15s ease;
+
+    &:has(.docs-tag-remove:hover) {
+      background-color: ${(props) => props.theme.background.surface2};
+    }
   }
 
   .docs-tag-icon {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
@@ -55,11 +55,6 @@ export const StyledWrapper = styled.div`
     background-color: transparent;
     border: 1px solid ${(props) => props.theme.border.border0};
     border-radius: ${(props) => props.theme.border.radius.base};
-    transition: background-color 0.15s ease;
-
-    &:has(.docs-tag-remove:hover) {
-      background-color: ${(props) => props.theme.background.surface2};
-    }
   }
 
   .docs-tag-icon {
@@ -81,15 +76,17 @@ export const StyledWrapper = styled.div`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0;
+    padding: 0.125rem;
     background: none;
     border: none;
+    border-radius: ${(props) => props.theme.border.radius.base};
     cursor: pointer;
     color: ${(props) => props.theme.colors.text.subtext0};
     flex-shrink: 0;
 
     &:hover {
       color: ${(props) => props.theme.text};
+      background-color: ${(props) => props.theme.background.surface1};
     }
   }
 `;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/index.jsx
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/index.jsx
@@ -23,6 +23,7 @@ const DocsTagList = ({
   const [highlighted, setHighlighted] = useState(-1);
   const [menuStyle, setMenuStyle] = useState(null);
   const fieldRef = useRef(null);
+  const inputRef = useRef(null);
 
   const suggestions = tagsHintList.filter((tag) => tag.toLowerCase().includes(text.trim().toLowerCase()));
 
@@ -70,13 +71,14 @@ const DocsTagList = ({
     setError('');
     setIsOpen(false);
     setHighlighted(-1);
+    inputRef.current?.blur();
   };
 
   const handleInputChange = (e) => {
     setText(e.target.value);
     setError('');
     setIsOpen(true);
-    setHighlighted(-1);
+    setHighlighted(e.target.value.trim() ? 0 : -1);
   };
 
   const showMenu = isOpen && suggestions.length > 0 && menuStyle;
@@ -115,6 +117,7 @@ const DocsTagList = ({
     <StyledWrapper>
       <div className="docs-tag-field" ref={fieldRef}>
         <input
+          ref={inputRef}
           type="text"
           className="docs-tag-input"
           value={text}
@@ -176,13 +179,12 @@ const DocsTagList = ({
           {tags.map((tag) => (
             <li key={tag} className="docs-tag-item">
               <IconTag size={16} className="docs-tag-icon" aria-hidden="true" strokeWidth={1.33} />
-              <span className="docs-tag-text" title={tag}>
+              <span className="docs-tag-text">
                 {tag}
               </span>
               <button
                 type="button"
                 className="docs-tag-remove"
-                title="Remove tag"
                 aria-label={`Remove ${tag}`}
                 onClick={() => handleRemoveTag(tag)}
               >


### PR DESCRIPTION
Ref: BRU-4022

### Problem

1. After selecting a tag in Include tags, the suggestions dropdown does not reopen for adding another tag until I click outside the field and then click back into it.

2. When typing in the Include/Exclude tags fields, the first matching suggestion should be focused by default so it can be selected with Enter, without needing to hover over it manually.

3. When I hover on the tag, Tool tip is displayed which is not required.

4. When I hover on “x“, the tag gets highlighted in the runner and kept the same behaviour in docs modal.

### Fix

These were minor fixes.

### Screenshots

<img width="1454" height="1800" alt="image" src="https://github.com/user-attachments/assets/3f3e7c79-9ff5-4880-8dc2-47acd487e0cb" />


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Updated documentation tag controls with clearer remove-button styling, including padding, rounded corners, and a dedicated hover background.
  - Tag backgrounds and transitions no longer change when hovering over the remove control.
  - Tag input fields now lose focus after a tag is added.
  - Suggestions highlight the first option when text is entered.
  - Removed hover tooltips from tag labels and remove controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->