### PR TITLE
fix(variables): scope list env name on creation

### DIFF
--- a/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
+++ b/packages/bruno-app/src/utils/codemirror/addToScopeSwitcher.js
@@ -67,8 +67,8 @@ const submitCreateEnvironment = ({
   nameInput.disabled = true;
 
   onCreateEnvironment(scope, name)
-    .then(() => {
-      onSuccess();
+    .then((updatedScope) => {
+      onSuccess(updatedScope || scope);
     })
     .catch((err) => {
       showError(err?.message || 'Failed to create environment');
@@ -121,11 +121,12 @@ const renderCreateEnvironment = (row, scope, actions) => {
   // can restore this row via `revert`.
   registerActiveCreateForm(revert, row);
 
-  // restore the created env as a dropdown option.
-  const onSuccess = () => {
+  // restore the created env as a dropdown option, using its fresh scope (label now includes
+  // the new environment's name, and it's enabled) rather than the stale pre-creation one.
+  const onSuccess = (updatedScope) => {
     unregisterActiveCreateForm(revert);
-    renderScopeOption(row, scope, actions);
-    handleScopeSwitch(scope, { keepDropdownOpen: true });
+    renderScopeOption(row, updatedScope, actions);
+    handleScopeSwitch(updatedScope, { keepDropdownOpen: true });
   };
 
   const submit = () =>

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.js
@@ -787,31 +787,35 @@ export const renderVarInfo = (token, options) => {
         }
       };
 
-      const addToScopesState = store.getState();
-      const globalEnvironmentsState = addToScopesState.globalEnvironments || {};
+      const buildAddToScopes = () => {
+        const addToScopesState = store.getState();
+        const globalEnvironmentsState = addToScopesState.globalEnvironments || {};
 
-      // Use the latest collection state so "Add to Environment" targets the real
-      // active environment, not the environment currently being viewed in environment settings.
-      const freshCollectionForScopes = collection?.uid
-        ? findCollectionByUid(addToScopesState.collections?.collections, collection.uid)
-        : null;
-      const activeEnvironmentName = (freshCollectionForScopes?.environments || []).find(
-        (env) => env.uid === freshCollectionForScopes?.activeEnvironmentUid
-      )?.name;
-      const activeGlobalEnvironmentName = (globalEnvironmentsState.globalEnvironments || []).find(
-        (env) => env.uid === globalEnvironmentsState.activeGlobalEnvironmentUid
-      )?.name;
-      const addToScopes = getAvailableAddToScopes({
-        // add activeEnvironmentUid only if activeEnvironmentName is there with the active id
-        activeEnvironmentUid: activeEnvironmentName ? freshCollectionForScopes?.activeEnvironmentUid : undefined,
-        activeEnvironmentName,
-        activeGlobalEnvironmentUid: globalEnvironmentsState.activeGlobalEnvironmentUid,
-        activeGlobalEnvironmentName,
-        item,
-        parentFolder: folderScopeTarget,
-        isSelfFolder: isInFolderSettings,
-        hasCollection: !!collection?.uid
-      });
+        const freshCollectionForScopes = collection?.uid
+          ? findCollectionByUid(addToScopesState.collections?.collections, collection.uid)
+          : null;
+        const activeEnvironmentName = (freshCollectionForScopes?.environments || []).find(
+          (env) => env.uid === freshCollectionForScopes?.activeEnvironmentUid
+        )?.name;
+        const activeGlobalEnvironmentName = (globalEnvironmentsState.globalEnvironments || []).find(
+          (env) => env.uid === globalEnvironmentsState.activeGlobalEnvironmentUid
+        )?.name;
+
+        return getAvailableAddToScopes({
+          activeEnvironmentUid: activeEnvironmentName ? freshCollectionForScopes?.activeEnvironmentUid : undefined,
+          activeEnvironmentName,
+          activeGlobalEnvironmentUid: globalEnvironmentsState.activeGlobalEnvironmentUid,
+          activeGlobalEnvironmentName,
+          item,
+          parentFolder: folderScopeTarget,
+          isSelfFolder: isInFolderSettings,
+          hasCollection: !!collection?.uid
+        });
+      };
+
+      const getFreshScopeForType = (type) => buildAddToScopes().find((s) => s.type === type);
+
+      const addToScopes = buildAddToScopes();
 
       // If there's only one available scope, select it by default. Otherwise, use the detected scope if it's available.
       const initialScope = addToScopes.find((s) => s.type === scopeInfo.type)
@@ -892,7 +896,8 @@ export const renderVarInfo = (token, options) => {
             return Promise.reject(new Error('Environment already exists'));
           }
 
-          return dispatch(addGlobalEnvironment({ name: trimmedName, variables: [] }));
+          return dispatch(addGlobalEnvironment({ name: trimmedName, variables: [] }))
+            .then(() => getFreshScopeForType(VARIABLE_ADD_SCOPES.GLOBAL));
         }
 
         if (scope.type === VARIABLE_ADD_SCOPES.ENVIRONMENT) {
@@ -907,7 +912,8 @@ export const renderVarInfo = (token, options) => {
 
           return dispatch(addEnvironment(trimmedName, collection.uid))
             .then(() => waitForEnvironmentByName(collection.uid, trimmedName))
-            .then((newEnvironment) => dispatch(selectEnvironment(newEnvironment.uid, collection.uid)));
+            .then((newEnvironment) => dispatch(selectEnvironment(newEnvironment.uid, collection.uid)))
+            .then(() => getFreshScopeForType(VARIABLE_ADD_SCOPES.ENVIRONMENT));
         }
 
         return Promise.reject(new Error(`"${scope.label}" does not support creating a new one`));

--- a/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
+++ b/packages/bruno-app/src/utils/codemirror/brunoVarInfo.spec.js
@@ -694,10 +694,15 @@ describe('renderVarInfo', () => {
 
     it('shows "Create One" when no environment exists, creates and selects the environment, and saves the variable once the tooltip is dismissed', async () => {
       getVariableScope.mockReturnValue(null);
-      getAvailableAddToScopes.mockReturnValue([
-        { type: 'collection', label: 'Collection Variable', enabled: true, supportsSecret: false },
-        { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
-      ]);
+      getAvailableAddToScopes
+        .mockReturnValueOnce([
+          { type: 'collection', label: 'Collection Variable', enabled: true, supportsSecret: false },
+          { type: 'environment', label: 'Collection Environment', enabled: false, supportsSecret: true }
+        ])
+        .mockReturnValue([
+          { type: 'collection', label: 'Collection Variable', enabled: true, supportsSecret: false },
+          { type: 'environment', label: 'Collection Environment (Dev)', enabled: true, supportsSecret: true }
+        ]);
 
       const collectionBeforeCreate = { uid: 'col-1', activeEnvironmentUid: null, environments: [] };
       const collectionAfterCreate = {
@@ -753,6 +758,12 @@ describe('renderVarInfo', () => {
       expect(updateVariableInScope).not.toHaveBeenCalled();
       // adding a new env will not close the switcher
       expect(switcher.querySelector('.var-add-to-list').style.display).toBe('block');
+
+      // The row is restored with the newly created environment's name in its label, not the
+      // stale pre-creation "no environment" label.
+      const environmentRow = switcher.querySelector('[data-testid="var-info-add-to-option-environment"]');
+      expect(environmentRow).not.toBeNull();
+      expect(environmentRow.querySelector('.var-add-to-option-label').textContent).toBe('Collection Environment (Dev)');
 
       valueContainer._cmEditor.getValue = () => 'a-new-value';
       await valueContainer._persistNewVariable();


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Creating a new env through the scope list option is not reflecting the created env name in the list.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
After creating a Global/Collection environment inline, the dropdown row re-rendered using the stale scope object captured before creation, so it kept showing the generic label (e.g. "Global Environment") instead of the new environment's name.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
onCreateEnvironment now re-fetches the scope from fresh store state after creation and passes that updated scope through to re-render the row, so it shows the correct name and enabled state.


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the environment scope switcher so newly created environments immediately appear with their updated names and availability.
  - Ensured the active scope switches to the newly created environment without relying on outdated scope information.
  - Kept the scope selector open after environment creation for a smoother workflow.

- **Tests**
  - Added coverage verifying that newly created environment options are refreshed and displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->