### PR TITLE
feat: add Reload Collection context menu option

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ConfirmReloadDrafts/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ConfirmReloadDrafts/StyledWrapper.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  .warning-text {
+    color: ${(props) => props.theme.status.warning.text};
+  }
+  .draft-list-item {
+    color: ${(props) => props.theme.colors.text.muted};
+  }
+  .transient-hint {
+    color: ${(props) => props.theme.colors.text.warning};
+  }
+  .transient-item {
+    background-color: ${(props) => props.theme.background.surface0};
+    border: 1px solid ${(props) => props.theme.border.border0};
+    border-radius: 4px;
+  }
+  .transient-item-name {
+    color: ${(props) => props.theme.text};
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/ConfirmReloadDrafts/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/ConfirmReloadDrafts/index.js
@@ -1,0 +1,202 @@
+import React, { useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  saveRequest,
+  saveMultipleRequests,
+  saveMultipleCollections,
+  saveMultipleFolders,
+  reloadCollection
+} from 'providers/ReduxStore/slices/collections/actions';
+import { deleteRequestDraft } from 'providers/ReduxStore/slices/collections';
+import { findCollectionByUid, getCollectionDrafts } from 'utils/collections/index';
+import { pluralizeWord } from 'utils/common';
+import { IconAlertTriangle, IconDeviceFloppy } from '@tabler/icons';
+import Modal from 'components/Modal';
+import toast from 'react-hot-toast';
+import Button from 'ui/Button';
+import StyledWrapper from './StyledWrapper';
+
+const MAX_UNSAVED_REQUESTS_TO_SHOW = 5;
+
+const ConfirmReloadDrafts = ({ onClose, collectionUid }) => {
+  const dispatch = useDispatch();
+  const allCollections = useSelector((state) => state.collections.collections || []);
+
+  const collection = useMemo(() => findCollectionByUid(allCollections, collectionUid), [allCollections, collectionUid]);
+
+  const {
+    requestDrafts: currentRequestDrafts,
+    transientDrafts: currentTransientDrafts,
+    folderDrafts: currentFolderDrafts,
+    collectionDrafts: currentCollectionDrafts
+  } = useMemo(() => (collection ? getCollectionDrafts([collection]) : {
+    requestDrafts: [],
+    transientDrafts: [],
+    folderDrafts: [],
+    collectionDrafts: []
+  }), [collection]);
+
+  const allDraftsCount = currentRequestDrafts.length + currentTransientDrafts.length + currentFolderDrafts.length + currentCollectionDrafts.length;
+
+  const handleReload = () => {
+    dispatch(reloadCollection({
+      collectionUid: collection.uid,
+      collectionPathname: collection.pathname,
+      brunoConfig: collection.brunoConfig
+    })).catch((error) => {
+      console.error('Error reloading the collection', error);
+      toast.error(error?.message || 'Error reloading the collection');
+    });
+    onClose();
+  };
+
+  const handleSaveAllAndReload = async () => {
+    if (currentTransientDrafts.length > 0) {
+      toast.error('Please save or discard transient requests first');
+      return;
+    }
+
+    try {
+      const savePromises = [];
+      if (currentCollectionDrafts.length > 0) savePromises.push(dispatch(saveMultipleCollections(currentCollectionDrafts)));
+      if (currentFolderDrafts.length > 0) savePromises.push(dispatch(saveMultipleFolders(currentFolderDrafts)));
+      if (currentRequestDrafts.length > 0) savePromises.push(dispatch(saveMultipleRequests(currentRequestDrafts)));
+
+      if (savePromises.length > 0) {
+        await Promise.all(savePromises);
+      }
+
+      handleReload();
+    } catch (err) {
+      toast.error('Failed to save drafts!');
+    }
+  };
+
+  const handleDiscardAndReload = () => {
+    const allRequestDrafts = [...currentRequestDrafts, ...currentTransientDrafts];
+    allRequestDrafts.forEach((draft) => {
+      dispatch(deleteRequestDraft({
+        collectionUid: draft.collectionUid,
+        itemUid: draft.uid
+      }));
+    });
+
+    handleReload();
+  };
+
+  const handleSaveTransient = (draft) => {
+    dispatch(saveRequest(draft.uid, collectionUid));
+  };
+
+  const otherDraftsCount = currentFolderDrafts.length + currentCollectionDrafts.length;
+
+  return (
+    <StyledWrapper>
+      <Modal
+        size="md"
+        title="Reload Collection"
+        handleCancel={onClose}
+        disableEscapeKey={true}
+        disableCloseOnOutsideClick={true}
+        closeModalFadeTimeout={150}
+        hideFooter={true}
+      >
+        <div className="flex items-center">
+          <IconAlertTriangle size={32} strokeWidth={1.5} className="warning-text" />
+          <h1 className="ml-2 text-lg font-medium">Hold on..</h1>
+        </div>
+        <p className="mt-4">
+          You have unsaved changes in <span className="font-medium">{allDraftsCount}</span>{' '}
+          {pluralizeWord('item', allDraftsCount)}. Reloading will re-read the collection from disk.
+        </p>
+
+        {currentRequestDrafts.length > 0 && (
+          <div className="mt-4">
+            <p className="text-sm font-medium mb-2">
+              Saved {pluralizeWord('Request', currentRequestDrafts.length)} ({currentRequestDrafts.length})
+            </p>
+            <ul className="ml-2">
+              {currentRequestDrafts.slice(0, MAX_UNSAVED_REQUESTS_TO_SHOW).map((item) => (
+                <li key={item.uid} className="mt-1 text-xs draft-list-item">
+                  • {item.filename || item.name}
+                </li>
+              ))}
+            </ul>
+            {currentRequestDrafts.length > MAX_UNSAVED_REQUESTS_TO_SHOW && (
+              <p className="ml-2 mt-1 text-xs draft-list-item">
+                ...{currentRequestDrafts.length - MAX_UNSAVED_REQUESTS_TO_SHOW} additional{' '}
+                {pluralizeWord('request', currentRequestDrafts.length - MAX_UNSAVED_REQUESTS_TO_SHOW)} not shown
+              </p>
+            )}
+          </div>
+        )}
+
+        {otherDraftsCount > 0 && (
+          <div className="mt-4">
+            <p className="text-sm font-medium mb-2">
+              Other Changes ({otherDraftsCount})
+            </p>
+            <p className="ml-2 text-xs text-muted">
+              {currentFolderDrafts.length > 0 && `${currentFolderDrafts.length} ${pluralizeWord('folder', currentFolderDrafts.length)}`}
+              {currentFolderDrafts.length > 0 && currentCollectionDrafts.length > 0 && ' and '}
+              {currentCollectionDrafts.length > 0 && `${currentCollectionDrafts.length} ${pluralizeWord('collection', currentCollectionDrafts.length)}`}
+              {' '}with unsaved changes will also be saved.
+            </p>
+          </div>
+        )}
+
+        {currentTransientDrafts.length > 0 && (
+          <div className="mt-4">
+            <p className="text-sm font-medium mb-2">
+              Transient {pluralizeWord('Request', currentTransientDrafts.length)} ({currentTransientDrafts.length})
+            </p>
+            <p className="text-xs transient-hint mb-3">
+              These requests need to be saved individually before reloading.
+            </p>
+            <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
+              {currentTransientDrafts.map((item) => (
+                <div
+                  key={item.uid}
+                  className="flex items-center justify-between py-2 px-3 transient-item"
+                >
+                  <span className="text-sm transient-item-name truncate mr-3">{item.name}</span>
+                  <Button
+                    color="primary"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleSaveTransient(item)}
+                    icon={<IconDeviceFloppy size={14} strokeWidth={1.5} />}
+                  >
+                    Save
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex justify-between mt-6">
+          <div>
+            <Button color="danger" onClick={handleDiscardAndReload}>
+              Discard and Reload
+            </Button>
+          </div>
+          <div>
+            <Button className="mr-2" color="secondary" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSaveAllAndReload}
+              disabled={currentTransientDrafts.length > 0}
+              title={currentTransientDrafts.length > 0 ? 'Please save or discard transient requests first' : ''}
+            >
+              {allDraftsCount > 1 ? 'Save All and Reload' : 'Save and Reload'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </StyledWrapper>
+  );
+};
+
+export default ConfirmReloadDrafts;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -41,7 +41,7 @@ import RemoveCollections from './RemoveCollections';
 import MoveToWorkspace from './MoveToWorkspace';
 import { isPathExternalToBasePath } from 'utils/common/path';
 import { doesCollectionHaveItemsMatchingSearchText } from 'utils/collections/search';
-import { isItemAFolder, isItemARequest, getSortedDraggedItems, getSelectionInfo } from 'utils/collections';
+import { isItemAFolder, isItemARequest, getSortedDraggedItems, getSelectionInfo, getCollectionDrafts } from 'utils/collections';
 import { isTabForItemActive } from 'src/selectors/tab';
 
 import RenameCollection from './RenameCollection';
@@ -50,6 +50,7 @@ import CloneCollection from './CloneCollection';
 import { scrollToTheActiveTab } from 'utils/tabs';
 import ShareCollection from 'components/ShareCollection/index';
 import GenerateDocumentation from './GenerateDocumentation';
+import ConfirmReloadDrafts from './ConfirmReloadDrafts';
 import { sortByNameThenSequence } from 'utils/common/index';
 import { getRevealInFolderLabel } from 'utils/common/platform';
 import { openDevtoolsAndSwitchToTerminal } from 'utils/terminal';
@@ -81,6 +82,7 @@ const Collection = ({ collection, searchText, openBulkMenu }) => {
   const [showRemoveCollectionModal, setShowRemoveCollectionModal] = useState(false);
   const [showMoveToWorkspaceModal, setShowMoveToWorkspaceModal] = useState(false);
   const [showCreateMockServerModal, setShowCreateMockServerModal] = useState(false);
+  const [showReloadConfirmModal, setShowReloadConfirmModal] = useState(false);
   const [dropType, setDropType] = useState(null);
   const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
   const [showEmptyState, setShowEmptyState] = useState(false);
@@ -247,11 +249,21 @@ const Collection = ({ collection, searchText, openBulkMenu }) => {
   };
 
   const handleReloadCollection = () => {
-    dispatch(reloadCollection({
-      collectionUid: collection.uid,
-      collectionPathname: collection.pathname,
-      brunoConfig: collection.brunoConfig
-    }));
+    const { requestDrafts, transientDrafts, folderDrafts, collectionDrafts } = getCollectionDrafts([collection]);
+    const hasDrafts = requestDrafts.length + transientDrafts.length + folderDrafts.length + collectionDrafts.length > 0;
+
+    if (hasDrafts) {
+      setShowReloadConfirmModal(true);
+    } else {
+      dispatch(reloadCollection({
+        collectionUid: collection.uid,
+        collectionPathname: collection.pathname,
+        brunoConfig: collection.brunoConfig
+      })).catch((error) => {
+        console.error('Error reloading the collection', error);
+        toast.error(error?.message || 'Error reloading the collection');
+      });
+    }
   };
 
   const handleShowInFolder = () => {
@@ -630,6 +642,9 @@ const Collection = ({ collection, searchText, openBulkMenu }) => {
       )}
       {showCloneCollectionModalOpen && (
         <CloneCollection collectionUid={collection.uid} onClose={() => setShowCloneCollectionModalOpen(false)} />
+      )}
+      {showReloadConfirmModal && (
+        <ConfirmReloadDrafts collectionUid={collection.uid} onClose={() => setShowReloadConfirmModal(false)} />
       )}
       {showCreateMockServerModal && (
         <CreateMockServerModal

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -23,11 +23,12 @@ import {
   IconBook,
   IconServer,
   IconFileArrowRight,
-  IconAppWindow
+  IconAppWindow,
+  IconRefresh
 } from '@tabler/icons';
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
 import { toggleCollection, collapseFullCollection, clearSidebarSelection } from 'providers/ReduxStore/slices/collections';
-import { mountCollection, moveCollectionAndPersist, handleMultipleCollectionItemsDrop, pasteItem, showInFolder, saveCollectionSecurityConfig } from 'providers/ReduxStore/slices/collections/actions';
+import { mountCollection, moveCollectionAndPersist, handleMultipleCollectionItemsDrop, pasteItem, showInFolder, saveCollectionSecurityConfig, reloadCollection } from 'providers/ReduxStore/slices/collections/actions';
 import { useDispatch, useSelector } from 'react-redux';
 import { addTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import { setFocusedSidebarPath } from 'providers/ReduxStore/slices/app';
@@ -243,6 +244,14 @@ const Collection = ({ collection, searchText, openBulkMenu }) => {
         type: 'collection-settings'
       })
     );
+  };
+
+  const handleReloadCollection = () => {
+    dispatch(reloadCollection({
+      collectionUid: collection.uid,
+      collectionPathname: collection.pathname,
+      brunoConfig: collection.brunoConfig
+    }));
   };
 
   const handleShowInFolder = () => {
@@ -537,6 +546,12 @@ const Collection = ({ collection, searchText, openBulkMenu }) => {
       leftSection: IconFoldDown,
       label: 'Collapse',
       onClick: handleCollapseFullCollection
+    },
+    {
+      id: 'reload',
+      leftSection: IconRefresh,
+      label: 'Reload',
+      onClick: handleReloadCollection
     },
     {
       id: 'show-in-folder',

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -44,7 +44,6 @@ import {
   sortCollections as _sortCollections,
   updateCollectionMountStatus,
   resetCollectionForReload,
-  updateCollectionTagsList,
   moveCollection,
   deleteItem as _deleteItemFromState,
   brunoConfigUpdateEvent as _brunoConfigUpdateEvent,
@@ -3387,7 +3386,6 @@ export const reloadCollection
 
       await dispatch(mountCollection({ collectionUid, collectionPathname, brunoConfig, skipTabRestore: true }));
 
-      dispatch(updateCollectionTagsList({ collectionUid }));
       toast.success('Collection reloaded');
     };
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -44,6 +44,7 @@ import {
   sortCollections as _sortCollections,
   updateCollectionMountStatus,
   resetCollectionForReload,
+  updateCollectionTagsList,
   moveCollection,
   deleteItem as _deleteItemFromState,
   brunoConfigUpdateEvent as _brunoConfigUpdateEvent,
@@ -3386,6 +3387,7 @@ export const reloadCollection
 
       await dispatch(mountCollection({ collectionUid, collectionPathname, brunoConfig, skipTabRestore: true }));
 
+      dispatch(updateCollectionTagsList({ collectionUid }));
       toast.success('Collection reloaded');
     };
 

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -43,6 +43,7 @@ import {
   applyDefaultEnvironment as _applyDefaultEnvironment,
   sortCollections as _sortCollections,
   updateCollectionMountStatus,
+  resetCollectionForReload,
   moveCollection,
   deleteItem as _deleteItemFromState,
   brunoConfigUpdateEvent as _brunoConfigUpdateEvent,
@@ -3371,6 +3372,19 @@ export const mountCollection
             reject();
           });
       });
+    };
+
+export const reloadCollection
+  = ({ collectionUid, collectionPathname, brunoConfig }) =>
+    async (dispatch, getState) => {
+      dispatch(resetCollectionForReload({ collectionUid }));
+      dispatch(updateCollectionMountStatus({ collectionUid, mountStatus: 'unmounted' }));
+
+      await callIpc('renderer:reload-collection', { collectionUid, collectionPathname });
+
+      await dispatch(mountCollection({ collectionUid, collectionPathname, brunoConfig, skipTabRestore: true }));
+
+      toast.success('Collection reloaded');
     };
 
 export const showInFolder = (collectionPath) => () => {

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -3773,6 +3773,7 @@ export const collectionsSlice = createSlice({
         annotateTransient(collection.items);
       }
       addDepth(collection.items);
+      collection.allTags = getUniqueTagsFromItems(collection.items);
     },
     collectionAddOauth2CredentialsByUrl: (state, action) => {
       const { collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo, executionMode } = action.payload;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -297,6 +297,13 @@ export const collectionsSlice = createSlice({
         collection.isLoading = action.payload.isLoading;
       }
     },
+    resetCollectionForReload: (state, action) => {
+      const { collectionUid } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+      if (!collection) return;
+      collection.items = [];
+      collection.environments = [];
+    },
     setCollectionSecurityConfig: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
       if (collection) {
@@ -4098,6 +4105,7 @@ export const {
   createCollection,
   updateCollectionMountStatus,
   updateCollectionLoadingState,
+  resetCollectionForReload,
   collectionLoadedFromTree,
   setCollectionSecurityConfig,
   updateCollectionVersion,

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -303,6 +303,7 @@ export const collectionsSlice = createSlice({
       if (!collection) return;
       collection.items = [];
       collection.environments = [];
+      collection.allTags = [];
     },
     setCollectionSecurityConfig: (state, action) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);

--- a/packages/bruno-electron/src/ipc/mount.js
+++ b/packages/bruno-electron/src/ipc/mount.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { ipcMain, BrowserWindow } = require('electron');
 const { MountManager } = require('../services/mount');
 
@@ -9,6 +10,18 @@ const registerMountIpc = () => {
   ipcMain.handle('renderer:clear-file-cache', () => {
     manager.clearCache();
     return manager.getCacheSize();
+  });
+
+  ipcMain.handle('renderer:reload-collection', async (event, { collectionUid, collectionPathname }) => {
+    const resolvedPath = path.resolve(collectionPathname);
+
+    await manager.unmount(collectionUid).catch(() => {});
+
+    const collectionWatcher = require('../app/collection-watcher');
+    const win = BrowserWindow.fromWebContents(event.sender);
+    try {
+      collectionWatcher.removeWatcher(resolvedPath, win, collectionUid);
+    } catch (_) {}
   });
 
   ipcMain.handle(

--- a/tests/collection/reload-collection/fixtures/collection/hello.yml
+++ b/tests/collection/reload-collection/fixtures/collection/hello.yml
@@ -1,0 +1,8 @@
+info:
+  name: hello
+  type: http
+  seq: 2
+
+http:
+  method: GET
+  url: https://echo.usebruno.com/hello

--- a/tests/collection/reload-collection/fixtures/collection/opencollection.yml
+++ b/tests/collection/reload-collection/fixtures/collection/opencollection.yml
@@ -1,0 +1,4 @@
+opencollection: "1.0.0"
+info:
+  name: ReloadTest
+  version: 1.0.0

--- a/tests/collection/reload-collection/fixtures/collection/ping.yml
+++ b/tests/collection/reload-collection/fixtures/collection/ping.yml
@@ -1,0 +1,8 @@
+info:
+  name: ping
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: https://echo.usebruno.com/ping

--- a/tests/collection/reload-collection/init-user-data/preferences.json
+++ b/tests/collection/reload-collection/init-user-data/preferences.json
@@ -1,0 +1,10 @@
+{
+  "maximized": false,
+  "lastOpenedCollections": ["{{collectionPath}}"],
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  }
+}

--- a/tests/collection/reload-collection/reload-collection.spec.ts
+++ b/tests/collection/reload-collection/reload-collection.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect, Page } from '../../../playwright';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+const COLLECTION_NAME = 'ReloadTest';
+
+const openCollectionActionsMenu = async (page: Page, collectionName: string) => {
+  const { sidebar } = buildCommonLocators(page);
+  const menu = sidebar.rowMenu(collectionName, 'collection');
+  await sidebar.collectionRow(collectionName).hover();
+  const trigger = menu.trigger();
+  await trigger.waitFor({ state: 'visible' });
+  await trigger.click();
+};
+
+test.describe('Reload Collection', () => {
+  test('reloads collection from context menu and preserves items', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+
+    await test.step('Verify collection is loaded with items', async () => {
+      await expect(locators.sidebar.collection(COLLECTION_NAME)).toBeVisible();
+      await locators.sidebar.collectionChevron(COLLECTION_NAME).click();
+      await expect(locators.sidebar.request('ping')).toBeVisible({ timeout: 10000 });
+      await expect(locators.sidebar.request('hello')).toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('Click Reload from the collection context menu', async () => {
+      await openCollectionActionsMenu(page, COLLECTION_NAME);
+      await page.getByTestId('collection-actions-reload').click();
+    });
+
+    await test.step('Verify success toast and items reappear', async () => {
+      await expect(page.getByText('Collection reloaded')).toBeVisible({ timeout: 10000 });
+      await expect(locators.sidebar.collection(COLLECTION_NAME)).toBeVisible();
+      await expect(locators.sidebar.request('ping')).toBeVisible({ timeout: 10000 });
+      await expect(locators.sidebar.request('hello')).toBeVisible({ timeout: 10000 });
+    });
+  });
+});

--- a/tests/collection/reload-collection/reload-collection.spec.ts
+++ b/tests/collection/reload-collection/reload-collection.spec.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { test, expect, Page } from '../../../playwright';
 import { buildCommonLocators } from '../../utils/page/locators';
 
@@ -13,28 +15,45 @@ const openCollectionActionsMenu = async (page: Page, collectionName: string) => 
 };
 
 test.describe('Reload Collection', () => {
-  test('reloads collection from context menu and preserves items', async ({
-    pageWithUserData: page
+  test('picks up a new request added on disk after reload', async ({
+    pageWithUserData: page,
+    collectionFixturePath
   }) => {
     const locators = buildCommonLocators(page);
+    const collectionPath = collectionFixturePath!;
 
-    await test.step('Verify collection is loaded with items', async () => {
+    await test.step('Verify collection is loaded with initial items', async () => {
       await expect(locators.sidebar.collection(COLLECTION_NAME)).toBeVisible();
       await locators.sidebar.collectionChevron(COLLECTION_NAME).click();
       await expect(locators.sidebar.request('ping')).toBeVisible({ timeout: 10000 });
       await expect(locators.sidebar.request('hello')).toBeVisible({ timeout: 10000 });
     });
 
-    await test.step('Click Reload from the collection context menu', async () => {
+    await test.step('Write a new request file on disk', async () => {
+      const newRequestYml = [
+        'info:',
+        '  name: added-externally',
+        '  type: http',
+        '  seq: 3',
+        '',
+        'http:',
+        '  method: POST',
+        '  url: https://echo.usebruno.com/post',
+        ''
+      ].join('\n');
+      fs.writeFileSync(path.join(collectionPath, 'added-externally.yml'), newRequestYml);
+    });
+
+    await test.step('Reload collection from the context menu', async () => {
       await openCollectionActionsMenu(page, COLLECTION_NAME);
       await page.getByTestId('collection-actions-reload').click();
     });
 
-    await test.step('Verify success toast and items reappear', async () => {
+    await test.step('Verify the new request appears after reload', async () => {
       await expect(page.getByText('Collection reloaded')).toBeVisible({ timeout: 10000 });
-      await expect(locators.sidebar.collection(COLLECTION_NAME)).toBeVisible();
       await expect(locators.sidebar.request('ping')).toBeVisible({ timeout: 10000 });
       await expect(locators.sidebar.request('hello')).toBeVisible({ timeout: 10000 });
+      await expect(locators.sidebar.request('added-externally')).toBeVisible({ timeout: 10000 });
     });
   });
 });


### PR DESCRIPTION
REF - BRU-3735

### Description

Adds a **Reload** option to the collection context menu so users can re-read the collection from disk without restarting Bruno.

Right-click a collection in the sidebar > Reload. The collection's file watcher is torn down, the in-memory tree is cleared, and the collection is remounted from disk. A success toast confirms the reload.

If there are unsaved draft changes, a confirmation dialog appears with Save All / Discard / Cancel options - matching the existing Close Collection and Move to Workspace patterns.

Ref: #5498

### Changes

- `packages/bruno-electron/src/ipc/mount.js` - new `renderer:reload-collection` IPC handler that unmounts the file watcher
- `packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js` - new `resetCollectionForReload` reducer that clears items, environments, and tags
- `packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js` - new `reloadCollection` thunk that coordinates clear, unmount, remount, and tag rebuild
- `packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js` - "Reload" menu item with refresh icon; checks for unsaved drafts before reloading
- `packages/bruno-app/src/components/Sidebar/Collections/Collection/ConfirmReloadDrafts/` - confirmation dialog for unsaved drafts (Save All / Discard / Cancel)
- `tests/collection/reload-collection/` - e2e test that writes a new request file on disk after initial load, reloads, and verifies the new request appears

### Testing done

- e2e test (Playwright, `--project=default`) passes: writes a file externally, reloads, verifies pickup
- Menu item renders correctly between "Collapse" and "Show in Folder"
- Error path tested: reload failures show an error toast
- Draft confirmation dialog matches existing Close Collection UX

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Ref #5498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reloading a collection now detects unsaved changes and offers options to save, discard, or cancel.
  * Transient requests can be saved individually before reloading.
  * Collection reloads now include externally added requests and refresh available tags.
  * Reload success and failure are communicated with notifications.

* **Bug Fixes**
  * Prevented stale requests, environments, and tags from remaining after a collection reload.

* **Tests**
  * Added coverage confirming externally added requests appear after reloading a collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
