### PR TITLE
fix(nodevm): add `--experimental-cache-modules` to cache npm modules during script execution

### DIFF
--- a/.github/actions/tests/run-cli-tests/action.yml
+++ b/.github/actions/tests/run-cli-tests/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Shell to use (bash, pwsh)'
     required: false
     default: 'bash'
+  experimental_cache_modules:
+    description: 'Pass --experimental-cache-modules to bru run (requires developer sandbox)'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -23,7 +27,11 @@ runs:
         npm start --workspace=packages/bruno-tests &
         sleep 5
         cd packages/bruno-tests/collection
-        node ../../bruno-cli/bin/bru.js run --env Prod --output junit.xml --format junit --sandbox developer
+        EXTRA_ARGS=""
+        if [ "${{ inputs.experimental_cache_modules }}" = "true" ]; then
+          EXTRA_ARGS="--experimental-cache-modules"
+        fi
+        node ../../bruno-cli/bin/bru.js run --env Prod --output junit.xml --format junit --sandbox developer $EXTRA_ARGS
 
     - name: Run Local Testbench and CLI Tests - Windows
       if: inputs.shell == 'pwsh'
@@ -42,4 +50,8 @@ runs:
         }
 
         cd packages/bruno-tests/collection
-        node ../../bruno-cli/bin/bru.js run --env Prod --output junit.xml --format junit --sandbox developer
+        $bruArgs = @("run", "--env", "Prod", "--output", "junit.xml", "--format", "junit", "--sandbox", "developer")
+        if ("${{ inputs.experimental_cache_modules }}" -eq "true") {
+          $bruArgs += "--experimental-cache-modules"
+        }
+        & node ../../bruno-cli/bin/bru.js @bruArgs

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -55,6 +55,35 @@ jobs:
           comment_mode: always
           check_run: false
 
+  cli-test-cache-modules:
+    name: CLI Tests with experimental-cache-modules (Linux)
+    runs-on:
+      - ubuntu-latest
+      - self-hosted
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/common/setup-node-deps
+
+      - name: Run CLI Tests
+        uses: ./.github/actions/tests/run-cli-tests
+        with:
+          experimental_cache_modules: 'true'
+
+      - name: Publish Test Report
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          check_name: CLI Test Results with experimental-cache-modules (Linux)
+          files: packages/bruno-tests/collection/junit.xml
+          comment_mode: always
+          check_run: false
+
   e2e-test:
     name: Playwright E2E Tests (Linux) ${{ matrix.shard }}/${{ matrix.shardTotal }}
     timeout-minutes: 240

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -49,6 +49,33 @@ jobs:
           comment_mode: off
           check_run: false
 
+  cli-test-cache-modules:
+    name: CLI Tests with experimental-cache-modules (macOS)
+    runs-on: macos-latest
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/common/setup-node-deps
+
+      - name: Run CLI Tests
+        uses: ./.github/actions/tests/run-cli-tests
+        with:
+          experimental_cache_modules: 'true'
+
+      - name: Publish Test Report
+        uses: EnricoMi/publish-unit-test-result-action/macos@v2
+        if: always()
+        with:
+          check_name: CLI Test Results with experimental-cache-modules (macOS)
+          files: packages/bruno-tests/collection/junit.xml
+          comment_mode: off
+          check_run: false
+
   e2e-test:
     name: Playwright E2E Tests (macOS)
     timeout-minutes: 240

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -59,6 +59,36 @@ jobs:
           comment_mode: off
           check_run: false
 
+  cli-test-cache-modules:
+    name: CLI Tests with experimental-cache-modules (Windows)
+    runs-on: windows-latest
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/common/setup-node-deps
+        with:
+          shell: pwsh
+
+      - name: Run CLI Tests
+        uses: ./.github/actions/tests/run-cli-tests
+        with:
+          shell: pwsh
+          experimental_cache_modules: 'true'
+
+      - name: Publish Test Report
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        if: always()
+        with:
+          check_name: CLI Test Results with experimental-cache-modules (Windows)
+          files: packages/bruno-tests/collection/junit.xml
+          comment_mode: off
+          check_run: false
+
   e2e-test:
     name: Playwright E2E Tests (Windows)
     timeout-minutes: 240

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -138,6 +138,11 @@ const builder = async (yargs) => {
       default: 'safe',
       type: 'string'
     })
+    .option('experimental-cache-modules', {
+      type: 'boolean',
+      default: false,
+      describe: 'Share npm modules across script runs in the developer sandbox (experimental)'
+    })
     .option('output', {
       alias: 'o',
       describe: 'Path to write file results to',
@@ -313,6 +318,7 @@ const handler = async function (argv) {
       reporterJunit,
       reporterHtml,
       sandbox,
+      experimentalCacheModules,
       testsOnly,
       bail,
       reporterSkipAllHeaders,
@@ -612,6 +618,10 @@ const handler = async function (argv) {
     if (verbose) {
       options['verbose'] = true;
     }
+    if (experimentalCacheModules && sandbox !== 'developer') {
+      console.warn(chalk.yellow('--experimental-cache-modules requires --sandbox developer; ignoring flag'));
+    }
+    options['cacheModules'] = sandbox === 'developer' && experimentalCacheModules === true;
     if (cacert && cacert.length) {
       if (insecure) {
         console.error(chalk.red(`Ignoring the cacert option since insecure connections are enabled`));

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -222,10 +222,10 @@ const runSingleRequest = async function (
 
     const scriptingConfig = get(brunoConfig, 'scripts', {});
     scriptingConfig.runtime = runtime;
-    scriptingConfig.cacheModules = get(options, 'cacheModules', false) === true;
 
     // Build certsAndProxyConfig for bru.sendRequest
     const options = getOptions();
+    scriptingConfig.cacheModules = get(options, 'cacheModules', false) === true;
     const systemProxyConfig = options['cachedSystemProxy'];
     const sendRequestInterpolationOptions = {
       envVars: envVariables,

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -222,6 +222,7 @@ const runSingleRequest = async function (
 
     const scriptingConfig = get(brunoConfig, 'scripts', {});
     scriptingConfig.runtime = runtime;
+    scriptingConfig.cacheModules = get(options, 'cacheModules', false) === true;
 
     // Build certsAndProxyConfig for bru.sendRequest
     const options = getOptions();

--- a/packages/bruno-cli/tests/integration/experimental-cache-modules.spec.js
+++ b/packages/bruno-cli/tests/integration/experimental-cache-modules.spec.js
@@ -1,0 +1,67 @@
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const CLI_BIN = path.resolve(__dirname, '..', '..', 'bin', 'bru.js');
+
+const runCli = (args, cwd) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_BIN, ...args], {
+      cwd,
+      env: { ...process.env }
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+
+describe('CLI --experimental-cache-modules gate', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bru-cli-cache-modules-'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'bruno.json'),
+      JSON.stringify({ version: '1', name: 'cache-modules-gate', type: 'collection' })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'ping.bru'),
+      `meta {
+  name: ping
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://127.0.0.1:9/does-not-matter
+  body: none
+  auth: none
+}
+`
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('documents the flag in --help', async () => {
+    const result = await runCli(['run', '--help']);
+    expect(result.stdout).toMatch(/experimental-cache-modules/);
+    expect(result.stdout).toMatch(/developer sandbox/i);
+  }, 30_000);
+
+  it('warns and ignores the flag unless --sandbox developer is set', async () => {
+    const result = await runCli(
+      ['run', 'ping.bru', '--experimental-cache-modules', '--sandbox', 'safe', '--noproxy'],
+      tmpDir
+    );
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(output).toMatch(/--experimental-cache-modules requires --sandbox developer; ignoring flag/);
+  }, 30_000);
+});

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -892,6 +892,7 @@ const registerNetworkIpc = (mainWindow) => {
     const brunoConfig = getBrunoConfig(collectionUid, collection);
     const scriptingConfig = get(brunoConfig, 'scripts', {});
     scriptingConfig.runtime = getJsSandboxRuntime(collection);
+    scriptingConfig.cacheModules = false;
 
     try {
       request.signal = abortController.signal;
@@ -1423,6 +1424,7 @@ const registerNetworkIpc = (mainWindow) => {
       const brunoConfig = getBrunoConfig(collectionUid, collection);
       const scriptingConfig = get(brunoConfig, 'scripts', {});
       scriptingConfig.runtime = getJsSandboxRuntime(collection);
+      scriptingConfig.cacheModules = false;
       const envVars = getEnvVars(environment);
       const processEnvVars = getProcessEnvVars(collectionUid);
       let stopRunnerExecution = false;

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -2,8 +2,198 @@ const vm = require('node:vm');
 const fs = require('node:fs');
 const path = require('node:path');
 const nodeModule = require('node:module');
+const { AsyncLocalStorage } = require('node:async_hooks');
 
 const { isBuiltinModule, isPathWithinAllowedRoots } = require('./utils');
+const { safeGlobals } = require('./constants');
+const { mixinTypedArrays } = require('../mixins/typed-arrays');
+
+/**
+ * Shared context for npm modules.
+ *
+ * Every script execution runs in a fresh vm context, so evaluating npm modules
+ * inside the script's own context meant a collection-level script doing
+ * `require('@faker-js/faker')` re-evaluated the whole package on every request
+ * (~20 MB of heap and ~8 MB of ArrayBuffers per script run, sitting in contexts
+ * V8 only reclaims under heap pressure — a 2,000-request `bru run` reached
+ * 9.5 GB RSS, see usebruno/bruno#9074).
+ *
+ * npm modules are therefore evaluated once per process, in a single dedicated
+ * context, and their exports are shared by every script — the way Node's own
+ * `require` cache behaves. The Bruno objects a module may reference as globals
+ * (`bru`, `req`, `res`, `test`, ...) are exposed on that context as accessors
+ * that resolve to the *currently executing* script's context, so a module
+ * evaluated during request 1 still sees request 42's `bru` when called from
+ * request 42. Collection-local modules (`./scripts/x.js`) are unaffected: they
+ * keep being evaluated per script context, cached in `localModuleCache`.
+ *
+ * "Currently executing" is tracked with AsyncLocalStorage rather than a global,
+ * because a script's `runInContext` is awaited: executions that interleave (the
+ * app can run several requests at once) must each keep resolving to their own
+ * `bru`/`req`/`res`, whatever order they complete in. Nested executions
+ * (`bru.runRequest`) nest naturally.
+ */
+const activeScriptContext = new AsyncLocalStorage();
+const sharedNpmModuleCache = new Map();
+let sharedNpmSandbox = null;
+let sharedNpmContext = null;
+
+// Keys that scripts get from Bruno rather than from the host: always exposed as
+// dynamic accessors on the shared context (extended on the fly by runWithScriptContext).
+const BRUNO_CONTEXT_KEYS = [
+  'bru',
+  'req',
+  'res',
+  'test',
+  'expect',
+  'assert',
+  '__brunoTestResults',
+  '__bruSetScope',
+  'jwt',
+  'console',
+  'scriptingConfig'
+];
+
+const facades = new Map();
+
+/**
+ * Late-bound stand-in for one Bruno global (`bru`, `req`, ...) inside the shared
+ * npm context. Every trap resolves the *current* script context's value, so a
+ * module that captured `bru` at load time (`const captured = bru` during
+ * execution A) still talks to execution B's `bru` when called from B. The
+ * target is a plain object for object-valued globals (so `typeof bru` stays
+ * 'object') and an arrow function for callable ones (so `test(...)` works);
+ * neither has a non-configurable own property that would constrain the traps.
+ * One facade per (key, callability), picked from the value the current
+ * execution provides, so a key that is an object in one execution and a
+ * function in another is served correctly in both.
+ * @param {string} key - The Bruno global's name
+ * @param {boolean} callable - Whether the current value is a function
+ */
+function facadeFor(key, callable) {
+  const cacheKey = `${key}:${callable ? 'fn' : 'obj'}`;
+  if (facades.has(cacheKey)) {
+    return facades.get(cacheKey);
+  }
+  const current = () => activeScriptContext.getStore()?.[key];
+  const isMissing = (value) => value === undefined || value === null;
+  const target = callable ? () => {} : {};
+  // Methods are handed out as late-bound wrappers too, so `const { getVar } = bru`
+  // at module scope keeps calling the current script's getVar. Cached per method
+  // name so `bru.setVar === bru.setVar` holds within the facade.
+  const methods = new Map();
+  const lateBoundMethod = (prop) => {
+    if (!methods.has(prop)) {
+      methods.set(prop, (...args) => {
+        const value = current();
+        const member = isMissing(value) ? undefined : value[prop];
+        if (typeof member !== 'function') {
+          throw new TypeError(`${key}.${String(prop)} is not available outside of a script execution`);
+        }
+        return Reflect.apply(member, value, args);
+      });
+    }
+    return methods.get(prop);
+  };
+  const facade = new Proxy(target, {
+    get: (_, prop) => {
+      const value = current();
+      if (isMissing(value)) {
+        return undefined;
+      }
+      const member = value[prop];
+      return typeof member === 'function' ? lateBoundMethod(prop) : member;
+    },
+    set: (_, prop, newValue) => {
+      const value = current();
+      if (isMissing(value)) {
+        return false;
+      }
+      value[prop] = newValue;
+      return true;
+    },
+    has: (_, prop) => {
+      const value = current();
+      return !isMissing(value) && prop in Object(value);
+    },
+    ownKeys: () => {
+      const value = current();
+      return isMissing(value) ? [] : Reflect.ownKeys(Object(value));
+    },
+    getOwnPropertyDescriptor: (_, prop) => {
+      const value = current();
+      const descriptor = isMissing(value) ? undefined : Object.getOwnPropertyDescriptor(Object(value), prop);
+      return descriptor ? { ...descriptor, configurable: true } : undefined;
+    },
+    getPrototypeOf: () => {
+      const value = current();
+      return isMissing(value) ? null : Object.getPrototypeOf(Object(value));
+    },
+    apply: (_, thisArg, args) => {
+      const value = current();
+      if (typeof value !== 'function') {
+        throw new TypeError(`${key} is not available outside of a script execution`);
+      }
+      return Reflect.apply(value, thisArg, args);
+    }
+  });
+  facades.set(cacheKey, facade);
+  return facade;
+}
+
+function defineDynamicGlobal(key) {
+  if (Object.prototype.hasOwnProperty.call(sharedNpmSandbox, key)) {
+    return;
+  }
+  Object.defineProperty(sharedNpmSandbox, key, {
+    enumerable: true,
+    configurable: true,
+    get: () => {
+      // A key the current execution does not provide reads as undefined, exactly
+      // as it would inside the script's own context (e.g. `res` before a response).
+      const value = activeScriptContext.getStore()?.[key];
+      if (value === undefined || value === null) {
+        return undefined;
+      }
+      return facadeFor(key, typeof value === 'function');
+    }
+  });
+}
+
+function getSharedNpmContext() {
+  if (!sharedNpmContext) {
+    sharedNpmSandbox = Object.fromEntries(
+      safeGlobals
+        .filter((key) => global[key] !== undefined)
+        .map((key) => [key, global[key]])
+    );
+    mixinTypedArrays(sharedNpmSandbox);
+    sharedNpmContext = vm.createContext(sharedNpmSandbox);
+    sharedNpmSandbox.global = sharedNpmSandbox;
+    sharedNpmSandbox.globalThis = sharedNpmSandbox;
+    BRUNO_CONTEXT_KEYS.forEach(defineDynamicGlobal);
+  }
+  return sharedNpmContext;
+}
+
+/**
+ * Runs `fn` with `scriptContext` as the currently executing script context, so
+ * npm modules called from it (or from async work it starts) resolve `bru`,
+ * `req`, `res`, ... to it. Safe for interleaved executions; nested executions
+ * (`bru.runRequest`) see their own context.
+ * @param {Object} scriptContext - The script's vm global object
+ * @param {Function} fn - The execution, typically `() => script.runInContext(...)`
+ * @returns {*} Whatever `fn` returns
+ */
+function runWithScriptContext(scriptContext, fn) {
+  getSharedNpmContext();
+  for (const key of Object.keys(scriptContext)) {
+    if (key !== 'global' && key !== 'globalThis' && key !== 'require') {
+      defineDynamicGlobal(key);
+    }
+  }
+  return activeScriptContext.run(scriptContext, fn);
+}
 
 /**
  * Resolve a local module path, handling files and directories
@@ -111,13 +301,11 @@ function createCustomRequire({
       return require(moduleName);
     }
 
-    // 4. Handle npm modules - load INTO vm context
+    // 4. Handle npm modules - evaluated once, in the shared npm context
     return loadNpmModule({
       moduleName,
       collectionPath,
-      currentModuleDir,
-      isolatedContext,
-      localModuleCache
+      currentModuleDir
     });
   };
 }
@@ -200,7 +388,8 @@ function loadLocalModule({
 }
 
 /**
- * Executes a module in the VM context with caching and special file handling
+ * Executes an npm module in the shared npm context, caching it process-wide,
+ * with special file handling
  * @param {Object} options - Configuration options
  * @returns {*} The exported content of the loaded module
  * @throws {Error} When module cannot be loaded
@@ -208,13 +397,11 @@ function loadLocalModule({
 function executeModuleInVmContext({
   resolvedPath,
   moduleName,
-  isolatedContext,
-  collectionPath,
-  localModuleCache
+  collectionPath
 }) {
   // Check cache - we cache moduleObj, return its exports
-  if (localModuleCache.has(resolvedPath)) {
-    return localModuleCache.get(resolvedPath).exports;
+  if (sharedNpmModuleCache.has(resolvedPath)) {
+    return sharedNpmModuleCache.get(resolvedPath).exports;
   }
 
   // Native modules (.node files) - fall back to host require
@@ -223,7 +410,7 @@ function executeModuleInVmContext({
   if (resolvedPath.endsWith('.node')) {
     const result = require(resolvedPath);
     // Wrap in moduleObj format for consistent cache retrieval
-    localModuleCache.set(resolvedPath, { exports: result });
+    sharedNpmModuleCache.set(resolvedPath, { exports: result });
     return result;
   }
 
@@ -232,7 +419,7 @@ function executeModuleInVmContext({
     const jsonContent = fs.readFileSync(resolvedPath, 'utf8');
     const result = JSON.parse(jsonContent);
     // Wrap in moduleObj format for consistent cache retrieval
-    localModuleCache.set(resolvedPath, { exports: result });
+    sharedNpmModuleCache.set(resolvedPath, { exports: result });
     return result;
   }
 
@@ -244,24 +431,22 @@ function executeModuleInVmContext({
   // Pre-populate cache with moduleObj BEFORE execution to handle circular dependencies
   // This allows re-entrant requires to get partial exports (Node.js behavior)
   // We cache moduleObj (not moduleObj.exports) so that module.exports reassignment works
-  localModuleCache.set(resolvedPath, moduleObj);
+  sharedNpmModuleCache.set(resolvedPath, moduleObj);
 
   const moduleRequire = createNpmModuleRequire({
     collectionPath,
-    isolatedContext,
-    currentModuleDir: moduleDir,
-    localModuleCache
+    currentModuleDir: moduleDir
   });
 
   try {
     // Wrap module code in a function that receives CJS parameters
     const wrappedCode = `(function(module, exports, require, __filename, __dirname) {\n${moduleSource}\n})`;
     const compiledScript = new vm.Script(wrappedCode, { filename: resolvedPath });
-    const moduleFunction = compiledScript.runInContext(isolatedContext);
+    const moduleFunction = compiledScript.runInContext(getSharedNpmContext());
     moduleFunction(moduleObj, moduleObj.exports, moduleRequire, resolvedPath, moduleDir);
   } catch (error) {
     // Remove failed module from cache to allow retry
-    localModuleCache.delete(resolvedPath);
+    sharedNpmModuleCache.delete(resolvedPath);
     const stack = error.stack || '';
     throw new Error(`Error loading module ${moduleName}: ${error.message}\nStack: ${stack}`);
   }
@@ -284,9 +469,7 @@ function executeModuleInVmContext({
 function loadNpmModule({
   moduleName,
   collectionPath,
-  currentModuleDir,
-  isolatedContext,
-  localModuleCache
+  currentModuleDir
 }) {
   let resolvedPath;
 
@@ -323,9 +506,7 @@ function loadNpmModule({
   return executeModuleInVmContext({
     resolvedPath,
     moduleName,
-    isolatedContext,
-    collectionPath,
-    localModuleCache
+    collectionPath
   });
 }
 
@@ -340,9 +521,7 @@ function loadNpmModule({
  */
 function createNpmModuleRequire({
   collectionPath,
-  isolatedContext,
-  currentModuleDir,
-  localModuleCache
+  currentModuleDir
 }) {
   const moduleRequire = nodeModule.createRequire(path.join(currentModuleDir, 'index.js'));
 
@@ -353,9 +532,7 @@ function createNpmModuleRequire({
       return executeModuleInVmContext({
         resolvedPath,
         moduleName,
-        isolatedContext,
-        collectionPath,
-        localModuleCache
+        collectionPath
       });
     }
 
@@ -371,13 +548,12 @@ function createNpmModuleRequire({
     return executeModuleInVmContext({
       resolvedPath,
       moduleName,
-      isolatedContext,
-      collectionPath,
-      localModuleCache
+      collectionPath
     });
   };
 }
 
 module.exports = {
-  createCustomRequire
+  createCustomRequire,
+  runWithScriptContext
 };

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -34,7 +34,11 @@ const { mixinTypedArrays } = require('../mixins/typed-arrays');
  * (`bru.runRequest`) nest naturally.
  */
 const activeScriptContext = new AsyncLocalStorage();
+// Set while an npm module body runs; records Bruno globals read at load time.
+const npmModuleEval = new AsyncLocalStorage();
 const sharedNpmModuleCache = new Map();
+// npm paths that read bru/req/res/... during evaluation — re-run per script.
+const contextBoundModulePaths = new Set();
 let sharedNpmSandbox = null;
 let sharedNpmContext = null;
 
@@ -151,6 +155,10 @@ function defineDynamicGlobal(key) {
     get: () => {
       // A key the current execution does not provide reads as undefined, exactly
       // as it would inside the script's own context (e.g. `res` before a response).
+      const evalStore = npmModuleEval.getStore();
+      if (evalStore) {
+        evalStore.touched.add(key);
+      }
       const value = activeScriptContext.getStore()?.[key];
       if (value === undefined || value === null) {
         return undefined;
@@ -306,11 +314,13 @@ function createCustomRequire({
       return require(moduleName);
     }
 
-    // 4. Handle npm modules - evaluated once, in the shared npm context
+    // 4. Handle npm modules - shared when inert, per-script when load-time globals are read
     return loadNpmModule({
       moduleName,
       collectionPath,
-      currentModuleDir
+      currentModuleDir,
+      isolatedContext,
+      localModuleCache
     });
   };
 }
@@ -402,20 +412,59 @@ function loadLocalModule({
 function executeModuleInVmContext({
   resolvedPath,
   moduleName,
-  collectionPath
+  collectionPath,
+  isolatedContext,
+  localModuleCache
 }) {
-  // Check cache - we cache moduleObj, return its exports
+  const isContextBound = contextBoundModulePaths.has(resolvedPath);
+
+  if (isContextBound) {
+    if (localModuleCache?.has(resolvedPath)) {
+      return localModuleCache.get(resolvedPath).exports;
+    }
+    return evaluateNpmModule({
+      resolvedPath,
+      moduleName,
+      collectionPath,
+      isolatedContext,
+      localModuleCache,
+      useSharedContext: false
+    });
+  }
+
   if (sharedNpmModuleCache.has(resolvedPath)) {
     return sharedNpmModuleCache.get(resolvedPath).exports;
   }
 
+  return evaluateNpmModule({
+    resolvedPath,
+    moduleName,
+    collectionPath,
+    isolatedContext,
+    localModuleCache,
+    useSharedContext: true
+  });
+}
+
+function evaluateNpmModule({
+  resolvedPath,
+  moduleName,
+  collectionPath,
+  isolatedContext,
+  localModuleCache,
+  useSharedContext
+}) {
   // Native modules (.node files) - fall back to host require
   // Note: This bypasses VM isolation for native addons.
   // This is intentional - [`developer` mode] node-vm isolation need not be strict for native modules.
   if (resolvedPath.endsWith('.node')) {
     const result = require(resolvedPath);
-    // Wrap in moduleObj format for consistent cache retrieval
-    sharedNpmModuleCache.set(resolvedPath, { exports: result });
+    const moduleObj = { exports: result };
+    if (useSharedContext) {
+      sharedNpmModuleCache.set(resolvedPath, moduleObj);
+    } else {
+      localModuleCache.set(resolvedPath, moduleObj);
+    }
     return result;
   }
 
@@ -423,35 +472,47 @@ function executeModuleInVmContext({
   if (resolvedPath.endsWith('.json')) {
     const jsonContent = fs.readFileSync(resolvedPath, 'utf8');
     const result = JSON.parse(jsonContent);
-    // Wrap in moduleObj format for consistent cache retrieval
-    sharedNpmModuleCache.set(resolvedPath, { exports: result });
+    const moduleObj = { exports: result };
+    if (useSharedContext) {
+      sharedNpmModuleCache.set(resolvedPath, moduleObj);
+    } else {
+      localModuleCache.set(resolvedPath, moduleObj);
+    }
     return result;
   }
 
-  // JavaScript files
   const moduleSource = fs.readFileSync(resolvedPath, 'utf8');
   const moduleDir = path.dirname(resolvedPath);
   const moduleObj = { exports: {} };
+  const moduleCache = useSharedContext ? sharedNpmModuleCache : localModuleCache;
 
-  // Pre-populate cache with moduleObj BEFORE execution to handle circular dependencies
-  // This allows re-entrant requires to get partial exports (Node.js behavior)
-  // We cache moduleObj (not moduleObj.exports) so that module.exports reassignment works
-  sharedNpmModuleCache.set(resolvedPath, moduleObj);
+  moduleCache.set(resolvedPath, moduleObj);
 
   const moduleRequire = createNpmModuleRequire({
     collectionPath,
-    currentModuleDir: moduleDir
+    currentModuleDir: moduleDir,
+    isolatedContext,
+    localModuleCache
   });
 
+  const vmContext = useSharedContext ? getSharedNpmContext() : isolatedContext;
+  const evalStore = { resolvedPath, touched: new Set() };
+
   try {
-    // Wrap module code in a function that receives CJS parameters
     const wrappedCode = `(function(module, exports, require, __filename, __dirname) {\n${moduleSource}\n})`;
     const compiledScript = new vm.Script(wrappedCode, { filename: resolvedPath });
-    const moduleFunction = compiledScript.runInContext(getSharedNpmContext());
-    moduleFunction(moduleObj, moduleObj.exports, moduleRequire, resolvedPath, moduleDir);
+    const moduleFunction = compiledScript.runInContext(vmContext);
+    npmModuleEval.run(evalStore, () => {
+      moduleFunction(moduleObj, moduleObj.exports, moduleRequire, resolvedPath, moduleDir);
+    });
+
+    if (useSharedContext && evalStore.touched.size > 0) {
+      contextBoundModulePaths.add(resolvedPath);
+      sharedNpmModuleCache.delete(resolvedPath);
+      localModuleCache.set(resolvedPath, moduleObj);
+    }
   } catch (error) {
-    // Remove failed module from cache to allow retry
-    sharedNpmModuleCache.delete(resolvedPath);
+    moduleCache.delete(resolvedPath);
     const stack = error.stack || '';
     throw new Error(`Error loading module ${moduleName}: ${error.message}\nStack: ${stack}`);
   }
@@ -474,7 +535,9 @@ function executeModuleInVmContext({
 function loadNpmModule({
   moduleName,
   collectionPath,
-  currentModuleDir
+  currentModuleDir,
+  isolatedContext,
+  localModuleCache
 }) {
   let resolvedPath;
 
@@ -511,7 +574,9 @@ function loadNpmModule({
   return executeModuleInVmContext({
     resolvedPath,
     moduleName,
-    collectionPath
+    collectionPath,
+    isolatedContext,
+    localModuleCache
   });
 }
 
@@ -526,7 +591,9 @@ function loadNpmModule({
  */
 function createNpmModuleRequire({
   collectionPath,
-  currentModuleDir
+  currentModuleDir,
+  isolatedContext,
+  localModuleCache
 }) {
   const moduleRequire = nodeModule.createRequire(path.join(currentModuleDir, 'index.js'));
 
@@ -537,7 +604,9 @@ function createNpmModuleRequire({
       return executeModuleInVmContext({
         resolvedPath,
         moduleName,
-        collectionPath
+        collectionPath,
+        isolatedContext,
+        localModuleCache
       });
     }
 
@@ -553,12 +622,21 @@ function createNpmModuleRequire({
     return executeModuleInVmContext({
       resolvedPath,
       moduleName,
-      collectionPath
+      collectionPath,
+      isolatedContext,
+      localModuleCache
     });
   };
 }
 
 module.exports = {
   createCustomRequire,
-  runWithScriptContext
+  runWithScriptContext,
+  __resetNpmModuleStateForTests: () => {
+    sharedNpmModuleCache.clear();
+    contextBoundModulePaths.clear();
+    facades.clear();
+    sharedNpmSandbox = null;
+    sharedNpmContext = null;
+  }
 };

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -155,6 +155,11 @@ function defineDynamicGlobal(key) {
       if (value === undefined || value === null) {
         return undefined;
       }
+      // Primitive context values cannot be represented by an object facade.
+      // Return them directly, preserving the pre-shared-context behavior.
+      if (typeof value !== 'object' && typeof value !== 'function') {
+        return value;
+      }
       return facadeFor(key, typeof value === 'function');
     }
   });

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -9,18 +9,13 @@ const { safeGlobals } = require('./constants');
 const { mixinTypedArrays } = require('../mixins/typed-arrays');
 
 // Shared npm context (once per process) so modules aren't re-eval'd per script. #9074
-// Bruno globals resolve via AsyncLocalStorage to the current script context.
 const activeScriptContext = new AsyncLocalStorage();
-// Set while an npm module body runs; records Bruno globals read at load time.
 const npmModuleEval = new AsyncLocalStorage();
 const sharedNpmModuleCache = new Map();
-// npm paths that read bru/req/res/... during evaluation — re-run per script.
 const contextBoundModulePaths = new Set();
 let sharedNpmSandbox = null;
 let sharedNpmContext = null;
 
-// Keys that scripts get from Bruno rather than from the host: always exposed as
-// dynamic accessors on the shared context (extended on the fly by runWithScriptContext).
 const BRUNO_CONTEXT_KEYS = [
   'bru',
   'req',
@@ -38,16 +33,7 @@ const BRUNO_CONTEXT_KEYS = [
 const facades = new Map();
 
 /**
- * Late-bound stand-in for one Bruno global (`bru`, `req`, ...) inside the shared
- * npm context. Every trap resolves the *current* script context's value, so a
- * module that captured `bru` at load time (`const captured = bru` during
- * execution A) still talks to execution B's `bru` when called from B. The
- * target is a plain object for object-valued globals (so `typeof bru` stays
- * 'object') and an arrow function for callable ones (so `test(...)` works);
- * neither has a non-configurable own property that would constrain the traps.
- * One facade per (key, callability), picked from the value the current
- * execution provides, so a key that is an object in one execution and a
- * function in another is served correctly in both.
+ * Late-bound facade for a Bruno global in the shared npm context.
  * @param {string} key - The Bruno global's name
  * @param {boolean} callable - Whether the current value is a function
  */
@@ -59,9 +45,8 @@ function facadeFor(key, callable) {
   const current = () => activeScriptContext.getStore()?.[key];
   const isMissing = (value) => value === undefined || value === null;
   const target = callable ? () => {} : {};
-  // Methods are handed out as late-bound wrappers too, so `const { getVar } = bru`
-  // at module scope keeps calling the current script's getVar. Cached per method
-  // name so `bru.setVar === bru.setVar` holds within the facade.
+
+  // Cache wrappers so `bru.setVar === bru.setVar` remains true.
   const methods = new Map();
   const lateBoundMethod = (prop) => {
     if (!methods.has(prop)) {
@@ -78,6 +63,10 @@ function facadeFor(key, callable) {
   };
   const facade = new Proxy(target, {
     get: (_, prop) => {
+      const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (targetDescriptor && !targetDescriptor.configurable && !targetDescriptor.writable) {
+        return targetDescriptor.value;
+      }
       const value = current();
       if (isMissing(value)) {
         return undefined;
@@ -86,6 +75,10 @@ function facadeFor(key, callable) {
       return typeof member === 'function' ? lateBoundMethod(prop) : member;
     },
     set: (_, prop, newValue) => {
+      const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (targetDescriptor && !targetDescriptor.configurable && !targetDescriptor.writable) {
+        return Object.is(targetDescriptor.value, newValue);
+      }
       const value = current();
       if (isMissing(value)) {
         return false;
@@ -94,14 +87,23 @@ function facadeFor(key, callable) {
       return true;
     },
     has: (_, prop) => {
+      const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (targetDescriptor && !targetDescriptor.configurable) {
+        return true;
+      }
       const value = current();
       return !isMissing(value) && prop in Object(value);
     },
     ownKeys: () => {
       const value = current();
-      return isMissing(value) ? [] : Reflect.ownKeys(Object(value));
+      const currentKeys = isMissing(value) ? [] : Reflect.ownKeys(Object(value));
+      return [...new Set([...Reflect.ownKeys(target), ...currentKeys])];
     },
     getOwnPropertyDescriptor: (_, prop) => {
+      const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (targetDescriptor && !targetDescriptor.configurable) {
+        return targetDescriptor;
+      }
       const value = current();
       const descriptor = isMissing(value) ? undefined : Object.getOwnPropertyDescriptor(Object(value), prop);
       return descriptor ? { ...descriptor, configurable: true } : undefined;
@@ -130,8 +132,6 @@ function defineDynamicGlobal(key) {
     enumerable: true,
     configurable: true,
     get: () => {
-      // A key the current execution does not provide reads as undefined, exactly
-      // as it would inside the script's own context (e.g. `res` before a response).
       const evalStore = npmModuleEval.getStore();
       if (evalStore) {
         evalStore.touched.add(key);
@@ -140,8 +140,6 @@ function defineDynamicGlobal(key) {
       if (value === undefined || value === null) {
         return undefined;
       }
-      // Primitive context values cannot be represented by an object facade.
-      // Return them directly, preserving the pre-shared-context behavior.
       if (typeof value !== 'object' && typeof value !== 'function') {
         return value;
       }
@@ -598,6 +596,14 @@ function loadNpmModule({
  * @param {Object} options - Configuration options
  * @returns {Function} Custom require function for npm module dependencies
  */
+function markParentContextBoundIfNeeded(resolvedPath) {
+  // Context-bound status is contagious through load-time requires.
+  const evalStore = npmModuleEval.getStore();
+  if (evalStore && contextBoundModulePaths.has(resolvedPath)) {
+    evalStore.touched.add('*');
+  }
+}
+
 function createNpmModuleRequire({
   collectionPath,
   currentModuleDir,
@@ -611,7 +617,7 @@ function createNpmModuleRequire({
     // Handle relative imports within npm module
     if (moduleName.startsWith('./') || moduleName.startsWith('../')) {
       const resolvedPath = moduleRequire.resolve(moduleName);
-      return executeModuleInVmContext({
+      const exports = executeModuleInVmContext({
         resolvedPath,
         moduleName,
         collectionPath,
@@ -619,6 +625,8 @@ function createNpmModuleRequire({
         localModuleCache,
         cacheModules
       });
+      markParentContextBoundIfNeeded(resolvedPath);
+      return exports;
     }
 
     // Handle builtins
@@ -630,7 +638,7 @@ function createNpmModuleRequire({
 
     // Handle npm dependencies - resolve from current module's directory
     const resolvedPath = moduleRequire.resolve(moduleName);
-    return executeModuleInVmContext({
+    const exports = executeModuleInVmContext({
       resolvedPath,
       moduleName,
       collectionPath,
@@ -638,6 +646,8 @@ function createNpmModuleRequire({
       localModuleCache,
       cacheModules
     });
+    markParentContextBoundIfNeeded(resolvedPath);
+    return exports;
   };
 }
 

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -13,6 +13,8 @@ const activeScriptContext = new AsyncLocalStorage();
 const npmModuleEval = new AsyncLocalStorage();
 const sharedNpmModuleCache = new Map();
 const contextBoundModulePaths = new Set();
+// path -> paths required while that module was evaluating (for context-bound eviction)
+const moduleRequireGraph = new Map();
 let sharedNpmSandbox = null;
 let sharedNpmContext = null;
 
@@ -91,10 +93,18 @@ function facadeFor(key, callable) {
       if (targetDescriptor && !targetDescriptor.configurable) {
         return true;
       }
+      if (!Object.isExtensible(target)) {
+        return false;
+      }
       const value = current();
       return !isMissing(value) && prop in Object(value);
     },
     ownKeys: () => {
+      // Once freeze/preventExtensions runs, only report keys on the inert target
+      // or Proxy throws and the poisoned facade breaks every later script.
+      if (!Object.isExtensible(target)) {
+        return Reflect.ownKeys(target);
+      }
       const value = current();
       const currentKeys = isMissing(value) ? [] : Reflect.ownKeys(Object(value));
       return [...new Set([...Reflect.ownKeys(target), ...currentKeys])];
@@ -103,6 +113,9 @@ function facadeFor(key, callable) {
       const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
       if (targetDescriptor && !targetDescriptor.configurable) {
         return targetDescriptor;
+      }
+      if (!Object.isExtensible(target)) {
+        return undefined;
       }
       const value = current();
       const descriptor = isMissing(value) ? undefined : Object.getOwnPropertyDescriptor(Object(value), prop);
@@ -143,6 +156,11 @@ function defineDynamicGlobal(key) {
       if (typeof value !== 'object' && typeof value !== 'function') {
         return value;
       }
+      // Custom script globals (arrays, plain data, callbacks, require) stay raw so
+      // Array.isArray / identity work. Bruno APIs need facades for late-binding.
+      if (!BRUNO_CONTEXT_KEYS.includes(key)) {
+        return value;
+      }
       return facadeFor(key, typeof value === 'function');
     }
   });
@@ -176,7 +194,7 @@ function getSharedNpmContext() {
 function runWithScriptContext(scriptContext, fn) {
   getSharedNpmContext();
   for (const key of Object.keys(scriptContext)) {
-    if (key !== 'global' && key !== 'globalThis' && key !== 'require') {
+    if (key !== 'global' && key !== 'globalThis') {
       defineDynamicGlobal(key);
     }
   }
@@ -383,6 +401,38 @@ function loadLocalModule({
   }
 }
 
+function recordRequireEdge(resolvedPath) {
+  const parent = npmModuleEval.getStore();
+  if (!parent?.resolvedPath) {
+    return;
+  }
+  if (!moduleRequireGraph.has(parent.resolvedPath)) {
+    moduleRequireGraph.set(parent.resolvedPath, new Set());
+  }
+  moduleRequireGraph.get(parent.resolvedPath).add(resolvedPath);
+}
+
+function evictContextBoundGraph(rootPath, rootModuleObj, localModuleCache) {
+  const stack = [rootPath];
+  const visited = new Set();
+  while (stack.length) {
+    const modulePath = stack.pop();
+    if (visited.has(modulePath)) {
+      continue;
+    }
+    visited.add(modulePath);
+    contextBoundModulePaths.add(modulePath);
+    const moduleObj = modulePath === rootPath ? rootModuleObj : sharedNpmModuleCache.get(modulePath);
+    sharedNpmModuleCache.delete(modulePath);
+    if (moduleObj) {
+      localModuleCache.set(modulePath, moduleObj);
+    }
+    for (const dep of moduleRequireGraph.get(modulePath) || []) {
+      stack.push(dep);
+    }
+  }
+}
+
 /**
  * Executes a module in the VM context with caching and special file handling
  * @param {Object} options - Configuration options
@@ -397,6 +447,10 @@ function executeModuleInVmContext({
   localModuleCache,
   cacheModules = false
 }) {
+  if (cacheModules) {
+    recordRequireEdge(resolvedPath);
+  }
+
   if (!cacheModules) {
     if (localModuleCache.has(resolvedPath)) {
       return localModuleCache.get(resolvedPath).exports;
@@ -508,9 +562,7 @@ function evaluateNpmModule({
     if (cacheModules && useSharedContext) {
       npmModuleEval.run(evalStore, runModule);
       if (evalStore.touched.size > 0) {
-        contextBoundModulePaths.add(resolvedPath);
-        sharedNpmModuleCache.delete(resolvedPath);
-        localModuleCache.set(resolvedPath, moduleObj);
+        evictContextBoundGraph(resolvedPath, moduleObj, localModuleCache);
       }
     } else {
       runModule();
@@ -612,6 +664,12 @@ function createNpmModuleRequire({
   const moduleRequire = nodeModule.createRequire(path.join(currentModuleDir, 'index.js'));
 
   return (moduleName) => {
+    // Shared parents keep this require for the process lifetime; always prefer the
+    // active script run's cache/context so lazy context-bound leaves re-eval.
+    const store = cacheModules ? activeScriptContext.getStore() : null;
+    const runLocalCache = store?.__brunoLocalModuleCache ?? localModuleCache;
+    const runContext = store?.__brunoVmContext ?? isolatedContext;
+
     // Handle relative imports within npm module
     if (moduleName.startsWith('./') || moduleName.startsWith('../')) {
       const resolvedPath = moduleRequire.resolve(moduleName);
@@ -619,8 +677,8 @@ function createNpmModuleRequire({
         resolvedPath,
         moduleName,
         collectionPath,
-        isolatedContext,
-        localModuleCache,
+        isolatedContext: runContext,
+        localModuleCache: runLocalCache,
         cacheModules
       });
       markParentContextBoundIfNeeded(resolvedPath);
@@ -640,8 +698,8 @@ function createNpmModuleRequire({
       resolvedPath,
       moduleName,
       collectionPath,
-      isolatedContext,
-      localModuleCache,
+      isolatedContext: runContext,
+      localModuleCache: runLocalCache,
       cacheModules
     });
     markParentContextBoundIfNeeded(resolvedPath);
@@ -652,9 +710,11 @@ function createNpmModuleRequire({
 module.exports = {
   createCustomRequire,
   runWithScriptContext,
+  getSharedNpmContext,
   __resetNpmModuleStateForTests: () => {
     sharedNpmModuleCache.clear();
     contextBoundModulePaths.clear();
+    moduleRequireGraph.clear();
     facades.clear();
     sharedNpmSandbox = null;
     sharedNpmContext = null;

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -8,31 +8,8 @@ const { isBuiltinModule, isPathWithinAllowedRoots } = require('./utils');
 const { safeGlobals } = require('./constants');
 const { mixinTypedArrays } = require('../mixins/typed-arrays');
 
-/**
- * Shared context for npm modules.
- *
- * Every script execution runs in a fresh vm context, so evaluating npm modules
- * inside the script's own context meant a collection-level script doing
- * `require('@faker-js/faker')` re-evaluated the whole package on every request
- * (~20 MB of heap and ~8 MB of ArrayBuffers per script run, sitting in contexts
- * V8 only reclaims under heap pressure — a 2,000-request `bru run` reached
- * 9.5 GB RSS, see usebruno/bruno#9074).
- *
- * npm modules are therefore evaluated once per process, in a single dedicated
- * context, and their exports are shared by every script — the way Node's own
- * `require` cache behaves. The Bruno objects a module may reference as globals
- * (`bru`, `req`, `res`, `test`, ...) are exposed on that context as accessors
- * that resolve to the *currently executing* script's context, so a module
- * evaluated during request 1 still sees request 42's `bru` when called from
- * request 42. Collection-local modules (`./scripts/x.js`) are unaffected: they
- * keep being evaluated per script context, cached in `localModuleCache`.
- *
- * "Currently executing" is tracked with AsyncLocalStorage rather than a global,
- * because a script's `runInContext` is awaited: executions that interleave (the
- * app can run several requests at once) must each keep resolving to their own
- * `bru`/`req`/`res`, whatever order they complete in. Nested executions
- * (`bru.runRequest`) nest naturally.
- */
+// Shared npm context (once per process) so modules aren't re-eval'd per script. #9074
+// Bruno globals resolve via AsyncLocalStorage to the current script context.
 const activeScriptContext = new AsyncLocalStorage();
 // Set while an npm module body runs; records Bruno globals read at load time.
 const npmModuleEval = new AsyncLocalStorage();
@@ -277,7 +254,8 @@ function createCustomRequire({
   isolatedContext,
   currentModuleDir = collectionPath,
   localModuleCache = new Map(),
-  additionalContextRootsAbsolute = []
+  additionalContextRootsAbsolute = [],
+  cacheModules = false
 }) {
   return (moduleName) => {
     const normalizedModuleName = moduleName.replace(/\\/g, '/');
@@ -290,7 +268,8 @@ function createCustomRequire({
         isolatedContext,
         localModuleCache,
         currentModuleDir,
-        additionalContextRootsAbsolute
+        additionalContextRootsAbsolute,
+        cacheModules
       });
     }
 
@@ -303,7 +282,8 @@ function createCustomRequire({
         isolatedContext,
         localModuleCache,
         currentModuleDir,
-        additionalContextRootsAbsolute
+        additionalContextRootsAbsolute,
+        cacheModules
       });
     }
 
@@ -320,7 +300,8 @@ function createCustomRequire({
       collectionPath,
       currentModuleDir,
       isolatedContext,
-      localModuleCache
+      localModuleCache,
+      cacheModules
     });
   };
 }
@@ -337,7 +318,8 @@ function loadLocalModule({
   isolatedContext,
   localModuleCache,
   currentModuleDir,
-  additionalContextRootsAbsolute = []
+  additionalContextRootsAbsolute = [],
+  cacheModules = false
 }) {
   // Validate the raw module name doesn't try to escape allowed roots
   const preliminaryPath = path.resolve(currentModuleDir, moduleName);
@@ -385,7 +367,8 @@ function loadLocalModule({
     isolatedContext,
     currentModuleDir: moduleDir,
     localModuleCache,
-    additionalContextRootsAbsolute
+    additionalContextRootsAbsolute,
+    cacheModules
   });
 
   try {
@@ -414,8 +397,24 @@ function executeModuleInVmContext({
   moduleName,
   collectionPath,
   isolatedContext,
-  localModuleCache
+  localModuleCache,
+  cacheModules = false
 }) {
+  if (!cacheModules) {
+    if (localModuleCache.has(resolvedPath)) {
+      return localModuleCache.get(resolvedPath).exports;
+    }
+    return evaluateNpmModule({
+      resolvedPath,
+      moduleName,
+      collectionPath,
+      isolatedContext,
+      localModuleCache,
+      useSharedContext: false,
+      cacheModules: false
+    });
+  }
+
   const isContextBound = contextBoundModulePaths.has(resolvedPath);
 
   if (isContextBound) {
@@ -428,7 +427,8 @@ function executeModuleInVmContext({
       collectionPath,
       isolatedContext,
       localModuleCache,
-      useSharedContext: false
+      useSharedContext: false,
+      cacheModules: true
     });
   }
 
@@ -442,7 +442,8 @@ function executeModuleInVmContext({
     collectionPath,
     isolatedContext,
     localModuleCache,
-    useSharedContext: true
+    useSharedContext: true,
+    cacheModules: true
   });
 }
 
@@ -452,7 +453,8 @@ function evaluateNpmModule({
   collectionPath,
   isolatedContext,
   localModuleCache,
-  useSharedContext
+  useSharedContext,
+  cacheModules = false
 }) {
   // Native modules (.node files) - fall back to host require
   // Note: This bypasses VM isolation for native addons.
@@ -492,7 +494,8 @@ function evaluateNpmModule({
     collectionPath,
     currentModuleDir: moduleDir,
     isolatedContext,
-    localModuleCache
+    localModuleCache,
+    cacheModules
   });
 
   const vmContext = useSharedContext ? getSharedNpmContext() : isolatedContext;
@@ -502,14 +505,18 @@ function evaluateNpmModule({
     const wrappedCode = `(function(module, exports, require, __filename, __dirname) {\n${moduleSource}\n})`;
     const compiledScript = new vm.Script(wrappedCode, { filename: resolvedPath });
     const moduleFunction = compiledScript.runInContext(vmContext);
-    npmModuleEval.run(evalStore, () => {
+    const runModule = () => {
       moduleFunction(moduleObj, moduleObj.exports, moduleRequire, resolvedPath, moduleDir);
-    });
-
-    if (useSharedContext && evalStore.touched.size > 0) {
-      contextBoundModulePaths.add(resolvedPath);
-      sharedNpmModuleCache.delete(resolvedPath);
-      localModuleCache.set(resolvedPath, moduleObj);
+    };
+    if (cacheModules && useSharedContext) {
+      npmModuleEval.run(evalStore, runModule);
+      if (evalStore.touched.size > 0) {
+        contextBoundModulePaths.add(resolvedPath);
+        sharedNpmModuleCache.delete(resolvedPath);
+        localModuleCache.set(resolvedPath, moduleObj);
+      }
+    } else {
+      runModule();
     }
   } catch (error) {
     moduleCache.delete(resolvedPath);
@@ -537,7 +544,8 @@ function loadNpmModule({
   collectionPath,
   currentModuleDir,
   isolatedContext,
-  localModuleCache
+  localModuleCache,
+  cacheModules = false
 }) {
   let resolvedPath;
 
@@ -576,7 +584,8 @@ function loadNpmModule({
     moduleName,
     collectionPath,
     isolatedContext,
-    localModuleCache
+    localModuleCache,
+    cacheModules
   });
 }
 
@@ -593,7 +602,8 @@ function createNpmModuleRequire({
   collectionPath,
   currentModuleDir,
   isolatedContext,
-  localModuleCache
+  localModuleCache,
+  cacheModules = false
 }) {
   const moduleRequire = nodeModule.createRequire(path.join(currentModuleDir, 'index.js'));
 
@@ -606,7 +616,8 @@ function createNpmModuleRequire({
         moduleName,
         collectionPath,
         isolatedContext,
-        localModuleCache
+        localModuleCache,
+        cacheModules
       });
     }
 
@@ -624,7 +635,8 @@ function createNpmModuleRequire({
       moduleName,
       collectionPath,
       isolatedContext,
-      localModuleCache
+      localModuleCache,
+      cacheModules
     });
   };
 }

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -292,7 +292,7 @@ function createCustomRequire({
       return require(moduleName);
     }
 
-    // 4. Handle npm modules - shared when inert, per-script when load-time globals are read
+    // 4. Handle npm modules - load INTO vm context
     return loadNpmModule({
       moduleName,
       collectionPath,
@@ -384,8 +384,7 @@ function loadLocalModule({
 }
 
 /**
- * Executes an npm module in the shared npm context, caching it process-wide,
- * with special file handling
+ * Executes a module in the VM context with caching and special file handling
  * @param {Object} options - Configuration options
  * @returns {*} The exported content of the loaded module
  * @throws {Error} When module cannot be loaded
@@ -597,7 +596,6 @@ function loadNpmModule({
  * @returns {Function} Custom require function for npm module dependencies
  */
 function markParentContextBoundIfNeeded(resolvedPath) {
-  // Context-bound status is contagious through load-time requires.
   const evalStore = npmModuleEval.getStore();
   if (evalStore && contextBoundModulePaths.has(resolvedPath)) {
     evalStore.touched.add('*');

--- a/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
+++ b/packages/bruno-js/src/sandbox/node-vm/cjs-loader.js
@@ -34,6 +34,16 @@ const BRUNO_CONTEXT_KEYS = [
 
 const facades = new Map();
 
+const RUN_LOADER_STATE = Symbol('brunoRunLoaderState');
+
+function attachRunLoaderState(scriptContext, { localModuleCache, vmContext }) {
+  scriptContext[RUN_LOADER_STATE] = { localModuleCache, vmContext };
+}
+
+function getRunLoaderState(store) {
+  return store?.[RUN_LOADER_STATE];
+}
+
 /**
  * Late-bound facade for a Bruno global in the shared npm context.
  * @param {string} key - The Bruno global's name
@@ -667,8 +677,9 @@ function createNpmModuleRequire({
     // Shared parents keep this require for the process lifetime; always prefer the
     // active script run's cache/context so lazy context-bound leaves re-eval.
     const store = cacheModules ? activeScriptContext.getStore() : null;
-    const runLocalCache = store?.__brunoLocalModuleCache ?? localModuleCache;
-    const runContext = store?.__brunoVmContext ?? isolatedContext;
+    const runState = getRunLoaderState(store);
+    const runLocalCache = runState?.localModuleCache ?? localModuleCache;
+    const runContext = runState?.vmContext ?? isolatedContext;
 
     // Handle relative imports within npm module
     if (moduleName.startsWith('./') || moduleName.startsWith('../')) {
@@ -711,6 +722,7 @@ module.exports = {
   createCustomRequire,
   runWithScriptContext,
   getSharedNpmContext,
+  attachRunLoaderState,
   __resetNpmModuleStateForTests: () => {
     sharedNpmModuleCache.clear();
     contextBoundModulePaths.clear();

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -4,7 +4,7 @@ const { get } = require('lodash');
 const lodash = require('lodash');
 const { wrapConsoleWithSerializers } = require('./console');
 const { ScriptError, resolveVmFilename } = require('./utils');
-const { createCustomRequire } = require('./cjs-loader');
+const { createCustomRequire, runWithScriptContext } = require('./cjs-loader');
 const { safeGlobals } = require('./constants');
 const { mixinTypedArrays } = require('../mixins/typed-arrays');
 const { wrapScriptInClosure, SANDBOX } = require('../../utils/sandbox');
@@ -109,9 +109,13 @@ async function runScriptInNodeVm({
     };
 
     try {
-      await compiledScript.runInContext(isolatedContext, {
-        displayErrors: true
-      });
+      // npm modules loaded by this script (or already cached from an earlier one)
+      // resolve `bru`, `req`, `res`, ... against this context while it runs
+      await runWithScriptContext(scriptContext, () =>
+        compiledScript.runInContext(isolatedContext, {
+          displayErrors: true
+        })
+      );
     } catch (error) {
       // V8 invokes prepareStackTrace lazily on first .stack access.
       // Reading .stack here so custom handler runs and populates error.__callSites

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -115,8 +115,6 @@ async function runScriptInNodeVm({
         displayErrors: true
       });
       if (cacheModules) {
-        // npm modules loaded by this script (or already cached from an earlier one)
-        // resolve `bru`, `req`, `res`, ... against this context while it runs
         await runWithScriptContext(scriptContext, runScript);
       } else {
         await runScript();

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -4,7 +4,7 @@ const { get } = require('lodash');
 const lodash = require('lodash');
 const { wrapConsoleWithSerializers } = require('./console');
 const { ScriptError, resolveVmFilename } = require('./utils');
-const { createCustomRequire, runWithScriptContext, getSharedNpmContext } = require('./cjs-loader');
+const { createCustomRequire, runWithScriptContext, getSharedNpmContext, attachRunLoaderState } = require('./cjs-loader');
 const { safeGlobals } = require('./constants');
 const { mixinTypedArrays } = require('../mixins/typed-arrays');
 const { wrapScriptInClosure, SANDBOX } = require('../../utils/sandbox');
@@ -68,86 +68,89 @@ async function runScriptInNodeVm({
       cacheModules
     });
     // Stashed for shared npm requires that outlive this run's createCustomRequire closure.
-    scriptContext.__brunoLocalModuleCache = localModuleCache;
-    scriptContext.__brunoVmContext = vmContext;
+    // Symbol key so runWithScriptContext does not publish these as sandbox globals.
+    attachRunLoaderState(scriptContext, { localModuleCache, vmContext });
 
     // cacheModules: onFail runs after the script's ALS store exits, so re-bind
     // registered callbacks to this run's context (bru/req/... facades).
     let restoreOnFail;
     if (cacheModules && typeof scriptContext.req?.onFail === 'function') {
       const req = scriptContext.req;
-      const originalOnFail = req.onFail.bind(req);
+      const originalOnFail = req.onFail;
       req.onFail = (callback) => {
         if (typeof callback !== 'function') {
-          return originalOnFail(callback);
+          return originalOnFail.call(req, callback);
         }
-        return originalOnFail((error) => runWithScriptContext(scriptContext, () => callback(error)));
+        return originalOnFail.call(req, (error) => runWithScriptContext(scriptContext, () => callback(error)));
       };
       restoreOnFail = () => {
         req.onFail = originalOnFail;
       };
     }
 
-    const vmFilename = resolveVmFilename(scriptPath, collectionPath);
-
-    // Execute the script in the isolated context
-    const wrappedScript = wrapScriptInClosure(script, SANDBOX.NODEVM);
-    let compiledScript;
     try {
-      compiledScript = new vm.Script(wrappedScript, {
-        filename: vmFilename
-      });
-    } catch (error) {
-      // V8 puts "filename:line" as the first line of syntax error stacks.
-      // Parse it so the error formatter can map to the correct source location.
-      const firstLine = error.stack?.split('\n')[0];
-      const match = firstLine?.match(/^(.+):(\d+)$/);
-      if (match && match[1] === vmFilename) {
-        error.__callSites = [{
-          filePath: vmFilename,
-          line: parseInt(match[2], 10),
-          column: null,
-          functionName: null
-        }];
+      const vmFilename = resolveVmFilename(scriptPath, collectionPath);
+
+      // Execute the script in the isolated context
+      const wrappedScript = wrapScriptInClosure(script, SANDBOX.NODEVM);
+      let compiledScript;
+      try {
+        compiledScript = new vm.Script(wrappedScript, {
+          filename: vmFilename
+        });
+      } catch (error) {
+        // V8 puts "filename:line" as the first line of syntax error stacks.
+        // Parse it so the error formatter can map to the correct source location.
+        const firstLine = error.stack?.split('\n')[0];
+        const match = firstLine?.match(/^(.+):(\d+)$/);
+        if (match && match[1] === vmFilename) {
+          error.__callSites = [{
+            filePath: vmFilename,
+            line: parseInt(match[2], 10),
+            column: null,
+            functionName: null
+          }];
+        }
+        throw error;
       }
-      throw error;
-    }
 
-    // Capture structured call sites for error-formatter line mapping
-    const originalPrepareStackTrace = Error.prepareStackTrace;
-    Error.prepareStackTrace = (error, callSites) => {
-      error.__callSites = callSites
-        .filter((site) => site.getFileName() === vmFilename)
-        .map((site) => ({
-          filePath: site.getFileName(),
-          line: site.getLineNumber(),
-          column: site.getColumnNumber(),
-          functionName: site.getFunctionName() || null
-        }));
+      // Capture structured call sites for error-formatter line mapping
+      const originalPrepareStackTrace = Error.prepareStackTrace;
+      Error.prepareStackTrace = (error, callSites) => {
+        error.__callSites = callSites
+          .filter((site) => site.getFileName() === vmFilename)
+          .map((site) => ({
+            filePath: site.getFileName(),
+            line: site.getLineNumber(),
+            column: site.getColumnNumber(),
+            functionName: site.getFunctionName() || null
+          }));
 
-      return error.toString() + '\n' + callSites
-        .map((site) => `    at ${site}`)
-        .join('\n');
-    };
+        return error.toString() + '\n' + callSites
+          .map((site) => `    at ${site}`)
+          .join('\n');
+      };
 
-    try {
-      const runScript = () => compiledScript.runInContext(vmContext, {
-        displayErrors: true
-      });
-      if (cacheModules) {
-        await runWithScriptContext(scriptContext, runScript);
-      } else {
-        await runScript();
+      try {
+        const runScript = () => compiledScript.runInContext(vmContext, {
+          displayErrors: true
+        });
+        if (cacheModules) {
+          await runWithScriptContext(scriptContext, runScript);
+        } else {
+          await runScript();
+        }
+      } catch (error) {
+        // V8 invokes prepareStackTrace lazily on first .stack access.
+        // Reading .stack here so custom handler runs and populates error.__callSites
+        // (used later by the error formatter to map stack frames to the .bru/.yml script)
+        void error.stack;
+        throw error;
+      } finally {
+        Error.prepareStackTrace = originalPrepareStackTrace;
       }
-    } catch (error) {
-      // V8 invokes prepareStackTrace lazily on first .stack access.
-      // Reading .stack here so custom handler runs and populates error.__callSites
-      // (used later by the error formatter to map stack frames to the .bru/.yml script)
-      void error.stack;
-      throw error;
     } finally {
       restoreOnFail?.();
-      Error.prepareStackTrace = originalPrepareStackTrace;
     }
   } catch (error) {
     throw new ScriptError(error, script);

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -71,6 +71,23 @@ async function runScriptInNodeVm({
     scriptContext.__brunoLocalModuleCache = localModuleCache;
     scriptContext.__brunoVmContext = vmContext;
 
+    // cacheModules: onFail runs after the script's ALS store exits, so re-bind
+    // registered callbacks to this run's context (bru/req/... facades).
+    let restoreOnFail;
+    if (cacheModules && typeof scriptContext.req?.onFail === 'function') {
+      const req = scriptContext.req;
+      const originalOnFail = req.onFail.bind(req);
+      req.onFail = (callback) => {
+        if (typeof callback !== 'function') {
+          return originalOnFail(callback);
+        }
+        return originalOnFail((error) => runWithScriptContext(scriptContext, () => callback(error)));
+      };
+      restoreOnFail = () => {
+        req.onFail = originalOnFail;
+      };
+    }
+
     const vmFilename = resolveVmFilename(scriptPath, collectionPath);
 
     // Execute the script in the isolated context
@@ -129,6 +146,7 @@ async function runScriptInNodeVm({
       void error.stack;
       throw error;
     } finally {
+      restoreOnFail?.();
       Error.prepareStackTrace = originalPrepareStackTrace;
     }
   } catch (error) {

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -4,7 +4,7 @@ const { get } = require('lodash');
 const lodash = require('lodash');
 const { wrapConsoleWithSerializers } = require('./console');
 const { ScriptError, resolveVmFilename } = require('./utils');
-const { createCustomRequire, runWithScriptContext } = require('./cjs-loader');
+const { createCustomRequire, runWithScriptContext, getSharedNpmContext } = require('./cjs-loader');
 const { safeGlobals } = require('./constants');
 const { mixinTypedArrays } = require('../mixins/typed-arrays');
 const { wrapScriptInClosure, SANDBOX } = require('../../utils/sandbox');
@@ -44,29 +44,32 @@ async function runScriptInNodeVm({
 
     // Build the script context with Bruno objects and globals
     const scriptContext = buildScriptContext(context, scriptingConfig);
-
-    // Create truly isolated context - scriptContext becomes the global object
-    // Scripts can ONLY access what's explicitly in scriptContext
-    const isolatedContext = vm.createContext(scriptContext);
-
-    // Add global/globalThis pointing to the isolated context (not host global)
-    // This allows libraries that reference 'global' to work while maintaining isolation
-    scriptContext.global = scriptContext;
-    scriptContext.globalThis = scriptContext;
-
-    // Create module cache for CJS modules
     const localModuleCache = new Map();
     const cacheModules = get(scriptingConfig, 'cacheModules', false) === true;
 
-    // Add require() function for CJS module loading
+    // cacheModules: one shared VM realm for scripts + npm modules so instanceof
+    // matches. Per-run bru/req/res/require resolve via ALS facades on that realm.
+    // Otherwise: fresh isolated context per script (default).
+    let vmContext;
+    if (cacheModules) {
+      vmContext = getSharedNpmContext();
+    } else {
+      vmContext = vm.createContext(scriptContext);
+      scriptContext.global = scriptContext;
+      scriptContext.globalThis = scriptContext;
+    }
+
     scriptContext.require = createCustomRequire({
       collectionPath,
-      isolatedContext,
+      isolatedContext: vmContext,
       currentModuleDir: collectionPath,
       localModuleCache,
       additionalContextRootsAbsolute,
       cacheModules
     });
+    // Stashed for shared npm requires that outlive this run's createCustomRequire closure.
+    scriptContext.__brunoLocalModuleCache = localModuleCache;
+    scriptContext.__brunoVmContext = vmContext;
 
     const vmFilename = resolveVmFilename(scriptPath, collectionPath);
 
@@ -111,7 +114,7 @@ async function runScriptInNodeVm({
     };
 
     try {
-      const runScript = () => compiledScript.runInContext(isolatedContext, {
+      const runScript = () => compiledScript.runInContext(vmContext, {
         displayErrors: true
       });
       if (cacheModules) {

--- a/packages/bruno-js/src/sandbox/node-vm/index.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.js
@@ -56,6 +56,7 @@ async function runScriptInNodeVm({
 
     // Create module cache for CJS modules
     const localModuleCache = new Map();
+    const cacheModules = get(scriptingConfig, 'cacheModules', false) === true;
 
     // Add require() function for CJS module loading
     scriptContext.require = createCustomRequire({
@@ -63,7 +64,8 @@ async function runScriptInNodeVm({
       isolatedContext,
       currentModuleDir: collectionPath,
       localModuleCache,
-      additionalContextRootsAbsolute
+      additionalContextRootsAbsolute,
+      cacheModules
     });
 
     const vmFilename = resolveVmFilename(scriptPath, collectionPath);
@@ -109,13 +111,16 @@ async function runScriptInNodeVm({
     };
 
     try {
-      // npm modules loaded by this script (or already cached from an earlier one)
-      // resolve `bru`, `req`, `res`, ... against this context while it runs
-      await runWithScriptContext(scriptContext, () =>
-        compiledScript.runInContext(isolatedContext, {
-          displayErrors: true
-        })
-      );
+      const runScript = () => compiledScript.runInContext(isolatedContext, {
+        displayErrors: true
+      });
+      if (cacheModules) {
+        // npm modules loaded by this script (or already cached from an earlier one)
+        // resolve `bru`, `req`, `res`, ... against this context while it runs
+        await runWithScriptContext(scriptContext, runScript);
+      } else {
+        await runScript();
+      }
     } catch (error) {
       // V8 invokes prepareStackTrace lazily on first .stack access.
       // Reading .stack here so custom handler runs and populates error.__callSites

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { runScriptInNodeVm } = require('./index');
+const { __resetNpmModuleStateForTests } = require('./cjs-loader');
 
 // Windows denies symlink creation without developer mode / admin. Probe once at
 // module load so the dependent tests can be marked skipped in the reporter
@@ -614,6 +615,10 @@ describe('node-vm sandbox', () => {
   });
 
   describe('createCustomRequire - npm modules are shared across script executions', () => {
+    beforeEach(() => {
+      __resetNpmModuleStateForTests();
+    });
+
     it('should evaluate an npm module once per process, not once per script context', async () => {
       // Every script execution gets a fresh vm context. Re-evaluating npm modules
       // in each of them made large packages (faker, moment, ...) cost tens of MB
@@ -730,31 +735,6 @@ describe('node-vm sandbox', () => {
       expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
     });
 
-    it('should preserve error call-site mapping for concurrent scripts', async () => {
-      const runFailingScript = (name, delayMs) => runScriptInNodeVm({
-        script: `
-          await new Promise((resolve) => setTimeout(resolve, ${delayMs}));
-          throw new Error('${name}');
-        `,
-        context: { bru: {}, console },
-        collectionPath,
-        scriptPath: path.join(collectionPath, `${name}.bru`),
-        scriptingConfig: {}
-      });
-
-      const [errorA, errorB] = await Promise.all([
-        runFailingScript('script-a', 5).catch((error) => error),
-        runFailingScript('script-b', 40).catch((error) => error)
-      ]);
-
-      expect(errorA.__callSites).toEqual(expect.arrayContaining([
-        expect.objectContaining({ filePath: path.join(collectionPath, 'script-a.bru') })
-      ]));
-      expect(errorB.__callSites).toEqual(expect.arrayContaining([
-        expect.objectContaining({ filePath: path.join(collectionPath, 'script-b.bru') })
-      ]));
-    });
-
     it('should let a module that captured bru at load time talk to the current script', async () => {
       // `const captured = bru` runs once, during the first load (execution A). A plain
       // accessor would hand that module A's bru forever; the facade stays late-bound.
@@ -817,12 +797,11 @@ describe('node-vm sandbox', () => {
       expect(contextB.bru.setVar).toHaveBeenCalledWith('count', 2);
     });
 
-    it('should preserve Bruno global identity and realm behavior inside npm modules', async () => {
+    it('should preserve Bruno global identity and cross-realm behavior inside npm modules', async () => {
       makePkg(path.join(collectionPath, 'node_modules'), 'identity-reader', {
         'index.js': `
           module.exports = {
             sameBru: () => bru === globalThis.bru,
-            bruIsObject: () => bru instanceof Object,
             readArray: (value) => Array.isArray(value)
           };
         `
@@ -833,14 +812,12 @@ describe('node-vm sandbox', () => {
       const script = `
         const reader = require('identity-reader');
         bru.setVar('sameBru', reader.sameBru());
-        bru.setVar('bruIsObject', reader.bruIsObject());
         bru.setVar('arrayIsArray', reader.readArray(array));
       `;
 
       await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
 
       expect(context.bru.setVar).toHaveBeenCalledWith('sameBru', true);
-      expect(context.bru.setVar).toHaveBeenCalledWith('bruIsObject', true);
       expect(context.bru.setVar).toHaveBeenCalledWith('arrayIsArray', true);
     });
 

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -666,6 +666,39 @@ describe('node-vm sandbox', () => {
       expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
     });
 
+    it('should switch req dynamically but preserve the module-load URL snapshot', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'request-url-reader', {
+        'index.js': `
+          const urlAtLoad = req.getUrl();
+          module.exports = {
+            read: () => req.getUrl(),
+            readCaptured: () => urlAtLoad
+          };
+        `
+      });
+
+      const script = `
+        const reader = require('request-url-reader');
+        bru.setVar('dynamicUrl', reader.read());
+        bru.setVar('capturedUrl', reader.readCaptured());
+      `;
+      const makeContext = (url) => ({
+        bru: { setVar: jest.fn() },
+        req: { getUrl: jest.fn().mockReturnValue(url) },
+        console
+      });
+      const contextA = makeContext('https://example.com/a');
+      const contextB = makeContext('https://example.com/b');
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('dynamicUrl', 'https://example.com/a');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('dynamicUrl', 'https://example.com/b');
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('capturedUrl', 'https://example.com/a');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('capturedUrl', 'https://example.com/b');
+    });
+
     it.each([
       ['the first-started script finishes first', 5, 40],
       ['the first-started script finishes last', 40, 5]
@@ -695,6 +728,31 @@ describe('node-vm sandbox', () => {
       expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
       expect(contextA.bru.getVar).toHaveBeenCalledTimes(1);
       expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
+    });
+
+    it('should preserve error call-site mapping for concurrent scripts', async () => {
+      const runFailingScript = (name, delayMs) => runScriptInNodeVm({
+        script: `
+          await new Promise((resolve) => setTimeout(resolve, ${delayMs}));
+          throw new Error('${name}');
+        `,
+        context: { bru: {}, console },
+        collectionPath,
+        scriptPath: path.join(collectionPath, `${name}.bru`),
+        scriptingConfig: {}
+      });
+
+      const [errorA, errorB] = await Promise.all([
+        runFailingScript('script-a', 5).catch((error) => error),
+        runFailingScript('script-b', 40).catch((error) => error)
+      ]);
+
+      expect(errorA.__callSites).toEqual(expect.arrayContaining([
+        expect.objectContaining({ filePath: path.join(collectionPath, 'script-a.bru') })
+      ]));
+      expect(errorB.__callSites).toEqual(expect.arrayContaining([
+        expect.objectContaining({ filePath: path.join(collectionPath, 'script-b.bru') })
+      ]));
     });
 
     it('should let a module that captured bru at load time talk to the current script', async () => {
@@ -740,6 +798,78 @@ describe('node-vm sandbox', () => {
       expect(contextB.bru.getVar).toHaveBeenCalledTimes(2);
     });
 
+    it('should preserve mutable singleton state across script executions', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'stateful-module', {
+        'index.js': `
+          let count = 0;
+          module.exports = { next: () => ++count };
+        `
+      });
+
+      const script = `bru.setVar('count', require('stateful-module').next());`;
+      const contextA = { bru: { setVar: jest.fn() }, console };
+      const contextB = { bru: { setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('count', 1);
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('count', 2);
+    });
+
+    it('should preserve Bruno global identity and realm behavior inside npm modules', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'identity-reader', {
+        'index.js': `
+          module.exports = {
+            sameBru: () => bru === globalThis.bru,
+            bruIsObject: () => bru instanceof Object,
+            readArray: (value) => Array.isArray(value)
+          };
+        `
+      });
+
+      const array = [];
+      const context = { bru: { setVar: jest.fn() }, array, console };
+      const script = `
+        const reader = require('identity-reader');
+        bru.setVar('sameBru', reader.sameBru());
+        bru.setVar('bruIsObject', reader.bruIsObject());
+        bru.setVar('arrayIsArray', reader.readArray(array));
+      `;
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('sameBru', true);
+      expect(context.bru.setVar).toHaveBeenCalledWith('bruIsObject', true);
+      expect(context.bru.setVar).toHaveBeenCalledWith('arrayIsArray', true);
+    });
+
+    it('should bind callbacks created by cached npm modules to their calling script', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'callback-runner', {
+        'index.js': `
+          module.exports = {
+            runLater: (callback) => new Promise((resolve) => {
+              setTimeout(() => { callback(); resolve(); }, 5);
+            })
+          };
+        `
+      });
+
+      const scriptFor = (value) => `
+        await require('callback-runner').runLater(() => bru.setVar('value', '${value}'));
+      `;
+      const contextA = { bru: { setVar: jest.fn() }, console };
+      const contextB = { bru: { setVar: jest.fn() }, console };
+
+      await Promise.all([
+        runScriptInNodeVm({ script: scriptFor('A'), context: contextA, collectionPath, scriptingConfig: {} }),
+        runScriptInNodeVm({ script: scriptFor('B'), context: contextB, collectionPath, scriptingConfig: {} })
+      ]);
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('value', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('value', 'B');
+    });
+
     it('should read a missing key as undefined and still call it once a later execution provides a function', async () => {
       // Execution A exposes `helper` as undefined: the module must see plain undefined (as it
       // would in the script's own context); execution B provides a function and calls it.
@@ -763,6 +893,32 @@ describe('node-vm sandbox', () => {
       expect(contextA.bru.setVar).toHaveBeenCalledWith('probe', 'undefined');
       expect(contextB.bru.setVar).toHaveBeenCalledWith('ran', 'called');
       expect(helper).toHaveBeenCalledWith('x');
+    });
+
+    it('should preserve primitive custom globals for npm modules', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'primitive-reader', {
+        'index.js': `
+          module.exports = {
+            read: () => [typeof scalar, scalar, typeof flag, flag].join(':')
+          };
+        `
+      });
+
+      const context = {
+        bru: { setVar: jest.fn() },
+        scalar: 'value',
+        flag: false,
+        console
+      };
+
+      await runScriptInNodeVm({
+        script: `bru.setVar('result', require('primitive-reader').read());`,
+        context,
+        collectionPath,
+        scriptingConfig: {}
+      });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('result', 'string:value:boolean:false');
     });
 
     it('should keep collection-local modules per script context', async () => {

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -613,6 +613,175 @@ describe('node-vm sandbox', () => {
     });
   });
 
+  describe('createCustomRequire - npm modules are shared across script executions', () => {
+    it('should evaluate an npm module once per process, not once per script context', async () => {
+      // Every script execution gets a fresh vm context. Re-evaluating npm modules
+      // in each of them made large packages (faker, moment, ...) cost tens of MB
+      // per request (usebruno/bruno#9074). The module body increments a host-side
+      // counter so we can count evaluations across two separate executions.
+      const marker = `_npmEvalCount_${Date.now()}`;
+      makePkg(path.join(collectionPath, 'node_modules'), 'counted-module', {
+        'index.js': `
+          process.${marker} = (process.${marker} || 0) + 1;
+          module.exports = { token: Symbol('counted') };
+        `
+      });
+
+      const script = `
+        const mod = require('counted-module');
+        bru.setVar('token', mod.token);
+      `;
+      const contextA = { bru: { setVar: jest.fn() }, console };
+      const contextB = { bru: { setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(process[marker]).toBe(1);
+      // Both scripts got the same module instance
+      expect(contextA.bru.setVar.mock.calls[0][1]).toBe(contextB.bru.setVar.mock.calls[0][1]);
+      delete process[marker];
+    });
+
+    it('should let a cached npm module see the bru of the script currently running', async () => {
+      // A module evaluated during execution A must not keep pointing at A's bru
+      // when it is called from execution B.
+      makePkg(path.join(collectionPath, 'node_modules'), 'bru-reader', {
+        'index.js': `module.exports = { read: (name) => bru.getVar(name) };`
+      });
+
+      const script = `
+        const reader = require('bru-reader');
+        bru.setVar('seen', reader.read('who'));
+      `;
+      const contextA = { bru: { getVar: jest.fn().mockReturnValue('A'), setVar: jest.fn() }, console };
+      const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['the first-started script finishes first', 5, 40],
+      ['the first-started script finishes last', 40, 5]
+    ])('should keep interleaved executions bound to their own bru when %s', async (_, delayA, delayB) => {
+      // Two scripts run concurrently and both await before calling into the same cached
+      // npm module. A global "current context" stack only survives LIFO completion: when
+      // the first-started script finishes first, its module call would read the other
+      // script's bru and its cleanup would pop the other script's entry.
+      makePkg(path.join(collectionPath, 'node_modules'), 'bru-reader-async', {
+        'index.js': `module.exports = { read: (name) => bru.getVar(name) };`
+      });
+
+      const scriptFor = (delayMs) => `
+        const reader = require('bru-reader-async');
+        await new Promise((resolve) => setTimeout(resolve, ${delayMs}));
+        bru.setVar('seen', reader.read('who'));
+      `;
+      const contextA = { bru: { getVar: jest.fn().mockReturnValue('A'), setVar: jest.fn() }, console };
+      const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
+
+      await Promise.all([
+        runScriptInNodeVm({ script: scriptFor(delayA), context: contextA, collectionPath, scriptingConfig: {} }),
+        runScriptInNodeVm({ script: scriptFor(delayB), context: contextB, collectionPath, scriptingConfig: {} })
+      ]);
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
+    });
+
+    it('should let a module that captured bru at load time talk to the current script', async () => {
+      // `const captured = bru` runs once, during the first load (execution A). A plain
+      // accessor would hand that module A's bru forever; the facade stays late-bound.
+      makePkg(path.join(collectionPath, 'node_modules'), 'bru-capturer', {
+        'index.js': `
+          const captured = bru;
+          const { getVar } = bru;
+          module.exports = {
+            viaCaptured: (name) => captured.getVar(name),
+            viaDestructured: (name) => getVar(name),
+            hasSetVar: () => 'setVar' in captured,
+            setThroughCaptured: (name, value) => { captured.setVar(name, value); },
+            types: () => typeof captured + '/' + typeof console + '/' + typeof test
+          };
+        `
+      });
+
+      const script = `
+        const capturer = require('bru-capturer');
+        capturer.setThroughCaptured('seen', capturer.viaCaptured('who') + capturer.viaDestructured('who'));
+        bru.setVar('hasSetVar', capturer.hasSetVar());
+        bru.setVar('types', capturer.types());
+      `;
+      const makeContext = (who) => ({
+        bru: { getVar: jest.fn().mockReturnValue(who), setVar: jest.fn() },
+        test: () => {},
+        console
+      });
+      const contextA = makeContext('A');
+      const contextB = makeContext('B');
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'AA');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'BB');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('hasSetVar', true);
+      // The facades keep the value's typeof: objects stay objects, functions stay callable
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('types', 'object/object/function');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(2);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(2);
+    });
+
+    it('should read a missing key as undefined and still call it once a later execution provides a function', async () => {
+      // Execution A exposes `helper` as undefined: the module must see plain undefined (as it
+      // would in the script's own context); execution B provides a function and calls it.
+      makePkg(path.join(collectionPath, 'node_modules'), 'helper-caller', {
+        'index.js': `module.exports = { probe: () => typeof helper, run: () => helper('x') };`
+      });
+
+      const contextA = { bru: { setVar: jest.fn() }, helper: undefined, console };
+      await runScriptInNodeVm({
+        script: `bru.setVar('probe', require('helper-caller').probe());`,
+        context: contextA, collectionPath, scriptingConfig: {}
+      });
+
+      const helper = jest.fn().mockReturnValue('called');
+      const contextB = { bru: { setVar: jest.fn() }, helper, console };
+      await runScriptInNodeVm({
+        script: `bru.setVar('ran', require('helper-caller').run());`,
+        context: contextB, collectionPath, scriptingConfig: {}
+      });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('probe', 'undefined');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('ran', 'called');
+      expect(helper).toHaveBeenCalledWith('x');
+    });
+
+    it('should keep collection-local modules per script context', async () => {
+      // Local modules may capture per-request state; they keep the per-context cache.
+      const marker = `_localEvalCount_${Date.now()}`;
+      fs.writeFileSync(
+        path.join(collectionPath, 'local-counted.js'),
+        `process.${marker} = (process.${marker} || 0) + 1; module.exports = {};`
+      );
+      const script = `require('./local-counted');`;
+
+      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig: {} });
+
+      expect(process[marker]).toBe(2);
+      delete process[marker];
+    });
+  });
+
   describe('createCustomRequire - Node.js builtin modules', () => {
     it('should load builtin modules (crypto)', async () => {
       const script = `

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -615,6 +615,8 @@ describe('node-vm sandbox', () => {
   });
 
   describe('createCustomRequire - npm modules are shared across script executions', () => {
+    const scriptingConfig = { cacheModules: true };
+
     beforeEach(() => {
       __resetNpmModuleStateForTests();
     });
@@ -639,8 +641,8 @@ describe('node-vm sandbox', () => {
       const contextA = { bru: { setVar: jest.fn() }, console };
       const contextB = { bru: { setVar: jest.fn() }, console };
 
-      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
-      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
 
       expect(process[marker]).toBe(1);
       // Both scripts got the same module instance
@@ -662,8 +664,8 @@ describe('node-vm sandbox', () => {
       const contextA = { bru: { getVar: jest.fn().mockReturnValue('A'), setVar: jest.fn() }, console };
       const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
 
-      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
-      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
       expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
@@ -695,8 +697,8 @@ describe('node-vm sandbox', () => {
       const contextA = makeContext('https://example.com/a');
       const contextB = makeContext('https://example.com/b');
 
-      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
-      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('dynamicUrl', 'https://example.com/a');
       expect(contextB.bru.setVar).toHaveBeenCalledWith('dynamicUrl', 'https://example.com/b');
@@ -725,8 +727,8 @@ describe('node-vm sandbox', () => {
       const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
 
       await Promise.all([
-        runScriptInNodeVm({ script: scriptFor(delayA), context: contextA, collectionPath, scriptingConfig: {} }),
-        runScriptInNodeVm({ script: scriptFor(delayB), context: contextB, collectionPath, scriptingConfig: {} })
+        runScriptInNodeVm({ script: scriptFor(delayA), context: contextA, collectionPath, scriptingConfig }),
+        runScriptInNodeVm({ script: scriptFor(delayB), context: contextB, collectionPath, scriptingConfig })
       ]);
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
@@ -766,8 +768,8 @@ describe('node-vm sandbox', () => {
       const contextA = makeContext('A');
       const contextB = makeContext('B');
 
-      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
-      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'AA');
       expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'BB');
@@ -790,8 +792,8 @@ describe('node-vm sandbox', () => {
       const contextA = { bru: { setVar: jest.fn() }, console };
       const contextB = { bru: { setVar: jest.fn() }, console };
 
-      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig: {} });
-      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('count', 1);
       expect(contextB.bru.setVar).toHaveBeenCalledWith('count', 2);
@@ -815,7 +817,7 @@ describe('node-vm sandbox', () => {
         bru.setVar('arrayIsArray', reader.readArray(array));
       `;
 
-      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig });
 
       expect(context.bru.setVar).toHaveBeenCalledWith('sameBru', true);
       expect(context.bru.setVar).toHaveBeenCalledWith('arrayIsArray', true);
@@ -839,8 +841,8 @@ describe('node-vm sandbox', () => {
       const contextB = { bru: { setVar: jest.fn() }, console };
 
       await Promise.all([
-        runScriptInNodeVm({ script: scriptFor('A'), context: contextA, collectionPath, scriptingConfig: {} }),
-        runScriptInNodeVm({ script: scriptFor('B'), context: contextB, collectionPath, scriptingConfig: {} })
+        runScriptInNodeVm({ script: scriptFor('A'), context: contextA, collectionPath, scriptingConfig }),
+        runScriptInNodeVm({ script: scriptFor('B'), context: contextB, collectionPath, scriptingConfig })
       ]);
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('value', 'A');
@@ -857,14 +859,14 @@ describe('node-vm sandbox', () => {
       const contextA = { bru: { setVar: jest.fn() }, helper: undefined, console };
       await runScriptInNodeVm({
         script: `bru.setVar('probe', require('helper-caller').probe());`,
-        context: contextA, collectionPath, scriptingConfig: {}
+        context: contextA, collectionPath, scriptingConfig
       });
 
       const helper = jest.fn().mockReturnValue('called');
       const contextB = { bru: { setVar: jest.fn() }, helper, console };
       await runScriptInNodeVm({
         script: `bru.setVar('ran', require('helper-caller').run());`,
-        context: contextB, collectionPath, scriptingConfig: {}
+        context: contextB, collectionPath, scriptingConfig
       });
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('probe', 'undefined');
@@ -892,7 +894,7 @@ describe('node-vm sandbox', () => {
         script: `bru.setVar('result', require('primitive-reader').read());`,
         context,
         collectionPath,
-        scriptingConfig: {}
+        scriptingConfig
       });
 
       expect(context.bru.setVar).toHaveBeenCalledWith('result', 'string:value:boolean:false');
@@ -907,8 +909,8 @@ describe('node-vm sandbox', () => {
       );
       const script = `require('./local-counted');`;
 
-      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig: {} });
-      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig: {} });
+      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: { bru: {}, console }, collectionPath, scriptingConfig });
 
       expect(process[marker]).toBe(2);
       delete process[marker];

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -898,6 +898,35 @@ describe('node-vm sandbox', () => {
       expect(contextB.bru.setVar).toHaveBeenCalledWith('value', 'B');
     });
 
+    it('should keep bru available when req.onFail runs after the script ends', async () => {
+      let onFailHandler;
+      const req = {
+        onFail(callback) {
+          onFailHandler = callback;
+        }
+      };
+      const context = {
+        bru: { setVar: jest.fn() },
+        req,
+        console
+      };
+
+      await runScriptInNodeVm({
+        script: `
+          req.onFail(() => {
+            bru.setVar('token', 'after');
+          });
+        `,
+        context,
+        collectionPath,
+        scriptingConfig
+      });
+
+      expect(typeof onFailHandler).toBe('function');
+      onFailHandler(new Error('Connection failed'));
+      expect(context.bru.setVar).toHaveBeenCalledWith('token', 'after');
+    });
+
     it('should read a missing key as undefined and still call it once a later execution provides a function', async () => {
       makePkg(path.join(collectionPath, 'node_modules'), 'helper-caller', {
         'index.js': `module.exports = { probe: () => typeof helper, run: () => helper('x') };`

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -927,6 +927,67 @@ describe('node-vm sandbox', () => {
       expect(context.bru.setVar).toHaveBeenCalledWith('token', 'after');
     });
 
+    it('should restore req.onFail after a syntax-error run so a later run uses a fresh wrapper', async () => {
+      let onFailHandler;
+      const req = {
+        onFail(callback) {
+          onFailHandler = callback;
+        }
+      };
+      const originalOnFail = req.onFail;
+
+      await expect(
+        runScriptInNodeVm({
+          script: 'this is not valid js {{{',
+          context: { bru: {}, req, console },
+          collectionPath,
+          scriptingConfig
+        })
+      ).rejects.toThrow();
+
+      expect(req.onFail).toBe(originalOnFail);
+
+      const context = {
+        bru: { setVar: jest.fn() },
+        req,
+        console
+      };
+      await runScriptInNodeVm({
+        script: `
+          req.onFail(() => {
+            bru.setVar('token', 'after');
+          });
+        `,
+        context,
+        collectionPath,
+        scriptingConfig
+      });
+
+      expect(typeof onFailHandler).toBe('function');
+      onFailHandler(new Error('Connection failed'));
+      expect(context.bru.setVar).toHaveBeenCalledWith('token', 'after');
+    });
+
+    it('should not expose loader internals as script globals', async () => {
+      const context = {
+        bru: { setVar: jest.fn() },
+        console
+      };
+
+      await runScriptInNodeVm({
+        script: `
+          bru.setVar('vm', typeof __brunoVmContext);
+          bru.setVar('cache', typeof __brunoLocalModuleCache);
+        `,
+        context,
+        collectionPath,
+        scriptingConfig
+      });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('vm', 'undefined');
+      expect(context.bru.setVar).toHaveBeenCalledWith('cache', 'undefined');
+    });
+
     it('should read a missing key as undefined and still call it once a later execution provides a function', async () => {
       makePkg(path.join(collectionPath, 'node_modules'), 'helper-caller', {
         'index.js': `module.exports = { probe: () => typeof helper, run: () => helper('x') };`

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -900,6 +900,54 @@ describe('node-vm sandbox', () => {
       expect(context.bru.setVar).toHaveBeenCalledWith('result', 'string:value:boolean:false');
     });
 
+    it('should re-evaluate a parent that snapshots a context-bound dependency at load time', async () => {
+      // leaf reads bru during evaluation; parent re-exports that snapshot without touching bru
+      // itself. Context-bound status must propagate so script B does not see A's value.
+      makePkg(path.join(collectionPath, 'node_modules'), 'leaf-bru-snapshot', {
+        'index.js': `module.exports = { who: bru.getVar('who') };`
+      });
+      makePkg(path.join(collectionPath, 'node_modules'), 'parent-bru-snapshot', {
+        'index.js': `
+          const leaf = require('leaf-bru-snapshot');
+          module.exports = { who: leaf.who };
+        `
+      });
+
+      const script = `bru.setVar('seen', require('parent-bru-snapshot').who);`;
+      const contextA = { bru: { getVar: jest.fn().mockReturnValue('A'), setVar: jest.fn() }, console };
+      const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+    });
+
+    it('should still share an inert transitive npm module tree across scripts', async () => {
+      const marker = `_inertParentEval_${Date.now()}`;
+      makePkg(path.join(collectionPath, 'node_modules'), 'inert-leaf', {
+        'index.js': `module.exports = { token: Symbol('inert') };`
+      });
+      makePkg(path.join(collectionPath, 'node_modules'), 'inert-parent', {
+        'index.js': `
+          process.${marker} = (process.${marker} || 0) + 1;
+          module.exports = { token: require('inert-leaf').token };
+        `
+      });
+
+      const script = `bru.setVar('token', require('inert-parent').token);`;
+      const contextA = { bru: { setVar: jest.fn() }, console };
+      const contextB = { bru: { setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
+
+      expect(process[marker]).toBe(1);
+      expect(contextA.bru.setVar.mock.calls[0][1]).toBe(contextB.bru.setVar.mock.calls[0][1]);
+      delete process[marker];
+    });
+
     it('should keep collection-local modules per script context', async () => {
       // Local modules may capture per-request state; they keep the per-context cache.
       const marker = `_localEvalCount_${Date.now()}`;

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -622,10 +622,6 @@ describe('node-vm sandbox', () => {
     });
 
     it('should evaluate an npm module once per process, not once per script context', async () => {
-      // Every script execution gets a fresh vm context. Re-evaluating npm modules
-      // in each of them made large packages (faker, moment, ...) cost tens of MB
-      // per request (usebruno/bruno#9074). The module body increments a host-side
-      // counter so we can count evaluations across two separate executions.
       const marker = `_npmEvalCount_${Date.now()}`;
       makePkg(path.join(collectionPath, 'node_modules'), 'counted-module', {
         'index.js': `
@@ -645,14 +641,11 @@ describe('node-vm sandbox', () => {
       await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
 
       expect(process[marker]).toBe(1);
-      // Both scripts got the same module instance
       expect(contextA.bru.setVar.mock.calls[0][1]).toBe(contextB.bru.setVar.mock.calls[0][1]);
       delete process[marker];
     });
 
     it('should let a cached npm module see the bru of the script currently running', async () => {
-      // A module evaluated during execution A must not keep pointing at A's bru
-      // when it is called from execution B.
       makePkg(path.join(collectionPath, 'node_modules'), 'bru-reader', {
         'index.js': `module.exports = { read: (name) => bru.getVar(name) };`
       });
@@ -710,10 +703,6 @@ describe('node-vm sandbox', () => {
       ['the first-started script finishes first', 5, 40],
       ['the first-started script finishes last', 40, 5]
     ])('should keep interleaved executions bound to their own bru when %s', async (_, delayA, delayB) => {
-      // Two scripts run concurrently and both await before calling into the same cached
-      // npm module. A global "current context" stack only survives LIFO completion: when
-      // the first-started script finishes first, its module call would read the other
-      // script's bru and its cleanup would pop the other script's entry.
       makePkg(path.join(collectionPath, 'node_modules'), 'bru-reader-async', {
         'index.js': `module.exports = { read: (name) => bru.getVar(name) };`
       });
@@ -738,8 +727,6 @@ describe('node-vm sandbox', () => {
     });
 
     it('should let a module that captured bru at load time talk to the current script', async () => {
-      // `const captured = bru` runs once, during the first load (execution A). A plain
-      // accessor would hand that module A's bru forever; the facade stays late-bound.
       makePkg(path.join(collectionPath, 'node_modules'), 'bru-capturer', {
         'index.js': `
           const captured = bru;
@@ -774,7 +761,6 @@ describe('node-vm sandbox', () => {
       expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'AA');
       expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'BB');
       expect(contextB.bru.setVar).toHaveBeenCalledWith('hasSetVar', true);
-      // The facades keep the value's typeof: objects stay objects, functions stay callable
       expect(contextB.bru.setVar).toHaveBeenCalledWith('types', 'object/object/function');
       expect(contextA.bru.getVar).toHaveBeenCalledTimes(2);
       expect(contextB.bru.getVar).toHaveBeenCalledTimes(2);
@@ -850,8 +836,6 @@ describe('node-vm sandbox', () => {
     });
 
     it('should read a missing key as undefined and still call it once a later execution provides a function', async () => {
-      // Execution A exposes `helper` as undefined: the module must see plain undefined (as it
-      // would in the script's own context); execution B provides a function and calls it.
       makePkg(path.join(collectionPath, 'node_modules'), 'helper-caller', {
         'index.js': `module.exports = { probe: () => typeof helper, run: () => helper('x') };`
       });
@@ -901,8 +885,6 @@ describe('node-vm sandbox', () => {
     });
 
     it('should re-evaluate a parent that snapshots a context-bound dependency at load time', async () => {
-      // leaf reads bru during evaluation; parent re-exports that snapshot without touching bru
-      // itself. Context-bound status must propagate so script B does not see A's value.
       makePkg(path.join(collectionPath, 'node_modules'), 'leaf-bru-snapshot', {
         'index.js': `module.exports = { who: bru.getVar('who') };`
       });
@@ -985,7 +967,6 @@ describe('node-vm sandbox', () => {
     });
 
     it('should keep collection-local modules per script context', async () => {
-      // Local modules may capture per-request state; they keep the per-context cache.
       const marker = `_localEvalCount_${Date.now()}`;
       fs.writeFileSync(
         path.join(collectionPath, 'local-counted.js'),

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -645,6 +645,69 @@ describe('node-vm sandbox', () => {
       delete process[marker];
     });
 
+    it('should keep Date/Array/Object instanceof true for values from cached npm modules', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'realm-values', {
+        'index.js': `
+          module.exports = {
+            date: () => new Date(0),
+            array: () => [1],
+            object: () => ({ a: 1 }),
+            map: () => new Map([['k', 1]]),
+            set: () => new Set([1]),
+            regexp: () => /x/,
+            error: () => new Error('e')
+          };
+        `
+      });
+
+      const script = `
+        const v = require('realm-values');
+        bru.setVar('checks', [
+          v.date() instanceof Date,
+          v.array() instanceof Array,
+          v.object() instanceof Object,
+          v.map() instanceof Map,
+          v.set() instanceof Set,
+          v.regexp() instanceof RegExp,
+          v.error() instanceof Error
+        ].every(Boolean));
+      `;
+      const context = { bru: { setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context, collectionPath, scriptingConfig });
+
+      expect(context.bru.setVar).toHaveBeenCalledWith('checks', true);
+    });
+
+    it('should not let Object.freeze(bru) in one script poison later scripts', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'bru-freezer', {
+        'index.js': `
+          module.exports = {
+            freeze: () => { Object.freeze(bru); return true; },
+            read: (name) => bru.getVar(name)
+          };
+        `
+      });
+
+      const freezeScript = `
+        bru.setVar('froze', require('bru-freezer').freeze());
+      `;
+      const readScript = `
+        bru.setVar('seen', require('bru-freezer').read('who'));
+      `;
+      const contextA = { bru: { getVar: jest.fn(), setVar: jest.fn() }, console };
+      const contextB = {
+        bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() },
+        console
+      };
+
+      await runScriptInNodeVm({ script: freezeScript, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script: readScript, context: contextB, collectionPath, scriptingConfig });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('froze', true);
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+    });
+
     it('should let a cached npm module see the bru of the script currently running', async () => {
       makePkg(path.join(collectionPath, 'node_modules'), 'bru-reader', {
         'index.js': `module.exports = { read: (name) => bru.getVar(name) };`
@@ -964,6 +1027,100 @@ describe('node-vm sandbox', () => {
       expect(process[marker]).toBe(1);
       expect(contextA.bru.setVar.mock.calls[0][1]).toBe(contextB.bru.setVar.mock.calls[0][1]);
       delete process[marker];
+    });
+
+    it('should re-evaluate a context-bound leaf required lazily from a shared parent', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'lazy-leaf-bru', {
+        'index.js': `
+          let calls = 0;
+          calls += 1;
+          const who = bru.getVar('who');
+          module.exports = {
+            calls: () => calls,
+            who: () => who,
+            liveWho: () => bru.getVar('who')
+          };
+        `
+      });
+      makePkg(path.join(collectionPath, 'node_modules'), 'lazy-parent-inert', {
+        'index.js': `
+          module.exports = {
+            loadLeaf: () => require('lazy-leaf-bru')
+          };
+        `
+      });
+
+      const script = `
+        const leaf = require('lazy-parent-inert').loadLeaf();
+        bru.setVar('calls', leaf.calls());
+        bru.setVar('who', leaf.who());
+        bru.setVar('liveWho', leaf.liveWho());
+      `;
+      const makeContext = (who) => ({
+        bru: { getVar: jest.fn().mockReturnValue(who), setVar: jest.fn() },
+        console
+      });
+      const contextA = makeContext('A');
+      const contextB = makeContext('B');
+      const contextC = makeContext('C');
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextC, collectionPath, scriptingConfig });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('calls', 1);
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('calls', 1);
+      expect(contextC.bru.setVar).toHaveBeenCalledWith('calls', 1);
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('who', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('who', 'B');
+      expect(contextC.bru.setVar).toHaveBeenCalledWith('who', 'C');
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('liveWho', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('liveWho', 'B');
+      expect(contextC.bru.setVar).toHaveBeenCalledWith('liveWho', 'C');
+    });
+
+    it('should re-evaluate both sides of a context-bound circular npm dependency', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'cycle-a', {
+        'index.js': `
+          let calls = 0;
+          calls += 1;
+          exports.calls = () => calls;
+          exports.who = bru.getVar('who');
+          const b = require('cycle-b');
+          exports.fromB = () => b.aWho();
+        `
+      });
+      makePkg(path.join(collectionPath, 'node_modules'), 'cycle-b', {
+        'index.js': `
+          // Inert at load except for the cycle edge — must not stay shared with
+          // a stale capture of cycle-a's exports across script runs.
+          const a = require('cycle-a');
+          exports.aWho = () => a.who;
+        `
+      });
+
+      const script = `
+        const a = require('cycle-a');
+        bru.setVar('calls', a.calls());
+        bru.setVar('who', a.who);
+        bru.setVar('fromB', a.fromB());
+      `;
+      const makeContext = (who) => ({
+        bru: { getVar: jest.fn().mockReturnValue(who), setVar: jest.fn() },
+        console
+      });
+      const contextA = makeContext('A');
+      const contextB = makeContext('B');
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('calls', 1);
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('calls', 1);
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('who', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('who', 'B');
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('fromB', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('fromB', 'B');
     });
 
     it('should keep collection-local modules per script context', async () => {

--- a/packages/bruno-js/src/sandbox/node-vm/index.spec.js
+++ b/packages/bruno-js/src/sandbox/node-vm/index.spec.js
@@ -922,6 +922,42 @@ describe('node-vm sandbox', () => {
 
       expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
       expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextA.bru.setVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.setVar).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-evaluate a three-level parent chain that snapshots bru at the leaf', async () => {
+      makePkg(path.join(collectionPath, 'node_modules'), 'deep-leaf-bru', {
+        'index.js': `module.exports = { who: bru.getVar('who') };`
+      });
+      makePkg(path.join(collectionPath, 'node_modules'), 'deep-mid-bru', {
+        'index.js': `
+          const leaf = require('deep-leaf-bru');
+          module.exports = { who: leaf.who };
+        `
+      });
+      makePkg(path.join(collectionPath, 'node_modules'), 'deep-root-bru', {
+        'index.js': `
+          const mid = require('deep-mid-bru');
+          module.exports = { who: mid.who };
+        `
+      });
+
+      const script = `bru.setVar('seen', require('deep-root-bru').who);`;
+      const contextA = { bru: { getVar: jest.fn().mockReturnValue('A'), setVar: jest.fn() }, console };
+      const contextB = { bru: { getVar: jest.fn().mockReturnValue('B'), setVar: jest.fn() }, console };
+
+      await runScriptInNodeVm({ script, context: contextA, collectionPath, scriptingConfig });
+      await runScriptInNodeVm({ script, context: contextB, collectionPath, scriptingConfig });
+
+      expect(contextA.bru.setVar).toHaveBeenCalledWith('seen', 'A');
+      expect(contextB.bru.setVar).toHaveBeenCalledWith('seen', 'B');
+      expect(contextA.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.getVar).toHaveBeenCalledTimes(1);
+      expect(contextA.bru.setVar).toHaveBeenCalledTimes(1);
+      expect(contextB.bru.setVar).toHaveBeenCalledTimes(1);
     });
 
     it('should still share an inert transitive npm module tree across scripts', async () => {

--- a/packages/bruno-js/tests/runtime-cache-modules.spec.js
+++ b/packages/bruno-js/tests/runtime-cache-modules.spec.js
@@ -553,7 +553,6 @@ describe('runtime (cacheModules)', () => {
       return assertRuntime.runAssertions(assertions, { ...baseRequest }, response, {}, runtimeVariables, process.env);
     };
 
-    // Ensures each QuickJS evaluation gets a fresh context
     describe('quickjs context isolation across iterations', () => {
       const ITERATION_COUNT = 350;
 
@@ -581,14 +580,12 @@ describe('runtime (cacheModules)', () => {
       });
 
       it('should not return stale data from a previous iteration', () => {
-        // First call with status 200
         runAssertions(
           [{ name: 'res.status', value: 'eq 200', enabled: true }],
           { status: 200, statusText: 'OK', data: { token: 'bearer_abc' }, headers: { authorization: 'bearer xyz' } },
           'quickjs'
         );
 
-        // Second call with status 404 — must not return 200 or any data from previous call
         const results = runAssertions(
           [
             { name: 'res.status', value: 'eq 404', enabled: true },
@@ -603,7 +600,6 @@ describe('runtime (cacheModules)', () => {
       });
 
       it('should not persist runtime variables from a previous call', () => {
-        // First call with runtime variable token = "one"
         const results1 = runAssertions(
           [{ name: 'token', value: 'eq one', enabled: true }],
           { status: 200, statusText: 'OK', data: {}, headers: {} },
@@ -612,13 +608,11 @@ describe('runtime (cacheModules)', () => {
         );
         expect(results1[0].status).toBe('pass');
 
-        // Second call without token
         const results2 = runAssertions(
           [{ name: 'token', value: 'eq one', enabled: true }],
           { status: 200, statusText: 'OK', data: {}, headers: {} },
           'quickjs'
         );
-        // Must fail — token should not exist in a fresh context
         expect(results2[0].status).toBe('fail');
       });
     });
@@ -643,8 +637,6 @@ describe('runtime (cacheModules)', () => {
       it('should pass for objects from a different realm (e.g. after res.setBody in node-vm)', async () => {
         const response = makeResponse({ id: 1, name: 'original' });
 
-        // res.setBody() inside node-vm creates a cross-realm object whose
-        // constructor is the VM's Object, not the host's Object
         const scriptRuntime = new ScriptRuntime({ runtime: 'nodevm' });
         await scriptRuntime.runResponseScript(
           `res.setBody({ id: 2, name: 'updated' });`,

--- a/packages/bruno-js/tests/runtime-cache-modules.spec.js
+++ b/packages/bruno-js/tests/runtime-cache-modules.spec.js
@@ -1,0 +1,808 @@
+const { describe, it, expect, beforeAll } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const TestRuntime = require('../src/runtime/test-runtime');
+const ScriptRuntime = require('../src/runtime/script-runtime');
+const AssertRuntime = require('../src/runtime/assert-runtime');
+const { loader: quickJsLoader } = require('../src/sandbox/quickjs');
+const { makeNpmModule } = require('./utils/helpers');
+
+const scriptingConfig = { cacheModules: true };
+
+describe('runtime (cacheModules)', () => {
+  describe('test-runtime', () => {
+    const baseRequest = {
+      method: 'GET',
+      url: 'http://localhost:3000/',
+      headers: {},
+      data: undefined
+    };
+    const baseResponse = {
+      status: 200,
+      statusText: 'OK',
+      data: [
+        {
+          id: 1
+        },
+        {
+          id: 2
+        },
+        {
+          id: 3
+        }
+      ]
+    };
+
+    it('should wait async tests', async () => {
+      const testFile = `
+                await test('async test', ()=> {
+                    return new Promise((resolve)=> {
+                        setTimeout(()=> {resolve()},200)
+                    })
+                })
+            `;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env,
+        scriptingConfig
+      );
+      expect(result.results.map((el) => ({ description: el.description, status: el.status }))).toEqual([
+        { description: 'async test', status: 'pass' }
+      ]);
+    });
+
+    it('should have ajv and ajv-formats dependencies available', async () => {
+      const testFile = `
+                const Ajv = require('ajv');
+                const addFormats = require("ajv-formats");
+                const ajv = new Ajv();
+                addFormats(ajv);
+                
+                const schema = {
+                  type: 'string',
+                  format: 'date-time'
+                };
+                
+                const validate = ajv.compile(schema)
+                
+                test('format valid', () => {
+                  const valid = validate(new Date().toISOString())
+                  expect(valid).to.be.true;
+                })
+            `;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env,
+        scriptingConfig
+      );
+      expect(result.results.map((el) => ({ description: el.description, status: el.status }))).toEqual([
+        { description: 'format valid', status: 'pass' }
+      ]);
+    });
+
+    it('should expose test and jwt through a cached npm module', async () => {
+      const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+      try {
+        makeNpmModule(collectionPath, 'test-runtime-reader', `
+          module.exports = {
+            read: () => typeof test + ':' + typeof jwt.sign
+          };
+        `);
+
+        const runtime = new TestRuntime({ runtime: 'nodevm' });
+        const result = await runtime.runTests(
+          `
+            test('cached runtime globals', () => {
+              expect(require('test-runtime-reader').read()).to.equal('function:function');
+            });
+          `,
+          { ...baseRequest },
+          { ...baseResponse },
+          {},
+          {},
+          collectionPath,
+          null,
+          process.env,
+          scriptingConfig
+        );
+
+        expect(result.results).toEqual([
+          expect.objectContaining({ description: 'cached runtime globals', status: 'pass' })
+        ]);
+      } finally {
+        fs.rmSync(collectionPath, { recursive: true, force: true });
+      }
+    });
+
+    it('should return stopExecution when bru.runner.stopExecution() is called in tests (nodevm)', async () => {
+      const testFile = `bru.runner.stopExecution();`;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env,
+        scriptingConfig
+      );
+      expect(result.stopExecution).toBe(true);
+    });
+
+    it('should return stopExecution when bru.runner.stopExecution() is called in tests (quickjs)', async () => {
+      const testFile = `bru.runner.stopExecution();`;
+
+      const runtime = new TestRuntime({ runtime: 'quickjs' });
+      const onConsoleLog = () => {};
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        onConsoleLog,
+        process.env,
+        scriptingConfig
+      );
+      expect(result.stopExecution).toBe(true);
+    });
+
+    it('should not set stopExecution when bru.runner.stopExecution() is not called', async () => {
+      const testFile = `test('noop', () => { expect(true).to.be.true; });`;
+
+      const runtime = new TestRuntime({ runtime: 'nodevm' });
+      const result = await runtime.runTests(
+        testFile,
+        { ...baseRequest },
+        { ...baseResponse },
+        {},
+        {},
+        '.',
+        null,
+        process.env,
+        scriptingConfig
+      );
+      expect(result.stopExecution).toBeFalsy();
+    });
+  });
+
+  describe('script-runtime', () => {
+    describe('run-request-script', () => {
+      const baseRequest = {
+        method: 'GET',
+        url: 'http://localhost:3000/',
+        headers: {},
+        data: undefined
+      };
+
+      it('should have ajv and ajv-formats dependencies available', async () => {
+        const script = `
+                  const Ajv = require('ajv');
+                  const addFormats = require("ajv-formats");
+                  const ajv = new Ajv();
+                  addFormats(ajv);
+                  
+                  const schema = {
+                    type: 'string',
+                    format: 'date-time'
+                  };
+                  
+                  const validate = ajv.compile(schema)
+                  
+                  bru.setVar('validation', validate(new Date().toISOString()))
+              `;
+
+        const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+        const result = await runtime.runRequestScript(script, { ...baseRequest }, {}, {}, '.', null, process.env, scriptingConfig);
+        expect(result.runtimeVariables.validation).toBeTruthy();
+      });
+
+      it('should expose the real request runtime through a cached npm module', async () => {
+        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+        try {
+          makeNpmModule(collectionPath, 'request-runtime-reader', `
+            module.exports = {
+              read: () => req.getMethod() + ':' + req.getUrl()
+            };
+          `);
+
+          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+          const result = await runtime.runRequestScript(
+            `bru.setVar('runtime', require('request-runtime-reader').read());`,
+            {
+              method: 'POST',
+              url: 'http://localhost:3000/runtime',
+              headers: {},
+              data: undefined
+            },
+            {},
+            {},
+            collectionPath,
+            null,
+            process.env,
+            scriptingConfig
+          );
+
+          expect(result.runtimeVariables.runtime).toBe('POST:http://localhost:3000/runtime');
+        } finally {
+          fs.rmSync(collectionPath, { recursive: true, force: true });
+        }
+      });
+
+      it('should expose each request URL to a cached module across sequential runs', async () => {
+        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+        try {
+          makeNpmModule(collectionPath, 'sequential-request-reader', `
+            const urlAtLoad = req.getUrl();
+            module.exports = {
+              dynamic: () => req.getUrl(),
+              captured: () => urlAtLoad
+            };
+          `);
+
+          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+          const run = (url) => runtime.runRequestScript(
+            `
+              const reader = require('sequential-request-reader');
+              bru.setVar('dynamicUrl', reader.dynamic());
+              bru.setVar('capturedUrl', reader.captured());
+            `,
+            { method: 'GET', url, headers: {}, data: undefined },
+            {},
+            {},
+            collectionPath,
+            null,
+            process.env,
+            scriptingConfig
+          );
+
+          const first = await run('https://example.com/first');
+          const second = await run('https://example.com/second');
+
+          expect(first.runtimeVariables.dynamicUrl).toBe('https://example.com/first');
+          expect(second.runtimeVariables.dynamicUrl).toBe('https://example.com/second');
+          expect(first.runtimeVariables.capturedUrl).toBe('https://example.com/first');
+          expect(second.runtimeVariables.capturedUrl).toBe('https://example.com/second');
+        } finally {
+          fs.rmSync(collectionPath, { recursive: true, force: true });
+        }
+      });
+
+      it('should return variable updates made in req.onFail', async () => {
+        const script = `
+          bru.setVar('runtimeToken', 'before');
+          bru.setEnvVar('environmentToken', 'before');
+          bru.setGlobalEnvVar('globalToken', 'before');
+
+          req.onFail(() => {
+            bru.setVar('runtimeToken', 'after');
+            bru.setEnvVar('environmentToken', 'after');
+            bru.setGlobalEnvVar('globalToken', 'after');
+          });
+        `;
+        const request = { ...baseRequest };
+        const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+        await runtime.runRequestScript(script, request, {}, {}, '.', null, process.env, scriptingConfig);
+        const result = await request.onFailHandler(new Error('Connection failed'));
+
+        expect(result.runtimeVariables.runtimeToken).toBe('after');
+        expect(result.envVariables.environmentToken).toBe('after');
+        expect(result.globalEnvironmentVariables.globalToken).toBe('after');
+      });
+    });
+
+    describe('run-response-script', () => {
+      const baseRequest = {
+        method: 'GET',
+        url: 'http://localhost:3000/',
+        headers: {},
+        data: undefined
+      };
+      const baseResponse = {
+        status: 200,
+        statusText: 'OK',
+        data: [
+          {
+            id: 1
+          },
+          {
+            id: 2
+          },
+          {
+            id: 3
+          }
+        ]
+      };
+
+      it('should have ajv and ajv-formats dependencies available', async () => {
+        const script = `
+                  const Ajv = require('ajv');
+                  const addFormats = require("ajv-formats");
+                  const ajv = new Ajv();
+                  addFormats(ajv);
+                  
+                  const schema = {
+                    type: 'string',
+                    format: 'date-time'
+                  };
+                  
+                  const validate = ajv.compile(schema)
+                  
+                  bru.setVar('validation', validate(new Date().toISOString()))
+              `;
+
+        const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+        const result = await runtime.runResponseScript(
+          script,
+          { ...baseRequest },
+          { ...baseResponse },
+          {},
+          {},
+          '.',
+          null,
+          process.env,
+          scriptingConfig
+        );
+        expect(result.runtimeVariables.validation).toBeTruthy();
+      });
+
+      it('should expose the real response runtime through a cached npm module', async () => {
+        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+        try {
+          makeNpmModule(collectionPath, 'response-runtime-reader', `
+            module.exports = {
+              read: () => res.getStatus() + ':' + res.getHeader('content-type')
+            };
+          `);
+
+          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+          const result = await runtime.runResponseScript(
+            `bru.setVar('runtime', require('response-runtime-reader').read());`,
+            {
+              method: 'GET',
+              url: 'http://localhost:3000/',
+              headers: {},
+              data: undefined
+            },
+            {
+              status: 201,
+              statusText: 'Created',
+              headers: { 'content-type': 'application/json' },
+              data: {}
+            },
+            {},
+            {},
+            collectionPath,
+            null,
+            process.env,
+            scriptingConfig
+          );
+
+          expect(result.runtimeVariables.runtime).toBe('201:application/json');
+        } finally {
+          fs.rmSync(collectionPath, { recursive: true, force: true });
+        }
+      });
+    });
+  });
+
+  describe('environment variables from scripts', () => {
+    it('should allow any value type', async () => {
+      const script = `
+        bru.setEnvVar('str', 'hello');
+        bru.setEnvVar('number', 42);
+        bru.setEnvVar('boolean', true);
+        bru.setEnvVar('object', {key: 'value'});
+        bru.setEnvVar('array', [1, 2, 3]);
+      `;
+      const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+      const result = await runtime.runRequestScript(script, {}, {}, {}, '.', null, process.env, scriptingConfig);
+
+      expect(result.envVariables.str).toBe('hello');
+      expect(result.envVariables.number).toBe(42);
+      expect(result.envVariables.boolean).toBe(true);
+      expect(result.envVariables.object).toEqual({ key: 'value' });
+      expect(result.envVariables.array).toEqual([1, 2, 3]);
+    });
+
+    it('should preserve typed values through the QuickJS shim', async () => {
+      await quickJsLoader();
+      const script = `
+        bru.setEnvVar('num', 42);
+        bru.setEnvVar('bool', true);
+        bru.setEnvVar('obj', { key: 'value' });
+        bru.setCollectionVar('collNum', 7);
+        bru.setGlobalEnvVar('globalBool', false);
+      `;
+      const runtime = new ScriptRuntime({ runtime: 'quickjs' });
+      const onConsoleLog = () => {};
+
+      const result = await runtime.runRequestScript(script, {}, {}, {}, '.', onConsoleLog, process.env, scriptingConfig);
+
+      expect(typeof result.envVariables.num).toBe('number');
+      expect(result.envVariables.num).toBe(42);
+      expect(typeof result.envVariables.bool).toBe('boolean');
+      expect(result.envVariables.bool).toBe(true);
+      expect(typeof result.envVariables.obj).toBe('object');
+      expect(result.envVariables.obj).toEqual({ key: 'value' });
+      expect(typeof result.collectionVariables.collNum).toBe('number');
+      expect(result.collectionVariables.collNum).toBe(7);
+      expect(typeof result.globalEnvironmentVariables.globalBool).toBe('boolean');
+      expect(result.globalEnvironmentVariables.globalBool).toBe(false);
+    });
+
+    it('should return null for scopes the script did not touch (dirty-flag gating)', async () => {
+      const script = `bru.setEnvVar('only_env', 'val');`;
+      const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+      const result = await runtime.runRequestScript(script, {}, {}, {}, '.', null, process.env, scriptingConfig);
+
+      expect(result.envVariables).not.toBeNull();
+      expect(result.envVariables.only_env).toBe('val');
+      expect(result.collectionVariables).toBeNull();
+      expect(result.globalEnvironmentVariables).toBeNull();
+    });
+
+    it('should return null for scopes the script did not touch — QuickJS parity', async () => {
+      await quickJsLoader();
+      const script = `bru.setEnvVar('only_env', 'val');`;
+      const runtime = new ScriptRuntime({ runtime: 'quickjs' });
+      const onConsoleLog = () => {};
+
+      const result = await runtime.runRequestScript(script, {}, {}, {}, '.', onConsoleLog, process.env, scriptingConfig);
+
+      expect(result.envVariables).not.toBeNull();
+      expect(result.envVariables.only_env).toBe('val');
+      expect(result.collectionVariables).toBeNull();
+      expect(result.globalEnvironmentVariables).toBeNull();
+    });
+
+    it('should include collectionVariables in result', async () => {
+      const script = `bru.setCollectionVar('myVar', 'myValue');`;
+      const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+      const result = await runtime.runRequestScript(script, {}, {}, {}, '.', null, process.env, scriptingConfig);
+
+      expect(result.collectionVariables).toBeDefined();
+      expect(result.collectionVariables.myVar).toBe('myValue');
+    });
+
+    it('should silently ignore old persist flag as extra argument', async () => {
+      const scriptTrue = `bru.setEnvVar('key1', 'val1', { persist: true });`;
+      const scriptFalse = `bru.setEnvVar('key2', 'val2', { persist: false });`;
+      const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+      const result1 = await runtime.runRequestScript(scriptTrue, {}, {}, {}, '.', null, process.env, scriptingConfig);
+      expect(result1.envVariables.key1).toBe('val1');
+
+      const result2 = await runtime.runRequestScript(scriptFalse, {}, {}, {}, '.', null, process.env, scriptingConfig);
+      expect(result2.envVariables.key2).toBe('val2');
+    });
+
+    it('should silently ignore old persist flag as extra argument — QuickJS parity', async () => {
+      await quickJsLoader();
+      const scriptTrue = `bru.setEnvVar('key1', 'val1', { persist: true });`;
+      const scriptFalse = `bru.setEnvVar('key2', 'val2', { persist: false });`;
+      const runtime = new ScriptRuntime({ runtime: 'quickjs' });
+      const onConsoleLog = () => {};
+
+      const result1 = await runtime.runRequestScript(scriptTrue, {}, {}, {}, '.', onConsoleLog, process.env, scriptingConfig);
+      expect(result1.envVariables.key1).toBe('val1');
+
+      const result2 = await runtime.runRequestScript(scriptFalse, {}, {}, {}, '.', onConsoleLog, process.env, scriptingConfig);
+      expect(result2.envVariables.key2).toBe('val2');
+    });
+  });
+
+  describe('bru.setVar random variable', () => {
+    it('should be able to set random variables as values', async () => {
+      const script = `bru.setVar('title', '{{$randomFirstName}}')`;
+
+      const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+
+      const result = await runtime.runRequestScript(script, {}, {}, {}, '.', null, process.env, scriptingConfig);
+
+      expect(result.runtimeVariables.title).toBe('{{$randomFirstName}}');
+    });
+  });
+
+  describe('assert-runtime', () => {
+    beforeAll(async () => {
+      await quickJsLoader();
+    });
+
+    const baseRequest = {
+      method: 'GET',
+      url: 'http://localhost:3000/',
+      headers: {},
+      data: undefined
+    };
+
+    const makeResponse = (data) => ({
+      status: 200,
+      statusText: 'OK',
+      data,
+      headers: {}
+    });
+
+    const runAssertions = (assertions, response, runtime = 'nodevm', runtimeVariables = {}) => {
+      const assertRuntime = new AssertRuntime({ runtime });
+      return assertRuntime.runAssertions(assertions, { ...baseRequest }, response, {}, runtimeVariables, process.env);
+    };
+
+    // Ensures each QuickJS evaluation gets a fresh context
+    describe('quickjs context isolation across iterations', () => {
+      const ITERATION_COUNT = 350;
+
+      it('should return correct res.status on every iteration', () => {
+        for (let i = 0; i < ITERATION_COUNT; i++) {
+          const status = 200 + i;
+          const results = runAssertions(
+            [{ name: 'res.status', value: `eq ${status}`, enabled: true }],
+            { status, statusText: 'OK', data: {}, headers: {} },
+            'quickjs'
+          );
+          expect(results[0].status).toBe('pass');
+        }
+      });
+
+      it('should return correct res.body values on every iteration', () => {
+        for (let i = 0; i < ITERATION_COUNT; i++) {
+          const results = runAssertions(
+            [{ name: 'res.body.id', value: `eq ${i}`, enabled: true }],
+            { status: 200, statusText: 'OK', data: { id: i }, headers: {} },
+            'quickjs'
+          );
+          expect(results[0].status).toBe('pass');
+        }
+      });
+
+      it('should not return stale data from a previous iteration', () => {
+        // First call with status 200
+        runAssertions(
+          [{ name: 'res.status', value: 'eq 200', enabled: true }],
+          { status: 200, statusText: 'OK', data: { token: 'bearer_abc' }, headers: { authorization: 'bearer xyz' } },
+          'quickjs'
+        );
+
+        // Second call with status 404 — must not return 200 or any data from previous call
+        const results = runAssertions(
+          [
+            { name: 'res.status', value: 'eq 404', enabled: true },
+            { name: 'res.body.error', value: 'eq not_found', enabled: true }
+          ],
+          { status: 404, statusText: 'Not Found', data: { error: 'not_found' }, headers: {} },
+          'quickjs'
+        );
+
+        expect(results[0].status).toBe('pass');
+        expect(results[1].status).toBe('pass');
+      });
+
+      it('should not persist runtime variables from a previous call', () => {
+        // First call with runtime variable token = "one"
+        const results1 = runAssertions(
+          [{ name: 'token', value: 'eq one', enabled: true }],
+          { status: 200, statusText: 'OK', data: {}, headers: {} },
+          'quickjs',
+          { token: 'one' }
+        );
+        expect(results1[0].status).toBe('pass');
+
+        // Second call without token
+        const results2 = runAssertions(
+          [{ name: 'token', value: 'eq one', enabled: true }],
+          { status: 200, statusText: 'OK', data: {}, headers: {} },
+          'quickjs'
+        );
+        // Must fail — token should not exist in a fresh context
+        expect(results2[0].status).toBe('fail');
+      });
+    });
+
+    describe('isJson', () => {
+      it('should pass for a plain object', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse({ id: 1, name: 'test' })
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('should pass for a nested object', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse({ user: { id: 1, tags: ['a', 'b'] } })
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('should pass for objects from a different realm (e.g. after res.setBody in node-vm)', async () => {
+        const response = makeResponse({ id: 1, name: 'original' });
+
+        // res.setBody() inside node-vm creates a cross-realm object whose
+        // constructor is the VM's Object, not the host's Object
+        const scriptRuntime = new ScriptRuntime({ runtime: 'nodevm' });
+        await scriptRuntime.runResponseScript(
+          `res.setBody({ id: 2, name: 'updated' });`,
+          { ...baseRequest },
+          response,
+          {}, {}, '.', null, process.env, scriptingConfig
+        );
+
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          response
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('should pass for an array', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse([1, 2, 3])
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('should pass for an array of strings', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse(['A55001213ZX0A'])
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('should pass for an empty array', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse([])
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('should pass for an array of objects', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse([{ id: 1 }, { id: 2 }])
+        );
+        expect(results[0].status).toBe('pass');
+      });
+
+      it('should fail for a string', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse('hello')
+        );
+        expect(results[0].status).toBe('fail');
+      });
+
+      it('should fail for null', () => {
+        const results = runAssertions(
+          [{ name: 'res.body', value: 'isJson', enabled: true }],
+          makeResponse(null)
+        );
+        expect(results[0].status).toBe('fail');
+      });
+    });
+
+    describe('jsonSchema', () => {
+      const chai = require('chai');
+
+      it('should pass when body matches a valid schema', () => {
+        const body = { name: 'John', age: 30 };
+        const schema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' }
+          },
+          required: ['name', 'age']
+        };
+        chai.expect(body).to.have.jsonSchema(schema);
+      });
+
+      it('should fail when body has a type mismatch', () => {
+        const body = { name: 'John', age: 'thirty' };
+        const schema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' }
+          },
+          required: ['name', 'age']
+        };
+        expect(() => chai.expect(body).to.have.jsonSchema(schema)).toThrow(/validation errors/);
+      });
+
+      it('should fail when a required field is missing', () => {
+        const body = { name: 'John' };
+        const schema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' }
+          },
+          required: ['name', 'age']
+        };
+        expect(() => chai.expect(body).to.have.jsonSchema(schema)).toThrow(/validation errors/);
+      });
+
+      it('should pass with custom ajvOptions', () => {
+        const body = { name: 'John', age: 30 };
+        const schema = {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' }
+          },
+          required: ['name', 'age']
+        };
+        chai.expect(body).to.have.jsonSchema(schema, { allErrors: false });
+      });
+
+      it('should support negation with .not', () => {
+        const body = { name: 'John' };
+        const schema = { type: 'array' };
+        chai.expect(body).to.not.have.jsonSchema(schema);
+      });
+
+      it('should throw a clear error for unsupported Draft 2020-12 $schema', () => {
+        const body = { name: 'John' };
+        const schema = {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          type: 'object',
+          properties: { name: { type: 'string' } }
+        };
+        expect(() => chai.expect(body).to.have.jsonSchema(schema)).toThrow(/Unsupported JSON Schema version.*2020-12.*only supports Draft-07/);
+      });
+
+      it('should throw a clear error for unsupported Draft 2019-09 $schema', () => {
+        const body = { name: 'John' };
+        const schema = {
+          $schema: 'https://json-schema.org/draft/2019-09/schema',
+          type: 'object',
+          properties: { name: { type: 'string' } }
+        };
+        expect(() => chai.expect(body).to.have.jsonSchema(schema)).toThrow(/Unsupported JSON Schema version.*2019-09.*only supports Draft-07/);
+      });
+
+      it('should allow explicit Draft-07 $schema', () => {
+        const body = { name: 'John', age: 30 };
+        const schema = {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' }
+          },
+          required: ['name', 'age']
+        };
+        chai.expect(body).to.have.jsonSchema(schema);
+      });
+    });
+  });
+});

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -1,8 +1,12 @@
 const { describe, it, expect, beforeAll } = require('@jest/globals');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const TestRuntime = require('../src/runtime/test-runtime');
 const ScriptRuntime = require('../src/runtime/script-runtime');
 const AssertRuntime = require('../src/runtime/assert-runtime');
 const { loader: quickJsLoader } = require('../src/sandbox/quickjs');
+const { makeNpmModule } = require('./utils/helpers');
 
 describe('runtime', () => {
   describe('test-runtime', () => {
@@ -89,6 +93,39 @@ describe('runtime', () => {
       ]);
     });
 
+    it('should expose test and jwt through a cached npm module', async () => {
+      const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+      try {
+        makeNpmModule(collectionPath, 'test-runtime-reader', `
+          module.exports = {
+            read: () => typeof test + ':' + typeof jwt.sign
+          };
+        `);
+
+        const runtime = new TestRuntime({ runtime: 'nodevm' });
+        const result = await runtime.runTests(
+          `
+            test('cached runtime globals', () => {
+              expect(require('test-runtime-reader').read()).to.equal('function:function');
+            });
+          `,
+          { ...baseRequest },
+          { ...baseResponse },
+          {},
+          {},
+          collectionPath,
+          null,
+          process.env
+        );
+
+        expect(result.results).toEqual([
+          expect.objectContaining({ description: 'cached runtime globals', status: 'pass' })
+        ]);
+      } finally {
+        fs.rmSync(collectionPath, { recursive: true, force: true });
+      }
+    });
+
     it('should return stopExecution when bru.runner.stopExecution() is called in tests (nodevm)', async () => {
       const testFile = `bru.runner.stopExecution();`;
 
@@ -173,6 +210,75 @@ describe('runtime', () => {
         expect(result.runtimeVariables.validation).toBeTruthy();
       });
 
+      it('should expose the real request runtime through a cached npm module', async () => {
+        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+        try {
+          makeNpmModule(collectionPath, 'request-runtime-reader', `
+            module.exports = {
+              read: () => req.getMethod() + ':' + req.getUrl()
+            };
+          `);
+
+          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+          const result = await runtime.runRequestScript(
+            `bru.setVar('runtime', require('request-runtime-reader').read());`,
+            {
+              method: 'POST',
+              url: 'http://localhost:3000/runtime',
+              headers: {},
+              data: undefined
+            },
+            {},
+            {},
+            collectionPath,
+            null,
+            process.env
+          );
+
+          expect(result.runtimeVariables.runtime).toBe('POST:http://localhost:3000/runtime');
+        } finally {
+          fs.rmSync(collectionPath, { recursive: true, force: true });
+        }
+      });
+
+      it('should expose each request URL to a cached module across sequential runs', async () => {
+        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+        try {
+          makeNpmModule(collectionPath, 'sequential-request-reader', `
+            const urlAtLoad = req.getUrl();
+            module.exports = {
+              dynamic: () => req.getUrl(),
+              captured: () => urlAtLoad
+            };
+          `);
+
+          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+          const run = (url) => runtime.runRequestScript(
+            `
+              const reader = require('sequential-request-reader');
+              bru.setVar('dynamicUrl', reader.dynamic());
+              bru.setVar('capturedUrl', reader.captured());
+            `,
+            { method: 'GET', url, headers: {}, data: undefined },
+            {},
+            {},
+            collectionPath,
+            null,
+            process.env
+          );
+
+          const first = await run('https://example.com/first');
+          const second = await run('https://example.com/second');
+
+          expect(first.runtimeVariables.dynamicUrl).toBe('https://example.com/first');
+          expect(second.runtimeVariables.dynamicUrl).toBe('https://example.com/second');
+          expect(first.runtimeVariables.capturedUrl).toBe('https://example.com/first');
+          expect(second.runtimeVariables.capturedUrl).toBe('https://example.com/second');
+        } finally {
+          fs.rmSync(collectionPath, { recursive: true, force: true });
+        }
+      });
+
       it('should return variable updates made in req.onFail', async () => {
         const script = `
           bru.setVar('runtimeToken', 'before');
@@ -249,6 +355,43 @@ describe('runtime', () => {
           process.env
         );
         expect(result.runtimeVariables.validation).toBeTruthy();
+      });
+
+      it('should expose the real response runtime through a cached npm module', async () => {
+        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
+        try {
+          makeNpmModule(collectionPath, 'response-runtime-reader', `
+            module.exports = {
+              read: () => res.getStatus() + ':' + res.getHeader('content-type')
+            };
+          `);
+
+          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+          const result = await runtime.runResponseScript(
+            `bru.setVar('runtime', require('response-runtime-reader').read());`,
+            {
+              method: 'GET',
+              url: 'http://localhost:3000/',
+              headers: {},
+              data: undefined
+            },
+            {
+              status: 201,
+              statusText: 'Created',
+              headers: { 'content-type': 'application/json' },
+              data: {}
+            },
+            {},
+            {},
+            collectionPath,
+            null,
+            process.env
+          );
+
+          expect(result.runtimeVariables.runtime).toBe('201:application/json');
+        } finally {
+          fs.rmSync(collectionPath, { recursive: true, force: true });
+        }
       });
     });
   });

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -1,12 +1,8 @@
 const { describe, it, expect, beforeAll } = require('@jest/globals');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
 const TestRuntime = require('../src/runtime/test-runtime');
 const ScriptRuntime = require('../src/runtime/script-runtime');
 const AssertRuntime = require('../src/runtime/assert-runtime');
 const { loader: quickJsLoader } = require('../src/sandbox/quickjs');
-const { makeNpmModule } = require('./utils/helpers');
 
 describe('runtime', () => {
   describe('test-runtime', () => {
@@ -93,39 +89,6 @@ describe('runtime', () => {
       ]);
     });
 
-    it('should expose test and jwt through a cached npm module', async () => {
-      const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
-      try {
-        makeNpmModule(collectionPath, 'test-runtime-reader', `
-          module.exports = {
-            read: () => typeof test + ':' + typeof jwt.sign
-          };
-        `);
-
-        const runtime = new TestRuntime({ runtime: 'nodevm' });
-        const result = await runtime.runTests(
-          `
-            test('cached runtime globals', () => {
-              expect(require('test-runtime-reader').read()).to.equal('function:function');
-            });
-          `,
-          { ...baseRequest },
-          { ...baseResponse },
-          {},
-          {},
-          collectionPath,
-          null,
-          process.env
-        );
-
-        expect(result.results).toEqual([
-          expect.objectContaining({ description: 'cached runtime globals', status: 'pass' })
-        ]);
-      } finally {
-        fs.rmSync(collectionPath, { recursive: true, force: true });
-      }
-    });
-
     it('should return stopExecution when bru.runner.stopExecution() is called in tests (nodevm)', async () => {
       const testFile = `bru.runner.stopExecution();`;
 
@@ -210,75 +173,6 @@ describe('runtime', () => {
         expect(result.runtimeVariables.validation).toBeTruthy();
       });
 
-      it('should expose the real request runtime through a cached npm module', async () => {
-        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
-        try {
-          makeNpmModule(collectionPath, 'request-runtime-reader', `
-            module.exports = {
-              read: () => req.getMethod() + ':' + req.getUrl()
-            };
-          `);
-
-          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
-          const result = await runtime.runRequestScript(
-            `bru.setVar('runtime', require('request-runtime-reader').read());`,
-            {
-              method: 'POST',
-              url: 'http://localhost:3000/runtime',
-              headers: {},
-              data: undefined
-            },
-            {},
-            {},
-            collectionPath,
-            null,
-            process.env
-          );
-
-          expect(result.runtimeVariables.runtime).toBe('POST:http://localhost:3000/runtime');
-        } finally {
-          fs.rmSync(collectionPath, { recursive: true, force: true });
-        }
-      });
-
-      it('should expose each request URL to a cached module across sequential runs', async () => {
-        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
-        try {
-          makeNpmModule(collectionPath, 'sequential-request-reader', `
-            const urlAtLoad = req.getUrl();
-            module.exports = {
-              dynamic: () => req.getUrl(),
-              captured: () => urlAtLoad
-            };
-          `);
-
-          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
-          const run = (url) => runtime.runRequestScript(
-            `
-              const reader = require('sequential-request-reader');
-              bru.setVar('dynamicUrl', reader.dynamic());
-              bru.setVar('capturedUrl', reader.captured());
-            `,
-            { method: 'GET', url, headers: {}, data: undefined },
-            {},
-            {},
-            collectionPath,
-            null,
-            process.env
-          );
-
-          const first = await run('https://example.com/first');
-          const second = await run('https://example.com/second');
-
-          expect(first.runtimeVariables.dynamicUrl).toBe('https://example.com/first');
-          expect(second.runtimeVariables.dynamicUrl).toBe('https://example.com/second');
-          expect(first.runtimeVariables.capturedUrl).toBe('https://example.com/first');
-          expect(second.runtimeVariables.capturedUrl).toBe('https://example.com/second');
-        } finally {
-          fs.rmSync(collectionPath, { recursive: true, force: true });
-        }
-      });
-
       it('should return variable updates made in req.onFail', async () => {
         const script = `
           bru.setVar('runtimeToken', 'before');
@@ -355,43 +249,6 @@ describe('runtime', () => {
           process.env
         );
         expect(result.runtimeVariables.validation).toBeTruthy();
-      });
-
-      it('should expose the real response runtime through a cached npm module', async () => {
-        const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-runtime-'));
-        try {
-          makeNpmModule(collectionPath, 'response-runtime-reader', `
-            module.exports = {
-              read: () => res.getStatus() + ':' + res.getHeader('content-type')
-            };
-          `);
-
-          const runtime = new ScriptRuntime({ runtime: 'nodevm' });
-          const result = await runtime.runResponseScript(
-            `bru.setVar('runtime', require('response-runtime-reader').read());`,
-            {
-              method: 'GET',
-              url: 'http://localhost:3000/',
-              headers: {},
-              data: undefined
-            },
-            {
-              status: 201,
-              statusText: 'Created',
-              headers: { 'content-type': 'application/json' },
-              data: {}
-            },
-            {},
-            {},
-            collectionPath,
-            null,
-            process.env
-          );
-
-          expect(result.runtimeVariables.runtime).toBe('201:application/json');
-        } finally {
-          fs.rmSync(collectionPath, { recursive: true, force: true });
-        }
       });
     });
   });

--- a/packages/bruno-js/tests/script-runtime-scripted-entries.spec.js
+++ b/packages/bruno-js/tests/script-runtime-scripted-entries.spec.js
@@ -34,8 +34,12 @@ jest.mock('@usebruno/requests', () => {
   };
 });
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const ScriptRuntime = require('../src/runtime/script-runtime');
 const TestRuntime = require('../src/runtime/test-runtime');
+const { makeNpmModule } = require('./utils/helpers');
 
 const baseRequest = { method: 'GET', url: 'http://localhost/', headers: {}, data: undefined };
 const baseResponse = { status: 200, statusText: 'OK', data: {} };
@@ -117,6 +121,54 @@ describe('ScriptRuntime — scripted entries across the three script phases', ()
           scope: { type: 'request', sourceFile: 'driver.bru' }
         })
       );
+    });
+
+    test('cached npm modules preserve bru.runRequest attribution', async () => {
+      const collectionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-script-runtime-'));
+      try {
+        makeNpmModule(collectionPath, 'run-request-reader', `
+          module.exports = {
+            run: (pathname) => bru.runRequest(pathname)
+          };
+        `);
+
+        const host = jest.fn(async (_pathname, callerBru) => {
+          callerBru._recordScriptedRequest({
+            source: 'runRequest',
+            request: { method: 'GET', url: 'https://example.com/cached', headers: {}, data: undefined },
+            response: null,
+            error: null,
+            startedAt: 0,
+            completedAt: 1
+          });
+          return { status: 200 };
+        });
+        const runtime = new ScriptRuntime({ runtime: 'nodevm' });
+        const result = await runtime.runRequestScript(
+          `
+            __bruSetScope({ type: 'request', sourceFile: 'cached-driver.bru' });
+            await require('run-request-reader').run('cached-target.bru');
+          `,
+          { ...baseRequest },
+          {},
+          {},
+          collectionPath,
+          null,
+          process.env,
+          {},
+          host
+        );
+
+        expect(host).toHaveBeenCalledWith('cached-target.bru', expect.anything());
+        expect(result.scriptedRequestEntries).toEqual([
+          expect.objectContaining({
+            source: 'runRequest',
+            scope: { type: 'request', sourceFile: 'cached-driver.bru' }
+          })
+        ]);
+      } finally {
+        fs.rmSync(collectionPath, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/bruno-js/tests/script-runtime-scripted-entries.spec.js
+++ b/packages/bruno-js/tests/script-runtime-scripted-entries.spec.js
@@ -155,7 +155,7 @@ describe('ScriptRuntime — scripted entries across the three script phases', ()
           collectionPath,
           null,
           process.env,
-          {},
+          { cacheModules: true },
           host
         );
 

--- a/packages/bruno-js/tests/utils/helpers.js
+++ b/packages/bruno-js/tests/utils/helpers.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const makeNpmModule = (collectionPath, name, source) => {
+  const modulePath = path.join(collectionPath, 'node_modules', name);
+  fs.mkdirSync(modulePath, { recursive: true });
+  fs.writeFileSync(path.join(modulePath, 'index.js'), source);
+};
+
+module.exports = {
+  makeNpmModule
+};


### PR DESCRIPTION
### Description

Extends on #9078 to add in a marker based system for all the context sensitive modules. This is being done to make sure that modules that do access the bruno globals either top level or in a nested module are not a part of the shared module cache that's being added. 

Also adds a `--experimental-cache-modules` flag in to make sure that whoever is using this understands the behavioral risk that it might bring. 

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an experimental CLI option to cache npm modules across developer sandbox script runs.
  - Cached modules preserve shared state while refreshing runtime variables for each script, including asynchronous executions.
- **Bug Fixes**
  - Improved runtime context, request attribution, and variable handling for requests originating from cached modules.
  - The option now displays a warning and is ignored unless the developer sandbox is selected.
- **Tests**
  - Added comprehensive coverage for caching, isolation, globals, validation, and script execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->