### PR TITLE
fix(mock-server): clearing validation errors on modal

### DIFF
--- a/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
@@ -104,7 +104,7 @@ const buildCollectionSelectOptions = (workspaceCollections, collections, editing
   return Array.from(optionsByUid.values()).sort((a, b) => a.name.localeCompare(b.name));
 };
 
-const SourceRadio = ({ value, label, checked, disabled, onChange, dataTestId }) => (
+const SourceRadio = ({ value, label, checked, disabled, onChange, onBlur, dataTestId }) => (
   <div className="flex items-center gap-2">
     <input
       id={dataTestId}
@@ -113,6 +113,7 @@ const SourceRadio = ({ value, label, checked, disabled, onChange, dataTestId }) 
       value={value}
       checked={checked}
       onChange={onChange}
+      onBlur={onBlur}
       disabled={disabled}
       data-testid={dataTestId}
     />

--- a/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
+++ b/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.js
@@ -544,8 +544,9 @@ const CreateMockServerModal = ({
               autoCapitalize="off"
               spellCheck="false"
               value={formik.values.name}
-              onChange={formik.handleChange}
-              onBlur={formik.handleBlur}
+              onChange={(event) => {
+                formik.setFieldValue('name', event.target.value, Boolean(formik.errors.name));
+              }}
               data-testid="mock-server-name-input"
             />
             {formik.touched.name && formik.errors.name ? (
@@ -563,6 +564,7 @@ const CreateMockServerModal = ({
                 disabled={!hasCollectionOptions}
                 onChange={formik.handleChange}
                 dataTestId="mock-server-source-collection"
+                onBlur={formik.handleBlur}
               />
               <SourceRadio
                 value="spec"
@@ -571,6 +573,7 @@ const CreateMockServerModal = ({
                 disabled={!hasSpecOptions}
                 onChange={formik.handleChange}
                 dataTestId="mock-server-source-spec"
+                onBlur={formik.handleBlur}
               />
               <SourceRadio
                 value="manual"
@@ -578,6 +581,7 @@ const CreateMockServerModal = ({
                 checked={formik.values.sourceType === 'manual'}
                 onChange={formik.handleChange}
                 dataTestId="mock-server-source-manual"
+                onBlur={formik.handleBlur}
               />
             </div>
           </div>
@@ -593,8 +597,9 @@ const CreateMockServerModal = ({
                   name="collectionUid"
                   className="textbox w-full mt-2"
                   value={formik.values.collectionUid}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
+                  onChange={(event) => {
+                    formik.setFieldValue('collectionUid', event.target.value, Boolean(formik.errors.collectionUid));
+                  }}
                   data-testid="mock-server-collection-select"
                 >
                   <option value="">Select a collection</option>
@@ -627,8 +632,9 @@ const CreateMockServerModal = ({
                   name="specUid"
                   className="textbox w-full mt-2"
                   value={formik.values.specUid}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
+                  onChange={(event) => {
+                    formik.setFieldValue('specUid', event.target.value, Boolean(formik.errors.specUid));
+                  }}
                   data-testid="mock-server-spec-select"
                 >
                   <option value="">Select an API spec</option>

--- a/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.spec.js
+++ b/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.spec.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useDispatch, useSelector } from 'react-redux';
+import CreateMockServerModal from './index';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+  shallowEqual: (a, b) => a === b
+}));
+
+jest.mock('react-hot-toast', () => ({
+  error: jest.fn(),
+  success: jest.fn()
+}));
+
+jest.mock('components/Portal', () => ({ children }) => <div>{children}</div>);
+
+jest.mock('components/Modal', () => ({ children, handleConfirm, handleCancel, confirmText }) => (
+  <div>
+    {children}
+    <button type="button" data-testid="modal-submit-btn" onClick={handleConfirm}>
+      {confirmText || 'Create'}
+    </button>
+    <button type="button" onClick={handleCancel}>Cancel</button>
+  </div>
+));
+
+jest.mock('providers/ReduxStore/slices/collections/actions', () => ({
+  mountCollection: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('providers/ReduxStore/slices/mock-server/index', () => ({
+  generateMockResponsesFromSpec: jest.fn(),
+  loadMockResponses: jest.fn(),
+  syncMockResponsesFromExamples: jest.fn()
+}));
+
+jest.mock('utils/mock-server/mock-server-instances', () => {
+  const actual = jest.requireActual('utils/mock-server/mock-server-instances');
+  return {
+    ...actual,
+    suggestAvailableMockServerPort: jest.fn().mockResolvedValue(4000),
+    checkMockServerPortAvailable: jest.fn().mockResolvedValue({ available: true }),
+    createMockServerInstance: jest.fn(),
+    saveMockServerInstance: jest.fn(),
+    openMockServerDashboard: jest.fn(),
+    updateMockServerTabName: jest.fn()
+  };
+});
+
+const collection = {
+  uid: 'col-1',
+  name: 'Shop API',
+  pathname: '/tmp/shop',
+  mountStatus: 'mounted'
+};
+
+const storeState = {
+  collections: { collections: [collection] },
+  apiSpec: { apiSpecs: [] },
+  workspaces: {
+    activeWorkspaceUid: 'ws-1',
+    workspaces: [{
+      uid: 'ws-1',
+      collections: [{ path: '/tmp/shop' }],
+      apiSpecs: []
+    }]
+  },
+  mockServer: { instancesByWorkspace: { 'ws-1': [] } }
+};
+
+const renderModal = () => {
+  useSelector.mockImplementation((selector) => selector(storeState));
+  return render(<CreateMockServerModal onClose={jest.fn()} />);
+};
+
+describe('CreateMockServerModal validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDispatch.mockReturnValue(jest.fn(() => Promise.resolve()));
+  });
+
+  it('does not show a name error while typing, then clears it after Create once the name is filled', async () => {
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('mock-server-source-manual'));
+    fireEvent.change(screen.getByTestId('mock-server-name-input'), { target: { value: 'x' } });
+    fireEvent.change(screen.getByTestId('mock-server-name-input'), { target: { value: '' } });
+    expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('modal-submit-btn'));
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('mock-server-name-input'), {
+      target: { value: 'Standalone Server' }
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+    });
+  });
+
+  it('clears the collection error when a collection is selected after Create', async () => {
+    renderModal();
+
+    fireEvent.change(screen.getByTestId('mock-server-name-input'), {
+      target: { value: 'Collection Server' }
+    });
+    fireEvent.click(screen.getByTestId('modal-submit-btn'));
+    expect(await screen.findByText('Collection is required')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('mock-server-collection-select'), {
+      target: { value: 'col-1' }
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Collection is required')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.spec.js
+++ b/packages/bruno-app/src/components/MockServer/CreateMockServerModal/index.spec.js
@@ -56,15 +56,22 @@ const collection = {
   mountStatus: 'mounted'
 };
 
+const apiSpec = {
+  uid: 'spec-1',
+  name: 'Petstore',
+  pathname: '/tmp/pet.yaml',
+  filename: 'pet.yaml'
+};
+
 const storeState = {
   collections: { collections: [collection] },
-  apiSpec: { apiSpecs: [] },
+  apiSpec: { apiSpecs: [apiSpec] },
   workspaces: {
     activeWorkspaceUid: 'ws-1',
     workspaces: [{
       uid: 'ws-1',
       collections: [{ path: '/tmp/shop' }],
-      apiSpecs: []
+      apiSpecs: [{ path: '/tmp/pet.yaml' }]
     }]
   },
   mockServer: { instancesByWorkspace: { 'ws-1': [] } }
@@ -114,6 +121,31 @@ describe('CreateMockServerModal validation', () => {
     });
     await waitFor(() => {
       expect(screen.queryByText('Collection is required')).not.toBeInTheDocument();
+    });
+  });
+
+  it('updates required-field errors after an invalid Create when switching to an API spec', async () => {
+    renderModal();
+
+    fireEvent.change(screen.getByTestId('mock-server-name-input'), {
+      target: { value: 'Spec Server' }
+    });
+    fireEvent.click(screen.getByTestId('modal-submit-btn'));
+    expect(await screen.findByText('Collection is required')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mock-server-source-spec'));
+    await waitFor(() => {
+      expect(screen.queryByText('Collection is required')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('modal-submit-btn'));
+    expect(await screen.findByText('API spec is required')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('mock-server-spec-select'), {
+      target: { value: 'spec-1' }
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('API spec is required')).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/mock-server/create-mock-server-modal.spec.ts
+++ b/tests/mock-server/create-mock-server-modal.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '../../playwright';
+import { buildMockServerLocators, openCreateMockServerModal } from '../utils/page/mock-server';
+
+const COLLECTION_NAME = 'mock-server-test-collection';
+
+test.describe('Create mock server modal validation', () => {
+  test('does not show name errors while typing, then clears them on change after Create', async ({
+    pageWithUserData: page
+  }) => {
+    const ms = buildMockServerLocators(page);
+
+    await openCreateMockServerModal(page);
+    await ms.sourceManualRadio().click();
+
+    await test.step('Typing before the first Create click does not show a name error', async () => {
+      await ms.nameInput().fill('x');
+      await ms.nameInput().fill('');
+      await expect(ms.nameRequiredError()).toHaveCount(0);
+    });
+
+    await test.step('Create with an empty name shows the error and keeps the modal open', async () => {
+      await ms.modalSubmit().click();
+      await expect(ms.createModal()).toBeVisible();
+      await expect(ms.nameRequiredError()).toBeVisible();
+    });
+
+    await test.step('Typing a name clears the error without another Create click', async () => {
+      await ms.nameInput().fill('Standalone Validation Server');
+      await expect(ms.nameRequiredError()).toHaveCount(0);
+    });
+
+    await test.step('A single Create click then submits', async () => {
+      await ms.modalSubmit().click();
+      await expect(ms.dashboard()).toBeVisible({ timeout: 10000 });
+    });
+  });
+
+  test('clears the collection error when a collection is selected after Create', async ({
+    pageWithUserData: page
+  }) => {
+    const ms = buildMockServerLocators(page);
+
+    await openCreateMockServerModal(page);
+    await ms.nameInput().fill('Collection Validation Server');
+
+    await test.step('Create with no collection shows the error and keeps the modal open', async () => {
+      await expect(ms.sourceCollectionRadio()).toBeChecked();
+      await expect(ms.collectionSelect()).toHaveValue('');
+      await ms.modalSubmit().click();
+      await expect(ms.createModal()).toBeVisible();
+      await expect(ms.collectionRequiredError()).toBeVisible();
+    });
+
+    await test.step('Choosing a collection clears the error', async () => {
+      await ms.collectionSelect().selectOption({ label: COLLECTION_NAME });
+      await expect(ms.collectionRequiredError()).toHaveCount(0);
+    });
+
+    await ms.modalCancel().click();
+    await expect(ms.createModal()).toHaveCount(0);
+  });
+});

--- a/tests/utils/page/mock-server.ts
+++ b/tests/utils/page/mock-server.ts
@@ -34,7 +34,11 @@ export const buildMockServerLocators = (page: Page) => ({
 
   createModal: () => page.locator('.bruno-modal-card'),
   nameInput: () => page.getByTestId('mock-server-name-input'),
+  nameRequiredError: () => page.getByText('Name is required'),
+  collectionRequiredError: () => page.getByText('Collection is required'),
+  collectionSelect: () => page.getByTestId('mock-server-collection-select'),
   modalSubmit: () => page.getByTestId('modal-submit-btn'),
+  modalCancel: () => page.locator('.bruno-modal-card').getByRole('button', { name: 'Cancel' }),
   sidebarCreateBtn: () => page.getByTestId('mock-servers-create-btn'),
   sourceCollectionRadio: () => page.getByTestId('mock-server-source-collection'),
   sourceSpecRadio: () => page.getByTestId('mock-server-source-spec'),


### PR DESCRIPTION
### Description

JIRA: BRU-4467
Create modal validation error does not clear after fixing name or selecting Collection/API spec

### Problem

The validation errors kept showing up even after the user fixed them and tabbed out of the input field or selected a collection/api-spec

### Fix

The onBlur was removed and the onChange handler for these was changed to setFieldValue to the target value and the third param looked for errors. 

### Screenshots

Before


https://github.com/user-attachments/assets/8ce7961c-87ba-42ac-8803-b02197687862



After

https://github.com/user-attachments/assets/97d4e89d-a781-406b-9bde-ec3f249d4763


#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation behavior in the mock server creation form.
  * Required-field errors now appear after submission when fields are empty.
  * Errors clear immediately after entering a valid name, selecting a collection, or choosing an API specification.
  * Switching the source type now updates validation correctly and displays the relevant missing-field error.
  * Source controls are correctly marked as visited when users leave them, providing more consistent feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->