### PR TITLE
feat(git): add branch selection to clone repository dialog

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/CloneGitRespository/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/CloneGitRespository/StyledWrapper.js
@@ -19,6 +19,19 @@ const StyledWrapper = styled.div`
     overflow-y: auto;
   }
 
+  .branch-select {
+    .input-wrapper-label {
+      font-size: ${(props) => props.theme.font.size.base};
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+    
+    .select-trigger.textbox {
+      font-size: ${(props) => props.theme.font.size.base};
+      border-radius: ${(props) => props.theme.border.radius.sm};
+    }
+  }
+
   .clone-progress-steps {
     margin-bottom: 0.5rem;
   }

--- a/packages/bruno-app/src/components/Sidebar/CloneGitRespository/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CloneGitRespository/index.js
@@ -5,6 +5,7 @@ import * as Yup from 'yup';
 import {
   browseDirectory,
   cloneGitRepository,
+  fetchBranchesForRepositoryUrl,
   openMultipleCollections,
   scanForBrunoFiles
 } from 'providers/ReduxStore/slices/collections/actions';
@@ -13,16 +14,19 @@ import Modal from 'components/Modal';
 import SelectionFooter from 'components/SelectionFooter';
 import path, { getRelativePath } from 'utils/common/path';
 import Portal from 'components/Portal';
-import { IconRefresh, IconAlertCircle, IconBrandGit } from '@tabler/icons';
+import { IconRefresh, IconAlertCircle, IconBrandGit, IconChevronDown } from '@tabler/icons';
 import { uuid } from 'utils/common/index';
 import StyledWrapper from './StyledWrapper';
 import SelectionList from 'components/SelectionList';
 import Button from 'ui/Button';
+import Select from 'ui/Select';
 import { getRepoNameFromUrl } from 'utils/git';
 import GitNotFoundModal from 'components/Git/GitNotFoundModal/index';
 import SkippedPathsWarning from 'components/SkippedPathsWarning';
 import toast from 'react-hot-toast';
 import get from 'lodash/get';
+
+const EMPTY_BRANCH_LISTING = { branches: [], defaultBranch: '', loading: false, failed: false };
 
 const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null }) => {
   const [collectionPaths, setCollectionPaths] = useState([]);
@@ -31,6 +35,7 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
   const [processUid, setProcessUid] = useState(uuid());
   const [steps, setSteps] = useState([]);
   const [view, setView] = useState('form');
+  const [branchListing, setBranchListing] = useState(EMPTY_BRANCH_LISTING);
 
   const progressData = useSelector((state) => state.app.gitOperationProgress[processUid]);
   const { gitVersion } = useSelector((state) => state.app);
@@ -56,9 +61,23 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
     }
   }, [progressData]);
 
+  const loadBranches = async (url) => {
+    setBranchListing({ ...EMPTY_BRANCH_LISTING, loading: true });
+    try {
+      const { branches, defaultBranch } = await dispatch(fetchBranchesForRepositoryUrl(url));
+      setBranchListing({ branches, defaultBranch: defaultBranch || '', loading: false, failed: false });
+    } catch (error) {
+      console.error(error);
+      setBranchListing({ ...EMPTY_BRANCH_LISTING, failed: true });
+    }
+  };
+
   useEffect(() => {
     if (inputRef?.current) {
       inputRef.current.focus();
+    }
+    if (collectionRepositoryUrl) {
+      loadBranches(collectionRepositoryUrl);
     }
   }, []);
 
@@ -118,7 +137,8 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
     enableReinitialize: true,
     initialValues: {
       repositoryUrl: collectionRepositoryUrl || '',
-      collectionLocation: defaultLocation
+      collectionLocation: defaultLocation,
+      branch: ''
     },
     validationSchema: Yup.object({
       repositoryUrl: Yup.string().required('Repository URL is required'),
@@ -128,12 +148,12 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
       try {
         setView('progress');
         cloneInProgress();
-        const { repositoryUrl, collectionLocation } = values;
+        const { repositoryUrl, collectionLocation, branch } = values;
 
         const repoName = getRepoNameFromUrl(repositoryUrl);
         const targetPath = path.join(collectionLocation, repoName);
 
-        await dispatch(cloneGitRepository({ url: values.repositoryUrl, path: targetPath, processUid }));
+        await dispatch(cloneGitRepository({ url: repositoryUrl, path: targetPath, processUid, branch }));
 
         cloneFinished();
         dispatch(removeGitOperationProgress(processUid));
@@ -329,6 +349,26 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
                     Browse
                   </span>
                 </div>
+                <Select
+                  className="branch-select mt-5"
+                  label="Branch"
+                  data={branchListing.branches}
+                  value={formik.values.branch || branchListing.defaultBranch}
+                  onChange={(branch) => formik.setFieldValue('branch', branch || '')}
+                  searchable
+                  allowDeselect={false}
+                  loading={branchListing.loading}
+                  rightSection={branchListing.loading ? undefined : <IconChevronDown size={12} strokeWidth={2} />}
+                  disabled={!branchListing.branches.length}
+                  placeholder={branchListing.loading ? 'Loading branches...' : 'Repository default'}
+                  nothingFoundMessage="No branches match your search"
+                  data-testid="clone-git-repository-branch-select"
+                />
+                {branchListing.failed && (
+                  <div className="text-muted text-xs mt-1">
+                    Branches could not be listed for this repository. Cloning will use the default branch.
+                  </div>
+                )}
               </div>
             </form>
           )}

--- a/packages/bruno-app/src/components/Sidebar/CloneGitRespository/index.js
+++ b/packages/bruno-app/src/components/Sidebar/CloneGitRespository/index.js
@@ -153,7 +153,14 @@ const CloneGitRepository = ({ onClose, onFinish, collectionRepositoryUrl = null 
         const repoName = getRepoNameFromUrl(repositoryUrl);
         const targetPath = path.join(collectionLocation, repoName);
 
-        await dispatch(cloneGitRepository({ url: repositoryUrl, path: targetPath, processUid, branch }));
+        await dispatch(
+          cloneGitRepository({
+            url: repositoryUrl,
+            path: targetPath,
+            processUid,
+            branch: branch || branchListing.defaultBranch
+          })
+        );
 
         cloneFinished();
         dispatch(removeGitOperationProgress(processUid));

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -3508,6 +3508,11 @@ export const cloneGitRepository = (data) => (dispatch, getState) => {
   });
 };
 
+export const fetchBranchesForRepositoryUrl = (url) => (dispatch, getState) => {
+  const { ipcRenderer } = window;
+  return ipcRenderer.invoke('renderer:list-remote-branches-for-url', { url });
+};
+
 export const scanForBrunoFiles = (dir) => (dispatch, getState) => {
   const { ipcRenderer } = window;
   return new Promise((resolve, reject) => {

--- a/packages/bruno-app/src/ui/InputWrapper/StyledWrapper.js
+++ b/packages/bruno-app/src/ui/InputWrapper/StyledWrapper.js
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import { INPUT_SIZES } from './constants';
+
+const StyledWrapper = styled.div`
+  position: relative;
+  width: 100%;
+
+  .input-wrapper-label {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-size: ${(props) => props.theme.font.size[INPUT_SIZES[props.$size || 'md'].labelFontSize]};
+    color: ${(props) => props.theme.colors.text.body};
+  }
+
+  .input-wrapper-required {
+    color: ${(props) => props.theme.colors.text.danger};
+    margin-left: 0.125rem;
+  }
+
+  .input-wrapper-description {
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.colors.text.muted};
+    margin-bottom: 0.25rem;
+  }
+
+  .input-wrapper-error {
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.colors.text.danger};
+    margin-top: 0.25rem;
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/ui/InputWrapper/constants.js
+++ b/packages/bruno-app/src/ui/InputWrapper/constants.js
@@ -1,0 +1,20 @@
+/**
+ * Input size definitions - shared across TextInput, MaskedInput, Select
+ *
+ * sm: compact inputs for inline/auth contexts
+ * md: default form inputs (matches .textbox)
+ */
+export const INPUT_SIZES = {
+  sm: {
+    padding: '0.15rem 0.4rem',
+    fontSize: 'xs',
+    borderRadius: 'sm',
+    labelFontSize: 'xs'
+  },
+  md: {
+    padding: '0.45rem',
+    fontSize: 'sm',
+    borderRadius: 'base',
+    labelFontSize: 'sm'
+  }
+};

--- a/packages/bruno-app/src/ui/InputWrapper/index.js
+++ b/packages/bruno-app/src/ui/InputWrapper/index.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import StyledWrapper from './StyledWrapper';
+
+/**
+ * InputWrapper - Shared form field wrapper for label, description, error
+ *
+ * Used internally by TextInput, Select, MaskedInput, and other form components.
+ *
+ * @param {string|ReactNode} props.label - Label above the input
+ * @param {string|ReactNode} props.description - Description text below the label
+ * @param {string} props.error - Error message below the input
+ * @param {string} props.htmlFor - Links label to input id
+ * @param {boolean} props.required - Shows asterisk on label
+ * @param {string} props.size - Input size: 'sm' | 'md' (default: 'md')
+ * @param {string} props.className - Additional CSS class
+ * @param {ReactNode} props.children - The actual input element
+ */
+const InputWrapper = ({ label, description, error, htmlFor, required, size = 'md', className, labelId, descriptionId, errorId, children }) => {
+  return (
+    <StyledWrapper className={className} $size={size}>
+      {label && (
+        <label id={labelId} className="input-wrapper-label" htmlFor={htmlFor}>
+          {label}
+          {required && <span className="input-wrapper-required">*</span>}
+        </label>
+      )}
+      {description && <div id={descriptionId} className="input-wrapper-description">{description}</div>}
+      {children}
+      {error && <div id={errorId} className="input-wrapper-error">{error}</div>}
+    </StyledWrapper>
+  );
+};
+
+export default InputWrapper;

--- a/packages/bruno-app/src/ui/Select/StyledWrapper.js
+++ b/packages/bruno-app/src/ui/Select/StyledWrapper.js
@@ -1,0 +1,122 @@
+import styled, { keyframes } from 'styled-components';
+import { INPUT_SIZES } from 'ui/InputWrapper/constants';
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const StyledWrapper = styled.div`
+  position: relative;
+  width: 100%;
+
+  .select-trigger {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    cursor: pointer;
+    user-select: none;
+    padding: ${(props) => INPUT_SIZES[props.$size || 'md'].padding};
+    font-size: ${(props) => props.theme.font.size[INPUT_SIZES[props.$size || 'md'].fontSize]};
+    border-radius: ${(props) => props.theme.border.radius[INPUT_SIZES[props.$size || 'md'].borderRadius]};
+
+    &.disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+
+    &.select-open {
+      border: solid 1px ${(props) => props.theme.input.focusBorder} !important;
+    }
+  }
+
+  .select-trigger-content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .select-trigger-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .select-trigger-placeholder {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    opacity: 0.5;
+  }
+
+  .select-section {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .select-left-section {
+    margin-right: 0.5rem;
+  }
+
+  .select-right-section {
+    margin-left: 0.5rem;
+    opacity: 0.6;
+  }
+
+  .select-caret {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    margin-left: 0.5rem;
+    opacity: 0.6;
+
+    svg {
+      fill: currentColor;
+    }
+  }
+
+  .select-clear {
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    opacity: 0.4;
+    transition: opacity 0.15s ease;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
+  .select-spinner {
+    animation: ${spin} 0.75s linear infinite;
+  }
+
+  .select-search-input {
+    border: none;
+    outline: none;
+    background: transparent;
+    width: 100%;
+    font-size: inherit;
+    font-family: inherit;
+    color: inherit;
+    padding: 0;
+
+    &::placeholder {
+      opacity: 0.5;
+    }
+  }
+
+  .select-nothing-found {
+    padding: 0.5rem 0.625rem;
+    font-size: ${(props) => props.theme.font.size.sm};
+    color: ${(props) => props.theme.colors.text.muted};
+  }
+
+`;
+
+export default StyledWrapper;

--- a/packages/bruno-app/src/ui/Select/index.js
+++ b/packages/bruno-app/src/ui/Select/index.js
@@ -1,0 +1,381 @@
+import React, { useState, useRef, useCallback, useEffect, useMemo, useId } from 'react';
+import Dropdown from 'components/Dropdown';
+import { IconCaretDown, IconX, IconLoader2 } from '@tabler/icons';
+import InputWrapper from 'ui/InputWrapper';
+import StyledWrapper from './StyledWrapper';
+
+const NAVIGATION_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Escape'];
+const ACTION_KEYS = ['Enter'];
+
+const getNextIndex = (currentIndex, total, key) => {
+  if (key === 'Home') return 0;
+  if (key === 'End') return total - 1;
+  if (key === 'ArrowDown') return currentIndex === -1 ? 0 : (currentIndex + 1) % total;
+  if (key === 'ArrowUp') return currentIndex === -1 ? total - 1 : (currentIndex - 1 + total) % total;
+  return currentIndex;
+};
+
+const normalizeData = (data) => {
+  if (!data) return [];
+  return data.map((item) => {
+    if (typeof item === 'string') {
+      return { value: item, label: item };
+    }
+    return { value: item.value, label: item.label || item.value, disabled: item.disabled };
+  });
+};
+
+const sameWidthModifier = {
+  name: 'sameWidth',
+  enabled: true,
+  phase: 'beforeWrite',
+  requires: ['computeStyles'],
+  fn: ({ state }) => {
+    state.styles.popper.width = `${state.rects.reference.width}px`;
+  },
+  effect: ({ state }) => {
+    state.elements.popper.style.width = `${state.elements.reference.offsetWidth}px`;
+  }
+};
+
+/**
+ * Select - A reusable select/dropdown component for forms
+ *
+ * @param {Array} props.data - Array of strings or { value, label, disabled? } objects
+ * @param {string} props.value - Controlled selected value
+ * @param {function} props.onChange - Called with the selected value string
+ * @param {string} props.placeholder - Placeholder text when no value selected
+ * @param {boolean} props.disabled - Disables interaction
+ * @param {string} props.error - Error message displayed below the select
+ * @param {boolean} props.searchable - Enables type-to-filter when dropdown is open
+ * @param {string} props.nothingFoundMessage - Message shown when search yields no results
+ * @param {boolean} props.clearable - Shows a clear button when a value is selected
+ * @param {boolean} props.allowDeselect - Clicking the selected option deselects it (default: true)
+ * @param {number} props.maxDropdownHeight - Max height of the dropdown in px (default: 250)
+ * @param {function} props.renderOption - Custom option renderer: ({ option, isSelected, isFocused }) => ReactNode
+ * @param {boolean} props.loading - Shows a loading spinner in the right section
+ * @param {ReactNode} props.leftSection - Element rendered on the left side of the trigger
+ * @param {ReactNode} props.rightSection - Element rendered on the right side (replaces default caret)
+ * @param {string} props.label - Label text displayed above the select
+ * @param {string} props.description - Description text displayed below the label
+ * @param {string} props.className - Additional CSS class for the wrapper
+ */
+const Select = ({
+  data,
+  value,
+  onChange,
+  placeholder = 'Select...',
+  disabled = false,
+  error,
+  label,
+  description,
+  searchable = false,
+  nothingFoundMessage = 'No options found',
+  clearable = false,
+  allowDeselect = true,
+  maxDropdownHeight = 250,
+  renderOption,
+  loading = false,
+  leftSection,
+  rightSection,
+  required = false,
+  size = 'md',
+  className,
+  'data-testid': testId
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const [searchValue, setSearchValue] = useState('');
+  const menuRef = useRef(null);
+  const inputRef = useRef(null);
+  const tippyRef = useRef(null);
+  const autoId = useId();
+  const labelId = label ? `${autoId}-label` : undefined;
+  const descriptionId = description ? `${autoId}-desc` : undefined;
+  const errorId = error ? `${autoId}-err` : undefined;
+  const describedBy = [descriptionId, errorId].filter(Boolean).join(' ') || undefined;
+
+  const options = useMemo(() => normalizeData(data), [data]);
+
+  const filteredOptions = useMemo(() => {
+    if (!searchable || !searchValue) return options;
+    const query = searchValue.toLowerCase();
+    return options.filter((opt) => opt.label.toLowerCase().includes(query));
+  }, [options, searchable, searchValue]);
+
+  const selectedOption = useMemo(
+    () => options.find((opt) => opt.value === value),
+    [options, value]
+  );
+
+  const handleOpen = useCallback(() => {
+    if (disabled) return;
+    setIsOpen(true);
+    setSearchValue('');
+    const idx = options.findIndex((opt) => opt.value === value);
+    setFocusedIndex(idx >= 0 ? idx : 0);
+  }, [disabled, options, value]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    setFocusedIndex(-1);
+    setSearchValue('');
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    if (isOpen) {
+      handleClose();
+    } else {
+      handleOpen();
+    }
+  }, [isOpen, handleOpen, handleClose]);
+
+  const handleSelect = useCallback(
+    (option) => {
+      if (option.disabled) return;
+      if (allowDeselect && option.value === value) {
+        onChange?.(null);
+      } else {
+        onChange?.(option.value);
+      }
+      handleClose();
+    },
+    [onChange, handleClose, allowDeselect, value]
+  );
+
+  const handleClear = useCallback(
+    (e) => {
+      e.stopPropagation();
+      onChange?.(null);
+    },
+    [onChange]
+  );
+
+  const handleClickOutside = useCallback(() => {
+    handleClose();
+  }, [handleClose]);
+
+  const handleTriggerKeyDown = useCallback(
+    (e) => {
+      if (disabled) return;
+      if (ACTION_KEYS.includes(e.key) || NAVIGATION_KEYS.includes(e.key)) {
+        e.preventDefault();
+        if (!isOpen) {
+          handleOpen();
+        }
+      }
+    },
+    [disabled, isOpen, handleOpen]
+  );
+
+  const handleKeyDown = useCallback(
+    (e) => {
+      if (NAVIGATION_KEYS.includes(e.key)) {
+        e.preventDefault();
+        if (e.key === 'Escape') {
+          handleClose();
+          return;
+        }
+        const enabledIndices = filteredOptions.reduce((acc, opt, i) => {
+          if (!opt.disabled) acc.push(i);
+          return acc;
+        }, []);
+        if (enabledIndices.length === 0) return;
+        const currentEnabledIdx = enabledIndices.indexOf(focusedIndex);
+        const nextEnabledIdx = getNextIndex(currentEnabledIdx, enabledIndices.length, e.key);
+        setFocusedIndex(enabledIndices[nextEnabledIdx] ?? 0);
+      }
+
+      if (ACTION_KEYS.includes(e.key)) {
+        e.preventDefault();
+        if (focusedIndex >= 0 && focusedIndex < filteredOptions.length) {
+          handleSelect(filteredOptions[focusedIndex]);
+        }
+      }
+
+      if (e.key === 'Tab') {
+        handleClose();
+      }
+    },
+    [filteredOptions, focusedIndex, handleClose, handleSelect]
+  );
+
+  const handleSearchChange = useCallback((e) => {
+    setSearchValue(e.target.value);
+    setFocusedIndex(0);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (searchable && inputRef.current) {
+        inputRef.current.focus();
+      } else if (menuRef.current) {
+        menuRef.current.focus();
+      }
+    }
+  }, [isOpen, searchable]);
+
+  useEffect(() => {
+    if (isOpen && menuRef.current && focusedIndex >= 0) {
+      const focusedEl = menuRef.current.querySelector(`[data-index="${focusedIndex}"]`);
+      if (focusedEl) {
+        focusedEl.scrollIntoView({ block: 'nearest' });
+      }
+    }
+  }, [isOpen, focusedIndex]);
+
+  const onDropdownCreate = useCallback((instance) => {
+    tippyRef.current = instance;
+  }, []);
+
+  // Right section: custom > loading spinner > clearable X > default caret
+  const renderRightSection = () => {
+    if (rightSection) return <span className="select-section select-right-section">{rightSection}</span>;
+    if (loading) {
+      return (
+        <span className="select-section select-right-section">
+          <IconLoader2 className="select-spinner" size={14} strokeWidth={2} />
+        </span>
+      );
+    }
+    if (clearable && value != null && value !== '') {
+      return (
+        <button
+          type="button"
+          className="select-section select-right-section select-clear"
+          onClick={handleClear}
+          aria-label="Clear selection"
+        >
+          <IconX size={14} strokeWidth={2} />
+        </button>
+      );
+    }
+    return (
+      <span className="select-caret">
+        <IconCaretDown size={14} strokeWidth={2} />
+      </span>
+    );
+  };
+
+  // Trigger content (label/placeholder or search input)
+  const renderTriggerContent = () => {
+    if (searchable && isOpen) {
+      return (
+        <input
+          ref={inputRef}
+          type="text"
+          className="select-search-input"
+          value={searchValue}
+          onChange={handleSearchChange}
+          onKeyDown={handleKeyDown}
+          placeholder={selectedOption ? selectedOption.label : placeholder}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck="false"
+        />
+      );
+    }
+    if (selectedOption) {
+      return <span className="select-trigger-label">{selectedOption.label}</span>;
+    }
+    return <span className="select-trigger-placeholder">{placeholder}</span>;
+  };
+
+  const triggerClickHandler = searchable
+    ? () => { if (!isOpen) handleOpen(); }
+    : handleToggle;
+
+  const triggerKeyHandler = searchable
+    ? (e) => {
+        if (!isOpen && (ACTION_KEYS.includes(e.key) || NAVIGATION_KEYS.includes(e.key))) {
+          e.preventDefault();
+          handleOpen();
+        }
+      }
+    : handleTriggerKeyDown;
+
+  const trigger = (
+    <div
+      className={`select-trigger textbox ${disabled ? 'disabled' : ''} ${isOpen ? 'select-open' : ''}`}
+      onClick={triggerClickHandler}
+      onKeyDown={triggerKeyHandler}
+      tabIndex={disabled ? -1 : 0}
+      role="combobox"
+      aria-expanded={isOpen}
+      aria-haspopup="listbox"
+      aria-labelledby={labelId}
+      aria-describedby={describedBy}
+      aria-required={required || undefined}
+      data-testid={testId}
+    >
+      {leftSection && <span className="select-section select-left-section">{leftSection}</span>}
+      <span className="select-trigger-content">
+        {renderTriggerContent()}
+      </span>
+      {renderRightSection()}
+    </div>
+  );
+
+  // Option rendering — shared between searchable and non-searchable
+  const renderOptions = () => {
+    if (filteredOptions.length === 0) {
+      return <div className="select-nothing-found">{nothingFoundMessage}</div>;
+    }
+    return filteredOptions.map((option, index) => {
+      const isSelected = option.value === value;
+      const isFocused = index === focusedIndex;
+      const classNames = [
+        'dropdown-item',
+        isSelected ? 'dropdown-item-active' : '',
+        isFocused ? 'dropdown-item-focused' : '',
+        option.disabled ? 'disabled' : ''
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      return (
+        <div
+          key={option.value}
+          className={classNames}
+          data-index={index}
+          role="option"
+          aria-selected={isSelected}
+          onClick={() => handleSelect(option)}
+        >
+          {renderOption
+            ? renderOption({ option, isSelected, isFocused })
+            : <span className="dropdown-label">{option.label}</span>}
+        </div>
+      );
+    });
+  };
+
+  return (
+    <InputWrapper label={label} description={description} error={error} required={required} size={size} className={className} labelId={labelId} descriptionId={descriptionId} errorId={errorId}>
+      <StyledWrapper $size={size}>
+        <Dropdown
+          onCreate={onDropdownCreate}
+          icon={trigger}
+          placement="bottom-start"
+          visible={isOpen}
+          onClickOutside={handleClickOutside}
+          popperOptions={{ modifiers: [sameWidthModifier] }}
+          maxWidth="none"
+        >
+          <div
+            ref={menuRef}
+            role="listbox"
+            tabIndex={searchable ? undefined : -1}
+            onKeyDown={searchable ? undefined : handleKeyDown}
+            style={{ maxHeight: maxDropdownHeight, overflowY: 'auto', outline: 'none' }}
+          >
+            {renderOptions()}
+          </div>
+        </Dropdown>
+      </StyledWrapper>
+    </InputWrapper>
+  );
+};
+
+export default Select;

--- a/packages/bruno-app/src/ui/Select/index.js
+++ b/packages/bruno-app/src/ui/Select/index.js
@@ -158,8 +158,9 @@ const Select = ({
   const handleTriggerKeyDown = useCallback(
     (e) => {
       if (disabled) return;
-      if (ACTION_KEYS.includes(e.key) || NAVIGATION_KEYS.includes(e.key)) {
+      if (e.key !== 'Escape' && (ACTION_KEYS.includes(e.key) || NAVIGATION_KEYS.includes(e.key))) {
         e.preventDefault();
+        e.stopPropagation();
         if (!isOpen) {
           handleOpen();
         }
@@ -172,6 +173,7 @@ const Select = ({
     (e) => {
       if (NAVIGATION_KEYS.includes(e.key)) {
         e.preventDefault();
+        e.stopPropagation();
         if (e.key === 'Escape') {
           handleClose();
           return;
@@ -188,6 +190,7 @@ const Select = ({
 
       if (ACTION_KEYS.includes(e.key)) {
         e.preventDefault();
+        e.stopPropagation();
         if (focusedIndex >= 0 && focusedIndex < filteredOptions.length) {
           handleSelect(filteredOptions[focusedIndex]);
         }
@@ -288,8 +291,9 @@ const Select = ({
 
   const triggerKeyHandler = searchable
     ? (e) => {
-        if (!isOpen && (ACTION_KEYS.includes(e.key) || NAVIGATION_KEYS.includes(e.key))) {
+        if (!isOpen && e.key !== 'Escape' && (ACTION_KEYS.includes(e.key) || NAVIGATION_KEYS.includes(e.key))) {
           e.preventDefault();
+          e.stopPropagation();
           handleOpen();
         }
       }

--- a/packages/bruno-electron/src/ipc/git.js
+++ b/packages/bruno-electron/src/ipc/git.js
@@ -1,5 +1,5 @@
 const { ipcMain } = require('electron');
-const { cloneGitRepository, getCollectionGitRepoUrl } = require('../utils/git');
+const { cloneGitRepository, getCollectionGitRepoUrl, listBranchesForRemoteUrl } = require('../utils/git');
 const { createDirectory, removeDirectory } = require('../utils/filesystem');
 
 const getCollectionGitRemoteUrl = async (collectionPath) => {
@@ -11,13 +11,26 @@ const getCollectionGitRemoteUrl = async (collectionPath) => {
   }
 };
 
+const handleListRemoteBranches = async (event, { url }) => {
+  const repositoryUrl = typeof url === 'string' ? url.trim() : '';
+  if (!repositoryUrl) {
+    throw new Error('Repository URL is required');
+  }
+  // git reads a dash-leading url as a command option, not a repository
+  if (repositoryUrl.startsWith('-')) {
+    throw new Error('Repository URL is not valid');
+  }
+
+  return listBranchesForRemoteUrl({ url: repositoryUrl });
+};
+
 const registerGitIpc = (mainWindow) => {
-  ipcMain.handle('renderer:clone-git-repository', async (event, { url, path, processUid }) => {
+  ipcMain.handle('renderer:clone-git-repository', async (event, { url, path, processUid, branch }) => {
     let directoryCreated = false;
     try {
       await createDirectory(path);
       directoryCreated = true;
-      await cloneGitRepository(mainWindow, { url, path, processUid });
+      await cloneGitRepository(mainWindow, { url, path, processUid, branch });
       return 'Repository cloned successfully';
     } catch (error) {
       if (directoryCreated) {
@@ -30,7 +43,10 @@ const registerGitIpc = (mainWindow) => {
   ipcMain.handle('renderer:get-collection-git-remote-url', (event, collectionPath) =>
     getCollectionGitRemoteUrl(collectionPath)
   );
+
+  ipcMain.handle('renderer:list-remote-branches-for-url', handleListRemoteBranches);
 };
 
 module.exports = registerGitIpc;
 module.exports.getCollectionGitRemoteUrl = getCollectionGitRemoteUrl;
+module.exports.handleListRemoteBranches = handleListRemoteBranches;

--- a/packages/bruno-electron/src/ipc/git.spec.js
+++ b/packages/bruno-electron/src/ipc/git.spec.js
@@ -1,15 +1,16 @@
 jest.mock('electron', () => ({ ipcMain: { handle: jest.fn() } }));
 jest.mock('../utils/git', () => ({
   cloneGitRepository: jest.fn(),
-  getCollectionGitRepoUrl: jest.fn()
+  getCollectionGitRepoUrl: jest.fn(),
+  listBranchesForRemoteUrl: jest.fn()
 }));
 jest.mock('../utils/filesystem', () => ({
   createDirectory: jest.fn(),
   removeDirectory: jest.fn()
 }));
 
-const { getCollectionGitRepoUrl } = require('../utils/git');
-const { getCollectionGitRemoteUrl } = require('./git');
+const { getCollectionGitRepoUrl, listBranchesForRemoteUrl } = require('../utils/git');
+const { getCollectionGitRemoteUrl, handleListRemoteBranches } = require('./git');
 
 describe('getCollectionGitRemoteUrl', () => {
   beforeEach(() => {
@@ -33,5 +34,32 @@ describe('getCollectionGitRemoteUrl', () => {
     getCollectionGitRepoUrl.mockRejectedValue(new Error('not a git repository'));
 
     expect(await getCollectionGitRemoteUrl('/tmp/not-a-repo')).toBeNull();
+  });
+});
+
+describe('handleListRemoteBranches', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the branch listing for the url', async () => {
+    listBranchesForRemoteUrl.mockResolvedValue({ branches: ['main', 'develop'], defaultBranch: 'main' });
+
+    expect(await handleListRemoteBranches({}, { url: '  https://github.com/org/repo.git  ' })).toEqual({
+      branches: ['main', 'develop'],
+      defaultBranch: 'main'
+    });
+    expect(listBranchesForRemoteUrl).toHaveBeenCalledWith({ url: 'https://github.com/org/repo.git' });
+  });
+
+  it('rejects a missing url', async () => {
+    await expect(handleListRemoteBranches({}, { url: '   ' })).rejects.toThrow('Repository URL is required');
+    expect(listBranchesForRemoteUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a url that git would read as a command option', async () => {
+    await expect(handleListRemoteBranches({}, { url: '--upload-pack=touch /tmp/pwned' }))
+      .rejects.toThrow('Repository URL is not valid');
+    expect(listBranchesForRemoteUrl).not.toHaveBeenCalled();
   });
 });

--- a/packages/bruno-electron/src/utils/filesystem.js
+++ b/packages/bruno-electron/src/utils/filesystem.js
@@ -267,6 +267,18 @@ const createDirectory = async (dir) => {
   return fs.mkdirSync(dir);
 };
 
+const removeDirectory = async (dir) => {
+  if (!dir) {
+    throw new Error(`directory: path is null`);
+  }
+
+  if (!fs.existsSync(dir)) {
+    throw new Error(`directory: ${dir} does not exist`);
+  }
+
+  return fs.rmdirSync(dir, { recursive: true });
+};
+
 const browseDirectory = async (win) => {
   const { filePaths } = await dialog.showOpenDialog(win, {
     properties: ['openDirectory', 'createDirectory']
@@ -764,6 +776,7 @@ module.exports = {
   hasBruExtension,
   hasRequestExtension,
   createDirectory,
+  removeDirectory,
   browseDirectory,
   browseDirectories,
   browseFiles,

--- a/packages/bruno-electron/src/utils/git.js
+++ b/packages/bruno-electron/src/utils/git.js
@@ -1,5 +1,6 @@
 const simpleGit = require('simple-git');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { exec } = require('child_process');
 const { parseRequest } = require('@usebruno/filestore');
@@ -7,6 +8,8 @@ const { parseRequest } = require('@usebruno/filestore');
 let collectionPathToGitRootPathMap = new Map();
 
 const simpleGitInstances = new Map();
+
+const REMOTE_BRANCH_LISTING_TIMEOUT_MS = 10000;
 
 const getGitVersion = () => {
   return new Promise((resolve, reject) => {
@@ -708,11 +711,12 @@ const getCollectionGitData = async (gitRootPath, collectionPath) => {
 
 const cloneGitRepository = async (win, data) => {
   return new Promise((resolve, reject) => {
-    const { url, path, processUid } = data;
+    const { url, path, processUid, branch } = data;
     const git = getSimpleGitInstanceForPath(path);
+    const cloneOptions = branch ? ['--progress', '--branch', branch] : ['--progress'];
 
     git.outputHandler(handleGitOutput({ win, processUid, sendStdout: true }));
-    git.clone(url, path, ['--progress'], (err, res) => {
+    git.clone(url, path, cloneOptions, (err, res) => {
       if (err) {
         reject(err);
         return;
@@ -720,6 +724,47 @@ const cloneGitRepository = async (win, data) => {
       resolve(res);
     });
   });
+};
+
+const parseRemoteBranches = (lsRemoteOutput) => {
+  const branches = [];
+  let defaultBranch = null;
+
+  String(lsRemoteOutput || '')
+    .split(/\r\n|\r|\n/)
+    .forEach((line) => {
+      const trimmedLine = line.trim();
+      if (!trimmedLine) return;
+
+      const symrefMatch = trimmedLine.match(/^ref:\s+refs\/heads\/(.+?)\s+HEAD$/);
+      if (symrefMatch) {
+        defaultBranch = symrefMatch[1];
+        return;
+      }
+
+      const branchMatch = trimmedLine.match(/\srefs\/heads\/(.+)$/);
+      if (branchMatch) {
+        branches.push(branchMatch[1]);
+      }
+    });
+
+  return { branches, defaultBranch };
+};
+
+const listBranchesForRemoteUrl = async ({ url }) => {
+  try {
+    const output = await simpleGit({
+      baseDir: os.tmpdir(),
+      timeout: { block: REMOTE_BRANCH_LISTING_TIMEOUT_MS, stdOut: false, stdErr: false }
+    })
+      .env({ ...process.env, GIT_TERMINAL_PROMPT: '0' })
+      .listRemote(['--symref', url, 'HEAD', 'refs/heads/*']);
+
+    return parseRemoteBranches(output);
+  } catch (error) {
+    console.error('Error listing remote branches:', error);
+    throw error;
+  }
 };
 
 const fetchRemotes = (gitRootPath) => {
@@ -1784,6 +1829,8 @@ module.exports = {
   getUnstagedFileDiff,
   getRenamedFileDiff,
   cloneGitRepository,
+  listBranchesForRemoteUrl,
+  parseRemoteBranches,
   fetchChanges,
   fetchRemotes,
   fetchRemoteBranches,

--- a/packages/bruno-electron/src/utils/git.spec.js
+++ b/packages/bruno-electron/src/utils/git.spec.js
@@ -1,0 +1,46 @@
+const { parseRemoteBranches } = require('./git');
+
+describe('parseRemoteBranches', () => {
+  it('reads the branch names and the default branch out of ls-remote output', () => {
+    const output = [
+      'ref: refs/heads/main\tHEAD',
+      '9c1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f\tHEAD',
+      '9c1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f\trefs/heads/main',
+      '1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b\trefs/heads/feature/branch-selector'
+    ].join('\n');
+
+    expect(parseRemoteBranches(output)).toEqual({
+      branches: ['main', 'feature/branch-selector'],
+      defaultBranch: 'main'
+    });
+  });
+
+  it('reads output written with CRLF line endings', () => {
+    const output = ['ref: refs/heads/main\tHEAD', '9c1f2a3\trefs/heads/main', '1a2b3c4\trefs/heads/develop'].join('\r\n');
+
+    expect(parseRemoteBranches(output)).toEqual({
+      branches: ['main', 'develop'],
+      defaultBranch: 'main'
+    });
+  });
+
+  it('reports no default branch when the remote sends no symref line', () => {
+    const output = ['9c1f2a3\trefs/heads/main', '1a2b3c4\trefs/heads/develop'].join('\n');
+
+    expect(parseRemoteBranches(output)).toEqual({
+      branches: ['main', 'develop'],
+      defaultBranch: null
+    });
+  });
+
+  it('ignores refs that are not branches', () => {
+    const output = ['9c1f2a3\trefs/heads/main', '1a2b3c4\trefs/tags/v1.0.0', '2b3c4d5\trefs/pull/12/head'].join('\n');
+
+    expect(parseRemoteBranches(output).branches).toEqual(['main']);
+  });
+
+  it('returns an empty listing for empty output', () => {
+    expect(parseRemoteBranches('')).toEqual({ branches: [], defaultBranch: null });
+    expect(parseRemoteBranches(undefined)).toEqual({ branches: [], defaultBranch: null });
+  });
+});

--- a/tests/collection/git/clone-branch-selection.spec.ts
+++ b/tests/collection/git/clone-branch-selection.spec.ts
@@ -1,0 +1,143 @@
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { test, expect, closeElectronApp } from '../../../playwright';
+import { switchWorkspace, waitForReadyPage, buildCommonLocators, openCloneDialogFromImport } from '../../utils/page';
+import { currentGitBranch, hasGitInstalled, runGit } from './helpers';
+
+const initUserDataPath = path.join(__dirname, 'init-user-data');
+const fixturesPath = path.join(__dirname, 'fixtures');
+
+const WORKSPACE_NAME = 'Clone WS';
+const REPOSITORY_URL = 'https://github.com/usebruno/github-rest-api-collection';
+const DEFAULT_BRANCH = 'main';
+const CLONED_COLLECTION_DIR = 'github-rest-api-collection';
+const BRANCH_SEARCH_TERM = 'feat/';
+
+const remoteIsReachable = () => {
+  try {
+    runGit(os.tmpdir(), ['ls-remote', '--heads', REPOSITORY_URL]);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const createWorkspace = async (createTmpDir: (tag?: string) => Promise<string>, tag: string): Promise<string> => {
+  const workspacePath = await createTmpDir(tag);
+  await fs.promises.cp(path.join(fixturesPath, 'clone-workspace'), workspacePath, { recursive: true });
+  return workspacePath;
+};
+
+const clonedCollectionPath = (workspacePath: string) =>
+  path.join(workspacePath, 'collections', CLONED_COLLECTION_DIR);
+
+test.describe('Clone Git Repository branch selection', () => {
+  test.skip(!hasGitInstalled(), 'requires git installed');
+  test.skip(!remoteIsReachable(), `Could not reach ${REPOSITORY_URL}.`);
+
+  test('clones the branch picked from the branch list', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-picked');
+
+    const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
+    const page = await waitForReadyPage(app);
+    const { cloneGitRepository } = buildCommonLocators(page);
+    await switchWorkspace(page, WORKSPACE_NAME);
+
+    await test.step('Import a git repository to open the clone dialog', async () => {
+      await openCloneDialogFromImport(page, REPOSITORY_URL);
+    });
+
+    await test.step('Branch field is prefilled with the repository default', async () => {
+      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH, { timeout: 15000 });
+    });
+
+    // Picked from what the dialog actually lists, so the assertion never pins a branch name
+    // that the upstream repository is free to rename.
+    let pickedBranch = '';
+
+    await test.step('Branch list offers the non-default branches', async () => {
+      await cloneGitRepository.branchSelect().click();
+      await expect(cloneGitRepository.branchOptions().first()).toBeVisible();
+
+      const branches = await cloneGitRepository.branchOptions().allTextContents();
+      pickedBranch = branches.map((branch) => branch.trim()).find((branch) => branch && branch !== DEFAULT_BRANCH)!;
+      expect(pickedBranch).toBeTruthy();
+
+      await cloneGitRepository.branchOption(pickedBranch).first().click();
+      await expect(cloneGitRepository.branchSelect()).toContainText(pickedBranch);
+    });
+
+    await test.step('Cloning lands on the selected branch', async () => {
+      await cloneGitRepository.button('Clone').click();
+      await expect(cloneGitRepository.button('Open')).toBeVisible({ timeout: 50000 });
+      expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(pickedBranch);
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('clones the prefilled default branch when no other branch is picked', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-default');
+
+    const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
+    const page = await waitForReadyPage(app);
+    const { cloneGitRepository } = buildCommonLocators(page);
+    await switchWorkspace(page, WORKSPACE_NAME);
+
+    await test.step('Import a git repository to open the clone dialog', async () => {
+      await openCloneDialogFromImport(page, REPOSITORY_URL);
+    });
+
+    await test.step('The remote default arrives prefilled and stays selected', async () => {
+      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH, { timeout: 15000 });
+      // Re-picking the selected branch must not empty the field.
+      await cloneGitRepository.branchSelect().click();
+      await cloneGitRepository.branchOption(DEFAULT_BRANCH).first().click();
+      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
+    });
+
+    await test.step('Cloning lands on the default branch', async () => {
+      await cloneGitRepository.button('Clone').click();
+      await expect(cloneGitRepository.button('Open')).toBeVisible({ timeout: 60000 });
+      expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(DEFAULT_BRANCH);
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('narrows the branch list to the search term', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-search');
+
+    const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
+    const page = await waitForReadyPage(app);
+    const { cloneGitRepository } = buildCommonLocators(page);
+    await switchWorkspace(page, WORKSPACE_NAME);
+
+    await test.step('Import a git repository to open the clone dialog', async () => {
+      await openCloneDialogFromImport(page, REPOSITORY_URL);
+    });
+
+    await test.step('Searching keeps only the matching branches', async () => {
+      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH, { timeout: 15000 });
+      await cloneGitRepository.branchSelect().click();
+
+      const unfiltered = await cloneGitRepository.branchOptions().count();
+      await cloneGitRepository.branchSearchInput().fill(BRANCH_SEARCH_TERM);
+
+      await expect(cloneGitRepository.branchOptions().first()).toBeVisible();
+      const filtered = await cloneGitRepository.branchOptions().allTextContents();
+      expect(filtered.length).toBeGreaterThan(0);
+      expect(filtered.length).toBeLessThan(unfiltered);
+      expect(filtered.every((branch) => branch.includes(BRANCH_SEARCH_TERM))).toBe(true);
+    });
+
+    await test.step('A term matching no branch offers nothing to select', async () => {
+      await cloneGitRepository.branchSearchInput().fill('does-not-exist');
+      await expect(cloneGitRepository.branchOptions()).toHaveCount(0);
+      await expect(cloneGitRepository.noBranchesFound()).toBeVisible();
+    });
+
+    await closeElectronApp(app);
+  });
+});

--- a/tests/collection/git/clone-branch-selection.spec.ts
+++ b/tests/collection/git/clone-branch-selection.spec.ts
@@ -10,6 +10,7 @@ const fixturesPath = path.join(__dirname, 'fixtures');
 
 const WORKSPACE_NAME = 'Clone WS';
 const REPOSITORY_URL = 'https://github.com/usebruno/github-rest-api-collection';
+const UNREACHABLE_REPOSITORY_URL = 'https://github.com/usebruno/this-repo-does-not-exist';
 const DEFAULT_BRANCH = 'main';
 const CLONED_COLLECTION_DIR = 'github-rest-api-collection';
 const BRANCH_SEARCH_TERM = 'feat/';
@@ -26,6 +27,7 @@ const remoteIsReachable = () => {
 const createWorkspace = async (createTmpDir: (tag?: string) => Promise<string>, tag: string): Promise<string> => {
   const workspacePath = await createTmpDir(tag);
   await fs.promises.cp(path.join(fixturesPath, 'clone-workspace'), workspacePath, { recursive: true });
+  await fs.promises.mkdir(path.join(workspacePath, 'collections'), { recursive: true });
   return workspacePath;
 };
 
@@ -49,7 +51,7 @@ test.describe('Clone Git Repository branch selection', () => {
     });
 
     await test.step('Branch field is prefilled with the repository default', async () => {
-      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH, { timeout: 15000 });
+      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
     });
 
     // Picked from what the dialog actually lists, so the assertion never pins a branch name
@@ -70,7 +72,7 @@ test.describe('Clone Git Repository branch selection', () => {
 
     await test.step('Cloning lands on the selected branch', async () => {
       await cloneGitRepository.button('Clone').click();
-      await expect(cloneGitRepository.button('Open')).toBeVisible({ timeout: 50000 });
+      await expect(cloneGitRepository.button('Open')).toBeVisible();
       expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(pickedBranch);
     });
 
@@ -90,7 +92,7 @@ test.describe('Clone Git Repository branch selection', () => {
     });
 
     await test.step('The remote default arrives prefilled and stays selected', async () => {
-      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH, { timeout: 15000 });
+      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
       // Re-picking the selected branch must not empty the field.
       await cloneGitRepository.branchSelect().click();
       await cloneGitRepository.branchOption(DEFAULT_BRANCH).first().click();
@@ -99,7 +101,7 @@ test.describe('Clone Git Repository branch selection', () => {
 
     await test.step('Cloning lands on the default branch', async () => {
       await cloneGitRepository.button('Clone').click();
-      await expect(cloneGitRepository.button('Open')).toBeVisible({ timeout: 60000 });
+      await expect(cloneGitRepository.button('Open')).toBeVisible();
       expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(DEFAULT_BRANCH);
     });
 
@@ -119,7 +121,7 @@ test.describe('Clone Git Repository branch selection', () => {
     });
 
     await test.step('Searching keeps only the matching branches', async () => {
-      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH, { timeout: 15000 });
+      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
       await cloneGitRepository.branchSelect().click();
 
       const unfiltered = await cloneGitRepository.branchOptions().count();
@@ -136,6 +138,32 @@ test.describe('Clone Git Repository branch selection', () => {
       await cloneGitRepository.branchSearchInput().fill('does-not-exist');
       await expect(cloneGitRepository.branchOptions()).toHaveCount(0);
       await expect(cloneGitRepository.noBranchesFound()).toBeVisible();
+    });
+
+    await closeElectronApp(app);
+  });
+
+  test('explains when the branches cannot be listed', async ({ launchElectronApp, createTmpDir }) => {
+    const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-listing-failed');
+
+    const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
+    const page = await waitForReadyPage(app);
+    const { cloneGitRepository } = buildCommonLocators(page);
+    await switchWorkspace(page, WORKSPACE_NAME);
+
+    await test.step('Import a repository the remote listing cannot resolve', async () => {
+      await openCloneDialogFromImport(page, UNREACHABLE_REPOSITORY_URL);
+    });
+
+    await test.step('The dialog says branches are unavailable and falls back to the default', async () => {
+      await expect(cloneGitRepository.branchListingFailed()).toBeVisible();
+      await expect(cloneGitRepository.branchSelect()).toContainText('Repository default');
+    });
+
+    await test.step('The branch field is disabled and no branches are listed', async () => {
+      await expect(cloneGitRepository.branchSelect()).toHaveClass(/disabled/);
+      await cloneGitRepository.branchSelect().click();
+      await expect(cloneGitRepository.branchOptions()).toHaveCount(0);
     });
 
     await closeElectronApp(app);

--- a/tests/collection/git/clone-branch-selection.spec.ts
+++ b/tests/collection/git/clone-branch-selection.spec.ts
@@ -42,130 +42,139 @@ test.describe('Clone Git Repository branch selection', () => {
     const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-picked');
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
-    const page = await waitForReadyPage(app);
-    const { cloneGitRepository } = buildCommonLocators(page);
-    await switchWorkspace(page, WORKSPACE_NAME);
 
-    await test.step('Import a git repository to open the clone dialog', async () => {
-      await openCloneDialogFromImport(page, REPOSITORY_URL);
-    });
+    try {
+      const page = await waitForReadyPage(app);
+      const { cloneGitRepository } = buildCommonLocators(page);
+      await switchWorkspace(page, WORKSPACE_NAME);
 
-    await test.step('Branch field is prefilled with the repository default', async () => {
-      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
-    });
+      await test.step('Import a git repository to open the clone dialog', async () => {
+        await openCloneDialogFromImport(page, REPOSITORY_URL);
+      });
 
-    // Picked from what the dialog actually lists, so the assertion never pins a branch name
-    // that the upstream repository is free to rename.
-    let pickedBranch = '';
+      await test.step('Branch field is prefilled with the repository default', async () => {
+        await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
+      });
 
-    await test.step('Branch list offers the non-default branches', async () => {
-      await cloneGitRepository.branchSelect().click();
-      await expect(cloneGitRepository.branchOptions().first()).toBeVisible();
+      // Picked from what the dialog actually lists, so the assertion never pins a branch name
+      // that the upstream repository is free to rename.
+      let pickedBranch = '';
 
-      const branches = await cloneGitRepository.branchOptions().allTextContents();
-      pickedBranch = branches.map((branch) => branch.trim()).find((branch) => branch && branch !== DEFAULT_BRANCH)!;
-      expect(pickedBranch).toBeTruthy();
+      await test.step('Branch list offers the non-default branches', async () => {
+        await cloneGitRepository.branchSelect().click();
+        await expect(cloneGitRepository.branchOptions().first()).toBeVisible();
 
-      await cloneGitRepository.branchOption(pickedBranch).first().click();
-      await expect(cloneGitRepository.branchSelect()).toContainText(pickedBranch);
-    });
+        const branches = await cloneGitRepository.branchOptions().allTextContents();
+        pickedBranch = branches.map((branch) => branch.trim()).find((branch) => branch && branch !== DEFAULT_BRANCH)!;
+        expect(pickedBranch).toBeTruthy();
 
-    await test.step('Cloning lands on the selected branch', async () => {
-      await cloneGitRepository.button('Clone').click();
-      await expect(cloneGitRepository.button('Open')).toBeVisible();
-      expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(pickedBranch);
-    });
+        await cloneGitRepository.branchOption(pickedBranch).first().click();
+        await expect(cloneGitRepository.branchSelect()).toContainText(pickedBranch);
+      });
 
-    await closeElectronApp(app);
+      await test.step('Cloning lands on the selected branch', async () => {
+        await cloneGitRepository.button('Clone').click();
+        await expect(cloneGitRepository.button('Open')).toBeVisible();
+        expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(pickedBranch);
+      });
+    } finally {
+      await closeElectronApp(app);
+    }
   });
 
   test('clones the prefilled default branch when no other branch is picked', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-default');
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
-    const page = await waitForReadyPage(app);
-    const { cloneGitRepository } = buildCommonLocators(page);
-    await switchWorkspace(page, WORKSPACE_NAME);
+    try {
+      const page = await waitForReadyPage(app);
+      const { cloneGitRepository } = buildCommonLocators(page);
+      await switchWorkspace(page, WORKSPACE_NAME);
 
-    await test.step('Import a git repository to open the clone dialog', async () => {
-      await openCloneDialogFromImport(page, REPOSITORY_URL);
-    });
+      await test.step('Import a git repository to open the clone dialog', async () => {
+        await openCloneDialogFromImport(page, REPOSITORY_URL);
+      });
 
-    await test.step('The remote default arrives prefilled and stays selected', async () => {
-      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
-      // Re-picking the selected branch must not empty the field.
-      await cloneGitRepository.branchSelect().click();
-      await cloneGitRepository.branchOption(DEFAULT_BRANCH).first().click();
-      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
-    });
+      await test.step('The remote default arrives prefilled and stays selected', async () => {
+        await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
+        // Re-picking the selected branch must not empty the field.
+        await cloneGitRepository.branchSelect().click();
+        await cloneGitRepository.branchOption(DEFAULT_BRANCH).first().click();
+        await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
+      });
 
-    await test.step('Cloning lands on the default branch', async () => {
-      await cloneGitRepository.button('Clone').click();
-      await expect(cloneGitRepository.button('Open')).toBeVisible();
-      expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(DEFAULT_BRANCH);
-    });
-
-    await closeElectronApp(app);
+      await test.step('Cloning lands on the default branch', async () => {
+        await cloneGitRepository.button('Clone').click();
+        await expect(cloneGitRepository.button('Open')).toBeVisible();
+        expect(currentGitBranch(clonedCollectionPath(workspacePath))).toBe(DEFAULT_BRANCH);
+      });
+    } finally {
+      await closeElectronApp(app);
+    }
   });
 
   test('narrows the branch list to the search term', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-search');
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
-    const page = await waitForReadyPage(app);
-    const { cloneGitRepository } = buildCommonLocators(page);
-    await switchWorkspace(page, WORKSPACE_NAME);
+    try {
+      const page = await waitForReadyPage(app);
+      const { cloneGitRepository } = buildCommonLocators(page);
+      await switchWorkspace(page, WORKSPACE_NAME);
 
-    await test.step('Import a git repository to open the clone dialog', async () => {
-      await openCloneDialogFromImport(page, REPOSITORY_URL);
-    });
+      await test.step('Import a git repository to open the clone dialog', async () => {
+        await openCloneDialogFromImport(page, REPOSITORY_URL);
+      });
 
-    await test.step('Searching keeps only the matching branches', async () => {
-      await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
-      await cloneGitRepository.branchSelect().click();
+      await test.step('Searching keeps only the matching branches', async () => {
+        await expect(cloneGitRepository.branchSelect()).toContainText(DEFAULT_BRANCH);
+        await cloneGitRepository.branchSelect().click();
 
-      const unfiltered = await cloneGitRepository.branchOptions().count();
-      await cloneGitRepository.branchSearchInput().fill(BRANCH_SEARCH_TERM);
+        const unfiltered = await cloneGitRepository.branchOptions().count();
+        await cloneGitRepository.branchSearchInput().fill(BRANCH_SEARCH_TERM);
 
-      await expect(cloneGitRepository.branchOptions().first()).toBeVisible();
-      const filtered = await cloneGitRepository.branchOptions().allTextContents();
-      expect(filtered.length).toBeGreaterThan(0);
-      expect(filtered.length).toBeLessThan(unfiltered);
-      expect(filtered.every((branch) => branch.includes(BRANCH_SEARCH_TERM))).toBe(true);
-    });
+        await expect(cloneGitRepository.branchOptions().first()).toBeVisible();
+        const filtered = await cloneGitRepository.branchOptions().allTextContents();
+        expect(filtered.length).toBeGreaterThan(0);
+        expect(filtered.length).toBeLessThan(unfiltered);
+        expect(filtered.every((branch) => branch.includes(BRANCH_SEARCH_TERM))).toBe(true);
+      });
 
-    await test.step('A term matching no branch offers nothing to select', async () => {
-      await cloneGitRepository.branchSearchInput().fill('does-not-exist');
-      await expect(cloneGitRepository.branchOptions()).toHaveCount(0);
-      await expect(cloneGitRepository.noBranchesFound()).toBeVisible();
-    });
-
-    await closeElectronApp(app);
+      await test.step('A term matching no branch offers nothing to select', async () => {
+        await cloneGitRepository.branchSearchInput().fill('does-not-exist');
+        await expect(cloneGitRepository.branchOptions()).toHaveCount(0);
+        await expect(cloneGitRepository.noBranchesFound()).toBeVisible();
+      });
+    } finally {
+      await closeElectronApp(app);
+    }
   });
 
   test('explains when the branches cannot be listed', async ({ launchElectronApp, createTmpDir }) => {
     const workspacePath = await createWorkspace(createTmpDir, 'clone-branch-listing-failed');
 
     const app = await launchElectronApp({ initUserDataPath, templateVars: { workspacePath } });
-    const page = await waitForReadyPage(app);
-    const { cloneGitRepository } = buildCommonLocators(page);
-    await switchWorkspace(page, WORKSPACE_NAME);
+    try {
+      const page = await waitForReadyPage(app);
+      const { cloneGitRepository } = buildCommonLocators(page);
+      await switchWorkspace(page, WORKSPACE_NAME);
 
-    await test.step('Import a repository the remote listing cannot resolve', async () => {
-      await openCloneDialogFromImport(page, UNREACHABLE_REPOSITORY_URL);
-    });
+      await test.step('Import a repository the remote listing cannot resolve', async () => {
+        await openCloneDialogFromImport(page, UNREACHABLE_REPOSITORY_URL);
+      });
 
-    await test.step('The dialog says branches are unavailable and falls back to the default', async () => {
-      await expect(cloneGitRepository.branchListingFailed()).toBeVisible();
-      await expect(cloneGitRepository.branchSelect()).toContainText('Repository default');
-    });
+      await test.step('The dialog says branches are unavailable and falls back to the default', async () => {
+        await expect(cloneGitRepository.branchListingFailed()).toBeVisible();
+        await expect(cloneGitRepository.branchSelect()).toContainText('Repository default');
+      });
 
-    await test.step('The branch field is disabled and no branches are listed', async () => {
-      await expect(cloneGitRepository.branchSelect()).toHaveClass(/disabled/);
-      await cloneGitRepository.branchSelect().click();
-      await expect(cloneGitRepository.branchOptions()).toHaveCount(0);
-    });
-
-    await closeElectronApp(app);
+      await test.step('The branch field is disabled and no branches are listed', async () => {
+        await expect(cloneGitRepository.branchSelect()).toHaveClass(/disabled/);
+        await cloneGitRepository.branchSelect().click();
+        await expect(cloneGitRepository.branchOptions()).toHaveCount(0);
+      });
+    } finally {
+      await closeElectronApp(app);
+    }
   });
 });

--- a/tests/collection/git/fixtures/clone-workspace/workspace.yml
+++ b/tests/collection/git/fixtures/clone-workspace/workspace.yml
@@ -1,0 +1,10 @@
+opencollection: 1.0.0
+info:
+  name: "Clone WS"
+  type: workspace
+
+collections:
+
+specs:
+
+docs: ''

--- a/tests/collection/git/helpers.ts
+++ b/tests/collection/git/helpers.ts
@@ -1,0 +1,19 @@
+import { execFileSync, execSync } from 'node:child_process';
+
+export const hasGitInstalled = () => {
+  try {
+    execSync('git --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const runGit = (cwd: string, args: string[]) => {
+  return execFileSync('git', args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).toString().trim();
+};
+
+export const currentGitBranch = (repoPath: string) => runGit(repoPath, ['rev-parse', '--abbrev-ref', 'HEAD']);

--- a/tests/collection/git/init-user-data/preferences.json
+++ b/tests/collection/git/init-user-data/preferences.json
@@ -1,0 +1,11 @@
+{
+  "preferences": {
+    "onboarding": {
+      "hasLaunchedBefore": true,
+      "hasSeenWelcomeModal": true
+    }
+  },
+  "workspaces": {
+    "lastOpenedWorkspaces": ["{{workspacePath}}"]
+  }
+}

--- a/tests/utils/page/git/clone-git-repository.ts
+++ b/tests/utils/page/git/clone-git-repository.ts
@@ -1,0 +1,40 @@
+import { Locator, Page, expect } from '../../../../playwright';
+import { buildCommonLocators } from '../locators';
+
+// Locators and actions for the Clone Git Repository dialog
+export const buildCloneGitRepositoryLocators = (page: Page) => {
+  const modal = (): Locator =>
+    page
+      .locator('.bruno-modal-card')
+      .filter({ has: page.locator('.bruno-modal-header-title', { hasText: 'Clone Git Repository' }) });
+  const branchOptions = (): Locator => page.getByRole('listbox').locator('.dropdown-item');
+
+  return {
+    modal,
+    branchOptions,
+    branchSelect: (): Locator => modal().getByTestId('clone-git-repository-branch-select'),
+    branchSearchInput: (): Locator => modal().locator('.select-search-input'),
+    branchOption: (branchName: string): Locator => branchOptions().filter({ hasText: branchName }),
+    noBranchesFound: (): Locator => page.getByText('No branches match your search'),
+    branchListingFailed: (): Locator => modal().getByText('Branches could not be listed for this repository'),
+    button: (name: string): Locator => modal().getByRole('button', { name })
+  };
+};
+
+export const openCloneDialogFromImport = async (page: Page, repositoryUrl: string) => {
+  const locators = buildCommonLocators(page);
+  const { modal } = buildCloneGitRepositoryLocators(page);
+
+  await locators.plusMenu.button().click();
+  await locators.plusMenu.importCollection().click();
+
+  const importModal = locators.import.modal();
+  await importModal.waitFor({ state: 'visible', timeout: 10000 });
+
+  await importModal.getByTestId('github-tab').click();
+  await importModal.getByTestId('git-url-input').fill(repositoryUrl);
+  await importModal.locator('#clone-git-button').click();
+
+  await modal().waitFor({ state: 'visible', timeout: 10000 });
+  await expect(modal()).toContainText(repositoryUrl);
+};

--- a/tests/utils/page/index.ts
+++ b/tests/utils/page/index.ts
@@ -6,6 +6,7 @@ export * from './runner';
 export * from './locators';
 export * from './websocket';
 export * from './sidebar';
+export * from './git/clone-git-repository';
 export * from './mounting';
 export * from './collection/migrate-to-yml';
 export * from './preferences';

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -18,6 +18,7 @@ import { buildTimelineHeaderLocators } from './timeline-headers';
 import { buildDevToolsLocators } from './devtools-console';
 import { buildVariablesTabLocators } from './variables-tab';
 import { buildWorkspaceOverviewLocators } from './workspace/workspace-overview';
+import { buildCloneGitRepositoryLocators } from './git/clone-git-repository';
 import { buildResponseExampleLocators } from './response-example';
 
 export type PresetRequestType = 'http' | 'graphql' | 'grpc' | 'ws';
@@ -48,6 +49,7 @@ export const buildCommonLocators = (page: Page) => ({
   openPreferences: () => page.getByRole('button', { name: 'Open Preferences' }),
   sidebar: buildSidebarLocators(page),
   workspaceOverview: buildWorkspaceOverviewLocators(page),
+  cloneGitRepository: buildCloneGitRepositoryLocators(page),
   migrateToYml: buildMigrateToYmlLocators(page),
   environment: buildEnvironmentLocators(page),
   variablesTab: buildVariablesTabLocators(page),


### PR DESCRIPTION
### Description

The Clone Git Repository dialog now lets users pick which branch to clone instead of always using the remote's default.

Ref: BRU-3457

### Problem

When cloning a repository through Bruno, users had no way to select a specific branch. The clone always landed on the remote's default branch, forcing users to manually checkout a different branch after cloning if they needed one.

### Fix

Added a branch selector to the clone dialog that:

- Fetches the list of remote branches from the repository
- Pre-fills the repository's default branch
- Supports searching/filtering when there are many branches
- Clones the selected branch directly

### Screenshots

| Before | After |
| --- | --- |
| <img width="788" height="420" alt="image" src="https://github.com/user-attachments/assets/5fcd17a8-0603-47b5-84fa-095c505f0294" /> | <img width="799" height="444" alt="image" src="https://github.com/user-attachments/assets/5879842b-c06f-4485-a0f3-5555d419b9d9" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branch selection when cloning Git repositories.
  * Branch lists load automatically with search, default-branch selection, and loading or error states.
  * Added reusable form fields and select controls with labels, descriptions, validation messages, sizing, and accessibility support.

* **Bug Fixes**
  * Improved repository URL validation and handling when branch information cannot be retrieved.

* **Tests**
  * Added coverage for branch selection, searching, defaults, and remote listing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->