### PR TITLE
fix(folder-Tests): use “folder” in Test tab helper text

### DIFF
--- a/packages/bruno-app/src/components/FolderSettings/Tests/index.js
+++ b/packages/bruno-app/src/components/FolderSettings/Tests/index.js
@@ -39,7 +39,7 @@ const Tests = ({ collection, folder }) => {
 
   return (
     <StyledWrapper className="w-full flex flex-col h-full">
-      <div className="text-xs mb-4 text-muted">These tests will run any time a request in this collection is sent.</div>
+      <div className="text-xs mb-4 text-muted">These tests will run any time a request in this folder is sent.</div>
       <div className="relative h-full">
         <CodeEditor
           ref={testsEditorRef}


### PR DESCRIPTION
Ref: BRU-4485

### Description

Updates the helper text on the folder Test tab so it refers to the folder instead of the collection.

### Problem

On a folder’s Test tab, the helper text said “These tests will run any time a request in this collection is sent.” Folder tests only apply to requests in that folder, so the wording was misleading.

### Fix

Changed the helper text in packages/bruno-app/src/components/FolderSettings/Tests/index.js from “collection” to “folder”. The collection Test tab is unchanged.

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

### Screenshots

| Before | After |
| --- | --- |
| <img width="1467" height="373" alt="image" src="https://github.com/user-attachments/assets/dcc9ae5f-5f5c-45c5-b975-92f4adcaa743" /> | <img width="1876" height="520" alt="image" src="https://github.com/user-attachments/assets/6f9066bc-c760-4064-b7f5-9e9b37123d0e" /> |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the folder tests editor helper text to clarify that tests run whenever a request within the folder is sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->