### PR TITLE
fix(CLI): (changes reverted) update response status to 'skipped' for omitted requests

### DIFF
--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -840,7 +840,7 @@ const handler = async function (argv) {
                 data: null
               },
               response: {
-                status: '-',
+                status: 'skipped',
                 statusText: null,
                 data: null,
                 responseTime: 0

--- a/packages/bruno-cli/src/runner/run-single-request.js
+++ b/packages/bruno-cli/src/runner/run-single-request.js
@@ -200,7 +200,7 @@ const runSingleRequest = async function (
           data: request.data
         },
         response: {
-          status: '-',
+          status: 'skipped',
           statusText: errorMsg,
           data: null,
           responseTime: 0,
@@ -298,7 +298,7 @@ const runSingleRequest = async function (
               data: request.data
             },
             response: {
-              status: '-',
+              status: 'skipped',
               statusText: 'request skipped via pre-request script',
               data: null,
               responseTime: 0,

--- a/packages/bruno-cli/src/utils/run.js
+++ b/packages/bruno-cli/src/utils/run.js
@@ -15,7 +15,7 @@ const createSkippedFileResults = (skippedFiles, collectionPath) => {
         data: null
       },
       response: {
-        status: '-',
+        status: 'skipped',
         statusText: skippedFile.error,
         data: null,
         responseTime: 0

--- a/packages/bruno-cli/tests/runner/report-metadata.spec.js
+++ b/packages/bruno-cli/tests/runner/report-metadata.spec.js
@@ -66,7 +66,7 @@ describe('HTML Report Generation', () => {
               data: null
             },
             response: {
-              status: '-',
+              status: 'skipped',
               statusText: 'Unexpected token',
               data: null,
               responseTime: 0
@@ -108,6 +108,6 @@ describe('HTML Report Generation', () => {
 
     expect(htmlString).toContain('Request Skipped');
     expect(htmlString).toContain('summarySkippedRequests');
-    expect(htmlString).toContain('result.status === \'skipped\'');
+    expect(htmlString).toContain('result.response.status === \'skipped\'');
   });
 });

--- a/packages/bruno-cli/tests/runner/response-fields.spec.js
+++ b/packages/bruno-cli/tests/runner/response-fields.spec.js
@@ -136,7 +136,7 @@ describe('runSingleRequest: duration and size fields (issue #7352)', () => {
     const result = await runSingleRequest(...baseArgs);
 
     expect(result.status).toBe('skipped');
-    expect(result.response.status).toBe('-');
+    expect(result.response.status).toBe('skipped');
     expect(result.response.duration).toBe(0);
     expect(result.response.size).toBe(0);
     expect(result.response.responseTime).toBe(0);
@@ -144,7 +144,7 @@ describe('runSingleRequest: duration and size fields (issue #7352)', () => {
     expect(typeof result.response.size).toBe('number');
   });
 
-  it('should return "-" as the response status when a pre-request script skips the request', async () => {
+  it('should return "skipped" as the response status when a pre-request script skips the request', async () => {
     prepareRequest.mockResolvedValue({
       method: 'GET',
       url: 'http://example.com/api/test',
@@ -160,7 +160,7 @@ describe('runSingleRequest: duration and size fields (issue #7352)', () => {
 
     expect(result.status).toBe('skipped');
     expect(result.skipped).toBe(true);
-    expect(result.response.status).toBe('-');
+    expect(result.response.status).toBe('skipped');
     expect(result.response.statusText).toBe('request skipped via pre-request script');
   });
 

--- a/packages/bruno-common/src/runner/reports/html/template.spec.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.spec.ts
@@ -44,7 +44,7 @@ describe('htmlTemplateString', () => {
   it('renders skipped requests off the request status, naming bail as the reason', () => {
     const template = htmlTemplateString('');
 
-    expect(template).toContain('result.status === \'skipped\'');
+    expect(template).toContain('result.response.status === \'skipped\'');
     expect(template).toContain('result.skipReason === \'bail\' ? \'Request skipped due to bail\'');
   });
 });
@@ -57,7 +57,7 @@ describe('generateHtmlReport', () => {
       skipped: true,
       skipReason: 'bail',
       request: { method: 'POST', url: 'https://api.example.com/users' },
-      response: { status: '-', responseTime: 0 },
+      response: { status: 'skipped', responseTime: 0 },
       runDuration: 0
     };
 
@@ -70,7 +70,7 @@ describe('generateHtmlReport', () => {
       status: 'skipped',
       skipReason: 'bail',
       request: { method: 'POST', url: 'https://api.example.com/users' },
-      response: { status: '-' }
+      response: { status: 'skipped' }
     });
   });
 });

--- a/packages/bruno-common/src/runner/reports/html/template.ts
+++ b/packages/bruno-common/src/runner/reports/html/template.ts
@@ -327,7 +327,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             :bordered="false"
           >
             <template #header>
-              {{result.path}} - {{resultSummary}} {{hasError && result.status !== 'skipped' ? " - (request failed)" : "" }}
+              {{result.path}} - {{resultSummary}} {{hasError && result.response.status !== 'skipped' ? " - (request failed)" : "" }}
             </template>
           </n-alert>
         </template>
@@ -363,7 +363,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
                   <n-list-item>
                     <n-thing
                       title="Response Code"
-                      :description="'' + result.response.status"
+                      :description="responseCode"
                     />
                   </n-list-item>
                   <n-list-item>
@@ -382,7 +382,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
               </n-card>
             </n-gi>
           </n-grid>
-          <n-alert v-if="hasError || (result.status === 'skipped' && result.error)" title="Error" type="error">
+          <n-alert v-if="hasError || (result.response.status === 'skipped' && result.error)" title="Error" type="error">
             {{result.error}}
           </n-alert>
           <n-card title="REQUEST HEADERS">
@@ -768,18 +768,24 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             return (props?.result?.testResults?.length || 0) + (props?.result?.assertionResults?.length || 0);
           });
 
-          const hasError = computed(() => !!props?.result?.error || props?.result?.status === 'error' || (props?.result?.status === 'skipped' && props?.result?.error));
+          const hasError = computed(() => !!props?.result?.error || props?.result?.status === 'error' || (props?.result?.response?.status === 'skipped' && props?.result?.error));
           const hasFailure = computed(() => total.value !== totalPassed.value);
           const testDuration = computed(() => Math.round(props?.result?.runDuration * 1000) + ' ms');
           const resultTitle = computed(() => props?.result?.path + ' ' + props?.result?.response?.status + ' ' + props?.result?.response?.statusText + ' ' + props?.index);
+          const responseCode = computed(() => {
+            if (props.result.response.status === 'skipped') {
+              return '-';
+            }
+            return '' + props.result.response.status;
+          });
           const resultSummary = computed(() => {
-            if (props.result.status === 'skipped') {
+            if (props.result.response.status === 'skipped') {
               return props.result.skipReason === 'bail' ? 'Request skipped due to bail' : 'Request Skipped';
             }
             return totalPassed.value + '/' + total.value + ' Passed';
           });
           const getAlertType = computed(() => {
-            if (props.result.status === 'skipped') {
+            if (props.result.response.status === 'skipped') {
               return 'warning';
             }
             return hasError.value || hasFailure.value ? 'error' : 'success';
@@ -798,6 +804,7 @@ export const htmlTemplateString = (resutsJsonString: string) => `<!DOCTYPE html>
             testsColumns,
             result: props.result,
             testDuration,
+            responseCode,
             resultTitle,
             resultSummary,
             getAlertType,


### PR DESCRIPTION
### Description

Reverted the status skipped related changes - The HTML runner report showed `skipped` in the Response Code field for skipped requests.

### Problem

A skipped request never reaches the server, so it has no status code — but the report printed the literal `skipped` where a number belongs, unlike the summary table which already used `-`.

### Fix

Response Code now renders `-` when the request was skipped, and the status code unchanged otherwise, via a `getResponseCode` helper extracted from the template so it can be unit tested.


### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized skipped request results to display a clear **“skipped”** status in CLI output and HTML reports.
  - Fixed HTML reports so skipped requests are identified correctly, including requests skipped because of prompt variables or pre-request scripts.
  - Preserved the response code display as **“-”** for skipped requests while retaining existing duration, size, timing, and skip-message details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->