### PR TITLE
fix(sidebar): align API spec row styling with collection rows

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
@@ -23,6 +23,13 @@ const ApiSpecItem = ({ apiSpec }) => {
     dispatch(setActiveApiSpecUid({ uid: apiSpec.uid }));
   };
 
+  const handleRowKeyDown = (e) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.preventDefault();
+    handleOpenApiSpec(apiSpec)(e);
+  };
+
   const menuItems = [
     {
       id: 'remove',
@@ -32,7 +39,7 @@ const ApiSpecItem = ({ apiSpec }) => {
     }
   ];
 
-  const isActive = showApiSpecPage && apiSpec?.uid == activeApiSpecUid;
+  const isActive = showApiSpecPage && apiSpec?.uid === activeApiSpecUid;
 
   return (
     <div
@@ -42,6 +49,7 @@ const ApiSpecItem = ({ apiSpec }) => {
       tabIndex={0}
       onFocus={() => setIsKeyboardFocused(true)}
       onBlur={() => setIsKeyboardFocused(false)}
+      onKeyDown={handleRowKeyDown}
     >
       {closeApiSpecModal && <CloseApiSpec apiSpec={apiSpec} onClose={() => setCloseApiSpecModal(false)} />}
       <div

--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
@@ -1,64 +1,66 @@
 import { setActiveApiSpecUid } from 'providers/ReduxStore/slices/apiSpec';
 import { showApiSpecPage as _showApiSpecPage } from 'providers/ReduxStore/slices/app';
-import Dropdown from 'components/Dropdown';
+import MenuDropdown from 'ui/MenuDropdown';
+import ActionIcon from 'ui/ActionIcon';
+import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 import { IconDots, IconX } from '@tabler/icons';
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CloseApiSpec from '../CloseApiSpec/index';
-import { forwardRef } from 'react';
 
 const ApiSpecItem = ({ apiSpec }) => {
   const dispatch = useDispatch();
+  const { dropdownContainerRef } = useSidebarAccordion();
 
   const activeApiSpecUid = useSelector((state) => state.apiSpec.activeApiSpecUid);
   const showApiSpecPage = useSelector((state) => state.app.showApiSpecPage);
 
   const [closeApiSpecModal, setCloseApiSpecModal] = useState(false);
-
-  const dropdownTippyRef = useRef();
-  const onDropdownCreate = (ref) => (dropdownTippyRef.current = ref);
+  const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
 
   const handleOpenApiSpec = (apiSpec) => (e) => {
     dispatch(_showApiSpecPage());
     dispatch(setActiveApiSpecUid({ uid: apiSpec.uid }));
   };
 
-  const MenuIcon = forwardRef((props, ref) => {
-    return (
-      <div ref={ref}>
-        <IconDots size={22} />
-      </div>
-    );
-  });
+  const menuItems = [
+    {
+      id: 'remove',
+      leftSection: IconX,
+      label: 'Remove',
+      onClick: () => setCloseApiSpecModal(true)
+    }
+  ];
+
+  const isActive = showApiSpecPage && apiSpec?.uid == activeApiSpecUid;
 
   return (
     <div
       className={`flex flex-grow api-spec-item items-center h-full overflow-hidden w-full justify-between ${
-        showApiSpecPage && apiSpec?.uid == activeApiSpecUid ? 'active' : ''
-      }`}
+        isActive && !isKeyboardFocused ? 'active' : ''
+      } ${isKeyboardFocused ? 'api-spec-keyboard-focused' : ''}`}
+      tabIndex={0}
+      onFocus={() => setIsKeyboardFocused(true)}
+      onBlur={() => setIsKeyboardFocused(false)}
     >
       {closeApiSpecModal && <CloseApiSpec apiSpec={apiSpec} onClose={() => setCloseApiSpecModal(false)} />}
       <div
-        className="cursor-pointer py-2 pl-4 h-8 flex items-center flex-grow w-[80%] justify-between"
+        className="cursor-pointer flex items-center flex-grow w-[80%] justify-between"
         onClick={handleOpenApiSpec(apiSpec)}
       >
         <span className="flex-nowrap whitespace-nowrap overflow-ellipsis overflow-hidden w-full">{apiSpec?.name}</span>
       </div>
-      <div className="menu-icon pr-2">
-        <Dropdown onCreate={onDropdownCreate} icon={<MenuIcon />} placement="bottom-start">
-          <div
-            className="dropdown-item close-item"
-            onClick={(e) => {
-              dropdownTippyRef.current.hide();
-              setCloseApiSpecModal(true);
-            }}
-          >
-            <span className="dropdown-icon">
-              <IconX size={16} strokeWidth={2} />
-            </span>
-            Remove
-          </div>
-        </Dropdown>
+      <div className="pr-2">
+        <MenuDropdown
+          items={menuItems}
+          placement="bottom-start"
+          appendTo={dropdownContainerRef?.current || document.body}
+          popperOptions={{ strategy: 'fixed' }}
+        >
+          <ActionIcon className="collection-actions">
+            <IconDots size={18} />
+          </ActionIcon>
+        </MenuDropdown>
       </div>
     </div>
   );

--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
@@ -47,6 +47,8 @@ const ApiSpecItem = ({ apiSpec }) => {
         isActive && !isKeyboardFocused ? 'active' : ''
       } ${isKeyboardFocused ? 'api-spec-keyboard-focused' : ''}`}
       tabIndex={0}
+      data-testid="sidebar-api-spec-row"
+      data-selected={isActive ? 'true' : undefined}
       onFocus={() => setIsKeyboardFocused(true)}
       onBlur={() => setIsKeyboardFocused(false)}
       onKeyDown={handleRowKeyDown}
@@ -56,7 +58,7 @@ const ApiSpecItem = ({ apiSpec }) => {
         className="cursor-pointer flex items-center flex-grow w-[80%] justify-between"
         onClick={handleOpenApiSpec(apiSpec)}
       >
-        <span className="flex-nowrap whitespace-nowrap overflow-ellipsis overflow-hidden w-full">{apiSpec?.name}</span>
+        <span className="pl-3 flex-nowrap whitespace-nowrap overflow-ellipsis overflow-hidden w-full">{apiSpec?.name}</span>
       </div>
       <div className="pr-2">
         <MenuDropdown
@@ -64,8 +66,9 @@ const ApiSpecItem = ({ apiSpec }) => {
           placement="bottom-start"
           appendTo={dropdownContainerRef?.current || document.body}
           popperOptions={{ strategy: 'fixed' }}
+          data-testid="api-spec-actions"
         >
-          <ActionIcon className="collection-actions">
+          <ActionIcon className="apispec-row-actions">
             <IconDots size={18} />
           </ActionIcon>
         </MenuDropdown>

--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/ApiSpecItem/index.js
@@ -55,10 +55,10 @@ const ApiSpecItem = ({ apiSpec }) => {
     >
       {closeApiSpecModal && <CloseApiSpec apiSpec={apiSpec} onClose={() => setCloseApiSpecModal(false)} />}
       <div
-        className="cursor-pointer flex items-center flex-grow w-[80%] justify-between"
+        className="cursor-pointer flex items-center flex-grow w-[80%] pl-3 justify-between"
         onClick={handleOpenApiSpec(apiSpec)}
       >
-        <span className="pl-3 flex-nowrap whitespace-nowrap overflow-ellipsis overflow-hidden w-full">{apiSpec?.name}</span>
+        <span className="flex-nowrap whitespace-nowrap overflow-ellipsis overflow-hidden w-full">{apiSpec?.name}</span>
       </div>
       <div className="pr-2">
         <MenuDropdown

--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/StyledWrapper.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import sidebarRowStyles from 'components/Sidebar/SidebarRowStyles';
 
 const Wrapper = styled.div`
   display: flex;
@@ -20,40 +21,7 @@ const Wrapper = styled.div`
   }
 
   .api-spec-item {
-    height: 1.6rem;
-    cursor: pointer;
-    &.active {
-      background: ${(props) => props.theme.sidebar.collection.item.bg};
-    }
-    &:hover {
-      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
-      .menu-icon {
-        .dropdown {
-          div[aria-expanded='false'] {
-            visibility: visible;
-          }
-        }
-      }
-    }
-  }
-
-  .menu-icon {
-    cursor: pointer;
-    color: ${(props) => props.theme.sidebar.dropdownIcon.color};
-
-    .dropdown {
-      div[aria-expanded='true'] {
-        visibility: visible;
-      }
-      div[aria-expanded='false'] {
-        visibility: hidden;
-      }
-    }
-  }
-
-  div.tippy-box {
-    position: relative;
-    top: -0.625rem;
+    ${sidebarRowStyles({ selectedClass: 'active', keyboardFocusedClass: 'api-spec-keyboard-focused' })}
   }
 
   .placeholder {

--- a/packages/bruno-app/src/components/Sidebar/ApiSpecs/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/ApiSpecs/StyledWrapper.js
@@ -21,7 +21,7 @@ const Wrapper = styled.div`
   }
 
   .api-spec-item {
-    ${sidebarRowStyles({ selectedClass: 'active', keyboardFocusedClass: 'api-spec-keyboard-focused' })}
+    ${sidebarRowStyles({ selectedClass: 'active', keyboardFocusedClass: 'api-spec-keyboard-focused', actionsClass: 'apispec-row-actions' })}
   }
 
   .placeholder {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
@@ -1,31 +1,13 @@
 import styled from 'styled-components';
+import sidebarRowStyles from 'components/Sidebar/SidebarRowStyles';
 
 const Wrapper = styled.div`
   .collection-name {
-    height: 1.6rem;
-    cursor: pointer;
-    user-select: none;
-    padding-left: 4px;
-    border-left: 4px solid transparent;
+    ${sidebarRowStyles({ selectedClass: 'collection-focused-in-tab', keyboardFocusedClass: 'collection-keyboard-focused' })}
 
     .rotate-90 {
       transform: rotateZ(90deg);
     }
-    .collection-actions {
-      visibility: hidden;
-    }
-
-    /* Single source of truth for hover/focus states: background and menu icon visibility */
-    &:hover,
-    &:focus-within,
-    &.collection-keyboard-focused {
-      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
-      .collection-actions {
-        visibility: visible;
-        background-color: transparent !important;
-      }
-    }
-
     &.item-hovered {
       border-top: ${(props) => props.theme.dragAndDrop.borderStyle} ${(props) => props.theme.dragAndDrop.border};
       border-bottom: 2px solid transparent;
@@ -65,24 +47,6 @@ const Wrapper = styled.div`
       margin-bottom: -2px;
       background: transparent;
       transition: ${(props) => props.theme.dragAndDrop.transition};
-    }
-
-    &.collection-focused-in-tab {
-      background: ${(props) => props.theme.sidebar.collection.item.bg};
-
-      &:hover {
-        background: ${(props) => props.theme.sidebar.collection.item.bg} !important;
-      }
-    }
-
-    &.collection-keyboard-focused {
-      border-top: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
-      border-bottom: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
-      outline: none;
-
-       &:hover {
-        background: ${(props) => props.theme.sidebar.collection.item.keyboardFocusBg} !important;
-      }
     }
 
   }

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/StyledWrapper.js
@@ -3,7 +3,8 @@ import sidebarRowStyles from 'components/Sidebar/SidebarRowStyles';
 
 const Wrapper = styled.div`
   .collection-name {
-    ${sidebarRowStyles({ selectedClass: 'collection-focused-in-tab', keyboardFocusedClass: 'collection-keyboard-focused' })}
+    padding-left: 4px;
+    ${sidebarRowStyles({ selectedClass: 'collection-focused-in-tab', keyboardFocusedClass: 'collection-keyboard-focused', actionsClass: 'collection-actions' })}
 
     .rotate-90 {
       transform: rotateZ(90deg);
@@ -15,10 +16,6 @@ const Wrapper = styled.div`
 
     &.drag-disabled:active {
       cursor: not-allowed !important;
-    }
-
-    &:hover {
-      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
     }
 
     div.tippy-box {

--- a/packages/bruno-app/src/components/Sidebar/SidebarRowStyles/index.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarRowStyles/index.js
@@ -1,0 +1,42 @@
+import { css } from 'styled-components';
+
+const sidebarRowStyles = ({ selectedClass, keyboardFocusedClass }) => css`
+  height: 1.6rem;
+  cursor: pointer;
+  user-select: none;
+  padding-left: 4px;
+  border-left: 4px solid transparent;
+
+  .collection-actions {
+    visibility: hidden;
+  }
+
+  &:hover,
+  &:focus-within,
+  &.${keyboardFocusedClass} {
+    background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+    .collection-actions {
+      visibility: visible;
+      background-color: transparent !important;
+    }
+  }
+
+  .collection-actions[aria-expanded='true'] {
+    visibility: visible;
+  }
+
+  &.${selectedClass} {
+    background: ${(props) => props.theme.sidebar.collection.item.bg};
+    &:hover {
+      background: ${(props) => props.theme.sidebar.collection.item.bg} !important;
+    }
+  }
+
+  &.${keyboardFocusedClass} {
+    border-top: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
+    border-bottom: 1px solid ${(props) => props.theme.sidebar.collection.item.focusBorder};
+    outline: none;
+  }
+`;
+
+export default sidebarRowStyles;

--- a/packages/bruno-app/src/components/Sidebar/SidebarRowStyles/index.js
+++ b/packages/bruno-app/src/components/Sidebar/SidebarRowStyles/index.js
@@ -1,13 +1,12 @@
 import { css } from 'styled-components';
 
-const sidebarRowStyles = ({ selectedClass, keyboardFocusedClass }) => css`
+const sidebarRowStyles = ({ selectedClass, keyboardFocusedClass, actionsClass }) => css`
   height: 1.6rem;
   cursor: pointer;
   user-select: none;
-  padding-left: 4px;
   border-left: 4px solid transparent;
 
-  .collection-actions {
+  .${actionsClass} {
     visibility: hidden;
   }
 
@@ -15,13 +14,13 @@ const sidebarRowStyles = ({ selectedClass, keyboardFocusedClass }) => css`
   &:focus-within,
   &.${keyboardFocusedClass} {
     background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
-    .collection-actions {
+    .${actionsClass} {
       visibility: visible;
       background-color: transparent !important;
     }
   }
 
-  .collection-actions[aria-expanded='true'] {
+  .${actionsClass}[aria-expanded='true'] {
     visibility: visible;
   }
 

--- a/packages/bruno-app/src/selectors/tab.js
+++ b/packages/bruno-app/src/selectors/tab.js
@@ -22,9 +22,10 @@ export const getTabUidForItem = ({ itemUid, itemPathname, collectionUid }) => cr
 
 export const isTabForItemActive = ({ itemUid, itemPathname, collectionUid }) => createSelector([
   (state) => state.tabs?.activeTabUid,
-  (state) => state.tabs.tabs
-], (activeTabUid, tabs) => {
-  if (!activeTabUid) {
+  (state) => state.tabs.tabs,
+  (state) => state.app?.showApiSpecPage && state.apiSpec?.activeApiSpecUid
+], (activeTabUid, tabs, isApiSpecPanelShown) => {
+  if (!activeTabUid || isApiSpecPanelShown) {
     return false;
   }
 

--- a/tests/sidebar/api-spec-row.spec.ts
+++ b/tests/sidebar/api-spec-row.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '../../playwright';
+import * as path from 'path';
+import { buildApiSpecPanelLocators, openApiSpecFromDialog } from '../utils/page/openapi/render-spec';
+
+const FIXTURES = path.resolve(__dirname, '..', 'import', 'openapi', 'fixtures');
+const SPEC_A = { file: path.join(FIXTURES, 'openapi-simple.json'), name: 'Simple Test API' };
+const SPEC_B = { file: path.join(FIXTURES, 'openapi-comprehensive.yaml'), name: 'Comprehensive API Test Collection' };
+
+test.describe('API Spec sidebar row', () => {
+  test.beforeAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      (dialog as any).__savedShowOpenDialog = dialog.showOpenDialog;
+    });
+  });
+
+  test.afterAll(async ({ electronApp }) => {
+    await electronApp.evaluate(({ dialog }) => {
+      dialog.showOpenDialog = (dialog as any).__savedShowOpenDialog;
+      delete (dialog as any).__savedShowOpenDialog;
+    });
+  });
+
+  // Re-opening an already open spec re-parses it and changes the active spec mid-test.
+  const openBothSpecs = async (page, electronApp) => {
+    const { sidebarRow } = buildApiSpecPanelLocators(page);
+    for (const spec of [SPEC_A, SPEC_B]) {
+      if ((await sidebarRow(spec.name).count()) === 0) {
+        await openApiSpecFromDialog(page, electronApp, spec.file);
+      }
+      await expect(sidebarRow(spec.name)).toBeVisible();
+    }
+  };
+
+  test('Enter on a focused row opens that spec', async ({ page, electronApp }) => {
+    const { sidebarRow, panelHeading } = buildApiSpecPanelLocators(page);
+    await openBothSpecs(page, electronApp);
+
+    await test.step('Select spec A with the mouse', async () => {
+      await sidebarRow(SPEC_A.name).click();
+      await expect(sidebarRow(SPEC_A.name)).toHaveAttribute('data-selected', 'true');
+    });
+
+    await test.step('Focus spec B and press Enter', async () => {
+      await sidebarRow(SPEC_B.name).focus();
+      await page.keyboard.press('Enter');
+    });
+
+    await test.step('Spec B is selected and shown', async () => {
+      await expect(sidebarRow(SPEC_B.name)).toHaveAttribute('data-selected', 'true');
+      await expect(sidebarRow(SPEC_A.name)).not.toHaveAttribute('data-selected', 'true');
+      await expect(panelHeading()).toBeVisible();
+    });
+  });
+
+  test('Space on a focused row opens that spec', async ({ page, electronApp }) => {
+    const { sidebarRow, panelHeading } = buildApiSpecPanelLocators(page);
+    await openBothSpecs(page, electronApp);
+
+    await test.step('Select spec B with the mouse', async () => {
+      await sidebarRow(SPEC_B.name).click();
+      await expect(sidebarRow(SPEC_B.name)).toHaveAttribute('data-selected', 'true');
+    });
+
+    await test.step('Focus spec A and press Space', async () => {
+      await sidebarRow(SPEC_A.name).focus();
+      await page.keyboard.press('Space');
+    });
+
+    await test.step('Spec A is selected and shown', async () => {
+      await expect(sidebarRow(SPEC_A.name)).toHaveAttribute('data-selected', 'true');
+      await expect(sidebarRow(SPEC_B.name)).not.toHaveAttribute('data-selected', 'true');
+      await expect(panelHeading()).toBeVisible();
+    });
+  });
+
+  test('Row actions menu opens from the actions icon', async ({ page, electronApp }) => {
+    const { sidebarRow, sidebarRowActions, sidebarRowRemoveMenuItem } = buildApiSpecPanelLocators(page);
+    await openBothSpecs(page, electronApp);
+
+    await test.step('Hover the row and click its actions icon', async () => {
+      await sidebarRow(SPEC_A.name).hover();
+      await sidebarRowActions(SPEC_A.name).click();
+    });
+
+    await test.step('Menu is open', async () => {
+      await expect(sidebarRowRemoveMenuItem()).toBeVisible();
+      await page.keyboard.press('Escape');
+      await expect(sidebarRowRemoveMenuItem()).toBeHidden();
+    });
+  });
+});

--- a/tests/sidebar/api-spec-row.spec.ts
+++ b/tests/sidebar/api-spec-row.spec.ts
@@ -78,14 +78,15 @@ test.describe('API Spec sidebar row', () => {
     await openBothSpecs(page, electronApp);
 
     await test.step('Hover the row and click its actions icon', async () => {
-      await sidebarRow(SPEC_A.name).hover();
+      await expect(async () => {
+        await sidebarRow(SPEC_A.name).hover();
+        await expect(sidebarRowActions(SPEC_A.name)).toBeVisible();
+      }).toPass();
       await sidebarRowActions(SPEC_A.name).click();
     });
 
     await test.step('Menu is open', async () => {
       await expect(sidebarRowRemoveMenuItem()).toBeVisible();
-      await page.keyboard.press('Escape');
-      await expect(sidebarRowRemoveMenuItem()).toBeHidden();
     });
   });
 });

--- a/tests/utils/page/openapi/render-spec.ts
+++ b/tests/utils/page/openapi/render-spec.ts
@@ -3,7 +3,11 @@ import { test, Page, ElectronApplication } from '../../../../playwright';
 export const buildApiSpecPanelLocators = (page: Page) => ({
   addMenuButton: () => page.getByTestId('api-specs-header-add-menu'),
   openApiSpecMenuItem: () => page.getByTestId('api-specs-header-add-menu-open-api-spec'),
-  sidebarItem: (name: string) => page.locator('.api-spec-item').filter({ hasText: name })
+  sidebarItem: (name: string) => page.locator('.api-spec-item').filter({ hasText: name }),
+  sidebarRow: (name: string | RegExp) => page.getByTestId('sidebar-api-spec-row').filter({ hasText: name }),
+  sidebarRowActions: (name: string | RegExp) => page.getByTestId('sidebar-api-spec-row').filter({ hasText: name }).getByTestId('api-spec-actions'),
+  sidebarRowRemoveMenuItem: () => page.getByTestId('api-spec-actions-remove'),
+  panelHeading: () => page.getByText('API Designer')
 });
 
 export const openApiSpecFromDialog = async (


### PR DESCRIPTION
### Description

_**REF:BRU-4443**_

API Spec rows in the sidebar were styled on their own, separate from collection rows.This PR makes This makes spec rows behave the same as collection rows and moves the shared row styling into one place so they can't drift again.

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Problem

- The actions menu icon shows on every row, larger than the collection row icon.
- The row is taller and indented further than a collection row.
- Hovering a selected row replaces the selected background with the hover one.
- The focus and keyboard-focus treatments collection rows have are absent.
- The row name is text-selectable, so a click and small drag selects text.

<!-- What issue does this PR solve? Link the related issue if one exists. -->

### Fix

- Swapped the old `Dropdown` and hand-built icon for `MenuDropdown` and `ActionIcon`, the same ones the collection row uses.
- The menu is now appended to the sidebar container instead of the row, which is what the collection row already does
-  Pulled the hover, focus and selected styling out of the collection wrapper into `sidebarRowStyles` and imported it in both wrappers, so there's one copy instead of two (Acceptance Criteria-7).

<!-- How does this PR fix the problem? Briefly describe your approach. -->

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="736" height="461" alt="image-20260831-092621" src="https://github.com/user-attachments/assets/af31a925-fe7e-471f-9175-bd99bc2c5ad1" />| https://github.com/user-attachments/assets/ad27bc14-09d8-43c2-bfc4-510fd4bd99b6 |



#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - API specification rows can be opened using Enter or Space when focused.
  - Keyboard focus is clearly indicated for API specification and collection rows.
  - Keyboard activation ignores events originating from child controls.

- **Improvements**
  - Sidebar rows now have more consistent sizing, selection highlights, hover states, and focus indicators.
  - Sidebar actions appear when rows are hovered, focused, or expanded.
  - API specification action menus provide clearer access to row actions.
  - Opening an API specification no longer incorrectly marks another sidebar item as active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->