### PR TITLE
docs: add Hindi README links

### DIFF
--- a/docs/readme/readme_ar.md
+++ b/docs/readme/readme_ar.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_bn.md
+++ b/docs/readme/readme_bn.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | **বাংলা**
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_cn.md
+++ b/docs/readme/readme_cn.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_de.md
+++ b/docs/readme/readme_de.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_es.md
+++ b/docs/readme/readme_es.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | **Español**
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_fa.md
+++ b/docs/readme/readme_fa.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | **فارسی**
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_fr.md
+++ b/docs/readme/readme_fr.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_it.md
+++ b/docs/readme/readme_it.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | **Italiano**
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ja.md
+++ b/docs/readme/readme_ja.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ka.md
+++ b/docs/readme/readme_ka.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_kr.md
+++ b/docs/readme/readme_kr.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | **한국어**
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_nl.md
+++ b/docs/readme/readme_nl.md
@@ -10,7 +10,7 @@
 [![Website](https://img.shields.io/badge/Website-Visit-blue)](https://www.usebruno.com)
 [![Download](https://img.shields.io/badge/Download-Latest-brightgreen)](https://www.usebruno.com/downloads)
 
-[English](../../readme.md) | [Українська](docs/readme/readme_ua.md) | [Русский](docs/readme/readme_ru.md) | [Türkçe](docs/readme/readme_tr.md) | [Deutsch](docs/readme/readme_de.md) | ** Nederlands ** | [Français](docs/readme/readme_fr.md) | [Português (BR)](docs/readme/readme_pt_br.md) | [한국어](docs/readme/readme_kr.md) | [বাংলা](docs/readme/readme_bn.md) | [Español](docs/readme/readme_es.md) | [Italiano](docs/readme/readme_it.md) | [Română](docs/readme/readme_ro.md) | [Polski](docs/readme/readme_pl.md) | [简体中文](docs/readme/readme_cn.md) | [正體中文](docs/readme/readme_zhtw.md) | [العربية](docs/readme/readme_ar.md) | [日本語](docs/readme/readme_ja.md)
+[English](../../readme.md) | [Українська](docs/readme/readme_ua.md) | [Русский](docs/readme/readme_ru.md) | [Türkçe](docs/readme/readme_tr.md) | [Deutsch](docs/readme/readme_de.md) | ** Nederlands ** | [Français](docs/readme/readme_fr.md) | [Português (BR)](docs/readme/readme_pt_br.md) | [한국어](docs/readme/readme_kr.md) | [বাংলা](docs/readme/readme_bn.md) | [Español](docs/readme/readme_es.md) | [Italiano](docs/readme/readme_it.md) | [Română](docs/readme/readme_ro.md) | [Polski](docs/readme/readme_pl.md) | [简体中文](docs/readme/readme_cn.md) | [正體中文](docs/readme/readme_zhtw.md) | [العربية](docs/readme/readme_ar.md) | [日本語](docs/readme/readme_ja.md) | [हिन्दी](./readme_hi.md)
 
 Bruno is een nieuwe en innovatieve API-client, gericht op het revolutioneren van de status quo die wordt vertegenwoordigd door Postman en vergelijkbare tools.
 

--- a/docs/readme/readme_pl.md
+++ b/docs/readme/readme_pl.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_pt_br.md
+++ b/docs/readme/readme_pt_br.md
@@ -19,6 +19,7 @@
 | **Português (BR)**
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ro.md
+++ b/docs/readme/readme_ro.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | **Română**

--- a/docs/readme/readme_ru.md
+++ b/docs/readme/readme_ru.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_tr.md
+++ b/docs/readme/readme_tr.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ua.md
+++ b/docs/readme/readme_ua.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_zhtw.md
+++ b/docs/readme/readme_zhtw.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@
 | [ქართული](docs/readme/readme_ka.md)
 | [Nederlands](docs/readme/readme_nl.md)
 | [فارسی](docs/readme/readme_fa.md)
+| [हिन्दी](docs/readme/readme_hi.md)
 
 Bruno is a new and innovative API client, aimed at revolutionizing the status quo represented by Postman and similar tools out there.
 


### PR DESCRIPTION
Closes #9148

### Description

Adds the Hindi README link to the main README and all translated README files.

### Problem

The Hindi README was not linked from the main README or from the other translated README files.

### Fix

Added the Hindi README link (`readme_hi.md`) to all README translations, excluding the Hindi README itself.

### Screenshots

Not applicable — this is a documentation-only change.

##### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hindi translation links to the README language selector across the main and translated documentation pages.
  * Improved discoverability of the Hindi README from all supported language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->