### PR TITLE
docs: add Hindi README links

### DIFF
--- a/docs/readme/readme_ar.md
+++ b/docs/readme/readme_ar.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_bn.md
+++ b/docs/readme/readme_bn.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | **বাংলা**
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_cn.md
+++ b/docs/readme/readme_cn.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_de.md
+++ b/docs/readme/readme_de.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_es.md
+++ b/docs/readme/readme_es.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | **Español**
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_fa.md
+++ b/docs/readme/readme_fa.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | **فارسی**
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_fr.md
+++ b/docs/readme/readme_fr.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_it.md
+++ b/docs/readme/readme_it.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | **Italiano**
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ja.md
+++ b/docs/readme/readme_ja.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ka.md
+++ b/docs/readme/readme_ka.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_kr.md
+++ b/docs/readme/readme_kr.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | **한국어**
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_nl.md
+++ b/docs/readme/readme_nl.md
@@ -10,7 +10,7 @@
 [![Website](https://img.shields.io/badge/Website-Visit-blue)](https://www.usebruno.com)
 [![Download](https://img.shields.io/badge/Download-Latest-brightgreen)](https://www.usebruno.com/downloads)
 
-[English](../../readme.md) | [Українська](docs/readme/readme_ua.md) | [Русский](docs/readme/readme_ru.md) | [Türkçe](docs/readme/readme_tr.md) | [Deutsch](docs/readme/readme_de.md) | ** Nederlands ** | [Français](docs/readme/readme_fr.md) | [Português (BR)](docs/readme/readme_pt_br.md) | [한국어](docs/readme/readme_kr.md) | [বাংলা](docs/readme/readme_bn.md) | [Español](docs/readme/readme_es.md) | [Italiano](docs/readme/readme_it.md) | [Română](docs/readme/readme_ro.md) | [Polski](docs/readme/readme_pl.md) | [简体中文](docs/readme/readme_cn.md) | [正體中文](docs/readme/readme_zhtw.md) | [العربية](docs/readme/readme_ar.md) | [日本語](docs/readme/readme_ja.md)
+[English](../../readme.md) | [Українська](docs/readme/readme_ua.md) | [Русский](docs/readme/readme_ru.md) | [Türkçe](docs/readme/readme_tr.md) | [Deutsch](docs/readme/readme_de.md) | ** Nederlands ** | [Français](docs/readme/readme_fr.md) | [Português (BR)](docs/readme/readme_pt_br.md) | [한국어](docs/readme/readme_kr.md) | [বাংলা](docs/readme/readme_bn.md) | [Español](docs/readme/readme_es.md) | [Italiano](docs/readme/readme_it.md) | [Română](docs/readme/readme_ro.md) | [Polski](docs/readme/readme_pl.md) | [简体中文](docs/readme/readme_cn.md) | [正體中文](docs/readme/readme_zhtw.md) | [العربية](docs/readme/readme_ar.md) | [日本語](docs/readme/readme_ja.md) | [हिन्दी](./readme_hi.md)
 
 Bruno is een nieuwe en innovatieve API-client, gericht op het revolutioneren van de status quo die wordt vertegenwoordigd door Postman en vergelijkbare tools.
 

--- a/docs/readme/readme_pl.md
+++ b/docs/readme/readme_pl.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_pt_br.md
+++ b/docs/readme/readme_pt_br.md
@@ -19,6 +19,7 @@
 | **Português (BR)**
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ro.md
+++ b/docs/readme/readme_ro.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | **Română**

--- a/docs/readme/readme_ru.md
+++ b/docs/readme/readme_ru.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_tr.md
+++ b/docs/readme/readme_tr.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_ua.md
+++ b/docs/readme/readme_ua.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/docs/readme/readme_zhtw.md
+++ b/docs/readme/readme_zhtw.md
@@ -19,6 +19,7 @@
 | [Português (BR)](./readme_pt_br.md)
 | [한국어](./readme_kr.md)
 | [বাংলা](./readme_bn.md)
+| [हिन्दी](./readme_hi.md)
 | [Español](./readme_es.md)
 | [Italiano](./readme_it.md)
 | [Română](./readme_ro.md)

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@
 | [ქართული](docs/readme/readme_ka.md)
 | [Nederlands](docs/readme/readme_nl.md)
 | [فارسی](docs/readme/readme_fa.md)
+| [हिन्दी](docs/readme/readme_hi.md)
 
 Bruno is a new and innovative API client, aimed at revolutionizing the status quo represented by Postman and similar tools out there.
 


### PR DESCRIPTION
REF - BRU-4471

Fecha https://github.com/usebruno/bruno/issues/9148

Descrição
Adiciona o link para o arquivo README em hindi ao README principal e a todos os arquivos README traduzidos.

Problema
O arquivo README em hindi não estava vinculado ao README principal nem aos outros arquivos README traduzidos.

Consertar
Adicionado o link README em hindi ( readme_hi.md) a todas as traduções de README, exceto o próprio README em hindi.

Capturas de tela
Não aplicável — esta é uma alteração que diz respeito apenas à documentação.

Lista de verificação de contribuição:
 Utilizei IA de forma significativa para criar esta solicitação de pull request.
 A solicitação de pull request aborda apenas um problema ou adiciona uma funcionalidade.
 A solicitação de pull request não introduz nenhuma alteração que quebre a compatibilidade.
 Adicionei capturas de tela ou GIFs para ajudar a explicar a mudança, quando aplicável.
 Li as [diretrizes de contribuição](https://github.com/usebruno/bruno/blob/main/contributing.md) .
 Crie uma issue e inclua um link para o pull request.
 Executei a habilidade de revisão de código do Claude localmente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hindi translation links to the language selectors across the main README and translated README pages.
  * Improved discoverability of the Hindi-language documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->