### PR TITLE
fix: align sidebar requests with and without examples

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.js
@@ -45,7 +45,7 @@ const RequestMethod = ({ item }) => {
   return (
     <StyledWrapper>
       <div className={className}>
-        <span className="uppercase">
+        <span className="uppercase" data-testid="sidebar-request-method">
           {methodText}
         </span>
       </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -822,7 +822,9 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
                   data-testid="request-item-chevron"
                 />
               </ActionIcon>
-            ) : null}
+            ) : (
+              <div style={{ width: 16, minWidth: 16 }} />
+            )}
 
             <div className="ml-1 flex w-full h-full items-center overflow-hidden">
               <CollectionItemIcon item={item} />

--- a/tests/response-examples/sidebar-alignment.spec.ts
+++ b/tests/response-examples/sidebar-alignment.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect, closeElectronApp, waitForReadyPage } from '../../playwright';
+import { buildCommonLocators, openCollection, openCollectionFromDialog } from '../utils/page';
+
+test('aligns request methods and names with and without examples', async ({ launchElectronApp, collectionFixturePath }) => {
+  const electronApp = await launchElectronApp();
+  try {
+    const page = await waitForReadyPage(electronApp);
+    const { sidebar } = buildCommonLocators(page);
+
+    await test.step('Open an isolated collection with both kinds of request', async () => {
+      await openCollectionFromDialog(page, electronApp, collectionFixturePath!);
+      await openCollection(page, 'collection');
+      await expect(sidebar.requestExamplesToggle('multipart-example')).toBeVisible();
+      await expect(sidebar.requestExamplesToggle('edit-example')).toHaveCount(0);
+    });
+
+    for (const expanded of [false, true]) {
+      await test.step(`Keep columns aligned with examples ${expanded ? 'expanded' : 'collapsed'}`, async () => {
+        if (expanded) {
+          await sidebar.requestExamplesToggle('multipart-example').click();
+          await expect(sidebar.example('Three Files Example')).toBeVisible();
+        }
+
+        for (const [column, locator] of [
+          ['method', sidebar.requestMethod],
+          ['name', sidebar.itemByName]
+        ] as const) {
+          const withExampleCell = locator('multipart-example');
+          const withoutExampleCell = locator('edit-example');
+          await expect(withExampleCell).toBeVisible();
+          await expect(withoutExampleCell).toBeVisible();
+          await expect.poll(async () => {
+            const withExample = await withExampleCell.boundingBox();
+            const withoutExample = await withoutExampleCell.boundingBox();
+            return withExample && withoutExample ? withExample.x - withoutExample.x : null;
+          }, { message: `The ${column} column should start at the same position` }).toBe(0);
+        }
+      });
+    }
+  } finally {
+    await closeElectronApp(electronApp);
+  }
+});

--- a/tests/utils/page/sidebar/index.ts
+++ b/tests/utils/page/sidebar/index.ts
@@ -19,6 +19,7 @@ export const buildSidebarLocators = (page: Page) => {
     collection: (name?: string) => name ? page.locator('#sidebar-collection-name').filter({ hasText: name }) : page.locator('#sidebar-collection-name'),
     folder: (name: string) => page.locator('.collection-item-name').filter({ hasText: name }),
     request: (name: string) => page.locator('.collection-item-name').filter({ hasText: name }),
+    requestMethod: (name: string) => itemRow(name).getByTestId('sidebar-request-method'),
     collectionChevron: (name: string) => collectionRow(name).getByTestId('collection-chevron'),
     folderRequest: (folderName: string, requestName: string) => {
       // Find the folder's collection-item-name, then navigate to its parent wrapper container (StyledWrapper),


### PR DESCRIPTION
REF - BRU-3275

### Description

I fixed the sidebar alignment for requests with and without examples. The method labels and request names now start at the same position for requests at the same level.

I used AI to help with the fix and regression test.

### Problem

Fixes #9186.

Requests without examples didn't reserve space for the chevron, so their method labels and names started 16 pixels to the left of requests with examples.

### Fix

I added an empty 16-pixel slot when a row has no chevron, using the same spacing pattern as the existing example rows. The slot isn't a button, and expanding or collapsing examples still works as before.

I also added an Electron regression test that compares the rendered method and name positions with examples collapsed and expanded. It uses an isolated app and a temporary copy of the existing collection fixture.

### Testing

- The regression test failed with a 16-pixel difference before the fix and passed twice after it.
- All 2,109 frontend unit tests passed with `TZ=UTC`. Two existing date-format tests depend on the local timezone.
- Scoped lint passed with no errors; existing warnings on unchanged lines remain.
- I checked alignment, example expansion, nested requests, and resizing manually in the local desktop build.

### Screenshots

Before, from the issue report:

![Before](https://github.com/user-attachments/assets/474c466f-4fcd-4ce2-9f83-1d803d7a6fee)

After, from the local build:

![After](https://github.com/user-attachments/assets/545a81fa-dde4-4130-aef2-accdc5e8bd6a)

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar alignment for collection items with and without response examples.
  * Kept request method and name columns consistently aligned when examples are collapsed or expanded.

* **Tests**
  * Added automated coverage to verify sidebar alignment across different request configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->