### PR TITLE
fix(environment): changed copy button text to new

### DIFF
--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/EnvironmentRow/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/EnvironmentRow/index.js
@@ -1,21 +1,6 @@
 import React, { memo } from 'react';
 import { ResolutionButton } from '../ReviewStep/StyledWrapper';
-import { RESOLUTION_TYPES, RESOLUTION_LABELS, RESOLUTION_SHORT_LABELS } from '../utils';
-
-const RESOLUTION_OPTIONS = [
-  {
-    value: RESOLUTION_TYPES.COPY,
-    label: RESOLUTION_LABELS[RESOLUTION_TYPES.COPY],
-    shortLabel: RESOLUTION_SHORT_LABELS[RESOLUTION_TYPES.COPY],
-    testId: 'env-import-copy-btn'
-  },
-  {
-    value: RESOLUTION_TYPES.REPLACE,
-    label: RESOLUTION_LABELS[RESOLUTION_TYPES.REPLACE],
-    shortLabel: RESOLUTION_SHORT_LABELS[RESOLUTION_TYPES.REPLACE],
-    testId: 'env-import-replace-btn'
-  }
-];
+import { RESOLUTION_OPTIONS } from '../utils';
 
 const EnvironmentRow = ({ env, isSelected, resolution, toggleItemSelection, setItemResolution, showResolutions }) => {
   const sourceFile = env.filePath || env.fileName;
@@ -36,7 +21,7 @@ const EnvironmentRow = ({ env, isSelected, resolution, toggleItemSelection, setI
       </label>
       {showResolutions && (
         <div className="env-actions">
-          {RESOLUTION_OPTIONS.map(({ value, label, shortLabel, testId }) => {
+          {RESOLUTION_OPTIONS.map(({ value, label, title, testId }) => {
             const selected = resolution === value;
 
             return (
@@ -45,10 +30,10 @@ const EnvironmentRow = ({ env, isSelected, resolution, toggleItemSelection, setI
                 $selected={selected}
                 aria-pressed={selected}
                 onClick={() => setItemResolution(env.id, value)}
-                title={label}
+                title={title}
                 data-testid={testId}
               >
-                {shortLabel}
+                {label}
               </ResolutionButton>
             );
           })}

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/EnvironmentRow/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/EnvironmentRow/index.js
@@ -3,8 +3,6 @@ import { ResolutionButton } from '../ReviewStep/StyledWrapper';
 import { RESOLUTION_OPTIONS } from '../utils';
 
 const EnvironmentRow = ({ env, isSelected, resolution, toggleItemSelection, setItemResolution, showResolutions }) => {
-  const sourceFile = env.filePath || env.fileName;
-
   return (
     <div className="env-item" data-testid="env-import-item">
       <label className="env-item-label">
@@ -16,7 +14,7 @@ const EnvironmentRow = ({ env, isSelected, resolution, toggleItemSelection, setI
           data-testid="env-import-item-checkbox"
         />
         <div className="env-item-content">
-          <div className="env-name" title={sourceFile}>{env.name}</div>
+          <div className="env-name" title={env.name}>{env.name}</div>
         </div>
       </label>
       {showResolutions && (

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/InvalidEnvironmentGroup/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/InvalidEnvironmentGroup/index.js
@@ -27,7 +27,7 @@ const InvalidEnvironmentGroup = ({ invalid, isExpanded, toggleExpanded }) => {
           {invalid.map((item, idx) => (
             <div key={`${item.fileName}-${idx}`} className="env-import-invalid-item" data-testid="env-import-invalid-item">
               <div className="env-item-content">
-                <div className="env-name">{item.fileName}</div>
+                <div className="env-name" title={item.fileName}>{item.fileName}</div>
                 <div className="env-error">{item.error}</div>
               </div>
             </div>

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/ReviewStep/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/ReviewStep/StyledWrapper.js
@@ -5,6 +5,8 @@ export const StyledWrapper = styled.div`
   .modal-content {
     display: flex;
     flex-direction: column;
+    width: 498px;
+    max-width: 100%;
     height: 450px;
     max-height: calc(100vh - 180px);
     overflow: hidden;
@@ -229,6 +231,9 @@ export const StyledWrapper = styled.div`
     font-weight: 400;
     font-size: ${(props) => props.theme.font.size.base};
     line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .env-error {
@@ -236,6 +241,9 @@ export const StyledWrapper = styled.div`
     font-weight: 400;
     color: ${(props) => props.theme.colors.text.danger};
     margin-top: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .env-actions {

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
@@ -34,7 +34,7 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
         const isDuplicate = environment.status === ENV_STATUS.DUPLICATE;
 
         if (isDuplicate) {
-          const resolution = itemResolutions.get(environment.id) || RESOLUTION_TYPES.COPY;
+          const resolution = itemResolutions.get(environment.id) || RESOLUTION_TYPES.CREATE_NEW;
           const normalizedName = normalizeEnvName(environment.name);
           if (resolution === RESOLUTION_TYPES.REPLACE && !replacedNames.has(normalizedName)) {
             const existingEnv = getExistingEnv(environment.name);
@@ -125,7 +125,7 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
       const initialResolutions = new Map();
       validItems
         .filter((item) => item.status === ENV_STATUS.DUPLICATE)
-        .forEach((item) => initialResolutions.set(item.id, RESOLUTION_TYPES.COPY));
+        .forEach((item) => initialResolutions.set(item.id, RESOLUTION_TYPES.CREATE_NEW));
       setResolutions(initialResolutions);
 
       setStep(IMPORT_STEPS.REVIEW);

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
@@ -10,18 +10,11 @@ export const detectEnvironmentFormat = (data) => {
 };
 
 export const RESOLUTION_TYPES = {
-  CUSTOM: 'custom',
   COPY: 'copy',
   REPLACE: 'replace'
 };
 
-export const RESOLUTION_SHORT_LABELS = {
-  [RESOLUTION_TYPES.COPY]: 'Clone',
-  [RESOLUTION_TYPES.REPLACE]: 'Replace'
-};
-
-export const RESOLUTION_LABELS = {
-  [RESOLUTION_TYPES.CUSTOM]: 'Custom',
-  [RESOLUTION_TYPES.COPY]: 'Import as clone',
-  [RESOLUTION_TYPES.REPLACE]: 'Replace existing'
-};
+export const RESOLUTION_OPTIONS = [
+  { value: RESOLUTION_TYPES.COPY, label: 'New', title: 'Import as a new environment', testId: 'env-import-copy-btn' },
+  { value: RESOLUTION_TYPES.REPLACE, label: 'Replace', title: 'Replace existing', testId: 'env-import-replace-btn' }
+];

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
@@ -10,11 +10,11 @@ export const detectEnvironmentFormat = (data) => {
 };
 
 export const RESOLUTION_TYPES = {
-  COPY: 'copy',
+  CREATE_NEW: 'create_new',
   REPLACE: 'replace'
 };
 
 export const RESOLUTION_OPTIONS = [
-  { value: RESOLUTION_TYPES.COPY, label: 'New', title: 'Import as a new environment', testId: 'env-import-copy-btn' },
+  { value: RESOLUTION_TYPES.CREATE_NEW, label: 'New', title: 'Import as a new environment', testId: 'env-import-create-new-btn' },
   { value: RESOLUTION_TYPES.REPLACE, label: 'Replace', title: 'Replace existing', testId: 'env-import-replace-btn' }
 ];

--- a/tests/environments/import-environment/name-conflicts/name-conflicts.spec.ts
+++ b/tests/environments/import-environment/name-conflicts/name-conflicts.spec.ts
@@ -51,13 +51,13 @@ test.describe('Import environment - name conflict handling', () => {
       await test.step('Copy is the default resolution and can be switched to Replace', async () => {
         const item = environment.importReviewItem('Production');
         await expect(item).toBeVisible();
-        await expect(environment.importCopyButton('Production')).toHaveAttribute('aria-pressed', 'true');
+        await expect(environment.importCreateNewButton('Production')).toHaveAttribute('aria-pressed', 'true');
         await expect(environment.importReplaceButton('Production')).toHaveAttribute('aria-pressed', 'false');
 
         await environment.importReplaceButton('Production').click();
 
         await expect(environment.importReplaceButton('Production')).toHaveAttribute('aria-pressed', 'true');
-        await expect(environment.importCopyButton('Production')).toHaveAttribute('aria-pressed', 'false');
+        await expect(environment.importCreateNewButton('Production')).toHaveAttribute('aria-pressed', 'false');
       });
 
       await modal.closeButton().click();

--- a/tests/utils/page/environments/index.ts
+++ b/tests/utils/page/environments/index.ts
@@ -131,7 +131,7 @@ export const buildEnvironmentLocators = (page: Page) => ({
   importSelectedCount: () => page.getByTestId('env-import-selected-count'),
   importReviewItem: (name: string) => page.getByTestId('env-import-item').filter({ has: page.getByText(name, { exact: true }) }),
   importItemCheckbox: (name: string) => buildEnvironmentLocators(page).importReviewItem(name).getByTestId('env-import-item-checkbox'),
-  importCopyButton: (name: string) => buildEnvironmentLocators(page).importReviewItem(name).getByTestId('env-import-copy-btn'),
+  importCreateNewButton: (name: string) => buildEnvironmentLocators(page).importReviewItem(name).getByTestId('env-import-create-new-btn'),
   importReplaceButton: (name: string) => buildEnvironmentLocators(page).importReviewItem(name).getByTestId('env-import-replace-btn'),
   importReviewItemNames: () => page.getByTestId('env-import-item').locator('.env-name'),
   importInvalidGroup: () => page.getByTestId('env-import-invalid-group'),


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Changed multi env import Clone option to new.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->

- Earlier we had a Clone option which was not clear to the user.
- Large env names was not handled properly making the modal width large and also name was spanning in next rows.


### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- Changed multi env import Clone option to new.
- Handled large names with elipsis and showing a tooltip for name.
- Code refactor removing the resolution types which was getting used when we had a dropdown to select a resolution for all files.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  | <img width="509" height="584" alt="image" src="https://github.com/user-attachments/assets/e2b0677f-62ef-423e-8272-b897ce57f527" />|

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Environment import reviews now display clearer resolution labels and more informative tooltips.
  * Long environment names and error messages truncate cleanly while remaining accessible on hover.
  * The import dialog adapts to smaller screen sizes for improved readability.
* **Changes**
  * Duplicate environments now default to **Create New** instead of copying.
  * Updated resolution terminology and controls to reflect the **Create New** option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->