### PR TITLE
fix: keep variable tooltips above the New Request modal

### DIFF
--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -298,7 +298,8 @@ const GlobalStyle = createGlobalStyle`
     padding: 0.5rem;
     position: fixed;
     transition: opacity 0.15s;
-    z-index: 10;
+    // Body-mounted variable popups must sit above modals (20), below autocomplete (50).
+    z-index: 30;
   }
 
   // Autocomplete hints dropdown container

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -138,7 +138,7 @@ export const buildCommonLocators = (page: Page) => ({
     searchInput: () => page.getByTestId('selection-search-input')
   },
   codeMirror: {
-    hint: (name: string) => page.locator('.CodeMirror-hint').filter({ hasText: name }),
+    hint: (name: string) => page.locator('.CodeMirror-hints:visible').getByRole('option', { name, exact: true }),
     byTestId: (testId: string) => page.getByTestId(testId).locator('.CodeMirror').first(),
     within: (scope: Locator) => scope.locator('.CodeMirror').first(),
     /** Nth row's value-column editor in an EditableTable (Headers / Params / Vars / Assertions). */

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -117,6 +117,8 @@ export const buildCommonLocators = (page: Page) => ({
     footer: () => page.locator('.bruno-modal-footer'),
     submitButton: () => page.locator('.bruno-modal-footer .submit'),
     newRequestMethodOption: (id: string) => page.getByTestId(`method-selector-${id.toLowerCase()}`),
+    newRequestVariableToken: (name: string) =>
+      page.getByTestId('new-request-url').locator('.cm-variable-valid').filter({ hasText: name }).first(),
     backdrop: () => page.locator('.bruno-modal-backdrop')
   },
   openCollectionPicker: {
@@ -136,6 +138,7 @@ export const buildCommonLocators = (page: Page) => ({
     searchInput: () => page.getByTestId('selection-search-input')
   },
   codeMirror: {
+    hint: (name: string) => page.locator('.CodeMirror-hint').filter({ hasText: name }),
     byTestId: (testId: string) => page.getByTestId(testId).locator('.CodeMirror').first(),
     within: (scope: Locator) => scope.locator('.CodeMirror').first(),
     /** Nth row's value-column editor in an EditableTable (Headers / Params / Vars / Assertions). */

--- a/tests/variable-tooltip/new-request-tooltip.spec.ts
+++ b/tests/variable-tooltip/new-request-tooltip.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../playwright';
 import {
-  addEnvironmentVariable,
+  addEnvironmentVariables,
   closeEnvironmentPanel,
   createCollection,
   createEnvironment,
@@ -26,16 +26,20 @@ for (const { position, prefix } of [
       await page.setViewportSize({ width: 1000, height: 720 });
       await createCollection(page, collectionName, await createTmpDir('new-request-tooltip'));
       await createEnvironment(page, 'Example', 'collection');
-      await addEnvironmentVariable(page, { name: 'apiKey', value: variableValue });
+      await addEnvironmentVariables(page, [
+        { name: 'apiKey', value: variableValue },
+        { name: 'apiKeyBackup', value: 'backup-api-key' }
+      ]);
       await saveEnvironment(page);
       await closeEnvironmentPanel(page);
     });
 
-    await test.step('Select URL autocomplete in the New Request dialog', async () => {
+    await test.step('Select the exact URL autocomplete option among overlapping variable names', async () => {
       await openNewRequestModal(page, collectionName);
       await request.requestNameInput().fill(requestName);
       await request.newRequestUrl().click();
       await page.keyboard.type(`${prefix}{{api`);
+      await expect(codeMirror.hint('apiKeyBackup')).toBeVisible();
       await codeMirror.hint('apiKey').click();
       await expect(request.newRequestUrl()).toContainClass('CodeMirror-focused');
       await page.keyboard.type('}}');

--- a/tests/variable-tooltip/new-request-tooltip.spec.ts
+++ b/tests/variable-tooltip/new-request-tooltip.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '../../playwright';
+import {
+  addEnvironmentVariable,
+  closeEnvironmentPanel,
+  createCollection,
+  createEnvironment,
+  openNewRequestModal,
+  openUrlVarTooltip,
+  saveEnvironment
+} from '../utils/page';
+import { buildCommonLocators } from '../utils/page/locators';
+
+for (const { position, prefix } of [
+  { position: 'below the URL', prefix: '' },
+  { position: 'across the right dialog edge', prefix: 'https://example.com/?key=' }
+]) {
+  test(`New Request variable tooltip is usable ${position}`, async ({ newPage: page, createTmpDir, installFakeClipboard }, testInfo) => {
+    const collectionName = 'Tooltip example';
+    const requestName = 'Variable request';
+    const variableValue = 'example-api-key';
+    const { codeMirror, modal, request, sidebar, varInfoPopup } = buildCommonLocators(page);
+    const clipboard = await installFakeClipboard(page);
+    const tooltip = varInfoPopup.byName('apiKey');
+
+    await test.step('Create an isolated collection with an environment variable', async () => {
+      await page.setViewportSize({ width: 1000, height: 720 });
+      await createCollection(page, collectionName, await createTmpDir('new-request-tooltip'));
+      await createEnvironment(page, 'Example', 'collection');
+      await addEnvironmentVariable(page, { name: 'apiKey', value: variableValue });
+      await saveEnvironment(page);
+      await closeEnvironmentPanel(page);
+    });
+
+    await test.step('Select URL autocomplete in the New Request dialog', async () => {
+      await openNewRequestModal(page, collectionName);
+      await request.requestNameInput().fill(requestName);
+      await request.newRequestUrl().click();
+      await page.keyboard.type(`${prefix}{{api`);
+      await codeMirror.hint('apiKey').click();
+      await expect(request.newRequestUrl()).toContainClass('CodeMirror-focused');
+      await page.keyboard.type('}}');
+      await expect(request.newRequestUrl()).toContainText(`${prefix}{{apiKey}}`);
+    });
+
+    await test.step('Hover the URL variable and verify the popup is not occluded', async () => {
+      await modal.newRequestVariableToken('apiKey').hover();
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip).toHaveCSS('opacity', '1');
+      await expect(varInfoPopup.editableValue(tooltip)).toHaveText(variableValue);
+      await expect(tooltip).toBeInViewport({ ratio: 1 });
+      await testInfo.attach('new-request-variable-tooltip', {
+        body: await page.screenshot(),
+        contentType: 'image/png'
+      });
+
+      // Visibility alone passes even when the modal covers the body-mounted popup.
+      await expect.poll(() => tooltip.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return [[0.5, 0.5], [0.1, 0.1], [0.9, 0.1], [0.1, 0.9], [0.9, 0.9]].every(([x, y]) =>
+          element.contains(document.elementFromPoint(rect.x + rect.width * x, rect.y + rect.height * y))
+        );
+      }), { message: 'The variable popup must be above the modal at its center and corners' }).toBe(true);
+    });
+
+    await test.step('Use the popup without closing the dialog, then create the request', async () => {
+      await varInfoPopup.copyButton(tooltip).click();
+      await expect.poll(clipboard.copiedText).toBe(variableValue);
+      await expect(modal.byTitle('New Request')).toBeVisible();
+      await expect(request.requestNameInput()).toHaveValue(requestName);
+      await request.requestNameInput().click();
+      await expect(tooltip).toHaveCount(0);
+      await modal.button('Create').click();
+      await expect(modal.any()).toHaveCount(0);
+      await expect(tooltip).toHaveCount(0);
+      await expect(sidebar.request(requestName)).toBeVisible();
+    });
+
+    await test.step('Use the same variable popup outside the dialog', async () => {
+      await sidebar.request(requestName).click();
+      await openUrlVarTooltip(page, 'apiKey');
+      await varInfoPopup.editableValue(tooltip).click();
+      await expect(varInfoPopup.editor(tooltip)).toBeVisible();
+    });
+  });
+}


### PR DESCRIPTION
REF - BRU-3302

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

Keep URL-variable hover information readable and interactive in the New Request dialog, including where the popup extends beyond the dialog edge. The production change is limited to the variable popup's stacking layer; the other changes add behavioral regression coverage and two shared locators.

**Outstanding contribution items:** native screenshot upload is blocked, and the exact parallel review workflow has not been completed. The local review method and remaining checklist items are disclosed below.

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->

Fixes #7927.

The variable information popup is appended directly to `document.body` with `position: fixed` and `z-index: 10`. The modal's stacking context is at `z-index: 20`, so both the dialog card and its backdrop cover the popup. A visibility-only assertion still passes despite the occlusion.

Reproduced against upstream main `5afc5c78f7044711352724d5617b2290e37b0f24` before changing production code:

1. Create a temporary collection and select an environment containing `apiKey = example-api-key`.
2. Open New Request and enter a request name.
3. Enter `{{apiKey}}`, or `https://example.com/?key={{apiKey}}` to place the popup across the dialog's right edge.
4. Hover `{{apiKey}}`. The popup is behind the modal and its value/copy control are obscured.

This is distinct from #5367 / #5459: that fix raised the autocomplete hints container, not the variable-information hover popup.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

Raise `.CodeMirror-brunoVarInfo` to `z-index: 30`: above the existing modal layer (`20`) and below autocomplete hints (`50`). Keep the body mount, viewport positioning, modal styles, and popup lifecycle unchanged. No dependencies or unrelated styling changes.

The new Electron/Playwright cases exercise both URL positions using isolated user data and temporary collections. They select the exact `apiKey` autocomplete suggestion with overlapping `apiKeyBackup` present, check the popup's viewport bounds and center/corner hit targets with `document.elementFromPoint`, copy the value without closing the dialog, dismiss the popup, create the request, and open/edit its variable popup outside the dialog. Clipboard assertions use the existing isolated fake-clipboard fixture, not the system clipboard.

#### Validation

Run locally on **macOS 26.3.1 (Apple Silicon), Node 22.12.0, Electron 37.6.1**. The original report is on Windows; Windows/Linux runtime validation was not performed locally.

- Baseline: both new cases fail specifically at the popup hit-testing assertion while the visibility/content assertions pass.
- Fixed: both new cases pass twice with two workers (**4/4**).
- Review follow-up (`547c2b95d`): the old substring locator fails with a strict-mode error when both `apiKey` and `apiKeyBackup` are offered. Scoping to visible CodeMirror hint lists and matching the option name exactly fixes that ambiguity without using `.first()`. Both updated cases pass twice with two workers (**4/4**).
- Existing popup editing, references, navigation and focus cases: **4/4** pass.
- Popup, autocomplete, modal and single-line editor unit suites: **139/139 tests, 4/4 suites** pass.
- Focused lint: **0 errors**; three existing warnings in `tests/utils/page/locators.ts` (unused import and two use-before-definition warnings) remain unchanged.

Commands below show the actual test selectors; local reporter/output-directory flags and log redirections are omitted:

```sh
npx playwright test tests/variable-tooltip/new-request-tooltip.spec.ts --project=default --workers=1
# Baseline: 2 expected failures at the occlusion assertion.

npx playwright test tests/variable-tooltip/new-request-tooltip.spec.ts --project=default --workers=2 --repeat-each=2

npx playwright test tests/variable-tooltip/variable-tooltip.spec.ts --project=default --workers=2 --grep 'should test tooltip with variable references|should keep tooltip open while editing|should go to definition into Environment Settings|should not steal focus'

npm test --workspace=packages/bruno-app -- --runInBand src/utils/codemirror/brunoVarInfo.spec.js src/utils/codemirror/autocomplete.spec.js src/components/Modal/Modal.spec.jsx src/components/SingleLineEditor/index.spec.js

npm run lint -- packages/bruno-app/src/globalStyles.js tests/utils/page/locators.ts tests/variable-tooltip/new-request-tooltip.spec.ts
```

#### Local review and AI disclosure

GitHub Copilot significantly assisted with investigation, implementation, regression tests and this description. The repository's `.claude/skills/code-review/SKILL.md` was invoked through Copilot. All eight applicable review lenses were applied in **one consolidated local Copilot-hosted review using Claude Sonnet 5**: correctness, architecture, conventions, React, cross-platform, security, DSL changes and E2E tests. No findings remained; the final screenshot fade-in wait was also reviewed.

**The Claude Code CLI was unavailable and was not executed. The prescribed parallel reviewer fan-out was not performed.** The exact review-workflow checklist item remains unchecked rather than implying either of those steps ran.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

Authentic before/after screenshots of the same isolated 1000 x 720 Electron scenario were captured after the popup's fade-in completed and retained locally. They contain only example data. **They are not attached yet:** the documented native `POST https://uploads.github.com/user-attachments/assets` flow returned **HTTP 404** with the upstream repository ID and existing authorized GitHub credentials. No attachment URL was returned. No screenshots, traces or generated artifacts are committed.

| Before | After |
| --- | --- |
| Captured locally; native attachment upload pending. | Captured locally; native attachment upload pending. |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

The existing issue #7927 is linked above; no duplicate issue was created. See the explicit local review-method disclosure and outstanding workflow step above.

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved variable information popups so they appear above request dialogs without covering autocomplete suggestions.
  - Ensured variable popups remain usable when positioned near or across the edge of the request dialog, including copying variable values and reopening them after saving a request.
  - Improved autocomplete selection when multiple variables have similar names by showing and targeting the correct visible suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->