### PR TITLE
fix: prevent electron app freeze on large file uploads (#9112)

### DIFF
--- a/packages/bruno-cli/src/runner/prepare-request.js
+++ b/packages/bruno-cli/src/runner/prepare-request.js
@@ -7,10 +7,7 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const { mergeHeaders, mergeScripts, mergeVars, mergeAuth, getTreePathFromCollectionToItem } = require('../utils/collection');
 const path = require('node:path');
-const { isLargeFile } = require('../utils/filesystem');
 const { getFormattedOauth2Credentials } = require('../utils/oauth2');
-
-const STREAMING_FILE_SIZE_THRESHOLD = 20 * 1024 * 1024; // 20MB
 
 const prepareRequest = async (item = {}, collection = {}) => {
   const request = item?.request;
@@ -396,7 +393,7 @@ const prepareRequest = async (item = {}, collection = {}) => {
 
   if (request.body.mode === 'file') {
     if (!contentTypeDefined) {
-      axiosRequest.headers['content-type'] = 'application/octet-stream'; // Default headers for binary file uploads
+      axiosRequest.headers['content-type'] = 'application/octet-stream';
     }
 
     const bodyFile = find(request.body.file, (param) => param.selected);
@@ -404,23 +401,32 @@ const prepareRequest = async (item = {}, collection = {}) => {
       let { filePath, contentType } = bodyFile;
 
       axiosRequest.headers['content-type'] = contentType;
-
       if (filePath) {
         if (!path.isAbsolute(filePath)) {
           filePath = path.join(collectionPath, filePath);
         }
 
         try {
-          // Large files can cause "JavaScript heap out of memory" errors when loaded entirely into memory.
-          if (isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)) {
-            // For large files: Use streaming to avoid memory issues
-            axiosRequest.data = fs.createReadStream(filePath);
-          } else {
-            // For smaller files: Use synchronous read for better performance
-            axiosRequest.data = fs.readFileSync(filePath);
-          }
+          const stats = fs.statSync(filePath);
+          const stream = fs.createReadStream(filePath, {
+            highWaterMark: 64 * 1024,
+            autoClose: true
+          });
+
+          stream.on('error', (error) => {
+            console.error(`Stream error for ${path.basename(filePath)}:`, error.message);
+          });
+
+          axiosRequest.data = stream;
+          axiosRequest.headers['content-length'] = stats.size;
+
+          // Prevent axios from buffering/limiting large file uploads
+          axiosRequest.maxContentLength = Infinity;
+          axiosRequest.maxBodyLength = Infinity;
+          axiosRequest.timeout = 0;
         } catch (error) {
-          console.error('Error reading file:', error);
+          console.error(`Error preparing file upload:`, error.message);
+          throw new Error(`Failed to prepare file upload for ${path.basename(filePath)}: ${error.message}`);
         }
       }
     }

--- a/packages/bruno-electron/src/ipc/network/axios-instance.js
+++ b/packages/bruno-electron/src/ipc/network/axios-instance.js
@@ -137,8 +137,8 @@ function makeAxiosInstance({
       message: `${config.method.toUpperCase()} ${config.url}`
     });
 
-    // Add request data if available
-    if (config.data) {
+    // Add request data if available (skip streams — they can't be meaningfully serialized)
+    if (config.data && typeof config.data?.pipe !== 'function') {
       let requestData = typeof config.data === 'string' ? config.data : JSON.stringify(config.data, null, 2);
       timeline.push({
         timestamp: new Date(),

--- a/packages/bruno-electron/src/ipc/network/prepare-request.js
+++ b/packages/bruno-electron/src/ipc/network/prepare-request.js
@@ -4,9 +4,6 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const { getTreePathFromCollectionToItem, mergeHeaders, mergeScripts, mergeVars, getFormattedCollectionOauth2Credentials, mergeAuth } = require('../../utils/collection');
 const path = require('node:path');
-const { isLargeFile } = require('../../utils/filesystem');
-
-const STREAMING_FILE_SIZE_THRESHOLD = 20 * 1024 * 1024; // 20MB
 
 const setAuthHeaders = (axiosRequest, request, collectionRoot) => {
   const collectionAuth = get(collectionRoot, 'request.auth');
@@ -479,14 +476,21 @@ const prepareRequest = async (item, collection = {}, abortController) => {
         }
 
         try {
-          // Large files can cause "JavaScript heap out of memory" errors when loaded entirely into memory.
-          if (isLargeFile(filePath, STREAMING_FILE_SIZE_THRESHOLD)) {
-            // For large files: Use streaming to avoid memory issues
-            axiosRequest.data = fs.createReadStream(filePath);
-          } else {
-            // For smaller files: Use synchronous read for better performance
-            axiosRequest.data = fs.readFileSync(filePath);
-          }
+          const stats = fs.statSync(filePath);
+          const stream = fs.createReadStream(filePath, {
+            highWaterMark: 64 * 1024,
+            autoClose: true
+          });
+          stream.on('error', (error) => {
+            console.error('Stream error:', error);
+          });
+          axiosRequest.data = stream;
+          axiosRequest.headers['content-length'] = stats.size;
+
+          // Prevent axios from buffering/limiting large file uploads
+          axiosRequest.maxContentLength = Infinity;
+          axiosRequest.maxBodyLength = Infinity;
+          axiosRequest.timeout = 0;
         } catch (error) {
           console.error('Error reading file:', error);
         }

--- a/packages/bruno-electron/src/utils/common.js
+++ b/packages/bruno-electron/src/utils/common.js
@@ -130,12 +130,16 @@ const parseDataFromResponse = (response, disableParsingResponseJson = false) => 
 };
 
 const parseDataFromRequest = (request) => {
+  // File uploads are redacted to avoid cloning/serializing the ReadStream.
+  if (request.mode === 'file') {
+    const redacted = '<request body redacted>';
+    const dataBuffer = Buffer.from(redacted);
+    return { data: redacted, dataBuffer };
+  }
+
   let requestDataString;
 
-  // File uploads are redacted, multipart FormData is formatted from original data for readability, and other types are stringified as-is.
-  if (request.mode === 'file') {
-    requestDataString = '<request body redacted>';
-  } else if (isFormData(request?.data) && Array.isArray(request._originalMultipartData)) {
+  if (isFormData(request?.data) && Array.isArray(request._originalMultipartData)) {
     const boundary = request.data._boundary || 'boundary';
     requestDataString = formatMultipartData(request._originalMultipartData, boundary);
   } else {


### PR DESCRIPTION
Internal - [BRU-4439]

### Description

This PR resolves an issue where uploading large files (>20 MB) via `body:file` mode (e.g. PUT requests to S3 pre-signed URLs) causes the Bruno Electron desktop app to freeze and stop responding.

### Problem

Closes #9112

When sending PUT/POST requests with files larger than 20 MB, the Electron app locks up and the operating system flags it as "Not Responding". This was caused by three interconnected issues:
1. **Axios Stream Limiting**: When `maxBodyLength` and `maxContentLength` are not set to `Infinity`, Axios 1.x wraps the data stream in an `AxiosTransformStream` that buffers and limits chunks, starving the Electron main process event loop.
2. **Deep Cloning of ReadStreams**: In `parseDataFromRequest` (`common.js`), `cloneDeep(request)` was executed on the entire request object. For file uploads, `request.data` is an active Node.js `fs.ReadStream`. Lodash's `cloneDeep` recursively traversed the stream's internal state machine, buffers, and event listeners, completely locking the main thread.
3. **Stream Serialization**: The Axios request timeline interceptor in `axios-instance.js` called `JSON.stringify(config.data)` on the stream instance.

### Fix

1. **`packages/bruno-electron/src/ipc/network/prepare-request.js`**:
   - Stream files using `fs.createReadStream` with `autoClose: true` and a 64KB `highWaterMark`.
   - Added stream error handling within `try/catch`.
   - Explicitly set `maxBodyLength = Infinity`, `maxContentLength = Infinity`, and `timeout = 0` on the Axios request config to allow direct streaming without buffer limits.
   - Set the `Content-Length` header accurately to the file size for S3/HTTP compatibility.
2. **`packages/bruno-electron/src/utils/common.js`**:
   - Added an early return for `request.mode === 'file'` in `parseDataFromRequest` so file uploads are redacted (`<request body redacted>`) without running `cloneDeep` on the `ReadStream`.
3. **`packages/bruno-electron/src/ipc/network/axios-instance.js`**:
   - Guarded timeline request data logging with `typeof config.data?.pipe !== 'function'` to skip serializing stream objects into JSON.
4. **`packages/bruno-cli/src/runner/prepare-request.js`**:
   - Kept the CLI stream configuration aligned with Electron.

### Screenshots

N/A (Performance and stream fix; no UI design changes).

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (Linked to #9112)
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file uploads by streaming files consistently, including smaller files, with more reliable size handling and error reporting.
  * Prevented request timeline logging from attempting to display file streams as request bodies.
  * Improved handling of file-based requests so sensitive file contents remain redacted during request parsing and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->