### PR TITLE
fix: honor ignore paths on initial collection scan

### DIFF
--- a/packages/bruno-electron/src/app/collection-watcher.js
+++ b/packages/bruno-electron/src/app/collection-watcher.js
@@ -818,6 +818,9 @@ class CollectionWatcher {
 
     this.startCollectionDiscovery(win, collectionUid);
 
+    // Seed the dynamic config lookup before chokidar evaluates the initial tree.
+    setBrunoConfig(collectionUid, brunoConfig);
+
     // Always ignore node_modules and .git, regardless of user config
     // This prevents infinite loops with symlinked directories (e.g., npm workspaces)
     const defaultIgnores = ['node_modules', '.git'];

--- a/packages/bruno-electron/src/app/collection-watcher.spec.js
+++ b/packages/bruno-electron/src/app/collection-watcher.spec.js
@@ -1,7 +1,6 @@
 const path = require('path');
 
 const watcherHandlers = {};
-const mockInitialIgnoreResults = [];
 const mockWatcher = {
   on: jest.fn((event, handler) => {
     watcherHandlers[event] = handler;
@@ -12,7 +11,8 @@ const mockWatcher = {
 
 jest.mock('chokidar', () => ({
   watch: jest.fn((watchPath, options) => {
-    mockInitialIgnoreResults.push(options.ignored(require('path').join(watchPath, 'myfolder', 'somefile.yml')));
+    // Chokidar evaluates the predicate during its initial scan, before watch returns.
+    expect(options.ignored(require('path').join(watchPath, 'myfolder', 'somefile.yml'))).toBe(true);
     return mockWatcher;
   })
 }));
@@ -80,7 +80,6 @@ describe('CollectionWatcher', () => {
   afterEach(() => {
     collectionWatcher.closeAllWatchers();
     Object.keys(watcherHandlers).forEach((event) => delete watcherHandlers[event]);
-    mockInitialIgnoreResults.length = 0;
     jest.clearAllMocks();
   });
 
@@ -93,9 +92,11 @@ describe('CollectionWatcher', () => {
     collectionWatcher.addWatcher(win, watchPath, collectionUid, brunoConfig);
 
     expect(getBrunoConfig(collectionUid)).toEqual(brunoConfig);
-    expect(mockInitialIgnoreResults).toEqual([true]);
 
     const ignored = require('chokidar').watch.mock.calls[0][1].ignored;
+    expect(ignored(path.join(watchPath, 'myfolder', 'somefile.yml'))).toBe(true);
     expect(ignored(path.join(watchPath, 'visible', 'somefile.yml'))).toBe(false);
+    expect(ignored(path.join(watchPath, '.git', 'config'))).toBe(true);
+    expect(ignored(path.join(watchPath, 'node_modules', 'package', 'index.js'))).toBe(true);
   });
 });

--- a/packages/bruno-electron/src/app/collection-watcher.spec.js
+++ b/packages/bruno-electron/src/app/collection-watcher.spec.js
@@ -1,0 +1,98 @@
+const path = require('path');
+
+const watcherHandlers = {};
+const mockWatcher = {
+  on: jest.fn((event, handler) => {
+    watcherHandlers[event] = handler;
+    return mockWatcher;
+  }),
+  close: jest.fn()
+};
+
+jest.mock('chokidar', () => ({
+  watch: jest.fn(() => mockWatcher)
+}));
+
+jest.mock('../utils/filesystem', () => ({
+  hasRequestExtension: jest.fn(),
+  isWSLPath: jest.fn(() => false),
+  normalizeAndResolvePath: jest.fn((pathname) => pathname),
+  sizeInMB: jest.fn(),
+  getCollectionFormat: jest.fn(() => 'bru')
+}));
+
+jest.mock('@usebruno/filestore', () => ({
+  parseEnvironment: jest.fn(),
+  parseRequest: jest.fn(),
+  parseRequestViaWorker: jest.fn(),
+  parseCollection: jest.fn(),
+  parseFolder: jest.fn()
+}), { virtual: true });
+
+jest.mock('@usebruno/common/utils', () => ({
+  parseValueByDataType: jest.fn()
+}), { virtual: true });
+
+jest.mock('../utils/common', () => ({
+  uuid: jest.fn(() => 'uuid')
+}));
+
+jest.mock('../cache/requestUids', () => ({
+  getRequestUid: jest.fn()
+}));
+
+jest.mock('../utils/encryption', () => ({
+  decryptStringSafe: jest.fn()
+}));
+
+jest.mock('../store/env-secrets', () => jest.fn().mockImplementation(() => ({})));
+
+jest.mock('../services/snapshot', () => ({
+  getCollection: jest.fn()
+}));
+
+jest.mock('../utils/collection', () => ({
+  parseFileMeta: jest.fn(),
+  hydrateRequestWithUuid: jest.fn()
+}));
+
+jest.mock('../utils/parse', () => ({
+  parseLargeRequestWithRedaction: jest.fn()
+}));
+
+jest.mock('../utils/transformBrunoConfig', () => ({
+  transformBrunoConfigAfterRead: jest.fn()
+}));
+
+jest.mock('./dotenv-watcher', () => ({
+  addCollectionWatcher: jest.fn(),
+  removeCollectionWatcher: jest.fn()
+}));
+
+const { getBrunoConfig } = require('../store/bruno-config');
+const collectionWatcher = require('./collection-watcher');
+
+describe('CollectionWatcher', () => {
+  afterEach(() => {
+    collectionWatcher.closeAllWatchers();
+    Object.keys(watcherHandlers).forEach((event) => delete watcherHandlers[event]);
+    jest.clearAllMocks();
+  });
+
+  it('honors configured ignore paths during the initial scan', () => {
+    const watchPath = path.join('tmp', 'collection');
+    const collectionUid = 'collection-uid';
+    const brunoConfig = { ignore: ['myfolder'] };
+    const win = { webContents: { send: jest.fn() } };
+
+    collectionWatcher.addWatcher(win, watchPath, collectionUid, brunoConfig);
+
+    const ignored = mockWatcher.on.mock.calls.length > 0
+      ? require('chokidar').watch.mock.calls[0][1].ignored
+      : null;
+
+    expect(getBrunoConfig(collectionUid)).toEqual(brunoConfig);
+    expect(ignored(path.join(watchPath, 'myfolder', 'somefile.yml'))).toBe(true);
+    expect(ignored(path.join(watchPath, 'visible', 'somefile.yml'))).toBe(false);
+  });
+});

--- a/packages/bruno-electron/src/app/collection-watcher.spec.js
+++ b/packages/bruno-electron/src/app/collection-watcher.spec.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 const watcherHandlers = {};
+const mockInitialIgnoreResults = [];
 const mockWatcher = {
   on: jest.fn((event, handler) => {
     watcherHandlers[event] = handler;
@@ -10,7 +11,10 @@ const mockWatcher = {
 };
 
 jest.mock('chokidar', () => ({
-  watch: jest.fn(() => mockWatcher)
+  watch: jest.fn((watchPath, options) => {
+    mockInitialIgnoreResults.push(options.ignored(require('path').join(watchPath, 'myfolder', 'somefile.yml')));
+    return mockWatcher;
+  })
 }));
 
 jest.mock('../utils/filesystem', () => ({
@@ -76,6 +80,7 @@ describe('CollectionWatcher', () => {
   afterEach(() => {
     collectionWatcher.closeAllWatchers();
     Object.keys(watcherHandlers).forEach((event) => delete watcherHandlers[event]);
+    mockInitialIgnoreResults.length = 0;
     jest.clearAllMocks();
   });
 
@@ -87,12 +92,10 @@ describe('CollectionWatcher', () => {
 
     collectionWatcher.addWatcher(win, watchPath, collectionUid, brunoConfig);
 
-    const ignored = mockWatcher.on.mock.calls.length > 0
-      ? require('chokidar').watch.mock.calls[0][1].ignored
-      : null;
-
     expect(getBrunoConfig(collectionUid)).toEqual(brunoConfig);
-    expect(ignored(path.join(watchPath, 'myfolder', 'somefile.yml'))).toBe(true);
+    expect(mockInitialIgnoreResults).toEqual([true]);
+
+    const ignored = require('chokidar').watch.mock.calls[0][1].ignored;
     expect(ignored(path.join(watchPath, 'visible', 'somefile.yml'))).toBe(false);
   });
 });


### PR DESCRIPTION
BRU-4545

### Description

Fixes the initial collection scan so configured `ignore` paths are honored when File cache is disabled.

### Problem

Closes #9130. `addWatcher` received the parsed Bruno config, but its chokidar `ignored` predicate read a separate dynamic store that was empty during the first scan. Ignored folders could therefore appear in the sidebar and nested YAML files could be misclassified as requests.

### Fix

Seed the dynamic Bruno-config store before creating the chokidar watcher. Added a regression test that evaluates the initial-scan ignore predicate for an ignored folder and a visible sibling.

### Screenshots

Not applicable; this is a backend watcher and regression-test change.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (Uses existing issue #9130.)
- [ ] **I've run the claude code review skill locally.**

Validation: focused Jest test passed; Electron source suite passed (25 suites, 323 tests, 4 skipped); ESLint reported 0 errors and one pre-existing warning; `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collection monitoring now applies the current Bruno configuration when determining which paths to ignore during startup.
  * Configured folders are excluded during the initial scan, preventing unwanted files from being monitored.

* **Tests**
  * Added coverage to verify configured ignore folders are excluded while other paths remain monitored.
  * Added checks for ignore behavior across configured folders, visible paths, and common excluded directories during watcher startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->