### PR TITLE
feat(sidebar): optimize multi-item drag summary calculation logic

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/index.js
@@ -22,16 +22,30 @@ function getItemStyles({ x, y }) {
 
 // Builds the "N folders, M requests and K apps"-style summary for a multi-item drag.
 function getMultiDragLabel(multiSelectedItems) {
-  const folders = multiSelectedItems.filter((i) => i.type === 'folder').length;
-  const apps = multiSelectedItems.filter((i) => i.type === 'app').length;
-  const requests = multiSelectedItems.filter((i) => i.type && i.type.includes('request')).length;
-  const collections = multiSelectedItems.filter((i) => !i.type || i.type === 'collection').length;
+  const itemsCount = multiSelectedItems.reduce(
+    (acc, i) => {
+      if (i.type === 'folder') {
+        acc.folder++;
+      } else if (i.type === 'app') {
+        acc.app++;
+      } else if (i.type && i.type.includes('request')) {
+        acc.request++;
+      } else if (!i.type || i.type === 'collection') {
+        acc.collection++;
+      }
+      return acc;
+    },
+    { folder: 0, app: 0, request: 0, collection: 0 }
+  );
 
   const parts = [];
-  if (collections > 0) parts.push(`${collections} collection${collections > 1 ? 's' : ''}`);
-  if (folders > 0) parts.push(`${folders} folder${folders > 1 ? 's' : ''}`);
-  if (apps > 0) parts.push(`${apps} app${apps > 1 ? 's' : ''}`);
-  if (requests > 0) parts.push(`${requests} request${requests > 1 ? 's' : ''}`);
+  const keyOrder = ['collection', 'folder', 'app', 'request'];
+  for (const key of keyOrder) {
+    const value = itemsCount[key];
+    if (value > 0) {
+      parts.push(`${value} ${key}${value > 1 ? 's' : ''}`);
+    }
+  }
 
   if (parts.length === 0) return `${multiSelectedItems.length} items`;
   return parts.join(', ').replace(/, ([^,]*)$/, ' and $1');


### PR DESCRIPTION

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Refactoring the logic for better readability and single loop instead of multiple loops
### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
Earlier we were using multiple loops to calculate count for each collectionItem type. which is causing increased loop complexity.
### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->
Using a single loop (Array reduce) to optimize the loops.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->
NA 
| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the efficiency of multi-item drag labels without changing their displayed counts, ordering, or pluralization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->