### PR TITLE
fix(response): sort response headers alphabetically

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.js
@@ -3,8 +3,12 @@ import StyledWrapper from './StyledWrapper';
 import { usePersistedState } from 'hooks/usePersistedState';
 import { useTrackScroll } from 'hooks/useTrackScroll';
 
+export const sortResponseHeaders = (headers) => {
+  return Object.entries(headers).sort(([firstName], [secondName]) => firstName.localeCompare(secondName));
+};
+
 const ResponseHeaders = ({ headers, item }) => {
-  const headersArray = typeof headers === 'object' ? Object.entries(headers) : [];
+  const headersArray = typeof headers === 'object' ? sortResponseHeaders(headers) : [];
   const wrapperRef = useRef(null);
   const [scroll, setScroll] = usePersistedState({ key: `response-headers-scroll-${item?.uid}`, default: 0 });
   useTrackScroll({ ref: wrapperRef, selector: '.response-tab-content', onChange: setScroll, initialValue: scroll });

--- a/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.spec.js
+++ b/packages/bruno-app/src/components/ResponsePane/ResponseHeaders/index.spec.js
@@ -1,0 +1,17 @@
+import { sortResponseHeaders } from './index';
+
+describe('sortResponseHeaders', () => {
+  it('sorts response headers alphabetically by name', () => {
+    const headers = {
+      'X-Request-Id': 'request-id',
+      'content-type': 'application/json',
+      'Accept': '*/*'
+    };
+
+    expect(sortResponseHeaders(headers)).toEqual([
+      ['Accept', '*/*'],
+      ['content-type', 'application/json'],
+      ['X-Request-Id', 'request-id']
+    ]);
+  });
+});


### PR DESCRIPTION
REF - BRU-4538

### Description

Sort response headers alphabetically in the response view.

### Problem

Closes #9199. Response headers were displayed in the transport object's insertion order, which made them harder to scan.

### Fix

Sort the response header entries by header name before rendering them. Added a focused regression test for the ordering.

### Screenshots

Not applicable; this is a deterministic ordering change.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (Uses existing issue #9199.)
- [x] **I've run the claude code review skill locally.**

Validation: focused regression test passed with Jest; ESLint reported no issues; `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Response headers are now displayed in alphabetical order by header name for more consistent viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->