### PR TITLE
fix(codegen): use CommonJS axios import for Node snippets

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -37,7 +37,8 @@ const addCurlAuthFlags = (curlCommand, auth) => {
 // the shared Axios instance used by interceptors and other global configuration.
 const normalizeNodeAxiosImport = (snippet, language) => {
   if (language.target === 'node' && language.client === 'axios') {
-    return snippet.replaceAll('require(\'axios\').default', 'require(\'axios\')');
+    const pattern = /^const axios = require\('axios'\)\.default;/;
+    return snippet.replace(pattern, 'const axios = require(\'axios\');');
   }
 
   return snippet;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -32,6 +32,17 @@ const addCurlAuthFlags = (curlCommand, auth) => {
   return curlCommand;
 };
 
+// HTTPSnippet's Node.js Axios target uses the ESM interop default export form,
+// but this generator emits CommonJS code. Requiring Axios directly preserves
+// the shared Axios instance used by interceptors and other global configuration.
+const normalizeNodeAxiosImport = (snippet, language) => {
+  if (language.target === 'node' && language.client === 'axios') {
+    return snippet.replaceAll('require(\'axios\').default', 'require(\'axios\')');
+  }
+
+  return snippet;
+};
+
 const generateSnippet = async ({ language, item, collection, shouldInterpolate = false }) => {
   try {
     // Get HTTPSnippet dynamically so mocks can be applied in tests
@@ -80,7 +91,7 @@ const generateSnippet = async ({ language, item, collection, shouldInterpolate =
 
     // Generate snippet using HTTPSnippet
     const snippet = new HTTPSnippet(har);
-    let result = snippet.convert(language.target, language.client);
+    let result = normalizeNodeAxiosImport(snippet.convert(language.target, language.client), language);
 
     // curl --digest / --ntlm flags. Snippet-text manipulation, not HAR.
     if (language.target === 'shell' && language.client === 'curl') {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -1557,6 +1557,18 @@ describe('generateSnippet – URL templates survive real httpsnippet targets', (
     expect(result).not.toContain('SECRET');
   });
 
+  it('uses the shared CommonJS Axios instance for Node.js snippets', async () => {
+    const result = await generateSnippet({
+      language: { target: 'node', client: 'axios' },
+      item: makeItem('https://example.com/data'),
+      collection: baseCollection,
+      shouldInterpolate: false
+    });
+
+    expect(result).toContain('const axios = require(\'axios\');');
+    expect(result).not.toContain('require(\'axios\').default');
+  });
+
   it('keeps the template when the resolved value holds a character encodeUrl would rewrite', async () => {
     const result = await generateSnippet({
       language: { target: 'shell', client: 'curl' },

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.spec.js
@@ -1569,6 +1569,26 @@ describe('generateSnippet – URL templates survive real httpsnippet targets', (
     expect(result).not.toContain('require(\'axios\').default');
   });
 
+  it('does not rewrite the same import text in request content', async () => {
+    const item = makeItem('https://example.com/data');
+    item.request.method = 'POST';
+    item.request.body = {
+      mode: 'json',
+      json: JSON.stringify({ literal: 'require(\'axios\').default' })
+    };
+
+    const result = await generateSnippet({
+      language: { target: 'node', client: 'axios' },
+      item,
+      collection: baseCollection,
+      shouldInterpolate: false
+    });
+
+    expect(result).toContain('const axios = require(\'axios\');');
+    // HTTPSnippet escapes the apostrophes inside the generated JavaScript string.
+    expect(result).toContain(String.raw`require(\'axios\').default`);
+  });
+
   it('keeps the template when the resolved value holds a character encodeUrl would rewrite', async () => {
     const result = await generateSnippet({
       language: { target: 'shell', client: 'curl' },


### PR DESCRIPTION
BRU-4514

### Description

Use the CommonJS Axios import in Node.js Axios snippets generated by Bruno.

### Problem

Closes #9207. The Node.js -> Axios generator emitted `const axios = require('axios').default;`, which selects the interop property instead of the shared CommonJS Axios export.

### Fix

Normalize only the generated Node.js Axios import declaration after HTTPSnippet conversion to `const axios = require('axios');`. Added regression coverage against the real HTTPSnippet target and verified that identical text in request content is preserved.

### Screenshots

Not applicable; this changes generated source text.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.** (Not applicable.)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.** (Uses existing issue #9207.)
- [ ] **I've run the claude code review skill locally.**

Validation: focused snippet-generator Jest suite passed (85 tests); ESLint reported no issues; `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated Node.js Axios snippets to use the correct CommonJS import format.
  * Prevented unnecessary `.default` usage in Axios `require` statements.
  * Preserved matching text in request body content without rewriting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->