### PR TITLE
fix(scripts): show sent headers for sendRequest & runRequest

### DIFF
--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -1528,7 +1528,8 @@ const registerNetworkIpc = (mainWindow) => {
                       data: res.data,
                       dataBuffer: res.dataBuffer,
                       size: res.size,
-                      duration: res.duration
+                      duration: res.duration,
+                      timeline: res.timeline
                     }
                   : null,
                 error: err || (res?.error ? { message: res.error } : null),

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -830,7 +830,8 @@ const registerNetworkIpc = (mainWindow) => {
                     data: res.data,
                     dataBuffer: res.dataBuffer,
                     size: res.size,
-                    duration: res.duration
+                    duration: res.duration,
+                    timeline: res.timeline
                   }
                 : null,
               error: err || (res?.error ? { message: res.error } : null),

--- a/packages/bruno-requests/src/scripting/send-request.ts
+++ b/packages/bruno-requests/src/scripting/send-request.ts
@@ -1,5 +1,6 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { makeAxiosInstance } from '../network';
+import { getSentHeaders } from '../network/sent-headers';
 import { getHttpHttpsAgents } from '../utils/http-https-agents';
 import type { GetHttpHttpsAgentsParams } from '../utils/http-https-agents';
 
@@ -22,6 +23,7 @@ type SendRequestEntry = {
     dataBuffer: string;
     size: number;
     duration: number;
+    timeline: any[] | null;
   } | null;
   error: any | null;
   startedAt: number;
@@ -43,6 +45,7 @@ type ScriptedEntryResponseInput = {
   dataBuffer?: string;
   size?: number;
   duration?: number;
+  timeline?: any[];
 } | null | undefined;
 
 type BuildScriptedEntryArgs = {
@@ -100,7 +103,10 @@ const buildScriptedEntry = ({
         : (dataBuffer ? Buffer.from(dataBuffer, 'base64').length : 0),
       duration: typeof response.duration === 'number'
         ? response.duration
-        : (completedAt - startedAt)
+        : (completedAt - startedAt),
+      /** bru.runRequest already has one, bru.sendRequest builds its own below. Null when the
+       *  request never reached a response. */
+      timeline: response.timeline ?? null
     };
   }
   return {
@@ -132,6 +138,28 @@ type SendRequestOptions = {
 const createSendRequest = (config?: SendRequestConfig, options?: SendRequestOptions) => {
   const onComplete = options?.onComplete;
 
+  /** bru.runRequest gets its timeline from the pipeline it runs through. bru.sendRequest has no
+   *  pipeline, so build the same entries here or its Timeline has no Network tab and no headers. */
+  const buildTimeline = (config: AxiosRequestConfig, response: AxiosResponse | null) => {
+    const timeline: Array<{ timestamp: Date; type: string; message: string }> = [];
+    const add = (type: string, message: string) => timeline.push({ timestamp: new Date(), type, message });
+
+    add('request', `${(config.method || 'get').toString().toUpperCase()} ${config.url}`);
+    for (const [name, value] of Object.entries(getSentHeaders((response as any)?.request))) {
+      add('requestHeader', `${name}: ${value}`);
+    }
+
+    if (response) {
+      const httpVersion = (response as any)?.request?.res?.httpVersion || '1.1';
+      add('response', `HTTP/${httpVersion} ${response.status} ${response.statusText}`);
+      for (const [name, value] of Object.entries(toPlainHeaders(response.headers))) {
+        add('responseHeader', `${name}: ${value}`);
+      }
+    }
+
+    return timeline;
+  };
+
   const recordEntry = (
     normalizedConfig: AxiosRequestConfig,
     response: AxiosResponse | null,
@@ -150,7 +178,7 @@ const createSendRequest = (config?: SendRequestConfig, options?: SendRequestOpti
           headers: normalizedConfig.headers,
           data: normalizedConfig.data
         },
-        response: resp,
+        response: resp ? { ...resp, timeline: buildTimeline(normalizedConfig, resp) } : resp,
         error,
         startedAt,
         completedAt


### PR DESCRIPTION
### Description

This PR is defect for : BRU-3731, Defect ticket : BRU-4520

`bru.sendRequest` and `bru.runRequest` each get their own Timeline entry, but the entry was missing the Network tab and the headers actually sent.

### Problem

Both read `response.timeline` - the Network tab is gated on it, and the Request tab's headers come from it. Neither scripted entry had one.

`runRequest` does build a timeline (it runs the full pipeline), but the entry never carried it. `sendRequest` has no pipeline, so nothing built one at all.

### Fix

`runRequest`: forward `res.timeline` into the entry, and let `buildScriptedEntry` keep the field.

`sendRequest`: build the same entries in `recordEntry`, reusing `getSentHeaders`. Checked against a live server - the timeline matches what the server received.


### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
|  |  |

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scripted request results now include response timeline information.
  - Timeline details cover request, request-header, response, and response-header events.
  - Timeline information is available for both successful and failed scripted requests.
  - Timeline data is included when running individual requests as well as requests within folders or collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->