### PR TITLE
fix(environments): invalid name and color import in multiple env

### DIFF
--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
@@ -5,11 +5,42 @@ import importBrunoEnvironment from 'utils/importers/bruno-environment';
 import { readMultipleFiles } from 'utils/importers/file-reader';
 import { toastError } from 'utils/common/error';
 import { generateCopyName, normalizeEnvName, orderEnvironmentsByInheritance } from 'utils/environments';
-import { detectEnvironmentFormat, RESOLUTION_TYPES } from '../../utils';
+import {
+  buildReviewItems,
+  detectEnvironmentFormat,
+  ENV_STATUS,
+  IMPORT_STEPS,
+  initialResolutions,
+  initialSelection,
+  RESOLUTION_TYPES
+} from '../../utils';
 import { useEnvironmentTarget } from '../useEnvironmentTarget';
 
-export const IMPORT_STEPS = { UPLOAD: 'UPLOAD', REVIEW: 'REVIEW' };
-export const ENV_STATUS = { NEW: 'new', DUPLICATE: 'duplicate', INVALID: 'invalid' };
+export { ENV_STATUS, IMPORT_STEPS };
+
+/**
+ * Reads every picked file with the importer its format calls for. A file that cannot be read is
+ * recorded and the loop moves on, so one bad file never costs the user the rest of the batch.
+ */
+const parseEnvironmentFiles = async (parsedFiles) => {
+  const valid = [];
+  const invalid = [];
+
+  for (const file of parsedFiles) {
+    try {
+      const format = detectEnvironmentFormat(file.content);
+      const result = format === 'postman'
+        ? await importPostmanEnvironment([file])
+        : await importBrunoEnvironment([file]);
+      valid.push(...result.valid);
+      invalid.push(...result.invalid);
+    } catch (err) {
+      invalid.push({ fileName: file.fileName || 'Unknown', error: 'Could not be read' });
+    }
+  }
+
+  return { valid, invalid };
+};
 
 export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCreated) => {
   const [step, setStep] = useState(IMPORT_STEPS.UPLOAD);
@@ -98,52 +129,19 @@ export const useEnvironmentImport = (type, collection, onClose, onEnvironmentCre
     if (isImporting) return;
     try {
       setIsImporting(true);
+
       const { parsedFiles, invalidFiles } = await readMultipleFiles(Array.from(files));
+      const { valid, invalid } = await parseEnvironmentFiles(parsedFiles);
 
-      const valid = [];
-      const invalid = [];
-
-      for (const file of parsedFiles) {
-        try {
-          const format = detectEnvironmentFormat(file.content);
-          const result = format === 'postman'
-            ? await importPostmanEnvironment([file])
-            : await importBrunoEnvironment([file]);
-          valid.push(...result.valid);
-          invalid.push(...result.invalid);
-        } catch (err) {
-          invalid.push({ fileName: file.fileName || 'Unknown', error: 'Could not be read' });
-        }
-      }
-
-      const validEnvironments = valid.filter((env) => env.name && env.name !== 'undefined');
-      const missingNameEnvs = valid
-        .filter((env) => !env.name || env.name === 'undefined')
-        .map((env) => ({ fileName: env.fileName || 'Unknown', error: 'Environment has no name' }));
-
-      const allInvalid = [...invalidFiles, ...invalid, ...missingNameEnvs];
-
-      const existingNamesNormalized = new Set(existingNames.map(normalizeEnvName));
-
-      let itemIndex = 0;
-      const validItems = validEnvironments.map((env) => {
-        const isDuplicate = existingNamesNormalized.has(normalizeEnvName(env.name));
-        return { ...env, id: `env-${itemIndex++}`, status: isDuplicate ? ENV_STATUS.DUPLICATE : ENV_STATUS.NEW };
+      const reviewItems = buildReviewItems({
+        valid,
+        invalid: [...invalidFiles, ...invalid],
+        existingNames
       });
 
-      const invalidItems = allInvalid.map((env) => ({
-        ...env, id: `env-${itemIndex++}`, status: ENV_STATUS.INVALID
-      }));
-
-      setItems([...validItems, ...invalidItems]);
-      setSelected(new Set(validItems.map((item) => item.id)));
-
-      const initialResolutions = new Map();
-      validItems
-        .filter((item) => item.status === ENV_STATUS.DUPLICATE)
-        .forEach((item) => initialResolutions.set(item.id, RESOLUTION_TYPES.CREATE_NEW));
-      setResolutions(initialResolutions);
-
+      setItems(reviewItems);
+      setSelected(initialSelection(reviewItems));
+      setResolutions(initialResolutions(reviewItems));
       setStep(IMPORT_STEPS.REVIEW);
     } catch (err) {
       toastError(err, 'Import environment failed');

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/hooks/useEnvironmentImport/index.js
@@ -18,10 +18,6 @@ import { useEnvironmentTarget } from '../useEnvironmentTarget';
 
 export { ENV_STATUS, IMPORT_STEPS };
 
-/**
- * Reads every picked file with the importer its format calls for. A file that cannot be read is
- * recorded and the loop moves on, so one bad file never costs the user the rest of the batch.
- */
 const parseEnvironmentFiles = async (parsedFiles) => {
   const valid = [];
   const invalid = [];

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
@@ -24,15 +24,8 @@ export const RESOLUTION_OPTIONS = [
   { value: RESOLUTION_TYPES.REPLACE, label: 'Replace', title: 'Replace existing', testId: 'env-import-replace-btn' }
 ];
 
-export const hasUsableName = (env) => typeof env?.name === 'string' && env.name.trim() !== '';
-
-export const describeUnusableName = (name) =>
-  name === undefined || name === null || typeof name === 'string'
-    ? 'Environment has no name'
-    : 'Environment name must be text';
-
-const failedRow = ({ fileName }, error) => ({
-  fileName: fileName || 'Unknown',
+const failedRow = (source, error) => ({
+  fileName: source?.fileName || 'Unknown',
   error,
   status: ENV_STATUS.INVALID
 });
@@ -40,14 +33,10 @@ const failedRow = ({ fileName }, error) => ({
 export const buildReviewItems = ({ valid = [], invalid = [], existingNames = [] }) => {
   const takenNames = new Set(existingNames.map(normalizeEnvName));
   const importable = [];
-  const failures = invalid.map((failure) => failedRow(failure, failure.error));
+  const failures = invalid.map((failure) => failedRow(failure, failure?.error));
 
   for (const env of valid) {
     try {
-      if (!hasUsableName(env)) {
-        failures.push(failedRow(env, describeUnusableName(env.name)));
-        continue;
-      }
       const status = takenNames.has(normalizeEnvName(env.name)) ? ENV_STATUS.DUPLICATE : ENV_STATUS.NEW;
       importable.push({ ...env, status });
     } catch (err) {

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.js
@@ -1,3 +1,8 @@
+import { normalizeEnvName } from 'utils/environments';
+
+export const IMPORT_STEPS = { UPLOAD: 'UPLOAD', REVIEW: 'REVIEW' };
+export const ENV_STATUS = { NEW: 'new', DUPLICATE: 'duplicate', INVALID: 'invalid' };
+
 export const detectEnvironmentFormat = (data) => {
   if (data.info && data.info.type === 'bruno-environment') {
     return 'bruno';
@@ -18,3 +23,49 @@ export const RESOLUTION_OPTIONS = [
   { value: RESOLUTION_TYPES.CREATE_NEW, label: 'New', title: 'Import as a new environment', testId: 'env-import-create-new-btn' },
   { value: RESOLUTION_TYPES.REPLACE, label: 'Replace', title: 'Replace existing', testId: 'env-import-replace-btn' }
 ];
+
+export const hasUsableName = (env) => typeof env?.name === 'string' && env.name.trim() !== '';
+
+export const describeUnusableName = (name) =>
+  name === undefined || name === null || typeof name === 'string'
+    ? 'Environment has no name'
+    : 'Environment name must be text';
+
+const failedRow = ({ fileName }, error) => ({
+  fileName: fileName || 'Unknown',
+  error,
+  status: ENV_STATUS.INVALID
+});
+
+export const buildReviewItems = ({ valid = [], invalid = [], existingNames = [] }) => {
+  const takenNames = new Set(existingNames.map(normalizeEnvName));
+  const importable = [];
+  const failures = invalid.map((failure) => failedRow(failure, failure.error));
+
+  for (const env of valid) {
+    try {
+      if (!hasUsableName(env)) {
+        failures.push(failedRow(env, describeUnusableName(env.name)));
+        continue;
+      }
+      const status = takenNames.has(normalizeEnvName(env.name)) ? ENV_STATUS.DUPLICATE : ENV_STATUS.NEW;
+      importable.push({ ...env, status });
+    } catch (err) {
+      failures.push(failedRow(env, 'Could not be read'));
+    }
+  }
+
+  return [...importable, ...failures].map((item, index) => ({ ...item, id: `env-${index}` }));
+};
+
+/** Everything the user can actually import starts out ticked. */
+export const initialSelection = (items) =>
+  new Set(items.filter((item) => item.status !== ENV_STATUS.INVALID).map((item) => item.id));
+
+/** A conflict defaults to landing as a new environment rather than overwriting one. */
+export const initialResolutions = (items) =>
+  new Map(
+    items
+      .filter((item) => item.status === ENV_STATUS.DUPLICATE)
+      .map((item) => [item.id, RESOLUTION_TYPES.CREATE_NEW])
+  );

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.spec.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.spec.js
@@ -1,0 +1,163 @@
+import { coerceEnvColor, coerceEnvName } from 'utils/environments';
+import {
+  buildReviewItems,
+  describeUnusableName,
+  ENV_STATUS,
+  hasUsableName,
+  initialResolutions,
+  initialSelection,
+  RESOLUTION_TYPES
+} from './utils';
+
+describe('hasUsableName', () => {
+  it.each([
+    ['a plain name', 'dev', true],
+    ['a name with surrounding space', '  dev  ', true],
+    ['an empty string', '', false],
+    ['whitespace only', '   ', false],
+    ['undefined', undefined, false],
+    ['null', null, false],
+    // The truthy non-strings are the ones that used to reach normalizeEnvName and throw.
+    ['a number', 123, false],
+    ['zero', 0, false],
+    ['a boolean', true, false],
+    ['an object', {}, false],
+    ['a non-empty array', ['dev'], false],
+    ['an empty array', [], false]
+  ])('rejects or accepts %s', (_label, name, expected) => {
+    expect(hasUsableName({ name })).toBe(expected);
+  });
+
+  it('tolerates a missing environment', () => {
+    expect(hasUsableName(undefined)).toBe(false);
+  });
+});
+
+describe('describeUnusableName', () => {
+  it.each([[undefined], [null], [''], ['   ']])('reports an absent name for %p', (name) => {
+    expect(describeUnusableName(name)).toBe('Environment has no name');
+  });
+
+  it.each([[123], [true], [{}], [['dev']]])('reports a wrong type for %p', (name) => {
+    expect(describeUnusableName(name)).toBe('Environment name must be text');
+  });
+});
+
+describe('coerceEnvName', () => {
+  it.each([
+    ['a plain name', 'dev', 'dev'],
+    ['an integer', 123, '123'],
+    ['zero', 0, '0'],
+    ['a negative number', -1, '-1'],
+    ['a decimal', 1.5, '1.5']
+  ])('reads %s as text', (_label, name, expected) => {
+    expect(coerceEnvName(name)).toBe(expected);
+  });
+
+  it.each([
+    ['an empty string', ''],
+    ['whitespace only', '   '],
+    ['undefined', undefined],
+    ['null', null],
+    ['a boolean', true],
+    ['an object', {}],
+    ['an array', ['dev']],
+    ['NaN', NaN],
+    ['Infinity', Infinity]
+  ])('has no usable name for %s', (_label, name) => {
+    expect(coerceEnvName(name)).toBeNull();
+  });
+});
+
+describe('coerceEnvColor', () => {
+  it.each([
+    ['a hex colour', '#CE4F3B'],
+    ['a short hex', '#fff'],
+    ['a named colour', 'red'],
+    ['an rgb colour', 'rgb(1, 2, 3)'],
+    ['an rgba colour', 'rgba(1, 2, 3, 0.5)'],
+    ['an hsl colour', 'hsl(120, 50%, 50%)']
+  ])('keeps %s', (_label, color) => {
+    expect(coerceEnvColor(color)).toBe(color);
+  });
+
+  it.each([
+    ['a word that is not a colour', 'notacolor'],
+    ['a truncated hex', '#12345'],
+    ['a value carrying a css injection', 'blue;background:url(x)'],
+    ['an empty string', ''],
+    ['whitespace only', '   '],
+    ['a number', 123],
+    ['an object', {}],
+    ['null', null],
+    ['undefined', undefined]
+  ])('drops %s', (_label, color) => {
+    expect(coerceEnvColor(color)).toBeUndefined();
+  });
+});
+
+describe('buildReviewItems', () => {
+  const env = (name, extra = {}) => ({ name, fileName: `${name}.json`, ...extra });
+
+  it('marks an environment whose name is free as new', () => {
+    const [item] = buildReviewItems({ valid: [env('dev')], existingNames: ['prod'] });
+
+    expect(item).toMatchObject({ name: 'dev', status: ENV_STATUS.NEW, id: 'env-0' });
+  });
+
+  it('marks an environment whose name is taken as a duplicate, ignoring case and padding', () => {
+    const [item] = buildReviewItems({ valid: [env('  DEV  ')], existingNames: ['dev'] });
+
+    expect(item.status).toBe(ENV_STATUS.DUPLICATE);
+  });
+
+  it('puts importable rows before failed ones and gives every row a distinct id', () => {
+    const items = buildReviewItems({
+      valid: [env('dev'), env('prod')],
+      invalid: [{ fileName: 'broken.json', error: 'Unable to parse JSON' }],
+      existingNames: []
+    });
+
+    expect(items.map((item) => [item.id, item.status])).toEqual([
+      ['env-0', ENV_STATUS.NEW],
+      ['env-1', ENV_STATUS.NEW],
+      ['env-2', ENV_STATUS.INVALID]
+    ]);
+    expect(new Set(items.map((item) => item.id)).size).toBe(items.length);
+  });
+
+  it('demotes an environment with an unusable name instead of dropping the batch', () => {
+    const items = buildReviewItems({ valid: [env('dev'), { name: 123, fileName: 'odd.json' }], existingNames: [] });
+
+    expect(items.map((item) => item.status)).toEqual([ENV_STATUS.NEW, ENV_STATUS.INVALID]);
+    expect(items[1]).toMatchObject({ fileName: 'odd.json', error: 'Environment name must be text' });
+  });
+
+  it('survives an environment that throws while being classified', () => {
+    const exploding = { fileName: 'boom.json', get name() { throw new Error('boom'); } };
+    const items = buildReviewItems({ valid: [exploding, env('prod')], existingNames: [] });
+
+    expect(items.map((item) => item.status)).toEqual([ENV_STATUS.NEW, ENV_STATUS.INVALID]);
+    expect(items[1]).toMatchObject({ fileName: 'boom.json', error: 'Could not be read' });
+  });
+
+  it('returns nothing for an empty import', () => {
+    expect(buildReviewItems({})).toEqual([]);
+  });
+});
+
+describe('initialSelection / initialResolutions', () => {
+  const items = [
+    { id: 'env-0', status: ENV_STATUS.NEW },
+    { id: 'env-1', status: ENV_STATUS.DUPLICATE },
+    { id: 'env-2', status: ENV_STATUS.INVALID }
+  ];
+
+  it('ticks everything importable and nothing that failed', () => {
+    expect([...initialSelection(items)]).toEqual(['env-0', 'env-1']);
+  });
+
+  it('defaults every conflict to landing as a new environment', () => {
+    expect([...initialResolutions(items)]).toEqual([['env-1', RESOLUTION_TYPES.CREATE_NEW]]);
+  });
+});

--- a/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.spec.js
+++ b/packages/bruno-app/src/components/Environments/Common/ImportEnvironmentModal/utils.spec.js
@@ -1,47 +1,11 @@
 import { coerceEnvColor, coerceEnvName } from 'utils/environments';
 import {
   buildReviewItems,
-  describeUnusableName,
   ENV_STATUS,
-  hasUsableName,
   initialResolutions,
   initialSelection,
   RESOLUTION_TYPES
 } from './utils';
-
-describe('hasUsableName', () => {
-  it.each([
-    ['a plain name', 'dev', true],
-    ['a name with surrounding space', '  dev  ', true],
-    ['an empty string', '', false],
-    ['whitespace only', '   ', false],
-    ['undefined', undefined, false],
-    ['null', null, false],
-    // The truthy non-strings are the ones that used to reach normalizeEnvName and throw.
-    ['a number', 123, false],
-    ['zero', 0, false],
-    ['a boolean', true, false],
-    ['an object', {}, false],
-    ['a non-empty array', ['dev'], false],
-    ['an empty array', [], false]
-  ])('rejects or accepts %s', (_label, name, expected) => {
-    expect(hasUsableName({ name })).toBe(expected);
-  });
-
-  it('tolerates a missing environment', () => {
-    expect(hasUsableName(undefined)).toBe(false);
-  });
-});
-
-describe('describeUnusableName', () => {
-  it.each([[undefined], [null], [''], ['   ']])('reports an absent name for %p', (name) => {
-    expect(describeUnusableName(name)).toBe('Environment has no name');
-  });
-
-  it.each([[123], [true], [{}], [['dev']]])('reports a wrong type for %p', (name) => {
-    expect(describeUnusableName(name)).toBe('Environment name must be text');
-  });
-});
 
 describe('coerceEnvName', () => {
   it.each([
@@ -126,11 +90,25 @@ describe('buildReviewItems', () => {
     expect(new Set(items.map((item) => item.id)).size).toBe(items.length);
   });
 
-  it('demotes an environment with an unusable name instead of dropping the batch', () => {
+  it('demotes an environment whose name never went through coercion', () => {
     const items = buildReviewItems({ valid: [env('dev'), { name: 123, fileName: 'odd.json' }], existingNames: [] });
 
     expect(items.map((item) => item.status)).toEqual([ENV_STATUS.NEW, ENV_STATUS.INVALID]);
-    expect(items[1]).toMatchObject({ fileName: 'odd.json', error: 'Environment name must be text' });
+    expect(items[1]).toMatchObject({ fileName: 'odd.json', error: 'Could not be read' });
+  });
+
+  it('survives a null entry among the importable environments', () => {
+    const items = buildReviewItems({ valid: [env('dev'), null, env('prod')], existingNames: [] });
+
+    expect(items.map((item) => item.status)).toEqual([ENV_STATUS.NEW, ENV_STATUS.NEW, ENV_STATUS.INVALID]);
+    expect(items[2]).toMatchObject({ fileName: 'Unknown', error: 'Could not be read' });
+  });
+
+  it('survives a null entry among the failures, which sits outside the loop', () => {
+    const items = buildReviewItems({ valid: [env('dev')], invalid: [null], existingNames: [] });
+
+    expect(items.map((item) => item.status)).toEqual([ENV_STATUS.NEW, ENV_STATUS.INVALID]);
+    expect(items[1]).toMatchObject({ fileName: 'Unknown' });
   });
 
   it('survives an environment that throws while being classified', () => {

--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
@@ -13,7 +13,7 @@ import ImportEnvironmentModal from 'components/Environments/Common/ImportEnviron
 import CreateGlobalEnvironment from 'components/WorkspaceHome/WorkspaceEnvironments/CreateEnvironment';
 import ToolHint from 'components/ToolHint';
 import StyledWrapper from './StyledWrapper';
-import { transparentize, toColorString, parseToRgb } from 'polished';
+import { transparentize } from 'polished';
 
 const TABS = [
   { id: 'collection', label: 'Collection', icon: <IconDatabase size={16} strokeWidth={1.5} /> },
@@ -27,9 +27,6 @@ const EMPTY_STATE_DESCRIPTIONS = {
 
 /**
  * Generates background color with transparency for environment badges.
- * polished throws on anything it cannot parse, and the colour comes from a .bru file that may
- * have been hand-edited, so an unreadable value has to degrade to no tint - not take the render
- * down with it.
  */
 const getEnvBackgroundColor = (color) => {
   if (!color) return 'transparent';

--- a/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/bruno-app/src/components/Environments/EnvironmentSelector/index.js
@@ -26,9 +26,19 @@ const EMPTY_STATE_DESCRIPTIONS = {
 };
 
 /**
- * Generates background color with transparency for environment badges
+ * Generates background color with transparency for environment badges.
+ * polished throws on anything it cannot parse, and the colour comes from a .bru file that may
+ * have been hand-edited, so an unreadable value has to degrade to no tint - not take the render
+ * down with it.
  */
-const getEnvBackgroundColor = (color) => (color ? transparentize(1 - 0.12, color) : 'transparent');
+const getEnvBackgroundColor = (color) => {
+  if (!color) return 'transparent';
+  try {
+    return transparentize(1 - 0.12, color);
+  } catch {
+    return 'transparent';
+  }
+};
 
 /**
  * Calculates the style for an environment badge section

--- a/packages/bruno-app/src/utils/environments.js
+++ b/packages/bruno-app/src/utils/environments.js
@@ -1,4 +1,5 @@
 import { isEqual } from 'lodash';
+import { parseToRgb } from 'polished';
 import { uuid } from './common/index';
 import { INVALID_VARIABLE_NAMES_ERROR_PREFIX } from './common/variables';
 
@@ -167,6 +168,28 @@ export const getDuplicateSecretNames = (variables) => {
     }
   });
   return new Set([...counts].filter(([, count]) => count > 1).map(([name]) => name));
+};
+
+export const coerceEnvName = (name) => {
+  if (typeof name === 'string') {
+    return name.trim() === '' ? null : name;
+  }
+  if (typeof name === 'number' && Number.isFinite(name)) {
+    return String(name);
+  }
+  return null;
+};
+
+export const coerceEnvColor = (color) => {
+  if (typeof color !== 'string' || color.trim() === '') {
+    return undefined;
+  }
+  try {
+    parseToRgb(color);
+    return color;
+  } catch {
+    return undefined;
+  }
 };
 
 export const normalizeEnvName = (name) => (name || '').toLowerCase().trim();

--- a/packages/bruno-app/src/utils/importers/bruno-environment.js
+++ b/packages/bruno-app/src/utils/importers/bruno-environment.js
@@ -1,10 +1,15 @@
 import { BrunoError } from 'utils/common/error';
-import { buildEnvVariable, dedupeImportedSecrets } from 'utils/environments';
+import { buildEnvVariable, coerceEnvColor, coerceEnvName, dedupeImportedSecrets } from 'utils/environments';
 import { validatedEnvironmentExtendsFrom } from '@usebruno/common/utils';
 
 const validateBrunoEnvironment = (env, filePath, fileName) => {
   if (!env || typeof env !== 'object') {
     throw new BrunoError('Invalid environment: expected an object');
+  }
+
+  const name = coerceEnvName(env.name);
+  if (name === null) {
+    throw new BrunoError('Invalid environment: missing or invalid name');
   }
 
   if (!Array.isArray(env.variables)) {
@@ -30,9 +35,9 @@ const validateBrunoEnvironment = (env, filePath, fileName) => {
   const variables = env.variables.map((envVariable) => buildEnvVariable({ envVariable, withUuid: true }));
 
   return {
-    name: env.name,
+    name,
     variables: dedupeImportedSecrets(variables),
-    color: env.color,
+    color: coerceEnvColor(env.color),
     extends: environmentExtendsFrom,
     filePath,
     fileName

--- a/packages/bruno-app/src/utils/importers/bruno-environment.spec.js
+++ b/packages/bruno-app/src/utils/importers/bruno-environment.spec.js
@@ -157,3 +157,112 @@ describe('importBrunoEnvironment — inheritance', () => {
     expect(environment.extends).toBeUndefined();
   });
 });
+
+describe('importBrunoEnvironment — environment names', () => {
+  const importSingleEnvironment = (env) => importBrunoEnvironment([parsedFile(env)]);
+
+  it.each([
+    ['an integer', 123, '123'],
+    ['a negative number', -1, '-1'],
+    ['a decimal', 1.5, '1.5'],
+    ['zero', 0, '0']
+  ])('imports a name given as %s, as text', (_label, name, expected) => {
+    const { valid, invalid } = importSingleEnvironment({ name, variables: [] });
+
+    expect(invalid).toEqual([]);
+    expect(valid[0].name).toBe(expected);
+  });
+
+  it.each([
+    ['a boolean', true],
+    ['an object', {}],
+    ['an array', ['dev']],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['whitespace only', '   ']
+  ])('rejects a name that is %s', (_label, name) => {
+    const { valid, invalid } = importSingleEnvironment({ name, variables: [] });
+
+    expect(valid).toEqual([]);
+    expect(invalid[0].error).toMatch(/missing or invalid name/);
+  });
+
+  it('keeps the rest of a multi-environment file when one name cannot be read as text', () => {
+    const { valid, invalid } = importBrunoEnvironment([
+      parsedFile({
+        info: { type: 'bruno-environment' },
+        environments: [
+          { name: 'dev', variables: [] },
+          { name: { nested: true }, variables: [] },
+          { name: 'prod', variables: [] }
+        ]
+      })
+    ]);
+
+    expect(valid.map((env) => env.name)).toEqual(['dev', 'prod']);
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0].error).toMatch(/missing or invalid name/);
+  });
+
+  it('keeps the other files when one file carries an unusable name', () => {
+    const { valid, invalid } = importBrunoEnvironment([
+      parsedFile({ name: 'dev', variables: [] }, 'dev.json'),
+      parsedFile({ name: ['a', 'b'], variables: [] }, 'broken.json'),
+      parsedFile({ name: 'prod', variables: [] }, 'prod.json')
+    ]);
+
+    expect(valid.map((env) => env.name)).toEqual(['dev', 'prod']);
+    expect(invalid).toEqual([expect.objectContaining({ fileName: 'broken.json' })]);
+  });
+
+  it('treats a numeric name as a conflict with the same name written as text', () => {
+    const { valid } = importBrunoEnvironment([
+      parsedFile({ name: 123, variables: [] }, 'numeric.json'),
+      parsedFile({ name: '123', variables: [] }, 'text.json')
+    ]);
+
+    expect(valid.map((env) => env.name)).toEqual(['123', '123']);
+  });
+});
+
+describe('importBrunoEnvironment — environment colour', () => {
+  const importSingleEnvironment = (env) => importBrunoEnvironment([parsedFile(env)]);
+
+  it('carries a colour polished can read', () => {
+    const { valid: [environment], invalid } = importSingleEnvironment({ name: 'dev', variables: [], color: '#CE4F3B' });
+
+    expect(invalid).toEqual([]);
+    expect(environment.color).toBe('#CE4F3B');
+  });
+
+  it('imports the environment without a colour when the colour is unreadable', () => {
+    const { valid: [environment], invalid } = importSingleEnvironment({ name: 'dev', variables: [], color: 'notacolor' });
+
+    expect(invalid).toEqual([]);
+    expect(environment.name).toBe('dev');
+    expect(environment.color).toBeUndefined();
+  });
+
+  it('does not let a bad colour cost the other environments in the file', () => {
+    const { valid, invalid } = importBrunoEnvironment([
+      parsedFile({
+        info: { type: 'bruno-environment' },
+        environments: [
+          { name: 'dev', variables: [], color: '#2E8A54' },
+          { name: 'staging', variables: [], color: 'notacolor' },
+          { name: 'prod', variables: [], color: 'red' }
+        ]
+      })
+    ]);
+
+    expect(invalid).toEqual([]);
+    expect(valid.map((env) => [env.name, env.color])).toEqual([
+      ['dev', '#2E8A54'],
+      ['staging', undefined],
+      ['prod', 'red']
+    ]);
+  });
+});

--- a/packages/bruno-app/src/utils/importers/postman-environment.js
+++ b/packages/bruno-app/src/utils/importers/postman-environment.js
@@ -1,6 +1,6 @@
 import { BrunoError } from 'utils/common/error';
 import { postmanToBrunoEnvironment } from '@usebruno/converters';
-import { dedupeImportedSecrets } from 'utils/environments';
+import { coerceEnvName, dedupeImportedSecrets } from 'utils/environments';
 
 const importEnvironment = async (parsedFiles) => {
   try {
@@ -10,7 +10,11 @@ const importEnvironment = async (parsedFiles) => {
     for (const parsedFile of parsedFiles) {
       try {
         const environment = postmanToBrunoEnvironment(parsedFile.content);
-        valid.push({ ...environment, variables: dedupeImportedSecrets(environment.variables), filePath: parsedFile.filePath, fileName: parsedFile.fileName });
+        const name = coerceEnvName(environment.name);
+        if (name === null) {
+          throw new BrunoError('Invalid environment: missing or invalid name');
+        }
+        valid.push({ ...environment, name, variables: dedupeImportedSecrets(environment.variables), filePath: parsedFile.filePath, fileName: parsedFile.fileName });
       } catch (err) {
         console.error(`Error processing file: ${parsedFile.fileName}`, err);
         invalid.push({ fileName: parsedFile.fileName, error: err.message });

--- a/tests/environments/import-environment/invalid-color-import/fixtures/unreadable-color-env.json
+++ b/tests/environments/import-environment/invalid-color-import/fixtures/unreadable-color-env.json
@@ -1,0 +1,10 @@
+{
+  "name": "Broken Colour Env",
+  "variables": [
+    { "name": "host", "value": "https://colour.example.com", "enabled": true, "secret": false }
+  ],
+  "color": "notacolor",
+  "info": {
+    "type": "bruno-environment"
+  }
+}

--- a/tests/environments/import-environment/invalid-color-import/invalid-color-import.spec.ts
+++ b/tests/environments/import-environment/invalid-color-import/invalid-color-import.spec.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { test, expect } from '../../../../playwright';
+import {
+  buildCommonLocators,
+  closeAllCollections,
+  createCollection,
+  importEnvironment,
+  selectEnvironment
+} from '../../../utils/page';
+
+const envFile = path.join(__dirname, 'fixtures', 'unreadable-color-env.json');
+
+test.describe('Import environment - a colour that cannot be read', () => {
+  test.afterEach(async ({ page }) => {
+    await closeAllCollections(page);
+  });
+
+  test('imports the environment without its colour and keeps the app on its feet once it is active', async ({
+    page,
+    createTmpDir
+  }) => {
+    const { environment } = buildCommonLocators(page);
+    await createCollection(page, 'invalid-color-import', await createTmpDir('invalid-color-import'));
+
+    await importEnvironment(page, envFile, 'collection');
+
+    await test.step('The environment lands despite the colour', async () => {
+      await expect(environment.sidebarListItem('collection', 'Broken Colour Env')).toBeVisible();
+    });
+
+    await test.step('Making it active renders the badge instead of the error screen', async () => {
+      await selectEnvironment(page, 'Broken Colour Env', 'collection');
+
+      await expect(page.locator('.current-environment')).toContainText('Broken Colour Env');
+      await expect(environment.selector()).toBeVisible();
+    });
+
+    await test.step('The app is still interactive, not a rendered-once error page', async () => {
+      await environment.selector().click();
+      await expect(environment.envOption('Broken Colour Env')).toBeVisible();
+      await page.keyboard.press('Escape');
+    });
+  });
+});

--- a/tests/environments/import-environment/multi-format-import/fixtures/numeric-name-env.json
+++ b/tests/environments/import-environment/multi-format-import/fixtures/numeric-name-env.json
@@ -1,0 +1,6 @@
+{
+  "name": 123,
+  "variables": [
+    { "name": "host", "value": "https://numeric.example.com", "enabled": true, "secret": false }
+  ]
+}

--- a/tests/environments/import-environment/multi-format-import/fixtures/object-name-env.json
+++ b/tests/environments/import-environment/multi-format-import/fixtures/object-name-env.json
@@ -1,0 +1,6 @@
+{
+  "name": { "value": "Not A Name" },
+  "variables": [
+    { "name": "host", "value": "https://object.example.com", "enabled": true, "secret": false }
+  ]
+}

--- a/tests/environments/import-environment/multi-format-import/multi-format-import.spec.ts
+++ b/tests/environments/import-environment/multi-format-import/multi-format-import.spec.ts
@@ -237,6 +237,39 @@ test.describe('Import environment - mixed format and invalid file handling', () 
 
       await modal.closeButton().click();
     });
+
+    test('a name that is not text never costs the batch the files imported alongside it', async ({ page, createTmpDir }) => {
+      const { environment } = buildCommonLocators(page);
+      await createCollection(page, 'multi-format-bad-names', await createTmpDir('multi-format-bad-names'));
+
+      await openImportReviewFromEmpty(
+        page,
+        'collection',
+        fixture('bruno-env.json'),
+        fixture('numeric-name-env.json'),
+        fixture('object-name-env.json')
+      );
+
+      await test.step('The review step opens with the numeric name read as text and the object name refused', async () => {
+        await expect(environment.importTotalCount()).toHaveText('3');
+        await expect(environment.importNewCount()).toHaveText('2');
+        await expect(environment.importReviewItem('Bruno Env')).toBeVisible();
+        await expect(environment.importReviewItem('123')).toBeVisible();
+
+        await expect(environment.importInvalidCount()).toHaveText('1');
+        const invalidItem = environment.importInvalidItem('object-name-env.json');
+        await expect(invalidItem).toBeVisible();
+        await expect(invalidItem).toContainText('missing or invalid name');
+      });
+
+      await environment.importSubmitButton('collection').click();
+
+      await test.step('Both usable environments land, the refused one does not', async () => {
+        await expect(environment.sidebarListItemExact('collection', 'Bruno Env')).toBeVisible();
+        await expect(environment.sidebarListItemExact('collection', '123')).toBeVisible();
+        await expect(environment.sidebarListItemExact('collection', 'object-name-env.json')).toBeHidden();
+      });
+    });
   });
 
   test.describe('global scope', () => {


### PR DESCRIPTION
### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

- Currrently if a file contains a invalid name(name is not string), then import is failing.
- File contains a invalid color then import is failing for other valid files also.

BRU-4517
BRU-4518

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
1. Environment name given as a number crashed the import

There is no validation for the name type, so "name": 123 reached normalizeEnvName — (name || '').toLowerCase() — and threw toLowerCase is not a function. The throw happened after the per-file loop, so one bad file aborted the whole batch and the review modal never opened.

2. An unreadable colour crashed the whole app

getEnvBackgroundColor calls polished's transparentize, which throws on any unparseable value. it runs during render of the active environment's badge, so a colour like "notacolor" took the entire app to the error boundary and since the value persists to the .bru file, it crashed on every relaunch.

3. One bad environment could take down the whole import

The per-file try/catch only covered parsing. the classification that followed ran in bare .map() calls that assumed every survivor was well-formed, so any unexpected throw escaped to batch level the shape behind both bugs above, and the detectEnvironmentFormat issue before them.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

- coerceEnvName settles the name at the importer boundary so a finite number becomes its text (123 → "123"), anything with no faithful text form (object, array, boolean, NaN) is rejected as one invalid row, and the rest of the batch imports normally.
- The render site now falls back to transparent instead of throwing, and coerceEnvColor drops an unparseable colour at import time.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

https://github.com/user-attachments/assets/b7535303-d563-43fb-be0c-d3fdf6e2cf4f

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Environment imports now handle missing or invalid names more clearly.
  - Numeric environment names are converted to text automatically.
  - Duplicate environments are identified during review, with new environments selected by default.
  - Invalid entries are isolated so valid environments can still be imported.

- **Bug Fixes**
  - Unreadable environment colors no longer interrupt imports or crash the environment selector.
  - Environment names and colors are normalized consistently during import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->