### PR TITLE
feat(sidebar): support multi-select for request examples 

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/BulkActionsDropdown/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/BulkActionsDropdown/index.js
@@ -4,10 +4,12 @@ import MenuDropdown from 'ui/MenuDropdown';
 import { IconX, IconFoldDown, IconFoldUp, IconTrash } from '@tabler/icons';
 import { collapseCollection, collapseItem, expandCollection, expandItem, clearSidebarSelection } from 'providers/ReduxStore/slices/collections';
 import toast from 'react-hot-toast';
-import { getSelectionInfo, isScratchCollection } from 'utils/collections/index';
+import { getSelectionInfo, isScratchCollection, isCollectionItemCollapsed } from 'utils/collections/index';
 import { mountCollection } from 'providers/ReduxStore/slices/collections/actions';
 
-const isEntryCollapsed = (entry) => (entry.type === 'collection' ? entry.collection.collapsed : entry.item.collapsed);
+const isEntryCollapsed = (entry) => (entry.type === 'collection' ? entry.collection.collapsed : isCollectionItemCollapsed(entry.item));
+const isEntryCollapsible = (entry) =>
+  entry.type === 'collection' || entry.type === 'folder' || (entry.type === 'request' && entry.item.examples?.length > 0);
 
 const BulkActionsDropdown = ({ visible, onClose, position, onRequestRemoveCollections, onRequestDeleteItems }) => {
   const dispatch = useDispatch();
@@ -21,14 +23,14 @@ const BulkActionsDropdown = ({ visible, onClose, position, onRequestRemoveCollec
     [collections, workspaces]
   );
 
-  const { effectiveSelection, hasCollection, hasFolder, hasRequest, hasApp } = useMemo(
+  const { effectiveSelection, hasCollection, hasFolder, hasRequest, hasApp, hasExample } = useMemo(
     () => getSelectionInfo({ collections: visibleCollections, selectedUids: selectedSidebarUids }),
     [visibleCollections, selectedSidebarUids]
   );
 
-  const isPureCollectionSelection = hasCollection && !hasFolder && !hasRequest && !hasApp;
-  const canDelete = !hasCollection && (hasFolder || hasRequest || hasApp);
-  const collapsibleEntries = effectiveSelection.filter((entry) => entry.type === 'collection' || entry.type === 'folder');
+  const isPureCollectionSelection = hasCollection && !hasFolder && !hasRequest && !hasApp && !hasExample;
+  const canDelete = !hasCollection && (hasFolder || hasRequest || hasApp || hasExample);
+  const collapsibleEntries = effectiveSelection.filter(isEntryCollapsible);
   const canCollapse = collapsibleEntries.length > 0;
   const allCollapsed = canCollapse && collapsibleEntries.every(isEntryCollapsed);
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/StyledWrapper.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 const StyledWrapper = styled.div`
   .drag-preview {
     background-color: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+    border-color: ${(props) => props.theme.border.border2};
   }
 `;
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/index.js
@@ -74,7 +74,7 @@ export const CollectionItemDragPreview = () => {
   if (!isDragging) return null;
   if (!item) return null;
 
-  const validTypes = ['collection', 'collection-item', 'disabled-drag'];
+  const validTypes = ['collection', 'collection-item'];
   if (!validTypes.includes(itemType)) return null;
 
   const { x, y } = clientOffset || {};
@@ -98,7 +98,7 @@ export const CollectionItemDragPreview = () => {
   return (
     <StyledWrapper>
       <div style={getItemStyles({ x, y })} className="p-2">
-        <div className="flex items-center gap-2 border border-gray-500/10 rounded-md px-2 py-1 drag-preview">
+        <div className="flex items-center gap-2 border rounded-md px-2 py-1 drag-preview">
           {Icon && <Icon size={16} />}
           {label}
         </div>

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemDragPreview/index.js
@@ -22,16 +22,30 @@ function getItemStyles({ x, y }) {
 
 // Builds the "N folders, M requests and K apps"-style summary for a multi-item drag.
 function getMultiDragLabel(multiSelectedItems) {
-  const folders = multiSelectedItems.filter((i) => i.type === 'folder').length;
-  const apps = multiSelectedItems.filter((i) => i.type === 'app').length;
-  const requests = multiSelectedItems.filter((i) => i.type && i.type.includes('request')).length;
-  const collections = multiSelectedItems.filter((i) => !i.type || i.type === 'collection').length;
+  const itemsCount = multiSelectedItems.reduce(
+    (acc, i) => {
+      if (i.type === 'folder') {
+        acc.folder++;
+      } else if (i.type === 'app') {
+        acc.app++;
+      } else if (i.type && i.type.includes('request')) {
+        acc.request++;
+      } else if (!i.type || i.type === 'collection') {
+        acc.collection++;
+      }
+      return acc;
+    },
+    { folder: 0, app: 0, request: 0, collection: 0 }
+  );
 
   const parts = [];
-  if (collections > 0) parts.push(`${collections} collection${collections > 1 ? 's' : ''}`);
-  if (folders > 0) parts.push(`${folders} folder${folders > 1 ? 's' : ''}`);
-  if (apps > 0) parts.push(`${apps} app${apps > 1 ? 's' : ''}`);
-  if (requests > 0) parts.push(`${requests} request${requests > 1 ? 's' : ''}`);
+  const keyOrder = ['collection', 'folder', 'app', 'request'];
+  for (const key of keyOrder) {
+    const value = itemsCount[key];
+    if (value > 0) {
+      parts.push(`${value} ${key}${value > 1 ? 's' : ''}`);
+    }
+  }
 
   if (parts.length === 0) return `${multiSelectedItems.length} items`;
   return parts.join(', ').replace(/, ([^,]*)$/, ' and $1');

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItems/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItems/index.js
@@ -2,8 +2,8 @@ import React from 'react';
 import toast from 'react-hot-toast';
 import { useDispatch } from 'react-redux';
 import Modal from 'components/Modal';
-import { deleteItem, closeTabs } from 'providers/ReduxStore/slices/collections/actions';
-import { clearSidebarSelection } from 'providers/ReduxStore/slices/collections';
+import { deleteItem, closeTabs, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { clearSidebarSelection, deleteResponseExample } from 'providers/ReduxStore/slices/collections';
 import { recursivelyGetAllItemUids, isItemAFolder, isItemARequest } from 'utils/collections/index';
 import { pluralizeWord } from 'utils/common';
 
@@ -17,20 +17,23 @@ const DeleteCollectionItems = ({ entries, onClose }) => {
   let folderCount = 0;
   let requestCount = 0;
   let appCount = 0;
+  let exampleCount = 0;
 
-  for (const { item } of entries) {
-    if (isItemAFolder(item)) folderCount++;
-    else if (isItemARequest(item)) requestCount++;
-    else if (item.type === 'app') appCount++;
+  for (const entry of entries) {
+    if (entry.type === 'example') exampleCount++;
+    else if (isItemAFolder(entry.item)) folderCount++;
+    else if (isItemARequest(entry.item)) requestCount++;
+    else if (entry.item.type === 'app') appCount++;
   }
 
   const folderDescription = folderCount > 0 ? `${folderCount} ${pluralizeWord('folder', folderCount)}` : null;
   const requestDescription = requestCount > 0 ? `${requestCount} ${pluralizeWord('request', requestCount)}` : null;
   const appDescription = appCount > 0 ? `${appCount} ${pluralizeWord('app', appCount)}` : null;
+  const exampleDescription = exampleCount > 0 ? `${exampleCount} ${pluralizeWord('example', exampleCount)}` : null;
 
-  const types = [folderDescription, requestDescription, appDescription].filter(Boolean);
+  const types = [folderDescription, requestDescription, appDescription, exampleDescription].filter(Boolean);
   const description = entries.length === 1 ? (
-    <span className="font-medium">{entries[0].item.name}</span>
+    <span className="font-medium">{entries[0].type === 'example' ? entries[0].example.name : entries[0].item.name}</span>
   ) : (
     types.length > 2
       ? `${types.slice(0, -1).join(', ')} and ${types[types.length - 1]}`
@@ -44,6 +47,8 @@ const DeleteCollectionItems = ({ entries, onClose }) => {
       return `Delete ${pluralizeWord('Folder', folderCount)}`;
     } else if (appCount > 0) {
       return `Delete ${pluralizeWord('App', appCount)}`;
+    } else if (exampleCount > 0) {
+      return `Delete ${pluralizeWord('Example', exampleCount)}`;
     }
     return `Delete ${pluralizeWord('Request', requestCount)}`;
   };
@@ -51,8 +56,17 @@ const DeleteCollectionItems = ({ entries, onClose }) => {
   const title = getTitle();
 
   const onConfirm = async () => {
+    const parentItemsToSave = new Map(); // itemUid -> collectionUid
+
     for (const entry of entries) {
       try {
+        if (entry.type === 'example') {
+          dispatch(deleteResponseExample({ itemUid: entry.item.uid, collectionUid: entry.collectionUid, exampleUid: entry.uid }));
+          dispatch(closeTabs({ tabUids: [entry.uid] }));
+          parentItemsToSave.set(entry.item.uid, entry.collectionUid);
+          continue;
+        }
+
         await dispatch(deleteItem(entry.uid, entry.collectionUid));
         const tabUids = isItemAFolder(entry.item)
           ? [...recursivelyGetAllItemUids(entry.item.items), entry.uid]
@@ -61,6 +75,15 @@ const DeleteCollectionItems = ({ entries, onClose }) => {
       } catch (error) {
         console.error(`Error deleting item ${entry.uid}`, error);
         toast.error(error?.message || `Error deleting ${entry.item?.name || 'item'}`);
+      }
+    }
+
+    for (const [itemUid, collectionUid] of parentItemsToSave) {
+      try {
+        await dispatch(saveRequest(itemUid, collectionUid, true));
+      } catch (error) {
+        console.error(`Error saving request ${itemUid} after deleting examples`, error);
+        toast.error(error?.message || 'Error saving request after deleting examples');
       }
     }
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItems/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/DeleteCollectionItems/index.js
@@ -83,7 +83,6 @@ const DeleteCollectionItems = ({ entries, onClose }) => {
         await dispatch(saveRequest(itemUid, collectionUid, true));
       } catch (error) {
         console.error(`Error saving request ${itemUid} after deleting examples`, error);
-        toast.error(error?.message || 'Error saving request after deleting examples');
       }
     }
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/StyledWrapper.js
@@ -17,7 +17,7 @@ const StyledWrapper = styled.div`
     }
   }
 
-  .collection-item-name {
+  &.collection-item-name {
     height: 1.6rem;
     cursor: pointer;
     user-select: none;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/StyledWrapper.js
@@ -44,6 +44,10 @@ const StyledWrapper = styled.div`
         background: ${(props) => props.theme.sidebar.collection.item.bg} !important;
       }
     }
+
+    &.drag-disabled:active {
+      cursor: not-allowed !important;
+    }
   }
 
   .example-icon {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
@@ -52,15 +52,14 @@ const ExampleItem = ({ example, item, collection, searchText, openBulkMenu, isPa
       wasSelected: true,
       ...(parentMultiDragItems ? { multiSelectedItems: parentMultiDragItems } : {})
     },
+    canDrag: isRedirectedToRequestDrag,
     collect: () => ({}),
     options: {
       dropEffect: 'move'
     }
   });
-  if (isRedirectedToRequestDrag) {
-    drag(exampleRef);
-    dragPreview(getEmptyImage(), { captureDraggingState: true });
-  }
+  drag(exampleRef);
+  dragPreview(getEmptyImage(), { captureDraggingState: true });
 
   // Calculate indentation: item depth + 1 for examples
   const indents = range((item.depth || 0) + 1);

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
@@ -1,5 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useDrag } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
 import { addTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import {
   updateResponseExample,
@@ -20,8 +22,10 @@ import GenerateCodeItem from '../GenerateCodeItem';
 import toast from 'react-hot-toast';
 import StyledWrapper from './StyledWrapper';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
+import useSidebarSelectionClick from 'hooks/useSidebarSelectionClick';
+import { startBlockedDragTracking } from 'utils/dragBlockedCursor';
 
-const ExampleItem = ({ example, item, collection }) => {
+const ExampleItem = ({ example, item, collection, searchText, openBulkMenu, isParentDragDisabled, parentMultiDragItems }) => {
   const { dropdownContainerRef } = useSidebarAccordion();
   const dispatch = useDispatch();
   const activeTabUid = useSelector((state) => state.tabs?.activeTabUid);
@@ -32,6 +36,31 @@ const ExampleItem = ({ example, item, collection }) => {
   const [generateCodeItemModalOpen, setGenerateCodeItemModalOpen] = useState(false);
   const exampleRef = useRef(null);
   const menuDropdownRef = useRef(null);
+
+  const selectedSidebarUids = useSelector((state) => state.collections.selectedSidebarUids);
+  const isSelected = selectedSidebarUids.includes(example.uid);
+  const isMultiSelected = isSelected && selectedSidebarUids.length > 1;
+  const handleSelectionClick = useSidebarSelectionClick({ uid: example.uid, searchText });
+
+  const isRedirectedToRequestDrag = isMultiSelected && selectedSidebarUids.includes(item.uid) && !isParentDragDisabled;
+
+  const [, drag, dragPreview] = useDrag({
+    type: 'collection-item',
+    item: {
+      ...item,
+      sourceCollectionUid: collection.uid,
+      wasSelected: true,
+      ...(parentMultiDragItems ? { multiSelectedItems: parentMultiDragItems } : {})
+    },
+    collect: () => ({}),
+    options: {
+      dropEffect: 'move'
+    }
+  });
+  if (isRedirectedToRequestDrag) {
+    drag(exampleRef);
+    dragPreview(getEmptyImage(), { captureDraggingState: true });
+  }
 
   // Calculate indentation: item depth + 1 for examples
   const indents = range((item.depth || 0) + 1);
@@ -48,6 +77,12 @@ const ExampleItem = ({ example, item, collection }) => {
       exampleName: example.name,
       exampleIndex: typeof exampleIndex === 'number' && exampleIndex >= 0 ? exampleIndex : undefined
     }));
+  };
+
+  const handleClick = (event) => {
+    if (handleSelectionClick(event)) return;
+    if (event && event.detail !== 1) return;
+    handleExampleClick();
   };
 
   const handleDoubleClick = () => {
@@ -175,19 +210,29 @@ const ExampleItem = ({ example, item, collection }) => {
   const handleContextMenu = (e) => {
     e.preventDefault();
     e.stopPropagation();
+
+    if (isMultiSelected) {
+      openBulkMenu(e);
+      return;
+    }
+
     menuDropdownRef.current?.show();
   };
 
   const itemRowClassName = classnames('flex collection-item-name relative items-center', {
-    'item-focused-in-tab': isExampleActive
+    'item-focused-in-tab': isExampleActive,
+    'collection-item-selected': isSelected,
+    'drag-disabled': !isRedirectedToRequestDrag
   });
 
   return (
     <StyledWrapper
       ref={exampleRef}
       data-testid="sidebar-response-example-item"
+      data-selected={isSelected ? 'true' : undefined}
       className={itemRowClassName}
-      onClick={handleExampleClick}
+      onMouseDown={isRedirectedToRequestDrag ? undefined : startBlockedDragTracking}
+      onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
     >
@@ -210,18 +255,20 @@ const ExampleItem = ({ example, item, collection }) => {
         <ExampleIcon size={16} color="currentColor" className="example-icon mr-1 flex-shrink-0" />
         <span className="item-name truncate">{example.name}</span>
       </div>
-      <div className="menu-icon pr-2">
-        <MenuDropdown
-          ref={menuDropdownRef}
-          items={buildMenuItems()}
-          placement="bottom-start"
-          appendTo={dropdownContainerRef?.current || document.body}
-          popperOptions={{ strategy: 'fixed' }}
-          data-testid="response-example-menu"
-        >
-          <IconDots size={22} data-testid="response-example-menu-icon" />
-        </MenuDropdown>
-      </div>
+      {!isMultiSelected && (
+        <div className="menu-icon pr-2">
+          <MenuDropdown
+            ref={menuDropdownRef}
+            items={buildMenuItems()}
+            placement="bottom-start"
+            appendTo={dropdownContainerRef?.current || document.body}
+            popperOptions={{ strategy: 'fixed' }}
+            data-testid="response-example-menu"
+          >
+            <IconDots size={22} data-testid="response-example-menu-icon" />
+          </MenuDropdown>
+        </div>
+      )}
 
       {showRenameModal && (
         <Modal

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/ExampleItem/index.js
@@ -53,7 +53,6 @@ const ExampleItem = ({ example, item, collection, searchText, openBulkMenu, isPa
       ...(parentMultiDragItems ? { multiSelectedItems: parentMultiDragItems } : {})
     },
     canDrag: isRedirectedToRequestDrag,
-    collect: () => ({}),
     options: {
       dropEffect: 'move'
     }
@@ -230,7 +229,7 @@ const ExampleItem = ({ example, item, collection, searchText, openBulkMenu, isPa
       data-testid="sidebar-response-example-item"
       data-selected={isSelected ? 'true' : undefined}
       className={itemRowClassName}
-      onMouseDown={isRedirectedToRequestDrag ? undefined : startBlockedDragTracking}
+      onMouseDown={isMultiSelected && !isRedirectedToRequestDrag ? startBlockedDragTracking : undefined}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -174,6 +174,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
           wasSelected: isSelected,
           ...(multiDragItems ? { multiSelectedItems: multiDragItems } : {})
         },
+    canDrag: !isDragDisabled,
     collect: (monitor) => ({
       isDragging: monitor.isDragging()
     }),
@@ -289,11 +290,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
     })
   });
 
-  drop(ref);
-  if (!isDragDisabled) {
-    drag(ref);
-    dragPreview(getEmptyImage(), { captureDraggingState: true });
-  }
+  drag(drop(ref));
+  dragPreview(getEmptyImage(), { captureDraggingState: true });
 
   useEffect(() => {
     if (!isOver) {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -76,7 +76,7 @@ import useSidebarSelectionClick from 'hooks/useSidebarSelectionClick';
 import { startBlockedDragTracking } from 'utils/dragBlockedCursor';
 import { clearSidebarSelection } from 'providers/ReduxStore/slices/collections/index';
 
-const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, openBulkMenu, isMultiDragDisabled, multiDragCollections, multiDragItems: multiDragItemsForSelection }) => {
+const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, openBulkMenu, isItemMultiDragDisabled, multiDragCollections, multiDragItems: multiDragItemsForSelection }) => {
   const { dropdownContainerRef } = useSidebarAccordion();
   const selectorInput = {
     itemUid: item.uid,
@@ -109,7 +109,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
 
   const multiDragItems = isMultiSelected ? multiDragItemsForSelection : null;
   const isRedirectedToCollectionDrag = isMultiSelected && multiDragCollections?.length > 0;
-  const isDragDisabled = isMultiSelected && isMultiDragDisabled && !isRedirectedToCollectionDrag;
+  const isDragDisabled = isMultiSelected && isItemMultiDragDisabled && !isRedirectedToCollectionDrag;
 
   // We use a single ref for drag and drop.
   const ref = useRef(null);
@@ -388,7 +388,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
     e.stopPropagation();
     e.preventDefault();
     dispatch(
-      (itemIsCollapsed ? expandItem : collapseItem)({
+      (isCollectionItemCollapsed(item) ? expandItem : collapseItem)({
         itemUid: item.uid,
         collectionUid: collectionUid
       })
@@ -850,17 +850,17 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
         <div>
           {folderItems && folderItems.length
             ? folderItems.map((i) => {
-                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isItemMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
               })
             : null}
           {appItems && appItems.length
             ? appItems.map((i) => {
-                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isItemMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
               })
             : null}
           {requestItems && requestItems.length
             ? requestItems.map((i) => {
-                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isItemMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
               })
             : null}
           {showEmptyFolderMessage ? (

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -27,7 +27,7 @@ import { addTab, focusTab, makeTabPermanent } from 'providers/ReduxStore/slices/
 import { handleMultipleCollectionItemsDrop, sendRequest, showInFolder, pasteItem, saveRequest, cloneItem } from 'providers/ReduxStore/slices/collections/actions';
 import { sanitizeName } from 'utils/common/regex';
 import { formatIpcError } from 'utils/common/error';
-import { toggleCollectionItem, addResponseExample } from 'providers/ReduxStore/slices/collections';
+import { toggleCollectionItem, addResponseExample, expandItem, collapseItem } from 'providers/ReduxStore/slices/collections';
 import { uuid } from 'utils/common';
 import { copyRequest, setFocusedSidebarPath, insertTaskIntoQueue } from 'providers/ReduxStore/slices/app';
 import NewRequest from 'components/Sidebar/NewRequest';
@@ -61,7 +61,8 @@ import {
   determineCollectionItemDrop,
   getInitialExampleName,
   findParentItemInCollection,
-  getSortedDraggedItems
+  getSortedDraggedItems,
+  isCollectionItemCollapsed
 } from 'utils/collections/index';
 import { sortByNameThenSequence } from 'utils/common/index';
 import { getRevealInFolderLabel } from 'utils/common/platform';
@@ -72,9 +73,10 @@ import MenuDropdown from 'ui/MenuDropdown';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 import useKeybinding from 'hooks/useKeybinding';
 import useSidebarSelectionClick from 'hooks/useSidebarSelectionClick';
+import { startBlockedDragTracking } from 'utils/dragBlockedCursor';
 import { clearSidebarSelection } from 'providers/ReduxStore/slices/collections/index';
 
-const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, openBulkMenu, isMultiDragDisabled, multiDragItems: multiDragItemsForSelection }) => {
+const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, openBulkMenu, isMultiDragDisabled, multiDragCollections, multiDragItems: multiDragItemsForSelection }) => {
   const { dropdownContainerRef } = useSidebarAccordion();
   const selectorInput = {
     itemUid: item.uid,
@@ -106,7 +108,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
   const dispatch = useDispatch();
 
   const multiDragItems = isMultiSelected ? multiDragItemsForSelection : null;
-  const isDragDisabled = isMultiSelected && isMultiDragDisabled;
+  const isRedirectedToCollectionDrag = isMultiSelected && multiDragCollections?.length > 0;
+  const isDragDisabled = isMultiSelected && isMultiDragDisabled && !isRedirectedToCollectionDrag;
 
   // We use a single ref for drag and drop.
   const ref = useRef(null);
@@ -122,10 +125,9 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
   const [newAppModalOpen, setNewAppModalOpen] = useState(false);
   const [runCollectionModalOpen, setRunCollectionModalOpen] = useState(false);
   const [itemInfoModalOpen, setItemInfoModalOpen] = useState(false);
-  const [examplesExpanded, setExamplesExpanded] = useState(false);
   const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
   const hasSearchText = searchText && searchText?.trim()?.length;
-  const itemIsCollapsed = hasSearchText ? false : item.collapsed;
+  const itemIsCollapsed = hasSearchText ? false : isCollectionItemCollapsed(item);
   const isFolder = isItemAFolder(item);
 
   const isCloneable = isFolder || isItemARequest(item) || item.type === 'app';
@@ -163,13 +165,15 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
   const [dropType, setDropType] = useState(null); // 'above', 'inside' or 'below'
 
   const [{ isDragging }, drag, dragPreview] = useDrag({
-    type: isDragDisabled ? 'disabled-drag' : 'collection-item',
-    item: {
-      ...item,
-      sourceCollectionUid: collectionUid,
-      wasSelected: isSelected,
-      ...(multiDragItems ? { multiSelectedItems: multiDragItems } : {})
-    },
+    type: isRedirectedToCollectionDrag ? 'collection' : 'collection-item',
+    item: isRedirectedToCollectionDrag
+      ? { ...collection, wasSelected: true, multiSelectedItems: multiDragCollections }
+      : {
+          ...item,
+          sourceCollectionUid: collectionUid,
+          wasSelected: isSelected,
+          ...(multiDragItems ? { multiSelectedItems: multiDragItems } : {})
+        },
     collect: (monitor) => ({
       isDragging: monitor.isDragging()
     }),
@@ -285,8 +289,11 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
     })
   });
 
-  drag(drop(ref));
-  dragPreview(getEmptyImage(), { captureDraggingState: true });
+  drop(ref);
+  if (!isDragDisabled) {
+    drag(ref);
+    dragPreview(getEmptyImage(), { captureDraggingState: true });
+  }
 
   useEffect(() => {
     if (!isOver) {
@@ -296,10 +303,6 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
 
   const iconClassName = classnames({
     'rotate-90': !itemIsCollapsed
-  });
-
-  const examplesIconClassName = classnames({
-    'rotate-90': examplesExpanded
   });
 
   const itemRowClassName = classnames('flex collection-item-name relative items-center', {
@@ -386,7 +389,12 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
   const handleExamplesCollapse = (e) => {
     e.stopPropagation();
     e.preventDefault();
-    setExamplesExpanded(!examplesExpanded);
+    dispatch(
+      (itemIsCollapsed ? expandItem : collapseItem)({
+        itemUid: item.uid,
+        collectionUid: collectionUid
+      })
+    );
   };
 
   // prevent the parent's double-click handler from firing
@@ -763,6 +771,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
         tabIndex={0}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        onMouseDown={isDragDisabled ? startBlockedDragTracking : undefined}
         onContextMenu={handleContextMenu}
         data-testid="sidebar-collection-item-row"
         data-selected={isSelected ? 'true' : undefined}
@@ -805,7 +814,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
                 <IconChevronRight
                   size={16}
                   strokeWidth={2}
-                  className={examplesIconClassName}
+                  className={iconClassName}
                   style={{ color: 'rgb(160 160 160)' }}
                   onClick={handleExamplesCollapse}
                   onDoubleClick={handleExamplesDoubleClick}
@@ -843,17 +852,17 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
         <div>
           {folderItems && folderItems.length
             ? folderItems.map((i) => {
-                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragItems={multiDragItemsForSelection} />;
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
               })
             : null}
           {appItems && appItems.length
             ? appItems.map((i) => {
-                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragItems={multiDragItemsForSelection} />;
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
               })
             : null}
           {requestItems && requestItems.length
             ? requestItems.map((i) => {
-                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragItems={multiDragItemsForSelection} />;
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
               })
             : null}
           {showEmptyFolderMessage ? (
@@ -880,7 +889,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
       ) : null}
 
       {/* Show examples when expanded (only for HTTP requests) */}
-      {isItemARequest(item) && item.type === 'http-request' && examplesExpanded && hasExamples && (
+      {isItemARequest(item) && item.type === 'http-request' && !itemIsCollapsed && hasExamples && (
         <div>
           {(item.examples || []).map((example, index) => {
             return (
@@ -890,6 +899,10 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText, o
                 item={item}
                 index={index}
                 collection={collection}
+                searchText={searchText}
+                openBulkMenu={openBulkMenu}
+                isParentDragDisabled={isDragDisabled}
+                parentMultiDragItems={multiDragItems}
               />
             );
           })}

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/RemoveCollections/index.js
@@ -72,8 +72,8 @@ const RemoveCollections = ({ onClose, collectionUid, collectionUids }) => {
 
   // Otherwise, show the standard remove confirmation modal
   return (
-    <StyledWrapper>
-      <Portal>
+    <Portal>
+      <StyledWrapper>
         <Modal
           size="sm"
           title={`Remove ${pluralizeWord('Collection', collections.length)}`}
@@ -100,8 +100,8 @@ const RemoveCollections = ({ onClose, collectionUid, collectionUids }) => {
             {isMultiple ? 'They' : 'It'} will still be available in the filesystem at the above location and can be re-opened later.
           </p>
         </Modal>
-      </Portal>
-    </StyledWrapper>
+      </StyledWrapper>
+    </Portal>
   );
 };
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -67,7 +67,7 @@ import { startBlockedDragTracking } from 'utils/dragBlockedCursor';
 // This prevents flicker from race condition between loading state and item batch updates
 const EMPTY_STATE_DELAY_MS = 300;
 
-const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled, isItemMultiDragDisabled, multiDragCollections, multiDragItems: multiDragItemsForSelection }) => {
+const Collection = ({ collection, searchText, openBulkMenu, isCollectionMultiDragDisabled, isItemMultiDragDisabled, multiDragCollections, multiDragItems: multiDragItemsForSelection }) => {
   const isMockServerEnabled = useBetaFeature(BETA_FEATURES.MOCK_SERVER);
   const { dropdownContainerRef } = useSidebarAccordion();
   const [showNewFolderModal, setShowNewFolderModal] = useState(false);
@@ -107,7 +107,7 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
   const allCollections = useSelector((state) => state.collections.collections);
   const isMoveToWorkspaceVisible = isPathExternalToBasePath(activeWorkspace?.pathname, collection.pathname);
 
-  const isDragDisabled = isMultiSelected && isMultiDragDisabled;
+  const isDragDisabled = isMultiSelected && isCollectionMultiDragDisabled;
   const multiDragItems = isMultiSelected ? multiDragCollections : null;
 
   // Open the OpenAPI Sync tab
@@ -667,13 +667,13 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
         {!collectionIsCollapsed ? (
           <div>
             {folderItems?.map?.((i) => {
-              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isItemMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
             })}
             {appItems?.map?.((i) => {
-              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isItemMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
             })}
             {requestItems?.map?.((i) => {
-              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isItemMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
             })}
             {showEmptyCollectionMessage ? (
               <div className="empty-collection-message">

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -293,6 +293,7 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
       wasSelected: isSelected,
       ...(multiDragItems ? { multiSelectedItems: multiDragItems } : {})
     },
+    canDrag: !isDragDisabled,
     collect: (monitor) => ({
       isDragging: monitor.isDragging()
     }),
@@ -375,11 +376,8 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
     })
   });
 
-  drop(collectionRef);
-  if (!isDragDisabled) {
-    drag(collectionRef);
-    dragPreview(getEmptyImage(), { captureDraggingState: true });
-  }
+  drag(drop(collectionRef));
+  dragPreview(getEmptyImage(), { captureDraggingState: true });
 
   useEffect(() => {
     if (isCollectionFocused && collectionRef.current) {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/index.js
@@ -61,12 +61,13 @@ import { useBetaFeature, BETA_FEATURES } from 'utils/beta-features';
 import StatusBadge from 'ui/StatusBadge';
 import CreateMockServerModal from 'components/MockServer/CreateMockServerModal';
 import useSidebarSelectionClick from 'hooks/useSidebarSelectionClick';
+import { startBlockedDragTracking } from 'utils/dragBlockedCursor';
 
 // Delay before showing empty collection state (ms)
 // This prevents flicker from race condition between loading state and item batch updates
 const EMPTY_STATE_DELAY_MS = 300;
 
-const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled, multiDragCollections, multiDragItems: multiDragItemsForSelection }) => {
+const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled, isItemMultiDragDisabled, multiDragCollections, multiDragItems: multiDragItemsForSelection }) => {
   const isMockServerEnabled = useBetaFeature(BETA_FEATURES.MOCK_SERVER);
   const { dropdownContainerRef } = useSidebarAccordion();
   const [showNewFolderModal, setShowNewFolderModal] = useState(false);
@@ -286,7 +287,7 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
   };
 
   const [{ isDragging }, drag, dragPreview] = useDrag({
-    type: isDragDisabled ? 'disabled-drag' : 'collection',
+    type: 'collection',
     item: {
       ...collection,
       wasSelected: isSelected,
@@ -374,8 +375,11 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
     })
   });
 
-  drag(drop(collectionRef));
-  dragPreview(getEmptyImage(), { captureDraggingState: true });
+  drop(collectionRef);
+  if (!isDragDisabled) {
+    drag(collectionRef);
+    dragPreview(getEmptyImage(), { captureDraggingState: true });
+  }
 
   useEffect(() => {
     if (isCollectionFocused && collectionRef.current) {
@@ -616,6 +620,7 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
         tabIndex={0}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        onMouseDown={isDragDisabled ? startBlockedDragTracking : undefined}
         data-testid="sidebar-collection-row"
         data-selected={isSelected ? 'true' : undefined}
       >
@@ -664,13 +669,13 @@ const Collection = ({ collection, searchText, openBulkMenu, isMultiDragDisabled,
         {!collectionIsCollapsed ? (
           <div>
             {folderItems?.map?.((i) => {
-              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragItems={multiDragItemsForSelection} />;
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
             })}
             {appItems?.map?.((i) => {
-              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragItems={multiDragItemsForSelection} />;
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
             })}
             {requestItems?.map?.((i) => {
-              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isMultiDragDisabled} multiDragItems={multiDragItemsForSelection} />;
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} openBulkMenu={openBulkMenu} isMultiDragDisabled={isItemMultiDragDisabled} multiDragCollections={multiDragCollections} multiDragItems={multiDragItemsForSelection} />;
             })}
             {showEmptyCollectionMessage ? (
               <div className="empty-collection-message">

--- a/packages/bruno-app/src/components/Sidebar/Collections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/index.js
@@ -36,10 +36,16 @@ const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismis
     [collections, selectedSidebarUids]
   );
 
-  const isMultiDragDisabled = !!selectionInfo && (
-    selectionInfo.hasExample || (selectionInfo.hasCollection && (selectionInfo.hasFolder || selectionInfo.hasRequest || selectionInfo.hasApp))
+  // A collection can't be dragged together with folders/requests/apps from inside it.
+  const hasMixedCollectionSelection = Boolean(
+    selectionInfo?.hasCollection
+    && (selectionInfo.hasFolder || selectionInfo.hasRequest || selectionInfo.hasApp)
   );
 
+  // Whether a selected collection row can be dragged as part of the multi-selection.
+  const isCollectionMultiDragDisabled = !!selectionInfo && (selectionInfo.hasExample || hasMixedCollectionSelection);
+
+  // Whether a selected folder/request/app row can be dragged as part of the multi-selection.
   const isItemMultiDragDisabled = !!selectionInfo && (selectionInfo.hasExample || selectionInfo.hasCollection);
 
   const multiDragCollections = useMemo(() => {
@@ -98,7 +104,7 @@ const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismis
                 collection={entry.collection}
                 key={entry.key}
                 openBulkMenu={openBulkMenu}
-                isMultiDragDisabled={isMultiDragDisabled}
+                isCollectionMultiDragDisabled={isCollectionMultiDragDisabled}
                 isItemMultiDragDisabled={isItemMultiDragDisabled}
                 multiDragCollections={multiDragCollections}
                 multiDragItems={multiDragItems}

--- a/packages/bruno-app/src/components/Sidebar/Collections/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/index.js
@@ -36,15 +36,19 @@ const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismis
     [collections, selectedSidebarUids]
   );
 
-  const isMultiDragDisabled = !!selectionInfo && selectionInfo.hasCollection && (selectionInfo.hasFolder || selectionInfo.hasRequest || selectionInfo.hasApp);
+  const isMultiDragDisabled = !!selectionInfo && (
+    selectionInfo.hasExample || (selectionInfo.hasCollection && (selectionInfo.hasFolder || selectionInfo.hasRequest || selectionInfo.hasApp))
+  );
+
+  const isItemMultiDragDisabled = !!selectionInfo && (selectionInfo.hasExample || selectionInfo.hasCollection);
 
   const multiDragCollections = useMemo(() => {
-    if (!selectionInfo || selectionInfo.hasFolder || selectionInfo.hasRequest) return null;
+    if (!selectionInfo || selectionInfo.hasFolder || selectionInfo.hasRequest || selectionInfo.hasApp || selectionInfo.hasExample) return null;
     return selectionInfo.effectiveSelection.filter((entry) => entry.type === 'collection').map((entry) => entry.collection);
   }, [selectionInfo]);
 
   const multiDragItems = useMemo(() => {
-    if (!selectionInfo || selectionInfo.hasCollection) return null;
+    if (!selectionInfo || selectionInfo.hasCollection || selectionInfo.hasExample) return null;
     return selectionInfo.effectiveSelection.map((entry) => ({ ...entry.item, sourceCollectionUid: entry.collectionUid }));
   }, [selectionInfo]);
 
@@ -95,6 +99,7 @@ const Collections = ({ showSearch, isCreatingCollection, onCreateClick, onDismis
                 key={entry.key}
                 openBulkMenu={openBulkMenu}
                 isMultiDragDisabled={isMultiDragDisabled}
+                isItemMultiDragDisabled={isItemMultiDragDisabled}
                 multiDragCollections={multiDragCollections}
                 multiDragItems={multiDragItems}
               />

--- a/packages/bruno-app/src/globalStyles.js
+++ b/packages/bruno-app/src/globalStyles.js
@@ -186,6 +186,10 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
+  body.dnd-blocked-cursor,
+  body.dnd-blocked-cursor * {
+    cursor: not-allowed !important;
+  }
 
   .collection-header-dropdown-label {
     max-width: 124px;

--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1122,7 +1122,7 @@ export const collectionsSlice = createSlice({
       if (collection) {
         const item = findItemInCollection(collection, action.payload.itemUid);
 
-        if (item && item.type === 'folder') {
+        if (item && (item.type === 'folder' || isItemARequest(item))) {
           item.collapsed = false;
         }
       }
@@ -1133,7 +1133,7 @@ export const collectionsSlice = createSlice({
       if (collection) {
         const item = findItemInCollection(collection, action.payload.itemUid);
 
-        if (item && item.type === 'folder') {
+        if (item && (item.type === 'folder' || isItemARequest(item))) {
           item.collapsed = true;
         }
       }

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -2017,21 +2017,27 @@ const getSelectionEntryType = (item) => {
 };
 
 // Returns whether a folder or request (with examples) is collapsed. Folders default to expanded; requests default to collapsed.
-export const isCollectionItemCollapsed = (item) => (isItemAFolder(item) ? !!item.collapsed : item.collapsed ?? true);
+export const isCollectionItemCollapsed = (item) => (isItemARequest(item) ? item.collapsed ?? true : !!item.collapsed);
 
-// Locates the collection, request, and example for an example uid in a single pass, since examples
-// are nested within requests and lack their own pathnames.
-const findExampleOwner = (collections, exampleUid) => {
+// Indexes every example by uid in a single pass over all collections, since examples are nested
+// within requests and lack their own pathnames. Built lazily (once per getSelectionInfo call) so
+// callers whose selection contains no examples never pay for it.
+const buildExampleOwnerIndex = (collections) => {
+  const index = new Map();
   for (const collection of collections) {
     for (const item of flattenItems(collection.items)) {
-      const example = item.examples && find(item.examples, (ex) => ex.uid === exampleUid);
-      if (example) return { collection, item, example };
+      if (!item.examples) continue;
+      for (const example of item.examples) {
+        index.set(example.uid, { collection, item, example });
+      }
     }
   }
-  return null;
+  return index;
 };
 
 export const getSelectionInfo = ({ collections = [], selectedUids = [] }) => {
+  let exampleOwnerIndex = null;
+
   const resolved = selectedUids
     .map((uid) => {
       const collection = findCollectionByUid(collections, uid);
@@ -2051,7 +2057,8 @@ export const getSelectionInfo = ({ collections = [], selectedUids = [] }) => {
         };
       }
 
-      const exampleOwner = findExampleOwner(collections, uid);
+      exampleOwnerIndex = exampleOwnerIndex || buildExampleOwnerIndex(collections);
+      const exampleOwner = exampleOwnerIndex.get(uid);
       if (exampleOwner) {
         return {
           uid,

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -1965,6 +1965,11 @@ export const getVisibleSidebarUidsInOrder = ({ sidebarEntries = [], searchText =
     requestItems.forEach((request) => {
       if (hasSearchText && !doesRequestMatchSearchText(request, searchText)) return;
       uids.push(request.uid);
+
+      const examplesVisible = request.type === 'http-request' && (hasSearchText || !isCollectionItemCollapsed(request));
+      if (examplesVisible && request.examples?.length) {
+        request.examples.forEach((example) => uids.push(example.uid));
+      }
     });
   };
 
@@ -2014,10 +2019,16 @@ const getSelectionEntryType = (item) => {
 // Returns whether a folder or request (with examples) is collapsed. Folders default to expanded; requests default to collapsed.
 export const isCollectionItemCollapsed = (item) => (isItemAFolder(item) ? !!item.collapsed : item.collapsed ?? true);
 
-// Finds the parent request of an example, since examples are nested within requests and lack their own pathnames.
-const findRequestOwningExample = (collection, exampleUid) => {
-  const flattenedItems = flattenItems(collection.items);
-  return find(flattenedItems, (i) => i.examples && find(i.examples, (ex) => ex.uid === exampleUid));
+// Locates the collection, request, and example for an example uid in a single pass, since examples
+// are nested within requests and lack their own pathnames.
+const findExampleOwner = (collections, exampleUid) => {
+  for (const collection of collections) {
+    for (const item of flattenItems(collection.items)) {
+      const example = item.examples && find(item.examples, (ex) => ex.uid === exampleUid);
+      if (example) return { collection, item, example };
+    }
+  }
+  return null;
 };
 
 export const getSelectionInfo = ({ collections = [], selectedUids = [] }) => {
@@ -2040,17 +2051,15 @@ export const getSelectionInfo = ({ collections = [], selectedUids = [] }) => {
         };
       }
 
-      const requestCollection = find(collections, (c) => findRequestOwningExample(c, uid));
-      const requestItem = requestCollection && findRequestOwningExample(requestCollection, uid);
-      const example = requestItem && find(requestItem.examples, (ex) => ex.uid === uid);
-      if (example) {
+      const exampleOwner = findExampleOwner(collections, uid);
+      if (exampleOwner) {
         return {
           uid,
           type: 'example',
-          collectionUid: requestCollection.uid,
+          collectionUid: exampleOwner.collection.uid,
           pathname: null,
-          item: requestItem,
-          example
+          item: exampleOwner.item,
+          example: exampleOwner.example
         };
       }
 

--- a/packages/bruno-app/src/utils/collections/index.js
+++ b/packages/bruno-app/src/utils/collections/index.js
@@ -2011,6 +2011,15 @@ const getSelectionEntryType = (item) => {
   return 'file';
 };
 
+// Returns whether a folder or request (with examples) is collapsed. Folders default to expanded; requests default to collapsed.
+export const isCollectionItemCollapsed = (item) => (isItemAFolder(item) ? !!item.collapsed : item.collapsed ?? true);
+
+// Finds the parent request of an example, since examples are nested within requests and lack their own pathnames.
+const findRequestOwningExample = (collection, exampleUid) => {
+  const flattenedItems = flattenItems(collection.items);
+  return find(flattenedItems, (i) => i.examples && find(i.examples, (ex) => ex.uid === exampleUid));
+};
+
 export const getSelectionInfo = ({ collections = [], selectedUids = [] }) => {
   const resolved = selectedUids
     .map((uid) => {
@@ -2021,23 +2030,52 @@ export const getSelectionInfo = ({ collections = [], selectedUids = [] }) => {
 
       const owningCollection = findCollectionByItemUid(collections, uid);
       const item = owningCollection && findItemInCollection(owningCollection, uid);
-      if (!item) return null;
+      if (item) {
+        return {
+          uid,
+          type: getSelectionEntryType(item),
+          collectionUid: owningCollection.uid,
+          pathname: item.pathname,
+          item
+        };
+      }
 
-      return {
-        uid,
-        type: getSelectionEntryType(item),
-        collectionUid: owningCollection.uid,
-        pathname: item.pathname,
-        item
-      };
+      const requestCollection = find(collections, (c) => findRequestOwningExample(c, uid));
+      const requestItem = requestCollection && findRequestOwningExample(requestCollection, uid);
+      const example = requestItem && find(requestItem.examples, (ex) => ex.uid === uid);
+      if (example) {
+        return {
+          uid,
+          type: 'example',
+          collectionUid: requestCollection.uid,
+          pathname: null,
+          item: requestItem,
+          example
+        };
+      }
+
+      return null;
     })
     .filter(Boolean);
 
   const selectedCollectionPathnames = resolved.filter((r) => r.type === 'collection').map((r) => r.pathname);
   const selectedFolderPathnames = resolved.filter((r) => r.type === 'folder').map((r) => r.pathname);
+  const selectedRequestPathnames = resolved.filter((r) => r.type === 'request').map((r) => r.pathname);
+
+  // Since examples lack pathnames, they are considered absorbed if their parent request is selected
+  // (either directly or via an ancestor folder/collection).
+  const isExampleAbsorbed = (entry) => {
+    const parentPathname = entry.item.pathname;
+    return (
+      selectedRequestPathnames.includes(parentPathname)
+      || selectedCollectionPathnames.some((p) => isPathnameDescendantOf(parentPathname, p))
+      || selectedFolderPathnames.some((p) => isPathnameDescendantOf(parentPathname, p))
+    );
+  };
 
   const effectiveSelection = resolved.filter((entry) => {
     if (entry.type === 'collection') return true;
+    if (entry.type === 'example') return !isExampleAbsorbed(entry);
     if (selectedCollectionPathnames.some((p) => isPathnameDescendantOf(entry.pathname, p))) return false;
     return !selectedFolderPathnames.some(
       (p) => p !== entry.pathname && isPathnameDescendantOf(entry.pathname, p)
@@ -2049,7 +2087,8 @@ export const getSelectionInfo = ({ collections = [], selectedUids = [] }) => {
     hasCollection: effectiveSelection.some((e) => e.type === 'collection'),
     hasFolder: effectiveSelection.some((e) => e.type === 'folder'),
     hasRequest: effectiveSelection.some((e) => e.type === 'request'),
-    hasApp: effectiveSelection.some((e) => e.type === 'app')
+    hasApp: effectiveSelection.some((e) => e.type === 'app'),
+    hasExample: effectiveSelection.some((e) => e.type === 'example')
   };
 };
 

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -624,6 +624,53 @@ describe('getVisibleSidebarUidsInOrder', () => {
     expect(getVisibleSidebarUidsInOrder({ sidebarEntries, searchText: 'alpha' }))
       .toEqual(['colA', 'folderA', 'reqA1']);
   });
+
+  const buildRequestWithExample = (overrides = {}) => ({
+    uid: 'reqRoot',
+    type: 'http-request',
+    request: {},
+    name: 'Root',
+    seq: 2,
+    pathname: '/colA/Root.bru',
+    examples: [{ uid: 'ex1', itemUid: 'reqRoot', name: 'Example 1', type: 'http-request' }],
+    ...overrides
+  });
+
+  it('includes a request\'s examples once its examples are expanded', () => {
+    const sidebarEntries = [
+      {
+        kind: 'loaded',
+        collection: buildCollectionA({ collection: { items: [buildFolderA(), buildRequestWithExample({ collapsed: false })] } })
+      }
+    ];
+
+    expect(getVisibleSidebarUidsInOrder({ sidebarEntries, searchText: '' }))
+      .toEqual(['colA', 'folderA', 'reqA1', 'reqRoot', 'ex1']);
+  });
+
+  it('excludes a request\'s examples while its examples are collapsed (the default)', () => {
+    const sidebarEntries = [
+      {
+        kind: 'loaded',
+        collection: buildCollectionA({ collection: { items: [buildFolderA(), buildRequestWithExample()] } })
+      }
+    ];
+
+    expect(getVisibleSidebarUidsInOrder({ sidebarEntries, searchText: '' }))
+      .toEqual(['colA', 'folderA', 'reqA1', 'reqRoot']);
+  });
+
+  it('includes examples while searching even though examples are otherwise collapsed', () => {
+    const sidebarEntries = [
+      {
+        kind: 'loaded',
+        collection: buildCollectionA({ collection: { items: [buildFolderA(), buildRequestWithExample()] } })
+      }
+    ];
+
+    expect(getVisibleSidebarUidsInOrder({ sidebarEntries, searchText: 'root' }))
+      .toEqual(['colA', 'reqRoot', 'ex1']);
+  });
 });
 
 describe('getSelectionInfo', () => {

--- a/packages/bruno-app/src/utils/collections/index.spec.js
+++ b/packages/bruno-app/src/utils/collections/index.spec.js
@@ -13,7 +13,8 @@ import {
   getVisibleSidebarUidsInOrder,
   getSelectionInfo,
   getUniqueTagsFromItems,
-  getCollectionVersion
+  getCollectionVersion,
+  isCollectionItemCollapsed
 } from './index';
 
 describe('mergeHeaders', () => {
@@ -654,6 +655,100 @@ describe('getSelectionInfo', () => {
 
     expect(info.effectiveSelection.map((e) => e.uid).sort()).toEqual(['colA', 'colB']);
     expect(info).toMatchObject({ hasCollection: true, hasFolder: false, hasRequest: false });
+  });
+
+  describe('examples', () => {
+    const collectionsWithExample = [
+      buildCollectionA({
+        collection: {
+          items: [
+            buildFolderA({
+              items: [
+                { uid: 'reqA1', type: 'http-request', request: {}, name: 'Alpha', seq: 1, pathname: '/colA/folderA/Alpha.bru', examples: [{ uid: 'exNested', itemUid: 'reqA1', name: 'Nested Example', type: 'http-request' }] }
+              ]
+            }),
+            {
+              uid: 'reqRoot',
+              type: 'http-request',
+              request: {},
+              name: 'Root',
+              seq: 2,
+              pathname: '/colA/Root.bru',
+              examples: [{ uid: 'ex1', itemUid: 'reqRoot', name: 'Example 1', type: 'http-request' }]
+            }
+          ]
+        }
+      }),
+      buildCollectionB()
+    ];
+
+    it('resolves a selected example to its parent request, with no pathname of its own', () => {
+      const info = getSelectionInfo({ collections: collectionsWithExample, selectedUids: ['ex1', 'reqB1'] });
+
+      expect(info.effectiveSelection.map((e) => e.uid).sort()).toEqual(['ex1', 'reqB1']);
+      expect(info).toMatchObject({ hasExample: true, hasRequest: true });
+
+      const exampleEntry = info.effectiveSelection.find((e) => e.uid === 'ex1');
+      expect(exampleEntry).toMatchObject({ type: 'example', collectionUid: 'colA', pathname: null });
+      expect(exampleEntry.item.uid).toBe('reqRoot');
+    });
+
+    it('blocks (stays in the effective selection) when selected alongside an unrelated collection', () => {
+      const info = getSelectionInfo({ collections: collectionsWithExample, selectedUids: ['colB', 'ex1'] });
+
+      expect(info.effectiveSelection.map((e) => e.uid).sort()).toEqual(['colB', 'ex1']);
+      expect(info).toMatchObject({ hasCollection: true, hasExample: true });
+    });
+
+    it('blocks (stays in the effective selection) when selected alongside a different, unrelated request', () => {
+      const info = getSelectionInfo({ collections: collectionsWithExample, selectedUids: ['reqRoot', 'exNested'] });
+
+      expect(info.effectiveSelection.map((e) => e.uid).sort()).toEqual(['exNested', 'reqRoot']);
+      expect(info).toMatchObject({ hasRequest: true, hasExample: true });
+    });
+
+    it('applies parent-wins when selected together with its own parent request', () => {
+      const info = getSelectionInfo({ collections: collectionsWithExample, selectedUids: ['reqRoot', 'ex1'] });
+
+      expect(info.effectiveSelection.map((e) => e.uid)).toEqual(['reqRoot']);
+      expect(info).toMatchObject({ hasRequest: true, hasExample: false });
+    });
+
+    it('applies parent-wins when selected together with an ancestor folder of its parent request', () => {
+      const info = getSelectionInfo({ collections: collectionsWithExample, selectedUids: ['folderA', 'exNested'] });
+
+      expect(info.effectiveSelection.map((e) => e.uid)).toEqual(['folderA']);
+      expect(info).toMatchObject({ hasFolder: true, hasExample: false });
+    });
+
+    it('applies parent-wins when selected together with an ancestor collection of its parent request', () => {
+      const info = getSelectionInfo({ collections: collectionsWithExample, selectedUids: ['colA', 'ex1'] });
+
+      expect(info.effectiveSelection.map((e) => e.uid)).toEqual(['colA']);
+      expect(info).toMatchObject({ hasCollection: true, hasExample: false });
+    });
+  });
+});
+
+describe('isCollectionItemCollapsed', () => {
+  it('treats a folder as expanded by default (item.collapsed unset)', () => {
+    expect(isCollectionItemCollapsed({ type: 'folder' })).toBe(false);
+  });
+
+  it('treats a folder as collapsed once item.collapsed is explicitly true', () => {
+    expect(isCollectionItemCollapsed({ type: 'folder', collapsed: true })).toBe(true);
+  });
+
+  it('treats a request as collapsed by default (item.collapsed unset), unlike a folder', () => {
+    expect(isCollectionItemCollapsed({ type: 'http-request', request: {} })).toBe(true);
+  });
+
+  it('treats a request as expanded once item.collapsed is explicitly false', () => {
+    expect(isCollectionItemCollapsed({ type: 'http-request', request: {}, collapsed: false })).toBe(false);
+  });
+
+  it('treats a request as collapsed once item.collapsed is explicitly true', () => {
+    expect(isCollectionItemCollapsed({ type: 'http-request', request: {}, collapsed: true })).toBe(true);
   });
 });
 

--- a/packages/bruno-app/src/utils/dragBlockedCursor.js
+++ b/packages/bruno-app/src/utils/dragBlockedCursor.js
@@ -1,0 +1,58 @@
+/**
+ * Provides a "not-allowed" cursor when attempting to drag undroppable items (like Examples or blocked multi-selections).
+ * Because native HTML5 drag-and-drop cannot customize mid-drag cursors, this module tracks mouse movements manually
+ * and applies a global CSS class. It also intercepts the trailing click event to prevent unintended selections.
+ */
+
+const BLOCKED_CURSOR_CLASS = 'dnd-blocked-cursor';
+const DRAG_THRESHOLD_PX = 4;
+
+let dragStart = null;
+let isTrackingDrag = false;
+let suppressNextClick = false;
+
+const distance = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+
+const stopTracking = () => {
+  window.removeEventListener('mousemove', onMouseMove);
+  window.removeEventListener('mouseup', onMouseUp);
+  document.body.classList.remove(BLOCKED_CURSOR_CLASS);
+  dragStart = null;
+  isTrackingDrag = false;
+};
+
+function onMouseMove(e) {
+  if (!dragStart || isTrackingDrag) return;
+  if (distance({ x: e.clientX, y: e.clientY }, dragStart) < DRAG_THRESHOLD_PX) return;
+
+  isTrackingDrag = true;
+  document.body.classList.add(BLOCKED_CURSOR_CLASS);
+}
+
+function onMouseUp() {
+  if (isTrackingDrag) {
+    suppressNextClick = true;
+  }
+  stopTracking();
+}
+
+export const startBlockedDragTracking = (e) => {
+  if (e.button !== 0) return;
+
+  dragStart = { x: e.clientX, y: e.clientY };
+  window.addEventListener('mousemove', onMouseMove);
+  window.addEventListener('mouseup', onMouseUp);
+};
+
+if (typeof document !== 'undefined') {
+  document.addEventListener(
+    'click',
+    (e) => {
+      if (!suppressNextClick) return;
+      suppressNextClick = false;
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    true
+  );
+}

--- a/packages/bruno-app/src/utils/dragBlockedCursor.js
+++ b/packages/bruno-app/src/utils/dragBlockedCursor.js
@@ -9,13 +9,13 @@ const DRAG_THRESHOLD_PX = 4;
 
 let dragStart = null;
 let isTrackingDrag = false;
-let suppressNextClick = false;
 
 const distance = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
 
 const stopTracking = () => {
   window.removeEventListener('mousemove', onMouseMove);
   window.removeEventListener('mouseup', onMouseUp);
+  window.removeEventListener('blur', onWindowBlur);
   document.body.classList.remove(BLOCKED_CURSOR_CLASS);
   dragStart = null;
   isTrackingDrag = false;
@@ -29,10 +29,26 @@ function onMouseMove(e) {
   document.body.classList.add(BLOCKED_CURSOR_CLASS);
 }
 
+// A click only follows mouseup when mousedown and mouseup shared a target, so releasing over a
+// different element never fires one — drop the listener on the next tick instead of waiting
+// indefinitely, or it would go on to swallow the user's next, unrelated click.
+function suppressTrailingClickOnce() {
+  const suppress = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+  document.addEventListener('click', suppress, { capture: true, once: true });
+  setTimeout(() => document.removeEventListener('click', suppress, true), 0);
+}
+
 function onMouseUp() {
   if (isTrackingDrag) {
-    suppressNextClick = true;
+    suppressTrailingClickOnce();
   }
+  stopTracking();
+}
+
+function onWindowBlur() {
   stopTracking();
 }
 
@@ -42,17 +58,5 @@ export const startBlockedDragTracking = (e) => {
   dragStart = { x: e.clientX, y: e.clientY };
   window.addEventListener('mousemove', onMouseMove);
   window.addEventListener('mouseup', onMouseUp);
+  window.addEventListener('blur', onWindowBlur);
 };
-
-if (typeof document !== 'undefined') {
-  document.addEventListener(
-    'click',
-    (e) => {
-      if (!suppressNextClick) return;
-      suppressNextClick = false;
-      e.preventDefault();
-      e.stopPropagation();
-    },
-    true
-  );
-}

--- a/tests/collection/multi-select/multi-select.spec.ts
+++ b/tests/collection/multi-select/multi-select.spec.ts
@@ -125,6 +125,37 @@ test.describe('Sidebar multi-select and bulk actions', () => {
     });
   });
 
+  test('Shift-click range spanning an expanded request\'s examples includes those examples too', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const collectionName = 'shiftexample Collection';
+
+    await createCollection(page, collectionName, await createTmpDir('shiftexample'));
+    await createFolder(page, 'Folder A', collectionName);
+    await expandFolder(page, 'Folder A');
+    await createRequest(page, 'Req A1', 'Folder A', { inFolder: true });
+    await createRequest(page, 'Req Root', collectionName, {});
+    await createExampleFromSidebar(page, 'Req Root', 'Example 1');
+    await locators.sidebar.requestExamplesToggle('Req Root').click();
+    await clickEmptySidebarSpace(page);
+
+    const folderARow = locators.sidebar.itemRow('Folder A');
+    const reqA1Row = locators.sidebar.itemRow('Req A1');
+    const reqRootRow = locators.sidebar.itemRow('Req Root');
+    const exampleRow = locators.sidebar.example('Example 1');
+
+    await test.step('Select Folder A, then Shift-click the expanded example', async () => {
+      await locators.sidebar.folder('Folder A').click({ modifiers: [SELECT_MODIFIER] });
+      await exampleRow.click({ modifiers: ['Shift'] });
+    });
+
+    await test.step('The range from Folder A through the example, inclusive, is selected', async () => {
+      await expect(folderARow).toHaveAttribute('data-selected', 'true');
+      await expect(reqA1Row).toHaveAttribute('data-selected', 'true');
+      await expect(reqRootRow).toHaveAttribute('data-selected', 'true');
+      await expect(exampleRow).toHaveAttribute('data-selected', 'true');
+    });
+  });
+
   test('Shift-click with no prior click anchor selects only the clicked row, not everything above it', async ({ page, createTmpDir }) => {
     const { locators, collectionAName } = await setupFixture(page, createTmpDir, 'shiftnoanchor');
 
@@ -984,8 +1015,9 @@ test.describe('Sidebar multi-select and bulk actions', () => {
       await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
 
       await reqRootRow.click({ button: 'right' });
-      await expect(locators.dropdown.item('Collapse')).toBeVisible();
-      await locators.dropdown.item('Collapse').click();
+      const collapseItem = locators.dropdown.item('Collapse');
+      await expect(collapseItem).toBeVisible();
+      await collapseItem.click();
 
       await expect(exampleRow).not.toBeVisible();
       await expect(locators.sidebar.request('Req One')).not.toBeVisible();
@@ -996,8 +1028,9 @@ test.describe('Sidebar multi-select and bulk actions', () => {
       await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
 
       await reqRootRow.click({ button: 'right' });
-      await expect(locators.dropdown.item('Expand')).toBeVisible();
-      await locators.dropdown.item('Expand').click();
+      const expandItem = locators.dropdown.item('Expand');
+      await expect(expandItem).toBeVisible();
+      await expandItem.click();
 
       await expect(exampleRow).toBeVisible();
       await expect(locators.sidebar.request('Req One')).toBeVisible();
@@ -1137,8 +1170,9 @@ test.describe('Sidebar multi-select and bulk actions', () => {
 
     await test.step('Right-click offers Delete, and bulk-deleting removes both the example and the unrelated request', async () => {
       await exampleRow.click({ button: 'right' });
-      await expect(locators.dropdown.item('Delete')).toBeVisible();
-      await locators.dropdown.item('Delete').click();
+      const deleteItem = locators.dropdown.item('Delete');
+      await expect(deleteItem).toBeVisible();
+      await deleteItem.click();
 
       const deleteModal = locators.modal.byTitle('Delete Items');
       await expect(deleteModal).toBeVisible();

--- a/tests/collection/multi-select/multi-select.spec.ts
+++ b/tests/collection/multi-select/multi-select.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../../playwright';
 import { buildCommonLocators } from '../../utils/page/locators';
-import { createCollection, createFolder, createRequest, expandFolder, closeAllCollections, clickEmptySidebarSpace, createApp } from '../../utils/page/actions';
+import { createCollection, createFolder, createRequest, expandFolder, closeAllCollections, clickEmptySidebarSpace, createApp, createExampleFromSidebar } from '../../utils/page/actions';
 
 // Ctrl on Windows/Linux, Cmd on macOS (matches app's navigator.userAgent check).
 const SELECT_MODIFIER: 'Meta' | 'Control' = process.platform === 'darwin' ? 'Meta' : 'Control';
@@ -614,6 +614,73 @@ test.describe('Sidebar multi-select and bulk actions', () => {
     await expect(rows.nth(2)).toContainText(collectionBName);
   });
 
+  test('A collection selected together with its own folder and request: dragging from a descendant row moves the collection itself (parent-wins takes over the drag)', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const collectionAName = 'collectiontakesover Collection A';
+    const collectionBName = 'collectiontakesover Collection B';
+    const collectionCName = 'collectiontakesover Collection C';
+
+    await createCollection(page, collectionAName, await createTmpDir('collectiontakesover-a'));
+    await createCollection(page, collectionBName, await createTmpDir('collectiontakesover-b'));
+    await createCollection(page, collectionCName, await createTmpDir('collectiontakesover-c'));
+    await createFolder(page, 'Folder A', collectionAName);
+    await expandFolder(page, 'Folder A');
+    await createRequest(page, 'Req A1', 'Folder A', { inFolder: true });
+    await clickEmptySidebarSpace(page);
+
+    const collectionARow = locators.sidebar.collectionRow(collectionAName);
+    const folderARow = locators.sidebar.itemRow('Folder A');
+    const reqA1Row = locators.sidebar.itemRow('Req A1');
+
+    await test.step('Select the collection together with its own folder and nested request', async () => {
+      await locators.sidebar.collection(collectionAName).click({ modifiers: [SELECT_MODIFIER] });
+      await locators.sidebar.folder('Folder A').click({ modifiers: [SELECT_MODIFIER] });
+      await locators.sidebar.request('Req A1').click({ modifiers: [SELECT_MODIFIER] });
+    });
+
+    await test.step('Parent-wins reduces this to a plain collection drag: none of the rows show as drag-disabled', async () => {
+      await expect(collectionARow).not.toHaveClass(/drag-disabled/);
+      await expect(folderARow).not.toHaveClass(/drag-disabled/);
+      await expect(reqA1Row).not.toHaveClass(/drag-disabled/);
+    });
+
+    await test.step('Dragging from the nested request row moves the whole collection, not just the request', async () => {
+      // Initial order is [A, B, C]; dropping A just above C reorders to [B, A, C] — a change
+      // only explainable by the collection itself having moved.
+      await reqA1Row.dragTo(locators.sidebar.collectionRow(collectionCName), {
+        targetPosition: { x: 5, y: 5 }
+      });
+
+      const rows = locators.sidebar.collectionRows();
+      await expect(rows.nth(0)).toContainText(collectionBName);
+      await expect(rows.nth(1)).toContainText(collectionAName);
+      await expect(rows.nth(2)).toContainText(collectionCName);
+
+      // Only the collection's position in the sidebar changed — its contents (Folder A, Req A1)
+      // stayed inside it, moving along as part of the same unit rather than independently.
+      await expect(locators.sidebar.scopedItem(collectionAName, 'Folder A')).toBeVisible();
+      await expect(locators.sidebar.scopedItem(collectionAName, 'Req A1')).toBeVisible();
+
+      // A successful drop clears the selection.
+      await expect(collectionARow).not.toHaveAttribute('data-selected', 'true');
+    });
+
+    await test.step('Re-select the collection with its folder and drag from the folder row this time', async () => {
+      await locators.sidebar.collection(collectionAName).click({ modifiers: [SELECT_MODIFIER] });
+      await locators.sidebar.folder('Folder A').click({ modifiers: [SELECT_MODIFIER] });
+
+      // Order is [B, A, C]; dropping A just above B reorders back to [A, B, C].
+      await folderARow.dragTo(locators.sidebar.collectionRow(collectionBName), {
+        targetPosition: { x: 5, y: 5 }
+      });
+
+      const rows = locators.sidebar.collectionRows();
+      await expect(rows.nth(0)).toContainText(collectionAName);
+      await expect(rows.nth(1)).toContainText(collectionBName);
+      await expect(rows.nth(2)).toContainText(collectionCName);
+    });
+  });
+
   test('Dragging a selection that mixes a collection with a folder, request, or app has no common target and is blocked', async ({ page, createTmpDir }) => {
     const { locators, collectionAName, collectionBName } = await setupFixture(page, createTmpDir, 'blockeddrag');
 
@@ -890,6 +957,53 @@ test.describe('Sidebar multi-select and bulk actions', () => {
     });
   });
 
+  test('A request with examples is eligible for bulk Collapse/Expand alongside a folder', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const collectionName = 'requestcollapse Collection';
+
+    await createCollection(page, collectionName, await createTmpDir('requestcollapse'));
+    await createFolder(page, 'Folder One', collectionName);
+    await expandFolder(page, 'Folder One');
+    await createRequest(page, 'Req One', 'Folder One', { inFolder: true });
+    await createRequest(page, 'Req Root', collectionName, {});
+    await createExampleFromSidebar(page, 'Req Root', 'Example 1');
+    await clickEmptySidebarSpace(page);
+
+    const reqRootRow = locators.sidebar.itemRow('Req Root');
+    const folderOneRow = locators.sidebar.itemRow('Folder One');
+    const exampleRow = locators.sidebar.example('Example 1');
+
+    await test.step('Examples are collapsed by default; expand via the request\'s own chevron', async () => {
+      await expect(exampleRow).not.toBeVisible();
+      await locators.sidebar.requestExamplesToggle('Req Root').click();
+      await expect(exampleRow).toBeVisible();
+    });
+
+    await test.step('Selected together with an already-expanded folder, bulk Collapse acts on both', async () => {
+      await folderOneRow.click({ modifiers: [SELECT_MODIFIER] });
+      await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
+
+      await reqRootRow.click({ button: 'right' });
+      await expect(locators.dropdown.item('Collapse')).toBeVisible();
+      await locators.dropdown.item('Collapse').click();
+
+      await expect(exampleRow).not.toBeVisible();
+      await expect(locators.sidebar.request('Req One')).not.toBeVisible();
+    });
+
+    await test.step('Bulk Expand brings both back', async () => {
+      await folderOneRow.click({ modifiers: [SELECT_MODIFIER] });
+      await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
+
+      await reqRootRow.click({ button: 'right' });
+      await expect(locators.dropdown.item('Expand')).toBeVisible();
+      await locators.dropdown.item('Expand').click();
+
+      await expect(exampleRow).toBeVisible();
+      await expect(locators.sidebar.request('Req One')).toBeVisible();
+    });
+  });
+
   test('Cancelling the bulk delete confirmation keeps the selection intact; confirming clears it', async ({ page, createTmpDir }) => {
     const { locators } = await setupFixture(page, createTmpDir, 'cancelkeep');
 
@@ -976,6 +1090,169 @@ test.describe('Sidebar multi-select and bulk actions', () => {
 
       await expect(locators.sidebar.collection(collectionAName)).not.toBeVisible();
       await expect(locators.sidebar.collection(collectionBName)).not.toBeVisible();
+    });
+  });
+
+  test('A response example is selectable, applies parent-wins when selected with its own request but blocks drag with anything else, and supports bulk delete', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const collectionAName = 'exampleselect Collection A';
+    const collectionBName = 'exampleselect Collection B';
+
+    await createCollection(page, collectionAName, await createTmpDir('exampleselect-a'));
+    await createCollection(page, collectionBName, await createTmpDir('exampleselect-b'));
+    await createRequest(page, 'Req Root', collectionAName, {});
+    await createRequest(page, 'Req Other', collectionAName, {});
+    await createExampleFromSidebar(page, 'Req Root', 'Example 1');
+    await clickEmptySidebarSpace(page);
+    await locators.sidebar.requestExamplesToggle('Req Root').click();
+
+    const reqRootRow = locators.sidebar.itemRow('Req Root');
+    const reqOtherRow = locators.sidebar.itemRow('Req Other');
+    const exampleRow = locators.sidebar.example('Example 1');
+
+    await test.step('Ctrl/Cmd-click selects the example', async () => {
+      await exampleRow.click({ modifiers: [SELECT_MODIFIER] });
+      await expect(exampleRow).toHaveAttribute('data-selected', 'true');
+      await clickEmptySidebarSpace(page);
+    });
+
+    await test.step('Selected together with its own parent request, parent-wins applies: both rows stay draggable', async () => {
+      await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
+      await exampleRow.click({ modifiers: [SELECT_MODIFIER] });
+
+      // Parent-wins absorbs the example into the request, so dragging from either row is
+      // redirected to moving the request — neither is drag-disabled in this state.
+      await expect(reqRootRow).not.toHaveClass(/drag-disabled/);
+      await expect(exampleRow).not.toHaveClass(/drag-disabled/);
+      await clickEmptySidebarSpace(page);
+    });
+
+    await test.step('Selected together with an unrelated request (not its parent), drag is blocked for the whole selection', async () => {
+      await reqOtherRow.click({ modifiers: [SELECT_MODIFIER] });
+      await exampleRow.click({ modifiers: [SELECT_MODIFIER] });
+
+      await expect(reqOtherRow).toHaveClass(/drag-disabled/);
+      await expect(exampleRow).toHaveClass(/drag-disabled/);
+    });
+
+    await test.step('Right-click offers Delete, and bulk-deleting removes both the example and the unrelated request', async () => {
+      await exampleRow.click({ button: 'right' });
+      await expect(locators.dropdown.item('Delete')).toBeVisible();
+      await locators.dropdown.item('Delete').click();
+
+      const deleteModal = locators.modal.byTitle('Delete Items');
+      await expect(deleteModal).toBeVisible();
+      await expect(deleteModal.getByText('1 request and 1 example')).toBeVisible();
+      await locators.modal.button('Delete').click();
+
+      await expect(exampleRow).not.toBeVisible();
+      await expect(reqOtherRow).not.toBeVisible();
+      await expect(reqRootRow).toBeVisible();
+    });
+  });
+
+  test('Dragging from an example whose parent request is also selected moves the request itself, not the example', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const collectionAName = 'exampledragredirect Collection A';
+    const collectionBName = 'exampledragredirect Collection B';
+
+    await createCollection(page, collectionAName, await createTmpDir('exampledragredirect-a'));
+    await createCollection(page, collectionBName, await createTmpDir('exampledragredirect-b'));
+    await createRequest(page, 'Req Root', collectionAName, {});
+    await createExampleFromSidebar(page, 'Req Root', 'Example 1');
+    await clickEmptySidebarSpace(page);
+    await locators.sidebar.requestExamplesToggle('Req Root').click();
+
+    const reqRootRow = locators.sidebar.itemRow('Req Root');
+    const exampleRow = locators.sidebar.example('Example 1');
+
+    await test.step('Select the request together with its own example', async () => {
+      await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
+      await exampleRow.click({ modifiers: [SELECT_MODIFIER] });
+
+      await expect(reqRootRow).not.toHaveClass(/drag-disabled/);
+      await expect(exampleRow).not.toHaveClass(/drag-disabled/);
+    });
+
+    await test.step('Dragging from the example row moves the parent request, not the example', async () => {
+      await exampleRow.dragTo(locators.sidebar.collection(collectionBName));
+
+      await expect(locators.sidebar.scopedItem(collectionBName, 'Req Root')).toBeVisible();
+      await expect(locators.sidebar.scopedItem(collectionAName, 'Req Root')).toHaveCount(0);
+
+      // A successful drop clears the selection.
+      await expect(reqRootRow).not.toHaveAttribute('data-selected', 'true');
+    });
+  });
+
+  test('The example-to-parent-request redirect is exclusive to that pairing: adding a third, unrelated collection blocks both rows again', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const collectionAName = 'exampleredirectexclusive Collection A';
+    const collectionBName = 'exampleredirectexclusive Collection B';
+
+    await createCollection(page, collectionAName, await createTmpDir('exampleredirectexclusive-a'));
+    await createCollection(page, collectionBName, await createTmpDir('exampleredirectexclusive-b'));
+    await createRequest(page, 'Req Root', collectionAName, {});
+    await createExampleFromSidebar(page, 'Req Root', 'Example 1');
+    await clickEmptySidebarSpace(page);
+    await locators.sidebar.requestExamplesToggle('Req Root').click();
+
+    const reqRootRow = locators.sidebar.itemRow('Req Root');
+    const exampleRow = locators.sidebar.example('Example 1');
+    const collectionBRow = locators.sidebar.collectionRow(collectionBName);
+
+    await test.step('Request + its own example alone: both draggable (redirect applies)', async () => {
+      await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
+      await exampleRow.click({ modifiers: [SELECT_MODIFIER] });
+
+      await expect(reqRootRow).not.toHaveClass(/drag-disabled/);
+      await expect(exampleRow).not.toHaveClass(/drag-disabled/);
+    });
+
+    await test.step('Adding an unrelated collection to the selection blocks the request\'s own drag, and the example follows suit', async () => {
+      await locators.sidebar.collection(collectionBName).click({ modifiers: [SELECT_MODIFIER] });
+
+      await expect(reqRootRow).toHaveClass(/drag-disabled/);
+      await expect(collectionBRow).toHaveClass(/drag-disabled/);
+      await expect(exampleRow).toHaveClass(/drag-disabled/);
+    });
+  });
+
+  test('Dragging from an example bundles in a sibling request also selected alongside its own parent request', async ({ page, createTmpDir }) => {
+    const locators = buildCommonLocators(page);
+    const collectionAName = 'examplebundle Collection A';
+    const collectionBName = 'examplebundle Collection B';
+
+    await createCollection(page, collectionAName, await createTmpDir('examplebundle-a'));
+    await createCollection(page, collectionBName, await createTmpDir('examplebundle-b'));
+    await createRequest(page, 'Req Root', collectionAName, {});
+    await createRequest(page, 'Req Sibling', collectionAName, {});
+    await createExampleFromSidebar(page, 'Req Root', 'Example 1');
+    await clickEmptySidebarSpace(page);
+    await locators.sidebar.requestExamplesToggle('Req Root').click();
+
+    const reqRootRow = locators.sidebar.itemRow('Req Root');
+    const reqSiblingRow = locators.sidebar.itemRow('Req Sibling');
+    const exampleRow = locators.sidebar.example('Example 1');
+
+    await test.step('Select the request, its own example, and an unrelated sibling request', async () => {
+      await reqRootRow.click({ modifiers: [SELECT_MODIFIER] });
+      await exampleRow.click({ modifiers: [SELECT_MODIFIER] });
+      await reqSiblingRow.click({ modifiers: [SELECT_MODIFIER] });
+
+      // A sibling request is a normal bundle partner, not a blocker — all three rows stay draggable.
+      await expect(reqRootRow).not.toHaveClass(/drag-disabled/);
+      await expect(reqSiblingRow).not.toHaveClass(/drag-disabled/);
+      await expect(exampleRow).not.toHaveClass(/drag-disabled/);
+    });
+
+    await test.step('Dragging from the example moves both requests, not just its own parent', async () => {
+      await exampleRow.dragTo(locators.sidebar.collection(collectionBName));
+
+      await expect(locators.sidebar.scopedItem(collectionBName, 'Req Root')).toBeVisible();
+      await expect(locators.sidebar.scopedItem(collectionBName, 'Req Sibling')).toBeVisible();
+      await expect(locators.sidebar.scopedItem(collectionAName, 'Req Root')).toHaveCount(0);
+      await expect(locators.sidebar.scopedItem(collectionAName, 'Req Sibling')).toHaveCount(0);
     });
   });
 });


### PR DESCRIPTION
BRU-4532

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
This PR adds the support of Multi-select for examples under the requests. This includes the Shift/Cmd+Click, and the bulk action options would be only `Delete` for this level. Adding to that, now we will support `Expand/Collapse` for requests with children (examples).

### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->

The left sidebar is inconsistent w.r.t. multi-selection. The multi-select is disabled for examples and is causing visually and functionally bad UX.

### Fix

<!-- How does this PR fix the problem? Briefly describe your approach. -->

We will now allow examples too to get multi-selected, bulk deletable. Drag/Drop is disabled for this with any combination unless parent request is selected and parent request takes the priority.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
| <img width="339" height="270" alt="Screenshot 2026-09-10 at 8 19 17 PM" src="https://github.com/user-attachments/assets/d3cdb568-74af-43d8-bdd4-7e282a9b844f" /> | <img width="339" height="270" alt="Screenshot 2026-09-10 at 8 18 50 PM" src="https://github.com/user-attachments/assets/f294e2d0-a4db-492d-b5f6-1a907df91ae7" /> |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-selection and drag-and-drop support for request examples in the sidebar.
  * Added bulk expand, collapse, and delete actions for requests and their examples.
  * Added clearer visual feedback when dragging is unavailable.
  * Sidebar searches now reveal matching examples, including those in collapsed requests.
  * Collapse and expansion state is now preserved for requests and folders.

* **Bug Fixes**
  * Improved selection and drag behavior when examples are selected with their parent requests, folders, or collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->