### PR TITLE
fix(docs): minor ui fixes in the generate docs modal

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/DocsTagList/StyledWrapper.js
@@ -26,7 +26,7 @@ export const StyledWrapper = styled.div`
     }
 
     &:focus {
-      border-color: ${(props) => props.theme.colors.text.subtext0};
+      border-color: ${(props) => props.theme.input.focusBorder};
     }
   }
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/StyledWrapper.js
@@ -87,35 +87,15 @@ const StyledWrapper = styled.div`
     margin-left: 1.125rem;
   }
 
-  .segmented {
+  .seg-row .seg-option {
+    height: 1.75rem;
+    padding: 0.375rem;
+  }
+
+  .seg-with-hint {
     display: inline-flex;
-    border: 1px solid ${(props) => props.theme.background.surface2};
-    border-radius: ${(props) => props.theme.border.radius.base};
-    overflow: hidden;
-
-    .seg {
-      display: inline-flex;
-      align-items: center;
-      gap: 2px;
-      padding: 0.375rem;
-      background-color: ${(props) => props.theme.background.base};
-      border: none;
-      cursor: pointer;
-      font-size: ${(props) => props.theme.font.size.sm};
-      font-weight: 400;
-      color: ${(props) => props.theme.colors.text.subtext1};
-
-      & + .seg {
-        border-left: 1px solid ${(props) => props.theme.background.surface2};
-      }
-
-      &.active {
-        background-color: ${(props) => props.theme.background.surface1};
-        color: ${(props) => props.theme.text};
-        font-weight: 500;
-      }
-
-    }
+    align-items: center;
+    gap: 2px;
   }
 
   .seg-hint {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/StyledWrapper.js
@@ -99,6 +99,8 @@ const StyledWrapper = styled.div`
   }
 
   .seg-hint {
+    position: relative;
+    z-index: 1;
     display: inline-flex;
     align-items: center;
     cursor: help;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.jsx
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.jsx
@@ -2,10 +2,28 @@ import React, { useId, useState } from 'react';
 import { IconChevronRight, IconListCheck, IconGitBranch, IconInfoCircle } from '@tabler/icons';
 import { Tooltip } from 'react-tooltip';
 import ToggleSwitch from 'components/ToggleSwitch';
+import SegmentedControl from 'ui/SegmentedControl';
 import IncludeExcludeTags from './IncludeExcludeTags';
 import StyledWrapper from './StyledWrapper';
 
 const TAGS_HINT = 'Tags are labels on requests (e.g. smoke, WIP). Manage tags in Request › Settings';
+
+const REQUEST_MODE_ITEMS = [
+  { 'value': 'all', 'label': 'All requests', 'className': 'seg-option', 'data-testid': 'docs-requests-all' },
+  {
+    'value': 'tags',
+    'className': 'seg-option',
+    'label': (
+      <span className="seg-with-hint">
+        Filter by Tags
+        <span className="seg-hint" data-tooltip-id="docs-tags-hint" data-tooltip-content={TAGS_HINT}>
+          <IconInfoCircle size={16} aria-hidden="true" />
+        </span>
+      </span>
+    ),
+    'data-testid': 'docs-requests-filter'
+  }
+];
 
 const Advanced = ({
   filterByTags,
@@ -43,33 +61,14 @@ const Advanced = ({
               </div>
 
               <div className="seg-row">
-                <div className="segmented" role="group" aria-labelledby={requestsLabelId}>
-                  <button
-                    type="button"
-                    aria-pressed={!filterByTags}
-                    className={`seg ${!filterByTags ? 'active' : ''}`}
-                    onClick={() => onFilterModeChange(false)}
-                    data-testid="docs-requests-all"
-                  >
-                    All requests
-                  </button>
-                  <button
-                    type="button"
-                    aria-pressed={filterByTags}
-                    className={`seg ${filterByTags ? 'active' : ''}`}
-                    onClick={() => onFilterModeChange(true)}
-                    data-testid="docs-requests-filter"
-                  >
-                    Filter by Tags
-                    <span
-                      className="seg-hint"
-                      data-tooltip-id="docs-tags-hint"
-                      data-tooltip-content={TAGS_HINT}
-                    >
-                      <IconInfoCircle size={16} aria-hidden="true" />
-                    </span>
-                  </button>
-                </div>
+                <SegmentedControl
+                  ariaLabelledBy={requestsLabelId}
+                  value={filterByTags ? 'tags' : 'all'}
+                  onChange={(value) => onFilterModeChange(value === 'tags')}
+                  items={REQUEST_MODE_ITEMS}
+                  variant="outlined"
+                  size="sm"
+                />
               </div>
 
               <Tooltip id="docs-tags-hint" className="adv-hint-tooltip" />

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/Advanced/index.spec.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, within } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import themes from 'themes/index';
 import Advanced from './index';
@@ -16,26 +16,44 @@ const defaultProps = {
   hasGitUrl: true
 };
 
-const renderAdvanced = (props = {}) =>
-  render(
+const renderAdvanced = (props = {}) => {
+  const utils = render(
     <ThemeProvider theme={themes.light}>
       <Advanced {...defaultProps} {...props} />
     </ThemeProvider>
   );
 
+  const rerenderWith = (nextProps) =>
+    utils.rerender(
+      <ThemeProvider theme={themes.light}>
+        <Advanced {...defaultProps} {...props} {...nextProps} />
+      </ThemeProvider>
+    );
+
+  return { ...utils, rerenderWith };
+};
+
 const expand = (getByTestId) => fireEvent.click(getByTestId('docs-advanced-toggle'));
 
 describe('Advanced (Generate Documentation)', () => {
-  it('exposes the requests selector as a labelled group of pressable options', () => {
+  it('offers a choice between all requests and filtering by tags, with all requests picked to begin with', () => {
     const { getByRole, getByTestId } = renderAdvanced();
     expand(getByTestId);
 
-    expect(getByRole('group', { name: 'Requests to include' })).toBeInTheDocument();
-    expect(getByTestId('docs-requests-all')).toHaveAttribute('aria-pressed', 'true');
-    expect(getByTestId('docs-requests-filter')).toHaveAttribute('aria-pressed', 'false');
+    const choices = within(getByRole('radiogroup', { name: 'Requests to include' }));
+    expect(choices.getByRole('radio', { name: 'All requests' })).toBeChecked();
+    expect(choices.getByRole('radio', { name: 'Filter by Tags' })).not.toBeChecked();
   });
 
-  it('switches the mode when "Filter by Tags" is pressed', () => {
+  it('shows filtering by tags as the current choice when the user is already filtering', () => {
+    const { getByRole, getByTestId } = renderAdvanced({ filterByTags: true });
+    expand(getByTestId);
+
+    expect(getByRole('radio', { name: 'Filter by Tags' })).toBeChecked();
+    expect(getByRole('radio', { name: 'All requests' })).not.toBeChecked();
+  });
+
+  it('starts filtering by tags when the user picks that choice', () => {
     const onFilterModeChange = jest.fn();
     const { getByTestId } = renderAdvanced({ onFilterModeChange });
     expand(getByTestId);
@@ -44,57 +62,55 @@ describe('Advanced (Generate Documentation)', () => {
     expect(onFilterModeChange).toHaveBeenCalledWith(true);
   });
 
-  it('reflects the active mode via aria-pressed', () => {
-    const { getByTestId } = renderAdvanced({ filterByTags: true });
-    expect(getByTestId('docs-requests-all')).toHaveAttribute('aria-pressed', 'false');
-    expect(getByTestId('docs-requests-filter')).toHaveAttribute('aria-pressed', 'true');
+  it('goes back to including every request when the user picks all requests', () => {
+    const onFilterModeChange = jest.fn();
+    const { getByTestId } = renderAdvanced({ filterByTags: true, onFilterModeChange });
+    expand(getByTestId);
+
+    fireEvent.click(getByTestId('docs-requests-all'));
+    expect(onFilterModeChange).toHaveBeenCalledWith(false);
   });
 
-  it('shows the include/exclude tag inputs only when filtering by tags', () => {
-    const { queryByLabelText, rerender } = renderAdvanced({ filterByTags: false });
+  it('asks for tags to include and exclude only while the user is filtering by tags', () => {
+    const { queryByLabelText, rerenderWith } = renderAdvanced({ filterByTags: false });
     expect(queryByLabelText('Include tags')).not.toBeInTheDocument();
+    expect(queryByLabelText('Exclude tags')).not.toBeInTheDocument();
 
-    rerender(
-      <ThemeProvider theme={themes.light}>
-        <Advanced {...defaultProps} filterByTags={true} />
-      </ThemeProvider>
-    );
+    rerenderWith({ filterByTags: true });
+
     expect(queryByLabelText('Include tags')).toBeInTheDocument();
+    expect(queryByLabelText('Exclude tags')).toBeInTheDocument();
   });
 
-  it('shows the tags help hint inside the Filter by Tags segment', () => {
+  it('explains what a tag is in a hint next to the filter choice', () => {
     const { getByTestId } = renderAdvanced();
     expand(getByTestId);
 
-    const hint = getByTestId('docs-requests-filter').querySelector('.seg-hint');
+    const hint = getByTestId('docs-requests-filter').closest('label').querySelector('.seg-hint');
     expect(hint).toBeInTheDocument();
     expect(hint.getAttribute('data-tooltip-content')).toContain('Tags are labels');
   });
 
-  it('toggles the git repo link when the switch is clicked', () => {
+  it('reports the change when the git repo link switch is flipped', () => {
     const onGitLinkToggle = jest.fn();
     const { getByTestId } = renderAdvanced({ onGitLinkToggle });
     expand(getByTestId);
 
-    expect(getByTestId('docs-git-link')).toBeInTheDocument();
     fireEvent.click(getByTestId('docs-git-link-toggle').querySelector('input[type="checkbox"]'));
     expect(onGitLinkToggle).toHaveBeenCalled();
   });
 
-  it('renders the git repo URL section only when a git url is present', () => {
-    const { getByTestId, queryByTestId, rerender } = renderAdvanced({ hasGitUrl: false });
+  it('offers the git repo link setting only when the collection has a git url', () => {
+    const { getByTestId, queryByTestId, rerenderWith } = renderAdvanced({ hasGitUrl: false });
     expand(getByTestId);
     expect(queryByTestId('docs-git-link')).not.toBeInTheDocument();
 
-    rerender(
-      <ThemeProvider theme={themes.light}>
-        <Advanced {...defaultProps} hasGitUrl={true} />
-      </ThemeProvider>
-    );
+    rerenderWith({ hasGitUrl: true });
+
     expect(queryByTestId('docs-git-link')).toBeInTheDocument();
   });
 
-  it('keeps the collapsible body out of the a11y tree and tab order until expanded', () => {
+  it('keeps the advanced options away from screen readers and the tab order until the section is opened', () => {
     const { getByTestId, container } = renderAdvanced();
     const collapse = container.querySelector('.advanced-collapse');
 

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/StyledWrapper.js
@@ -38,6 +38,9 @@ const StyledWrapper = styled.div`
           font-size: ${(props) => props.theme.font.size.base};
           color: ${(props) => props.theme.text};
           min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
         .version-value {
@@ -45,6 +48,7 @@ const StyledWrapper = styled.div`
           font-size: ${(props) => props.theme.font.size.sm};
           color: ${(props) => props.theme.colors.text.subtext2};
           white-space: nowrap;
+          flex-shrink: 0;
         }
 
         .version-value.unset {

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.js
@@ -17,7 +17,7 @@ import { useApp } from 'providers/App';
 import useCollectionGitRemoteUrl from 'hooks/useCollectionGitRemoteUrl';
 import { transformCollectionToSaveToExportAsFile, findCollectionByUid, areItemsLoading, sortItemsBySidebarOrder, getCollectionItemCounts, getCollectionVersion, getUniqueTagsFromItems } from 'utils/collections/index';
 import { brunoToOpenCollection } from '@usebruno/converters';
-import { generateApiDocsHtml, getApiDocsFileName } from '@usebruno/common';
+import { generateApiDocsHtml, getApiDocsFileName, filterRequestItemsByTags } from '@usebruno/common';
 
 const FEATURES = [
   'Standalone HTML file - no server required',
@@ -50,11 +50,6 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
   );
 
   const currentVersion = getCollectionVersion(collection);
-
-  const { folderCount, requestCount } = useMemo(
-    () => getCollectionItemCounts(collection?.items),
-    [collection?.items]
-  );
 
   const environments = useMemo(() => collection?.environments || [], [collection?.environments]);
 
@@ -89,6 +84,17 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
   const [filterByTags, setFilterByTags] = useState(false);
   const [docTags, setDocTags] = useState({ include: [], exclude: [] });
   const [includeGitLink, setIncludeGitLink] = useState(true);
+
+  const activeTags = useMemo(
+    () => (filterByTags ? docTags : { include: [], exclude: [] }),
+    [filterByTags, docTags]
+  );
+
+  const { folderCount, requestCount } = useMemo(
+    () => getCollectionItemCounts(filterRequestItemsByTags(collection?.items || [], activeTags.include, activeTags.exclude)),
+    [collection?.items, activeTags]
+  );
+
   const { gitCollectionUrl, isResolved: gitUrlLoaded } = useCollectionGitRemoteUrl(collection?.pathname);
   const hasGitUrl = gitUrlLoaded && Boolean(gitCollectionUrl);
 
@@ -107,7 +113,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       const htmlContent = generateApiDocsHtml(
         transformedCollection,
         {
-          tags: filterByTags ? docTags : { include: [], exclude: [] },
+          tags: activeTags,
           gitCollectionUrl: includeGitLink ? gitCollectionUrl : undefined,
           collectionVersion: currentVersion,
           exportedAt: new Date().toISOString(),
@@ -125,7 +131,7 @@ const GenerateDocumentation = ({ onClose, collectionUid }) => {
       console.error('Error generating documentation:', error);
       toast.error('Failed to generate documentation');
     }
-  }, [collection, version, onClose, currentVersion, selectedEnvUidsSet, filterByTags, docTags, includeGitLink, gitCollectionUrl]);
+  }, [collection, version, onClose, currentVersion, selectedEnvUidsSet, activeTags, includeGitLink, gitCollectionUrl]);
 
   if (!collection) {
     return <CollectionNotFound onClose={onClose} />;

--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.spec.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/GenerateDocumentation/index.spec.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { ThemeProvider } from 'styled-components';
@@ -68,6 +68,45 @@ const buildCollection = (overrides = {}) => ({
   environments: [],
   ...overrides
 });
+
+const buildTaggedCollection = () => buildCollection({
+  items: [
+    {
+      uid: 'folder-users',
+      name: 'Users',
+      type: 'folder',
+      items: [
+        { uid: 'req-list-users', name: 'List users', type: 'http-request', tags: ['smoke'], request: {} },
+        { uid: 'req-delete-user', name: 'Delete user', type: 'http-request', tags: ['wip'], request: {} }
+      ]
+    },
+    {
+      uid: 'folder-admin',
+      name: 'Admin',
+      type: 'folder',
+      items: [{ uid: 'req-audit-log', name: 'Audit log', type: 'http-request', tags: ['wip'], request: {} }]
+    },
+    { uid: 'req-health', name: 'Health', type: 'http-request', tags: ['smoke'], request: {} },
+    { uid: 'req-ping', name: 'Ping', type: 'http-request', tags: [], request: {} }
+  ]
+});
+
+const switchToTagFilter = () => {
+  fireEvent.click(screen.getByTestId('docs-advanced-toggle'));
+  fireEvent.click(screen.getByTestId('docs-requests-filter'));
+};
+
+const addTag = (listLabel, tag) => {
+  const input = screen.getByLabelText(listLabel);
+  fireEvent.change(input, { target: { value: tag } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+};
+
+const expectSummary = (folders, requests) => {
+  const summary = within(screen.getByTestId('version-summary'));
+  expect(summary.getByText(folders)).toBeInTheDocument();
+  expect(summary.getByText(requests)).toBeInTheDocument();
+};
 
 const renderModal = (collection, onClose = jest.fn()) => {
   const collections = collection ? [collection] : [];
@@ -153,5 +192,49 @@ describe('GenerateDocumentation', () => {
 
     expect(screen.getByTestId('docs-git-link')).toBeInTheDocument();
     expect(screen.getByTestId('docs-git-link-toggle').querySelector('input[type="checkbox"]')).toBeChecked();
+  });
+
+  describe('folder and request counts', () => {
+    it('shows every folder and request when no tag filter is applied', () => {
+      renderModal(buildTaggedCollection());
+      expectSummary('2 Folders', '5 requests');
+    });
+
+    it('counts only the requests that carry an included tag, and only the folders that still hold one', () => {
+      renderModal(buildTaggedCollection());
+      switchToTagFilter();
+      addTag('Include tags', 'smoke');
+      expectSummary('1 Folder', '2 requests');
+    });
+
+    it('leaves out the requests that carry an excluded tag and any folder that ends up empty', () => {
+      renderModal(buildTaggedCollection());
+      switchToTagFilter();
+      addTag('Exclude tags', 'wip');
+      expectSummary('1 Folder', '3 requests');
+    });
+
+    it('goes back to the full counts when the user switches to All requests', () => {
+      renderModal(buildTaggedCollection());
+      switchToTagFilter();
+      addTag('Include tags', 'smoke');
+      expectSummary('1 Folder', '2 requests');
+
+      fireEvent.click(screen.getByTestId('docs-requests-all'));
+      expectSummary('2 Folders', '5 requests');
+    });
+
+    it('generates the docs with the same tags the counts were based on', () => {
+      renderModal(buildTaggedCollection());
+      switchToTagFilter();
+      addTag('Include tags', 'smoke');
+      addTag('Exclude tags', 'wip');
+      expectSummary('1 Folder', '2 requests');
+
+      fireEvent.click(screen.getByTestId('generate-btn'));
+
+      const [, options] = generateApiDocsHtml.mock.calls[0];
+      expect(options.tags).toEqual({ include: ['smoke'], exclude: ['wip'] });
+    });
   });
 });

--- a/packages/bruno-common/src/index.ts
+++ b/packages/bruno-common/src/index.ts
@@ -6,7 +6,7 @@ export { transformExampleStatusInCollection } from './example-status';
 export { sortByNameThenSequence, resolveCollectionVersion } from './collection';
 export { normalizeOpenApiSyncConfigs } from './openapi-sync';
 
-export { generateApiDocsHtml, getApiDocsFileName } from './api-docs';
+export { generateApiDocsHtml, getApiDocsFileName, filterRequestItemsByTags } from './api-docs';
 export type {
   GenerateApiDocsOptions,
   ApiDocsDependencies,

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -362,11 +362,11 @@ test.describe('Generate Documentation', () => {
 
     await locators.generateDocs.advancedToggle().click();
 
-    await expect(locators.generateDocs.allRequestsButton()).toHaveAttribute('aria-pressed', 'true');
-    await expect(locators.generateDocs.filterByTagsButton()).toHaveAttribute('aria-pressed', 'false');
+    await expect(locators.generateDocs.allRequestsButton()).toBeChecked();
+    await expect(locators.generateDocs.filterByTagsButton()).not.toBeChecked();
 
-    await locators.generateDocs.filterByTagsButton().click();
-    await expect(locators.generateDocs.filterByTagsButton()).toHaveAttribute('aria-pressed', 'true');
+    await locators.generateDocs.filterByTagsButton().check();
+    await expect(locators.generateDocs.filterByTagsButton()).toBeChecked();
     await expect(locators.generateDocs.includeTagsInput()).toBeVisible();
     await expect(locators.generateDocs.excludeTagsInput()).toBeVisible();
 
@@ -383,7 +383,7 @@ test.describe('Generate Documentation', () => {
 
     const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
       await locators.generateDocs.advancedToggle().click();
-      await locators.generateDocs.filterByTagsButton().click();
+      await locators.generateDocs.filterByTagsButton().check();
       const include = locators.generateDocs.includeTagsInput();
       await include.fill('smoke');
       await include.press('Enter');
@@ -400,7 +400,7 @@ test.describe('Generate Documentation', () => {
 
     const { content } = await generateCollectionDocs(page, COLLECTION_NAME, async () => {
       await locators.generateDocs.advancedToggle().click();
-      await locators.generateDocs.filterByTagsButton().click();
+      await locators.generateDocs.filterByTagsButton().check();
       const exclude = locators.generateDocs.excludeTagsInput();
       await exclude.fill('wip');
       await exclude.press('Enter');

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -376,22 +376,6 @@ test.describe('Generate Documentation', () => {
     await expect(modal).toBeHidden();
   });
 
-  test('explains what a tag is when the hint beside "Filter by Tags" is hovered', async ({
-    pageWithUserData: page
-  }) => {
-    const locators = buildCommonLocators(page);
-
-    await locators.sidebar.collection(COLLECTION_NAME).hover();
-    await locators.actions.collectionActions(COLLECTION_NAME).click();
-    await locators.generateDocs.menuItem().click();
-    await expect(locators.generateDocs.modal()).toBeVisible();
-
-    await locators.generateDocs.advancedToggle().click();
-    await locators.generateDocs.tagsHint().hover();
-
-    await expect(locators.generateDocs.tooltip('Tags are labels')).toBeVisible();
-  });
-
   test('keeps only requests carrying an included tag in the generated docs', async ({
     pageWithUserData: page
   }) => {

--- a/tests/collection/generate-docs/generate-docs.spec.ts
+++ b/tests/collection/generate-docs/generate-docs.spec.ts
@@ -376,6 +376,22 @@ test.describe('Generate Documentation', () => {
     await expect(modal).toBeHidden();
   });
 
+  test('explains what a tag is when the hint beside "Filter by Tags" is hovered', async ({
+    pageWithUserData: page
+  }) => {
+    const locators = buildCommonLocators(page);
+
+    await locators.sidebar.collection(COLLECTION_NAME).hover();
+    await locators.actions.collectionActions(COLLECTION_NAME).click();
+    await locators.generateDocs.menuItem().click();
+    await expect(locators.generateDocs.modal()).toBeVisible();
+
+    await locators.generateDocs.advancedToggle().click();
+    await locators.generateDocs.tagsHint().hover();
+
+    await expect(locators.generateDocs.tooltip('Tags are labels')).toBeVisible();
+  });
+
   test('keeps only requests carrying an included tag in the generated docs', async ({
     pageWithUserData: page
   }) => {

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -246,6 +246,8 @@ export const buildCommonLocators = (page: Page) => ({
     advancedToggle: () => page.locator('.bruno-modal').getByTestId('docs-advanced-toggle'),
     allRequestsButton: () => page.locator('.bruno-modal').getByTestId('docs-requests-all'),
     filterByTagsButton: () => page.locator('.bruno-modal').getByTestId('docs-requests-filter'),
+    tagsHint: () => page.locator('.bruno-modal .seg-hint'),
+    tooltip: (text: string) => page.locator('.react-tooltip').filter({ hasText: text }),
     includeTagsInput: () => page.locator('.bruno-modal').getByLabel('Include tags'),
     excludeTagsInput: () => page.locator('.bruno-modal').getByLabel('Exclude tags'),
     tagChip: (name: string) => page.locator('.bruno-modal .docs-tag-item').filter({ hasText: name }),

--- a/tests/utils/page/locators.ts
+++ b/tests/utils/page/locators.ts
@@ -246,7 +246,6 @@ export const buildCommonLocators = (page: Page) => ({
     advancedToggle: () => page.locator('.bruno-modal').getByTestId('docs-advanced-toggle'),
     allRequestsButton: () => page.locator('.bruno-modal').getByTestId('docs-requests-all'),
     filterByTagsButton: () => page.locator('.bruno-modal').getByTestId('docs-requests-filter'),
-    tagsHint: () => page.locator('.bruno-modal .seg-hint'),
     tooltip: (text: string) => page.locator('.react-tooltip').filter({ hasText: text }),
     includeTagsInput: () => page.locator('.bruno-modal').getByLabel('Include tags'),
     excludeTagsInput: () => page.locator('.bruno-modal').getByLabel('Exclude tags'),


### PR DESCRIPTION
Ref - BRU-4022

### Problem

1. The active state should have the primary color border just like other input elements. 
2. The summary count of requests and folders should be updated based on the final requests included by selecting the tags.
3. The segmented control in the modal is not looking good in the dark mode.

### Fix

Filtered the collection from the include and exclude tags using filterRequestItemsByTags function taken from common. fixed style issues.


### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before |
<img width="1936" height="1784" alt="image" src="https://github.com/user-attachments/assets/14f795c9-e45a-45a8-b6ea-eec00905ac40" />

| After |
<img width="1854" height="1234" alt="image" src="https://github.com/user-attachments/assets/dc79a520-8f1b-4629-8340-f6d99f49c454" />
<img width="1656" height="1516" alt="image" src="https://github.com/user-attachments/assets/9afe761b-2abb-4e4b-84ca-ee79b217f990" />


#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [x] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessible controls for choosing all requests or filtering documentation by tags.
  * Documentation previews and generated files now reflect selected tag filters.
  * Folder and request counts update according to active tag filters.
  * Added explanatory hints, improved focus styling, and refined control spacing.
  * Long collection names now truncate cleanly without affecting version information.

* **Bug Fixes**
  * Restored accurate counts when switching back to all requests.

* **Tests**
  * Expanded coverage for tag filtering, mode switching, accessibility, and generated documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->