### PR TITLE
Feature: Mirror existing response behavior and make URLs clickable only while  Cmd/Ctrl is held

### DIFF
--- a/packages/bruno-app/src/components/Devtools/Console/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Devtools/Console/StyledWrapper.js
@@ -107,6 +107,12 @@ const StyledWrapper = styled.div`
     overflow-y: auto;
     background: ${(props) => props.theme.console.contentBg};
     min-height: 0;
+
+    &.cmd-ctrl-pressed .log-link:hover {
+      cursor: pointer;
+      color: ${(props) => props.theme.textLink};
+      text-decoration: underline;
+    }
   }
 
   .network-with-details {
@@ -346,6 +352,14 @@ const StyledWrapper = styled.div`
     white-space: pre-wrap;
     word-break: break-word;
     flex: 1;
+
+    .log-link {
+      cursor: text;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
     
     .log-object {
       margin: 4px 0;

--- a/packages/bruno-app/src/components/Devtools/Console/StyledWrapper.js
+++ b/packages/bruno-app/src/components/Devtools/Console/StyledWrapper.js
@@ -108,7 +108,8 @@ const StyledWrapper = styled.div`
     background: ${(props) => props.theme.console.contentBg};
     min-height: 0;
 
-    &.cmd-ctrl-pressed .log-link:hover {
+    &.cmd-ctrl-pressed .log-link:hover,
+    &.cmd-ctrl-pressed .log-link:focus-visible {
       cursor: pointer;
       color: ${(props) => props.theme.textLink};
       text-decoration: underline;
@@ -358,6 +359,12 @@ const StyledWrapper = styled.div`
 
       &:hover {
         text-decoration: underline;
+      }
+      
+      &:focus-visible {
+        outline: 1px solid ${(props) => props.theme.textLink};
+        outline-offset: 1px;
+        border-radius: 2px;
       }
     }
     

--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -139,7 +139,7 @@ const getLinkHint = () => (isMacOS() ? 'Hold Cmd and click to open link' : 'Hold
 
 const linkifyText = (text, key) => {
   if (!text || typeof text !== 'string') return text;
-  const urlRegex = /(https?:\/\/[^\s"'()]*[^\s"'().,;!?])/g;
+  const urlRegex = /(https?:\/\/[^\s"'()]+(?:\([^\s"'()]*\)[^\s"'()]*)*)/g;
   if (!text.match(urlRegex)) return text;
   const parts = text.split(urlRegex);
   const linkHint = getLinkHint();
@@ -147,7 +147,14 @@ const linkifyText = (text, key) => {
     <React.Fragment key={key}>
       {parts.map((part, index) =>
         part.match(urlRegex) ? (
-          <span key={index} className="log-link" data-url={part} title={linkHint}>
+          <span
+            key={index}
+            className="log-link"
+            data-url={part}
+            title={linkHint}
+            role="link"
+            tabIndex={0}
+          >
             {part}
           </span>
         ) : (
@@ -238,21 +245,27 @@ const ConsoleTab = ({ logs, filters, logCounts, onFilterToggle, onToggleAll, onC
       if (!el) return;
       el.classList.toggle('cmd-ctrl-pressed', isCmdOrCtrlPressed(event));
     };
+    // If the window loses focus while the modifier is held (e.g. Cmd+Tab
+    // to another app), this component never receives the matching keyup,
+    // so the class would otherwise stay stuck on — clear it explicitly.
+    const clearCmdCtrlClass = () => {
+      contentAreaRef.current?.classList.remove('cmd-ctrl-pressed');
+    };
     window.addEventListener('keydown', updateCmdCtrlClass);
     window.addEventListener('keyup', updateCmdCtrlClass);
+    window.addEventListener('blur', clearCmdCtrlClass);
     return () => {
       window.removeEventListener('keydown', updateCmdCtrlClass);
       window.removeEventListener('keyup', updateCmdCtrlClass);
+      window.removeEventListener('blur', clearCmdCtrlClass);
     };
   }, []);
 
-  // Single delegated click handler for every .log-link in the list, rather
-  // than one listener per link. Only opens the URL when the modifier is held
+  // Single delegated click handler for every .log-link, shared by mouse and
+  // keyboard activation, rather than one listener per link. Only opens the URL
+  // when the modifier is held a plain click/Enter is left alone.
 
-  const handleContentAreaClick = (event) => {
-    const linkEl = event.target.closest?.('.log-link');
-    if (!linkEl) return;
-
+  const activateLogLink = (event, linkEl) => {
     const modifierPressed = isMacOS() ? event.metaKey : event.ctrlKey;
     if (!modifierPressed) return;
 
@@ -262,11 +275,31 @@ const ConsoleTab = ({ logs, filters, logCounts, onFilterToggle, onToggleAll, onC
     if (url) window?.ipcRenderer?.openExternal(url);
   };
 
+  const handleContentAreaClick = (event) => {
+    const linkEl = event.target.closest?.('.log-link');
+    if (!linkEl) return;
+    activateLogLink(event, linkEl);
+  };
+
+  // Keyboard equivalent of modifier+click: focus the link (Tab), hold the
+  // same modifier, press Enter.
+  const handleContentAreaKeyDown = (event) => {
+    if (event.key !== 'Enter') return;
+    const linkEl = event.target.closest?.('.log-link');
+    if (!linkEl) return;
+    activateLogLink(event, linkEl);
+  };
+
   const filteredLogs = logs.filter((log) => filters[log.type]);
 
   return (
     <div className="tab-content">
-      <div className="tab-content-area" ref={contentAreaRef} onClick={handleContentAreaClick}>
+      <div
+        className="tab-content-area"
+        ref={contentAreaRef}
+        onClick={handleContentAreaClick}
+        onKeyDown={handleContentAreaKeyDown}
+      >
         {filteredLogs.length === 0 ? (
           <div className="console-empty">
             <IconTerminal2 size={48} strokeWidth={1} />

--- a/packages/bruno-app/src/components/Devtools/Console/index.js
+++ b/packages/bruno-app/src/components/Devtools/Console/index.js
@@ -32,6 +32,7 @@ import ErrorDetailsPanel from './ErrorDetailsPanel';
 import Performance from '../Performance';
 import StyledWrapper from './StyledWrapper';
 import { useResizablePanel } from 'hooks/useResizablePanel';
+import { isMacOS } from 'utils/common/platform';
 
 const MIN_DETAILS_PANEL_WIDTH = 280;
 const DETAILS_PANEL_MAX_RATIO = 0.7;
@@ -132,6 +133,31 @@ const getBrunoTypeMetadata = (obj) => {
   return {};
 };
 
+// Turns any http(s) URL inside a plain string into a marked, hoverable span.
+
+const getLinkHint = () => (isMacOS() ? 'Hold Cmd and click to open link' : 'Hold Ctrl and click to open link');
+
+const linkifyText = (text, key) => {
+  if (!text || typeof text !== 'string') return text;
+  const urlRegex = /(https?:\/\/[^\s"'()]*[^\s"'().,;!?])/g;
+  if (!text.match(urlRegex)) return text;
+  const parts = text.split(urlRegex);
+  const linkHint = getLinkHint();
+  return (
+    <React.Fragment key={key}>
+      {parts.map((part, index) =>
+        part.match(urlRegex) ? (
+          <span key={index} className="log-link" data-url={part} title={linkHint}>
+            {part}
+          </span>
+        ) : (
+          part
+        )
+      )}
+    </React.Fragment>
+  );
+};
+
 const LogMessage = ({ message, args }) => {
   const { displayedTheme } = useTheme();
 
@@ -172,10 +198,10 @@ const LogMessage = ({ message, args }) => {
             </div>
           );
         }
-        return String(arg);
+        return linkifyText(String(arg), index);
       });
     }
-    return msg;
+    return linkifyText(msg, 'msg');
   };
 
   const formattedMessage = formatMessage(message, args);
@@ -192,6 +218,7 @@ const LogMessage = ({ message, args }) => {
 const ConsoleTab = ({ logs, filters, logCounts, onFilterToggle, onToggleAll, onClearLogs }) => {
   const logsEndRef = useRef(null);
   const prevLogsCountRef = useRef(0);
+  const contentAreaRef = useRef(null);
 
   useEffect(() => {
     // Only scroll when new logs are added, not when switching tabs
@@ -201,11 +228,45 @@ const ConsoleTab = ({ logs, filters, logCounts, onFilterToggle, onToggleAll, onC
     prevLogsCountRef.current = logs.length;
   }, [logs]);
 
+  // Toggle a CSS-only class on the container while Cmd/Ctrl is held, so
+  // links visually become clickable
+
+  useEffect(() => {
+    const isCmdOrCtrlPressed = (event) => (isMacOS() ? event.metaKey : event.ctrlKey);
+    const updateCmdCtrlClass = (event) => {
+      const el = contentAreaRef.current;
+      if (!el) return;
+      el.classList.toggle('cmd-ctrl-pressed', isCmdOrCtrlPressed(event));
+    };
+    window.addEventListener('keydown', updateCmdCtrlClass);
+    window.addEventListener('keyup', updateCmdCtrlClass);
+    return () => {
+      window.removeEventListener('keydown', updateCmdCtrlClass);
+      window.removeEventListener('keyup', updateCmdCtrlClass);
+    };
+  }, []);
+
+  // Single delegated click handler for every .log-link in the list, rather
+  // than one listener per link. Only opens the URL when the modifier is held
+
+  const handleContentAreaClick = (event) => {
+    const linkEl = event.target.closest?.('.log-link');
+    if (!linkEl) return;
+
+    const modifierPressed = isMacOS() ? event.metaKey : event.ctrlKey;
+    if (!modifierPressed) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const url = linkEl.getAttribute('data-url');
+    if (url) window?.ipcRenderer?.openExternal(url);
+  };
+
   const filteredLogs = logs.filter((log) => filters[log.type]);
 
   return (
     <div className="tab-content">
-      <div className="tab-content-area">
+      <div className="tab-content-area" ref={contentAreaRef} onClick={handleContentAreaClick}>
         {filteredLogs.length === 0 ? (
           <div className="console-empty">
             <IconTerminal2 size={48} strokeWidth={1} />


### PR DESCRIPTION
INTERNAL REF - BRU-3466

Ref: BRU- #6275

### Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Makes http:// and https:// URLs in Bruno's Console log output clickable so they open in the default browser, 
### Problem

<!-- What issue does this PR solve? Link the related issue if one exists. -->
URLs printed in the Console panel are currently plain text, so they cannot be opened from the log line. 
### Fix

1. any http:// or https:// URL inside a log message gets wrapped in <span class="log-link" data-url="...">. It's visible and text-selectable immediately, no modifier needed.
2. Normal click (no modifier) — nothing happens. It behaves like plain text: you can click-drag to select it, double-click to select the word, copy it, etc. This is intentional, matching the response-panel convention — you don't want accidental navigation while reading logs.
3. Hover it — it gets an underline, regardless of modifier state. That's just a visual "this is a link" cue.
4. Hold Cmd (macOS) or Ctrl (Windows/Linux), then hover — the cursor becomes a pointer and the text turns the theme's link-blue color. This is the cmd-ctrl-pressed class getting toggled on .tab-content-area by the keydown/keyup listeners.
5. Click while still holding the modifier — handleContentAreaClick fires, detects event.target.closest('.log-link'), confirms metaKey/ctrlKey is true, and calls window.ipcRenderer.openExternal(url) — which opens it in your actual system browser (verified this is a real, working preload-exposed IPC method, same one the response viewer uses).
6. The title tooltip — hovering also shows "Hold Cmd and click to open link" (or "Ctrl" on Windows/Linux) as a native browser tooltip, in case someone doesn't already know the shortcut.

<!-- How does this PR fix the problem? Briefly describe your approach. -->

The PR detects `http://` and `https://` URLs in log messages and renders them as link elements while keeping them selectable like normal text. Links only become interactive when the user holds **Cmd/Ctrl**, preventing accidental navigation. When clicked with the modifier held, the URL is opened in the system browser using the existing `openExternal` IPC method, matching the behavior already used in the response panel.

### Screenshots

<!-- Add screenshots or gifs here if applicable, to help explain the change. -->

| Before | After |
| --- | --- |
<img width="1917" height="1079" alt="Screenshot 2026-09-11 200644" src="https://github.com/user-attachments/assets/bc9c65f8-fc66-4fed-8eab-9c565e2ac397" />

|  |  |

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - URLs displayed in the developer console are recognized as clickable links, including URLs containing balanced parentheses.
  - Hold Cmd on macOS or Ctrl on other platforms to open console links in an external browser.
  - Console links support keyboard focus and Cmd/Ctrl+Enter activation.
  - Added hover, focus, and platform-specific guidance for opening links.
  - Modifier-key styling is cleared when the application window loses focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->