### PR TITLE
feat(mock): update mock-server default state

### DIFF
--- a/packages/bruno-app/src/components/Preferences/Beta/index.js
+++ b/packages/bruno-app/src/components/Preferences/Beta/index.js
@@ -28,6 +28,8 @@ import { getDocsUrlWithVersion } from 'utils/url';
  *   - label       (required) short name shown next to the checkbox.
  *   - description (required) one-line explanation shown under the label.
  *   - docsUrl     (optional) URL to the documentation for the feature.
+ *   - defaultEnabled (optional) value used when the preference has never been saved. Must match the
+ *                 default in the electron preferences store, otherwise the toggle lies about the state.
  *   - action      (optional) object with { label, tab } to render a button that navigates to a specific preferences tab. The label is the button text, and the tab is the tab key (e.g. 'ai', 'cache').
  *
  * To add a beta feature:
@@ -66,6 +68,7 @@ const BETA_FEATURES = [
     label: 'Mock Server',
     description: 'Run a local mock server using response examples defined in your collection. Serve mock API responses for frontend development without a real backend.',
     toggle: true,
+    defaultEnabled: true,
     docsUrl: 'https://link.usebruno.com/docs/mock-server'
   },
   {
@@ -93,7 +96,7 @@ const Beta = ({ close }) => {
   const generateInitialValues = () => {
     const initialValues = {};
     BETA_FEATURES.forEach((feature) => {
-      initialValues[feature.id] = get(preferences, `beta.${feature.id}`, false);
+      initialValues[feature.id] = get(preferences, `beta.${feature.id}`, feature.defaultEnabled ?? false);
     });
     return initialValues;
   };

--- a/packages/bruno-electron/src/store/preferences.js
+++ b/packages/bruno-electron/src/store/preferences.js
@@ -55,7 +55,7 @@ const defaultPreferences = {
   },
   beta: {
     'openapi-sync': false,
-    'mock-server': false
+    'mock-server': true
   },
   onboarding: {
     hasLaunchedBefore: false,
@@ -357,6 +357,14 @@ class PreferencesStore {
         // Save the migrated preferences back to the store
         this.store.set('preferences', preferences);
       }
+    }
+
+    const hasExistingPreferences = Object.keys(preferences).length > 0;
+    const mockServerDefaultApplied = get(preferences, '_migrations.mockServerBetaOnByDefault', false);
+    if (hasExistingPreferences && !mockServerDefaultApplied) {
+      preferences.beta = { ...preferences.beta, 'mock-server': true };
+      preferences._migrations = { ...preferences._migrations, mockServerBetaOnByDefault: true };
+      this.store.set('preferences', preferences);
     }
 
     // Migrate from defaultCollectionLocation to defaultLocation


### PR DESCRIPTION
### Description

BRU-4530

The mock server is currently behind a toggle in beta features. This limits feature discovery. The goal is to keep it under beta, but turn it on by default so more people can discover it and use it. Users can still turn it off using the toggle.

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Mock Server beta feature is now enabled by default for new users.

- **Bug Fixes**
  - Existing preferences are updated once to enable the Mock Server beta feature, while preserving the migration status to prevent repeated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->