### PR TITLE
add e2e coverage for TC-6360 and TC-6361 flows

### DIFF
--- a/tests/mock-server/collection-mock-server.spec.ts
+++ b/tests/mock-server/collection-mock-server.spec.ts
@@ -1,15 +1,21 @@
+import path from 'path';
 import { test, expect } from '../../playwright';
 import { createRequest, sendRequest, getResponseBody } from '../utils/page/actions';
+import { buildApiSpecPanelLocators, openApiSpecFromDialog } from '../utils/page/openapi/render-spec';
 import {
   buildMockServerLocators,
   openMockServerTab,
   syncResponsesFromExamples,
   startMockServer,
   stopMockServer,
-  createMockServerFromCollection
+  createMockServerFromCollection,
+  openCreateMockServerModal,
+  createMockServerFromSidebar
 } from '../utils/page/mock-server';
 
 const COLLECTION_NAME = 'mock-server-test-collection';
+const SPEC_FIXTURE = path.resolve(__dirname, '..', 'import', 'openapi', 'fixtures', 'openapi-simple.json');
+const SPEC_TITLE = 'Simple Test API';
 const DEFAULT_MOCK_PORT = '4500';
 let currentMockPort = DEFAULT_MOCK_PORT;
 const getMockBase = () => `http://localhost:${currentMockPort}`;
@@ -401,5 +407,188 @@ test.describe.serial('Mock Server', () => {
     const ms = buildMockServerLocators(page);
     await openMockServerTab(page, COLLECTION_NAME);
     await expect(ms.statusText()).toContainText('Stopped');
+  });
+
+  test('TC-6360: Should show the matching source picker and block create until a source is selected', { tag: '@sanity' }, async ({
+    pageWithUserData: page,
+    reuseOrLaunchElectronApp
+  }, testInfo) => {
+    const ms = buildMockServerLocators(page);
+    const apiSpecPanel = buildApiSpecPanelLocators(page);
+    const app = await reuseOrLaunchElectronApp({ testFile: testInfo.file });
+
+    await test.step('Open an API spec so the API Spec source is available', async () => {
+      await openApiSpecFromDialog(page, app, SPEC_FIXTURE);
+      await expect(apiSpecPanel.sidebarItem(SPEC_TITLE)).toBeVisible({ timeout: 2000 });
+    });
+
+    await openCreateMockServerModal(page);
+    await ms.nameInput().fill('Source Picker Validation');
+
+    await test.step('Collection shows the collection selector and hides the API spec selector', async () => {
+      await ms.sourceCollectionRadio().click();
+      await expect(ms.collectionSelect()).toBeVisible();
+      await expect(ms.specSelect()).toHaveCount(0);
+      await expect(ms.syncOnCreateCheckbox()).toBeVisible();
+      await expect(ms.syncOnCreateLabel()).toContainText('Sync mock responses with collection examples');
+    });
+
+    await test.step('API spec shows the spec selector and hides the collection selector', async () => {
+      await ms.sourceSpecRadio().click();
+      await expect(ms.specSelect()).toBeVisible();
+      await expect(ms.collectionSelect()).toHaveCount(0);
+      await expect(ms.syncOnCreateCheckbox()).toBeVisible();
+      await expect(ms.syncOnCreateLabel()).toContainText('Sync mock responses with API spec');
+    });
+
+    await test.step('Standalone hides both selectors and the sync checkbox', async () => {
+      await ms.sourceManualRadio().click();
+      await expect(ms.sourceManualRadio()).toBeChecked();
+      await expect(ms.collectionSelect()).toHaveCount(0);
+      await expect(ms.specSelect()).toHaveCount(0);
+      await expect(ms.syncOnCreateCheckbox()).toHaveCount(0);
+      await expect(ms.standaloneHelpText()).toBeVisible();
+    });
+
+    await test.step('Create is blocked when Collection is selected without a collection', async () => {
+      await ms.sourceCollectionRadio().click();
+      await ms.collectionSelect().selectOption('');
+      await ms.modalSubmit().click();
+      await expect(ms.fieldError('Collection is required')).toBeVisible();
+      await expect(ms.createModal()).toBeVisible();
+    });
+
+    await test.step('Create is blocked when API spec is selected without a spec', async () => {
+      await ms.sourceSpecRadio().click();
+      await ms.specSelect().selectOption('');
+      await ms.modalSubmit().click();
+      await expect(ms.fieldError('API spec is required')).toBeVisible();
+      await expect(ms.createModal()).toBeVisible();
+    });
+
+    await ms.modalCancel().click();
+    await expect(ms.createModal()).toHaveCount(0);
+  });
+
+  test('TC-6361-A: Should create a standalone mock server with no auto-synced responses', { tag: '@sanity' }, async ({ pageWithUserData: page }) => {
+    const ms = buildMockServerLocators(page);
+
+    await createMockServerFromSidebar(page, 'Standalone Mock Server', { sourceType: 'manual' });
+
+    await expect(ms.dashboard()).toBeVisible();
+    await expect(ms.emptyResponsesTitle()).toBeVisible();
+    await expect(ms.emptyResponsesDescription()).toBeVisible();
+    await expect(ms.responseItems()).toHaveCount(0);
+    await expect(ms.syncExamplesBtn()).toHaveCount(0);
+    await expect(ms.syncSpecBtn()).toHaveCount(0);
+  });
+
+  test('TC-6361-B: Should keep responses empty when sync on create is unchecked, then sync collection examples', { tag: '@sanity' }, async ({
+    pageWithUserData: page
+  }) => {
+    const ms = buildMockServerLocators(page);
+
+    await test.step('Select Collection, uncheck sync, enter a name, and click Create', async () => {
+      await openCreateMockServerModal(page);
+      await ms.sourceCollectionRadio().click();
+      await ms.collectionSelect().selectOption({ label: COLLECTION_NAME });
+      await ms.collectionLoading().waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
+      await ms.syncOnCreateCheckbox().uncheck();
+      await ms.nameInput().fill('Collection Sync Off');
+      await expect(ms.modalSubmit()).toBeEnabled({ timeout: 2000 });
+      await ms.modalSubmit().click();
+      await ms.dashboard().waitFor({ state: 'visible', timeout: 2000 });
+    });
+
+    await test.step('Open Responses and Routes immediately after creation', async () => {
+      await ms.tabResponses().click();
+      await expect(ms.emptyResponsesTitle()).toBeVisible();
+      await expect(ms.responseItems()).toHaveCount(0);
+      await ms.tabRoutes().click();
+      await expect(ms.tabRoutesCount()).toHaveCount(0);
+    });
+
+    await test.step('Click Sync with examples and verify the route count', async () => {
+      await ms.tabResponses().click();
+      await ms.syncExamplesBtn().click();
+      await expect(ms.syncExamplesModal()).toBeVisible();
+      await ms.syncExamplesSubmit().click();
+      await expect(ms.syncSuccessToast()).toBeVisible();
+      await expect(ms.responseItems()).toHaveCount(4);
+      await ms.tabRoutes().click();
+      await expect(ms.tabRoutesCount()).toHaveText('3');
+    });
+  });
+
+  test('TC-6361-C: Should sync API spec responses on create when checked, and only after manual sync when unchecked', { tag: '@sanity' }, async ({
+    pageWithUserData: page,
+    reuseOrLaunchElectronApp
+  }, testInfo) => {
+    const ms = buildMockServerLocators(page);
+    const apiSpecPanel = buildApiSpecPanelLocators(page);
+    const app = await reuseOrLaunchElectronApp({ testFile: testInfo.file });
+    let specResponseCount = 0;
+    let specRouteCount = '';
+
+    await test.step('Open an API spec so the API Spec source is available', async () => {
+      if (await apiSpecPanel.sidebarItem(SPEC_TITLE).count() === 0) {
+        await openApiSpecFromDialog(page, app, SPEC_FIXTURE);
+      }
+      await expect(apiSpecPanel.sidebarItem(SPEC_TITLE)).toBeVisible({ timeout: 2000 });
+    });
+
+    await test.step('Select API spec and keep sync checked', async () => {
+      await openCreateMockServerModal(page);
+      await ms.sourceSpecRadio().click();
+      await ms.specSelect().selectOption({ label: SPEC_TITLE });
+      await expect(ms.syncOnCreateCheckbox()).toBeChecked();
+      await expect(ms.syncOnCreateLabel()).toContainText('Sync mock responses with API spec');
+      await ms.nameInput().fill('Spec Sync On');
+      await expect(ms.modalSubmit()).toBeEnabled({ timeout: 2000 });
+      await ms.modalSubmit().click();
+      await ms.dashboard().waitFor({ state: 'visible', timeout: 2000 });
+    });
+
+    await test.step('Responses and routes are generated from the spec without a manual sync', async () => {
+      await expect(ms.responseItems().first()).toBeVisible({ timeout: 2000 });
+      specResponseCount = await ms.responseItems().count();
+      expect(specResponseCount).toBeGreaterThan(0);
+      await expect(ms.syncSpecBtn()).toBeVisible();
+      await ms.tabRoutes().click();
+      await expect(ms.tabRoutesCount()).toBeVisible();
+      specRouteCount = await ms.tabRoutesCount().innerText();
+      expect(Number(specRouteCount)).toBeGreaterThan(0);
+    });
+
+    await test.step('Select API spec, uncheck sync, enter a name, and click Create', async () => {
+      await openCreateMockServerModal(page);
+      await ms.sourceSpecRadio().click();
+      await ms.specSelect().selectOption({ label: SPEC_TITLE });
+      await ms.syncOnCreateCheckbox().uncheck();
+      await ms.nameInput().fill('Spec Sync Off');
+      await expect(ms.modalSubmit()).toBeEnabled({ timeout: 2000 });
+      await ms.modalSubmit().click();
+      await ms.dashboard().waitFor({ state: 'visible', timeout: 2000 });
+    });
+
+    await test.step('Open Responses and Routes immediately after creation', async () => {
+      await ms.tabResponses().click();
+      await expect(ms.emptyResponsesTitle()).toBeVisible();
+      await expect(ms.responseItems()).toHaveCount(0);
+      await ms.tabRoutes().click();
+      await expect(ms.tabRoutesCount()).toHaveCount(0);
+    });
+
+    await test.step('Click Generate from API Spec and verify the route count', async () => {
+      await ms.tabResponses().click();
+      await expect(ms.generateFromSpecBtn()).toBeVisible();
+      await ms.generateFromSpecBtn().click();
+      await expect(ms.generateFromSpecModal()).toBeVisible();
+      await ms.generateFromSpecSubmit().click();
+      await expect(ms.generateFromSpecSuccessToast()).toBeVisible();
+      await expect(ms.responseItems()).toHaveCount(specResponseCount);
+      await ms.tabRoutes().click();
+      await expect(ms.tabRoutesCount()).toHaveText(specRouteCount);
+    });
   });
 });

--- a/tests/utils/page/mock-server.ts
+++ b/tests/utils/page/mock-server.ts
@@ -1,4 +1,4 @@
-import { test, Page } from '../../../playwright';
+import { test, expect, Page } from '../../../playwright';
 
 // Locators for the Mock Server dashboard, routes table, request log, and related modals.
 export const buildMockServerLocators = (page: Page) => ({
@@ -31,14 +31,19 @@ export const buildMockServerLocators = (page: Page) => ({
   syncExamplesModal: () => page.getByTestId('sync-mock-examples-modal'),
   syncExamplesSubmit: () => page.getByTestId('sync-mock-examples-modal-submit-btn'),
   syncSuccessToast: () => page.getByText('Mock responses synced with collection examples'),
+  emptyResponsesTitle: () => page.getByTestId('mock-server-dashboard').getByText('No mock responses yet', { exact: true }),
+  emptyResponsesDescription: () =>
+    page.getByTestId('mock-server-dashboard').getByText(
+      'Create one to define the routes and responses this mock server serves.',
+      { exact: true }
+    ),
+  responseItems: () => page.locator('[data-testid^="mock-response-open-"]'),
+  responseItem: (name: string) =>
+    page.locator('[data-testid^="mock-response-open-"]').filter({ hasText: name }),
 
   createModal: () => page.locator('.bruno-modal-card'),
   nameInput: () => page.getByTestId('mock-server-name-input'),
-  nameRequiredError: () => page.getByText('Name is required'),
-  collectionRequiredError: () => page.getByText('Collection is required'),
-  collectionSelect: () => page.getByTestId('mock-server-collection-select'),
   modalSubmit: () => page.getByTestId('modal-submit-btn'),
-  modalCancel: () => page.locator('.bruno-modal-card').getByRole('button', { name: 'Cancel' }),
   sidebarCreateBtn: () => page.getByTestId('mock-servers-create-btn'),
   sourceCollectionRadio: () => page.getByTestId('mock-server-source-collection'),
   sourceSpecRadio: () => page.getByTestId('mock-server-source-spec'),
@@ -47,6 +52,22 @@ export const buildMockServerLocators = (page: Page) => ({
   specSelect: () => page.getByTestId('mock-server-spec-select'),
   specSelectedOption: () => page.getByTestId('mock-server-spec-select').locator('option:checked'),
   specOption: (name: string) => page.getByTestId('mock-server-spec-select').locator('option').filter({ hasText: name }),
+  collectionSelect: () => page.getByTestId('mock-server-collection-select'),
+  collectionLoading: () => page.getByTestId('mock-server-collection-loading'),
+  syncOnCreateLabel: () =>
+    page.locator('label').filter({ has: page.getByTestId('mock-server-sync-on-create-checkbox') }),
+  standaloneHelpText: () =>
+    page.getByText('A standalone mock server has no source. Add responses manually from the dashboard.'),
+  modalCancel: () => page.locator('.bruno-modal-card').getByRole('button', { name: 'Cancel' }),
+  fieldError: (message: string) => page.locator('.bruno-modal-card').getByText(message, { exact: true }),
+  syncSpecBtn: () => page.getByTestId('mock-response-sync-spec-btn'),
+  syncSpecModal: () => page.getByTestId('mock-response-sync-spec-modal'),
+  syncSpecSubmit: () => page.getByTestId('mock-response-sync-spec-modal-submit-btn'),
+  syncSpecSuccessToast: () => page.getByText('Mock responses synced with spec'),
+  generateFromSpecBtn: () => page.getByTestId('mock-response-generate-from-spec-btn'),
+  generateFromSpecModal: () => page.getByTestId('mock-response-generate-from-spec-modal'),
+  generateFromSpecSubmit: () => page.getByTestId('mock-response-generate-from-spec-modal-submit-btn'),
+  generateFromSpecSuccessToast: () => page.getByText(/Generated \d+ mock response\(s\) from API spec/),
   settingsBtn: () => page.getByTestId('mock-server-settings-btn'),
   sidebarItem: (name: string) => page.locator('.mock-server-item').filter({ hasText: name }),
   sidebarSection: () => page.locator('.sidebar-section').filter({ hasText: 'Mock Servers' }),
@@ -130,7 +151,12 @@ export const openCreateMockServerModal = async (page: Page) => {
 };
 
 // Open the create-mock-server flow from a collection's actions menu and submit a name.
-export const createMockServerFromCollection = async (page: Page, collectionName: string, serverName: string) => {
+export const createMockServerFromCollection = async (
+  page: Page,
+  collectionName: string,
+  serverName: string,
+  options: { syncOnCreate?: boolean } = {}
+) => {
   await test.step(`Create mock server "${serverName}" for "${collectionName}"`, async () => {
     const ms = buildMockServerLocators(page);
     const collection = ms.collectionRow(collectionName);
@@ -140,8 +166,52 @@ export const createMockServerFromCollection = async (page: Page, collectionName:
     await ms.createMockServerMenuItem().click();
     await ms.createModal().waitFor({ state: 'visible', timeout: 10000 });
     await ms.nameInput().fill(serverName);
+    if (typeof options.syncOnCreate === 'boolean') {
+      await ms.syncOnCreateCheckbox().setChecked(options.syncOnCreate);
+    }
     await ms.modalSubmit().click();
     await ms.dashboard().waitFor({ state: 'visible', timeout: 10000 });
+  });
+};
+
+// Create a mock server from the Mock Servers sidebar plus button (source radios live here).
+export const createMockServerFromSidebar = async (
+  page: Page,
+  serverName: string,
+  options: {
+    sourceType?: 'collection' | 'spec' | 'manual';
+    collectionName?: string;
+    specName?: string;
+    syncOnCreate?: boolean;
+  } = {}
+) => {
+  await test.step(`Create mock server "${serverName}" from the sidebar`, async () => {
+    const ms = buildMockServerLocators(page);
+    await openCreateMockServerModal(page);
+    await ms.nameInput().fill(serverName);
+
+    if (options.sourceType === 'manual') {
+      await ms.sourceManualRadio().click();
+    } else if (options.sourceType === 'spec') {
+      await ms.sourceSpecRadio().click();
+      if (options.specName) {
+        await ms.specSelect().selectOption({ label: options.specName });
+      }
+    } else if (options.sourceType === 'collection') {
+      await ms.sourceCollectionRadio().click();
+      if (options.collectionName) {
+        await ms.collectionSelect().selectOption({ label: options.collectionName });
+      }
+      await ms.collectionLoading().waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
+    }
+
+    if (typeof options.syncOnCreate === 'boolean' && options.sourceType !== 'manual') {
+      await ms.syncOnCreateCheckbox().setChecked(options.syncOnCreate);
+    }
+
+    await expect(ms.modalSubmit()).toBeEnabled({ timeout: 2000 });
+    await ms.modalSubmit().click();
+    await ms.dashboard().waitFor({ state: 'visible', timeout: 2000 });
   });
 };
 


### PR DESCRIPTION
**Description**
BRU-4422
The create mock server modal uses Collection, API spec, and Standalone as radios, plus a sync-on-create checkbox when a source is selected.

**Problem**
The old “link to mock server” checkbox was easy to misread. Linking to a collection or spec still left the mock empty until the user ran Sync with examples. Standalone was not a first-class source, and create did not make it obvious that a collection or spec had to be chosen.

**Fix**
Added Playwright coverage for the create flow:

TC-6360: Source radios swap the collection vs spec selector, sync checkbox, and standalone help text. Create is blocked with “Collection is required” / “API spec is required” until a source is selected.
TC-6361-A: Standalone create opens an empty dashboard with no auto-synced responses and no sync/generate actions.
TC-6361-B: Collection with sync unchecked starts empty; Sync with examples then creates the responses and routes.
TC-6361-C: API spec with sync checked generates responses/routes on create; with sync unchecked it stays empty until Generate from API Spec.

**Screen-recording**

[Screen Recording 2026-09-11 164933.zip](https://github.com/user-attachments/files/32105603/Screen.Recording.2026-09-11.164933.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for creating mock servers from collections, API specifications, and manual setup.
  - Added validation for required fields, source selection, synchronization options, and empty-response states.
  - Added coverage confirming expected response synchronization behavior for standalone, collection-based, and API-spec mock servers.
  - Improved test utilities for validating sync and generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->