### PR TITLE
fix(scripts): keep {{variables}} intact in req.getHost()

### DIFF
--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -1,5 +1,16 @@
 const HeaderList = require('./header-list');
 
+// The authority of a raw, uninterpolated URL: the scheme (if any), userinfo,
+// path, query and fragment removed, and the case left alone.
+const getRawHost = (rawUrl) => {
+  if (typeof rawUrl !== 'string') {
+    return '';
+  }
+  const withoutScheme = rawUrl.trim().replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
+  const authority = withoutScheme.split(/[/?#]/, 1)[0];
+  return authority.slice(authority.lastIndexOf('@') + 1);
+};
+
 class BrunoRequest {
   /**
    * The following properties are available as shorthand:
@@ -47,6 +58,17 @@ class BrunoRequest {
   }
 
   getHost() {
+    // Pre-request scripts see the URL before variables are interpolated, and
+    // `new URL()` mangles a `{{var}}` in the authority: `{{baseUrl}}/users` has
+    // no scheme so it throws, and `https://{{HOST}}/users` parses with the host
+    // lowercased to `{{host}}`, which then no longer interpolates. Read such a
+    // host straight from the raw string so it round-trips through
+    // `bru.interpolate()`.
+    const rawHost = getRawHost(this.req.url);
+    if (rawHost.includes('{{')) {
+      return rawHost;
+    }
+
     try {
       const url = new URL(this.req.url);
       return url.host;

--- a/packages/bruno-js/tests/bruno-request-get-host.spec.js
+++ b/packages/bruno-js/tests/bruno-request-get-host.spec.js
@@ -1,0 +1,50 @@
+const { describe, it, expect } = require('@jest/globals');
+const BrunoRequest = require('../src/bruno-request');
+
+const getHost = (url) => new BrunoRequest({ url, method: 'GET', headers: {} }).getHost();
+
+describe('BrunoRequest - getHost()', () => {
+  describe('interpolated urls', () => {
+    it('returns the host and port', () => {
+      expect(getHost('http://localhost:5000/api')).toBe('localhost:5000');
+    });
+
+    it('lowercases a literal hostname, as URL does', () => {
+      expect(getHost('https://API.Example.com/users')).toBe('api.example.com');
+    });
+
+    it('returns an empty string for a url it cannot parse', () => {
+      expect(getHost('not a url')).toBe('');
+    });
+  });
+
+  describe('urls still holding {{variables}}', () => {
+    it('keeps the case of a variable in the hostname', () => {
+      // #9234: `new URL()` lowercased this to `{{host}}`, which no longer interpolates
+      expect(getHost('https://{{HOST}}/test')).toBe('{{HOST}}');
+    });
+
+    it('returns the variable when it carries the scheme as well', () => {
+      // #9233: `{{HOST}}/test` has no scheme, so `new URL()` threw and this was ''
+      expect(getHost('{{HOST}}/test')).toBe('{{HOST}}');
+    });
+
+    it('keeps a port, literal or variable', () => {
+      expect(getHost('http://{{host}}:{{port}}/x')).toBe('{{host}}:{{port}}');
+      expect(getHost('http://{{Host}}:8080/x')).toBe('{{Host}}:8080');
+    });
+
+    it('stops at a query string or fragment', () => {
+      expect(getHost('{{baseUrl}}?page=1')).toBe('{{baseUrl}}');
+      expect(getHost('https://{{HOST}}#section')).toBe('{{HOST}}');
+    });
+
+    it('drops userinfo', () => {
+      expect(getHost('https://{{user}}:{{pass}}@{{HOST}}/x')).toBe('{{HOST}}');
+    });
+
+    it('leaves a literal host alone when only the path has variables', () => {
+      expect(getHost('https://API.Example.com/users/{{id}}')).toBe('api.example.com');
+    });
+  });
+});


### PR DESCRIPTION
### Description

`req.getHost()` loses a `{{variable}}` that sits in the host part of the URL. In a pre-request script the URL has not been interpolated yet, and `getHost()` handed it to `new URL()`:

- `{{HOST}}/test` has no scheme, so `new URL()` throws and `getHost()` returns `''`.
- `https://{{HOST}}/test` parses, but the host comes back lowercased as `{{host}}`, so `bru.interpolate(req.getHost())` no longer resolves it.

### Problem

Fixes #9233
Fixes #9234

Both are the same function mishandling the same input, so they are fixed together.

### Fix

If the authority of the raw URL contains `{{`, `getHost()` now reads it straight from the string: scheme, userinfo, path, query and fragment stripped, case left alone. Any other URL still goes through `new URL()`, so a literal host is returned exactly as before (lowercased, port included).

One thing to call out for #9233: when the variable holds the scheme as well (`HOST=https://example.com`), `getHost()` returns `{{HOST}}`. The host can't be separated from the scheme until the variable is interpolated, but `bru.interpolate(req.getHost())` now gives the value back instead of an empty string.

### Tests

Added `packages/bruno-js/tests/bruno-request-get-host.spec.js` (9 cases). The 5 cases with placeholders fail on `main` and pass with this change; the other 4 pin the existing behaviour for literal hosts. ESLint is clean on both files.

### Screenshots

n/a, no UI change.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of URLs containing unresolved variables so hosts are preserved correctly during interpolation.
  - Preserved host casing when variables are present, while retaining standard hostname normalization for regular URLs.
  - Ensured ports, paths, query strings, fragments, and user information are handled consistently when extracting hosts.

- **Tests**
  - Added coverage for literal hosts, unresolved variables, variable schemes, ports, and other URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->