### PR TITLE
fix(scripts): resolve variables in req.getHost() during pre-request

### DIFF
--- a/packages/bruno-js/src/bruno-request.js
+++ b/packages/bruno-js/src/bruno-request.js
@@ -14,8 +14,9 @@ class BrunoRequest {
    * It must be noted that the user cannot set these properties directly.
    * They should use the respective setter methods to set these properties.
    */
-  constructor(req) {
+  constructor(req, { interpolate } = {}) {
     this.req = req;
+    this.__interpolate = interpolate;
     this.url = req.url;
     this.method = req.method;
     this.headers = req.headers;
@@ -48,7 +49,7 @@ class BrunoRequest {
 
   getHost() {
     try {
-      const url = new URL(this.req.url);
+      const url = new URL(this.__getInterpolatedUrl());
       return url.host;
     } catch (e) {
       return '';
@@ -57,7 +58,7 @@ class BrunoRequest {
 
   getPath() {
     try {
-      const url = new URL(this.req.url);
+      const url = new URL(this.__getInterpolatedUrl());
       let pathname = url.pathname;
 
       // If path params exist, interpolate them into the pathname
@@ -91,7 +92,7 @@ class BrunoRequest {
 
   getQueryString() {
     try {
-      const url = new URL(this.req.url);
+      const url = new URL(this.__getInterpolatedUrl());
       // Return query string without the leading '?'
       return url.search ? url.search.substring(1) : '';
     } catch (e) {
@@ -244,6 +245,10 @@ class BrunoRequest {
     } else if (callback) {
       throw new Error(`${callback} is not a function`);
     }
+  }
+
+  __getInterpolatedUrl() {
+    return this.__interpolate ? this.__interpolate(this.req.url) : this.req.url;
   }
 
   __safeParseJSON(str) {

--- a/packages/bruno-js/src/runtime/script-runtime.js
+++ b/packages/bruno-js/src/runtime/script-runtime.js
@@ -53,7 +53,9 @@ class ScriptRuntime {
       certsAndProxyConfig,
       requestUrl: request?.url
     });
-    const req = new BrunoRequest(request);
+    // Pre-request scripts run before the request is interpolated, so the URL helpers
+    // (getHost, getPath, getQueryString) resolve variables themselves
+    const req = new BrunoRequest(request, { interpolate: bru.interpolate });
 
     // extend bru with result getter methods
     const { __brunoTestResults, test, waitForPendingTests } = createBruTestResultMethods(bru, assertionResults, chai);

--- a/packages/bruno-js/tests/bruno-request-url-helpers.spec.js
+++ b/packages/bruno-js/tests/bruno-request-url-helpers.spec.js
@@ -1,0 +1,95 @@
+const { describe, it, expect } = require('@jest/globals');
+const { interpolate } = require('@usebruno/common');
+const BrunoRequest = require('../src/bruno-request');
+
+const makeReq = (overrides = {}) => ({
+  url: 'https://example.com/api',
+  method: 'GET',
+  headers: {},
+  data: undefined,
+  ...overrides
+});
+
+const createInterpolator = (vars) => (str) => interpolate(str, vars);
+
+describe('BrunoRequest - URL helpers', () => {
+  describe('without an interpolator', () => {
+    it('parses a literal URL', () => {
+      const req = new BrunoRequest(makeReq({ url: 'https://example.com:8080/api/users?page=2' }));
+
+      expect(req.getHost()).toBe('example.com:8080');
+      expect(req.getPath()).toBe('/api/users');
+      expect(req.getQueryString()).toBe('page=2');
+    });
+  });
+
+  describe('with an interpolator', () => {
+    it('resolves a host variable that includes the scheme', () => {
+      const req = new BrunoRequest(makeReq({ url: '{{HOST}}/test' }), {
+        interpolate: createInterpolator({ HOST: 'https://example.com' })
+      });
+
+      expect(req.getHost()).toBe('example.com');
+    });
+
+    it('resolves a host variable that follows a literal scheme without lowercasing the variable name', () => {
+      const req = new BrunoRequest(makeReq({ url: 'https://{{HOST}}/test' }), {
+        interpolate: createInterpolator({ HOST: 'example.com' })
+      });
+
+      expect(req.getHost()).toBe('example.com');
+    });
+
+    it('resolves host and port variables', () => {
+      const req = new BrunoRequest(makeReq({ url: 'https://{{HOST}}:{{PORT}}/test' }), {
+        interpolate: createInterpolator({ HOST: 'example.com', PORT: '8080' })
+      });
+
+      expect(req.getHost()).toBe('example.com:8080');
+    });
+
+    it('resolves variables in getPath() and getQueryString()', () => {
+      const req = new BrunoRequest(
+        makeReq({
+          url: '{{baseUrl}}/users/:userId?name={{name}}&age=30',
+          pathParams: [{ name: 'userId', value: '123', type: 'path' }]
+        }),
+        { interpolate: createInterpolator({ baseUrl: 'https://example.com/api', name: 'john' }) }
+      );
+
+      expect(req.getPath()).toBe('/api/users/123');
+      expect(req.getQueryString()).toBe('name=john&age=30');
+    });
+
+    it('uses the variable values at call time', () => {
+      const vars = { HOST: 'https://example.com' };
+      const req = new BrunoRequest(makeReq({ url: '{{HOST}}/test' }), {
+        interpolate: createInterpolator(vars)
+      });
+
+      vars.HOST = 'https://api.example.com';
+
+      expect(req.getHost()).toBe('api.example.com');
+    });
+
+    it('leaves the raw URL untouched', () => {
+      const rawReq = makeReq({ url: '{{HOST}}/test' });
+      const req = new BrunoRequest(rawReq, {
+        interpolate: createInterpolator({ HOST: 'https://example.com' })
+      });
+
+      req.getHost();
+
+      expect(req.getUrl()).toBe('{{HOST}}/test');
+      expect(rawReq.url).toBe('{{HOST}}/test');
+    });
+
+    it('returns an empty string when the resolved URL is not parseable', () => {
+      const req = new BrunoRequest(makeReq({ url: '{{HOST}}/test' }), {
+        interpolate: createInterpolator({})
+      });
+
+      expect(req.getHost()).toBe('');
+    });
+  });
+});

--- a/packages/bruno-js/tests/runtime.spec.js
+++ b/packages/bruno-js/tests/runtime.spec.js
@@ -195,6 +195,47 @@ describe('runtime', () => {
         expect(result.envVariables.environmentToken).toBe('after');
         expect(result.globalEnvironmentVariables.globalToken).toBe('after');
       });
+
+      describe.each(['nodevm', 'quickjs'])('URL helpers with variables (%s)', (runtimeName) => {
+        const onConsoleLog = () => {};
+
+        beforeAll(async () => {
+          if (runtimeName === 'quickjs') {
+            await quickJsLoader();
+          }
+        });
+
+        it('should resolve variables in req.getHost(), req.getPath() and req.getQueryString()', async () => {
+          const script = `
+            bru.setVar('resolvedHost', req.getHost());
+            bru.setVar('resolvedPath', req.getPath());
+            bru.setVar('resolvedQueryString', req.getQueryString());
+          `;
+          const request = { ...baseRequest, url: '{{HOST}}/test?page=1' };
+          const envVariables = { HOST: 'https://example.com' };
+          const runtime = new ScriptRuntime({ runtime: runtimeName });
+
+          const result = await runtime.runRequestScript(script, request, envVariables, {}, '.', onConsoleLog, process.env);
+
+          expect(result.runtimeVariables.resolvedHost).toBe('example.com');
+          expect(result.runtimeVariables.resolvedPath).toBe('/test');
+          expect(result.runtimeVariables.resolvedQueryString).toBe('page=1');
+          expect(request.url).toBe('{{HOST}}/test?page=1');
+        });
+
+        it('should resolve variables set earlier in the same script', async () => {
+          const script = `
+            bru.setVar('HOST', 'https://api.example.com');
+            bru.setVar('resolvedHost', req.getHost());
+          `;
+          const request = { ...baseRequest, url: '{{HOST}}/test' };
+          const runtime = new ScriptRuntime({ runtime: runtimeName });
+
+          const result = await runtime.runRequestScript(script, request, {}, {}, '.', onConsoleLog, process.env);
+
+          expect(result.runtimeVariables.resolvedHost).toBe('api.example.com');
+        });
+      });
     });
 
     describe('run-response-script', () => {


### PR DESCRIPTION
### Description

In a pre-request script, `req.getHost()` returns an empty string when the host comes from a variable. For example, with `HOST=https://example.com` and URL `{{HOST}}/test`, it logs `''`. `req.getPath()` and `req.getQueryString()` have the same problem.

### Problem

Closes #9233

Pre-request scripts run before the request is interpolated. The Electron `runPreRequest` path and the CLI runner both call `interpolateVars` after the script. The URL helpers in `BrunoRequest` call `new URL(this.req.url)` on the raw template:

- `new URL('{{HOST}}/test')` throws, and the helper's `catch` returns `''`.
- `new URL('https://{{HOST}}/test')` parses, but the WHATWG parser lowercases the host to `{{host}}`. This is the scenario in #9234, which has the same root cause.

In post-response scripts and tests the URL is already interpolated, so the helpers work there. The existing `getHost.bru` sanity test (`{{host}}/ping`) only passes because it runs in the `tests` block.

### Fix

- `BrunoRequest` takes an optional `{ interpolate }` option. `getHost()`, `getPath()` and `getQueryString()` now parse the interpolated URL instead of the raw one. Resolution happens at call time, so a variable set earlier in the same script with `bru.setVar()` is picked up, the same way the network layer will resolve it.
- `ScriptRuntime.runRequestScript` passes `bru.interpolate`. This is the same pattern `CookieList` already uses to resolve the request URL. The post-response, test, assert and vars runtimes don't pass it, because their URL is already resolved.
- `req.url` and `req.getUrl()` are unchanged and still return the raw template, and the request object is not mutated.
- Safe mode (QuickJS) is covered too, since its shim calls the host-side `req.getHost()`.

This also fixes the lowercased `{{host}}` case reported in #9234, because the placeholder never reaches `new URL`. I've left that issue open for you to confirm.

One case this PR does not cover: a variable holding a host without a scheme (`HOST=example.com`) still makes `getHost()` return `''`. The network layer prepends `http://` only at send time. Changing that here would also change how literal scheme-less URLs are parsed, so I kept it out of scope.

### Testing

- New `packages/bruno-js/tests/bruno-request-url-helpers.spec.js`. It covers a scheme inside the variable, a scheme outside the variable (#9234), host plus port variables, path params and a query string, call-time resolution, the raw URL staying untouched, and the unresolvable fallback.
- `packages/bruno-js/tests/runtime.spec.js`: `runRequestScript` with `{{HOST}}/test?page=1` in both `nodevm` and `quickjs`, plus a case where the script sets `HOST` before calling `getHost()`.
- With the `src` changes reverted, 9 of these tests fail (`Received: ""` / `Received: "{{host}}"`). With the fix, all pass.

```
cd packages/bruno-js && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js tests/bruno-request-url-helpers.spec.js tests/runtime.spec.js
npm test --workspace=packages/bruno-js        # 34 suites, 815 tests passing
npx eslint packages/bruno-js/src/bruno-request.js packages/bruno-js/src/runtime/script-runtime.js packages/bruno-js/tests/bruno-request-url-helpers.spec.js packages/bruno-js/tests/runtime.spec.js
```

### Screenshots

N/A. This is a scripting API change, covered by unit tests.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL helper methods in pre-request scripts now resolve environment and script-defined variables before extracting the host, path, or query string.
  * Request URLs remain unchanged while their parsed components reflect the latest variable values.

* **Tests**
  * Added coverage for URL parsing with variables, multiple runtimes, dynamic updates, and invalid URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->