### PR TITLE
Feature:Make_Timeline_URL_selectable_by_double_click

### DIFF
--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/StyledWrapper.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/StyledWrapper.js
@@ -121,9 +121,13 @@ const StyledWrapper = styled.div`
     color: ${(props) => props.theme.text};
   }
   .tl-header-url-method {
+    display: inline-block;
     font-weight: 600;
     margin-right: 6px;
     text-transform: uppercase;
+  }
+  .tl-header-url-text {
+    display: inline-block;
   }
   .tl-header-src {
     display: inline-flex;

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -165,7 +165,7 @@ const TimelineItem = ({
           <div className="tl-col-method">
             <Method method={method} />
           </div>
-          <div className="tl-col-url" title={url} data-testid="timeline-url">{url} onDoubleClick={selectAllTextOnDoubleClick}</div>
+          <div className="tl-col-url" title={url} data-testid="timeline-url" onDoubleClick={selectAllTextOnDoubleClick}>{url} </div>
           <div className="tl-col-badge">
             <span className={badge.badgeClass} data-testid={`timeline-badge-${badge.kind}`}>{badge.badgeLabel}</span>
           </div>

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -165,7 +165,7 @@ const TimelineItem = ({
           <div className="tl-col-method">
             <Method method={method} />
           </div>
-          <div className="tl-col-url" title={url} data-testid="timeline-url" onDoubleClick={selectAllTextOnDoubleClick}>{url} </div>
+          <div className="tl-col-url" title={url} data-testid="timeline-url" onDoubleClick={selectAllTextOnDoubleClick}>{url}</div>
           <div className="tl-col-badge">
             <span className={badge.badgeClass} data-testid={`timeline-badge-${badge.kind}`}>{badge.badgeLabel}</span>
           </div>

--- a/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
+++ b/packages/bruno-app/src/components/ResponsePane/Timeline/TimelineItem/index.js
@@ -63,6 +63,15 @@ const TimelineItem = ({
     setVisitedTabs((v) => (v[id] ? v : { ...v, [id]: true }));
   };
 
+  const selectAllTextOnDoubleClick = (event) => {
+    const el = event.currentTarget;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+  };
+
   const { method, url = '' } = request || {};
   // Main-request entries use `status`; scripted entries use `statusCode`.
   const { status, statusCode, statusText } = response || {};
@@ -156,7 +165,7 @@ const TimelineItem = ({
           <div className="tl-col-method">
             <Method method={method} />
           </div>
-          <div className="tl-col-url" title={url} data-testid="timeline-url">{url}</div>
+          <div className="tl-col-url" title={url} data-testid="timeline-url">{url} onDoubleClick={selectAllTextOnDoubleClick}</div>
           <div className="tl-col-badge">
             <span className={badge.badgeClass} data-testid={`timeline-badge-${badge.kind}`}>{badge.badgeLabel}</span>
           </div>
@@ -171,8 +180,8 @@ const TimelineItem = ({
           <div className="tl-detail" data-testid="timeline-detail">
             <div className="tl-header">
               <div className="tl-header-url" title={`${method || ''} ${url}`}>
-                <span className="tl-header-url-method">{method}</span>
-                <span className="tl-header-url-text">{url}</span>
+                <span className="tl-header-url-method">{method}</span>{' '}
+                <span className="tl-header-url-text" onDoubleClick={selectAllTextOnDoubleClick}>{url}</span>
               </div>
               {sourceFile && (
                 <a


### PR DESCRIPTION
BRU-#9236
### Description

Double-clicking the request URL in the Timeline (both the collapsed row and the expanded detail view) also selected the HTTP method sitting next to it, forcing users to manually delete the method after pasting the copied URL elsewhere. This is especially painful for URLs built from variables — Timeline is often the fastest place to grab the resolved URL mid-debugging, so getting the method tagged along on every double-click is annoying.

solve - #9236

### Fix

- Added an explicit `onDoubleClick` handler (`selectAllTextOnDoubleClick`) that selects the full text content of the clicked element via `Range`/`Selection`, instead of relying on the browser's native double-click word-boundary detection — which was inconsistent (sometimes grabbing the method too, sometimes only a punctuation-delimited fragment of the URL).
- Wired this handler onto the URL element in both places it's rendered: the collapsed row (`.tl-col-url`) and the expanded detail header (`.tl-header-url-text`). It's attached only to the URL element itself, so it's structurally impossible for it to include the adjacent method text.
- In the expanded detail view, the method and URL were previously rendered as two adjacent `<span>`s with no actual space character between them (only a CSS `margin-right`), so their underlying text ran together (e.g. `GEThttps://...`). Added a real space between them and set both spans to `display: inline-block` so each has its own isolated selection boundary.

Double-clicking the URL now always selects exactly the URL, nothing more.
https://github.com/user-attachments/assets/60164d32-fc86-44b4-8a31-b088a31ad7d7

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.

#### Publishing to New Package Managers

Please see [here](../publishing.md) for more information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-clicking a timeline request URL selects the full URL text for easier copying.

* **Style**
  * Improved timeline header layout for request methods and URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->